### PR TITLE
Make type check errors more understandable

### DIFF
--- a/chainer/function_set.py
+++ b/chainer/function_set.py
@@ -31,7 +31,12 @@ class FunctionSet(object):
 
         """
         for name, func in six.iteritems(functions):
-            setattr(self, name, func)
+            if func is None or isinstance(func, (function.Function,
+                                                 FunctionSet)):
+                setattr(self, name, func)
+            else:
+                msg = '{0} is not a Function or FunctionSet instance'
+                raise ValueError(msg.format(func))
 
     def collect_parameters(self):
         """Returns a tuple of parameters and gradients.

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -14,12 +14,14 @@ class ClippedReLU(function.Function):
 
     """
 
-    def __init__(self, z):
+    def __init__(self, z, name=None):
         if not isinstance(z, float):
             raise TypeError('z must be float value')
         # z must be positive.
         assert z > 0
         self.cap = z
+
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -47,7 +49,7 @@ class ClippedReLU(function.Function):
         return gx,
 
 
-def clipped_relu(x, z=20.0):
+def clipped_relu(x, z=20.0, name=None):
     """Clipped Rectifier Unit function.
 
     This function is expressed as :math:`ClippedReLU(x, z)
@@ -56,9 +58,10 @@ def clipped_relu(x, z=20.0):
     Args:
         x (~chainer.Variable): Input variable.
         z (float): Clipping value. (default = 20.0)
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return ClippedReLU(z)(x)
+    return ClippedReLU(z, name=name)(x)

--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -15,8 +15,9 @@ class LeakyReLU(function.Function):
 
     """Leaky rectifier unit."""
 
-    def __init__(self, slope=0.2):
+    def __init__(self, slope=0.2, name=None):
         self.slope = slope
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -44,7 +45,7 @@ class LeakyReLU(function.Function):
         return gx,
 
 
-def leaky_relu(x, slope=0.2):
+def leaky_relu(x, slope=0.2, name=None):
     """Leaky Rectified Linear Unit function.
 
     This function is expressed as :math:`f(x) = \max(x, ax)`, where :math:`a`
@@ -53,9 +54,10 @@ def leaky_relu(x, slope=0.2):
     Args:
         x (~chainer.Variable): Input variable.
         slope (float): Slope value :math:`a`.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return LeakyReLU(slope)(x)
+    return LeakyReLU(slope, name=name)(x)

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -131,7 +131,7 @@ class LSTM(function.Function):
         return gc_prev, gx
 
 
-def lstm(c_prev, x):
+def lstm(c_prev, x, name=None):
     """Long Short-Term Memory units as an activation function.
 
     This function implements LSTM units with forget gates. Let the previous
@@ -165,6 +165,7 @@ def lstm(c_prev, x):
             previous call of LSTM.
         x (~chainer.Variable): Variable that holds the incoming signal. It must
             have the second dimension four times of that of the cell state,
+        name (str): Function name
 
     Returns:
         tuple: Two :class:`~chainer.Variable` objects ``c`` and ``h``. ``c`` is
@@ -192,4 +193,4 @@ def lstm(c_prev, x):
         parameters are used for different kind of input sources.
 
     """
-    return LSTM()(c_prev, x)
+    return LSTM(name=name)(c_prev, x)

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -28,6 +28,7 @@ class PReLU(function.Function):
     Args:
         shape (tuple of ints): Shape of the parameter array.
         init (float): Initial parameter value.
+        name (str): Function name
 
     See detail in paper: `Delving Deep into Rectifiers: Surpassing \
     Human-Level Performance on ImageNet Classification \
@@ -37,9 +38,10 @@ class PReLU(function.Function):
     parameter_names = 'W',
     gradient_names = 'gW',
 
-    def __init__(self, shape=(), init=0.25):
+    def __init__(self, shape=(), init=0.25, name=None):
         self.W = numpy.full(shape, init, dtype=numpy.float32)
         self.gW = numpy.full_like(self.W, numpy.nan)
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -25,8 +25,9 @@ class ReLU(function.Function):
     """Rectified Linear Unit."""
     # TODO(beam2d): Implement in-place version.
 
-    def __init__(self, use_cudnn=True):
+    def __init__(self, use_cudnn=True, name=None):
         self.use_cudnn = use_cudnn
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(
@@ -71,16 +72,17 @@ class ReLU(function.Function):
         return gx,
 
 
-def relu(x, use_cudnn=True):
+def relu(x, use_cudnn=True, name=None):
     """Rectified Linear Unit function :math:`f(x)=\\max(0, x)`.
 
     Args:
         x (~chainer.Variable): Input variable.
         use_cudnn (bool): If True and CuDNN is enabled, then this function uses
             CuDNN as the core implementation.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return ReLU(use_cudnn)(x)
+    return ReLU(use_cudnn, name=name)(x)

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -15,8 +15,9 @@ class Sigmoid(function.Function):
 
     """Logistic sigmoid function."""
 
-    def __init__(self, use_cudnn=True):
+    def __init__(self, use_cudnn=True, name=None):
         self.use_cudnn = use_cudnn
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -62,16 +63,17 @@ class Sigmoid(function.Function):
         return gx,
 
 
-def sigmoid(x, use_cudnn=True):
+def sigmoid(x, use_cudnn=True, name=None):
     """Elementwise sigmoid logistic function :math:`f(x)=(1 + \\exp(-x))^{-1}`.
 
     Args:
         x (~chainer.Variable): Input variable.
         use_cudnn (bool): If True and CuDNN is enabled, then this function uses
             CuDNN as the core implementation.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Sigmoid(use_cudnn)(x)
+    return Sigmoid(use_cudnn, name=name)(x)

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -16,8 +16,9 @@ class Softmax(function.Function):
 
     """Softmax activation function."""
 
-    def __init__(self, use_cudnn=True):
+    def __init__(self, use_cudnn=True, name=None):
         self.use_cudnn = use_cudnn
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -65,7 +66,7 @@ class Softmax(function.Function):
         return gx,
 
 
-def softmax(x, use_cudnn=True):
+def softmax(x, use_cudnn=True, name=None):
     """Channelwise softmax function.
 
     This function computes its softmax along the second axis. Let
@@ -79,9 +80,10 @@ def softmax(x, use_cudnn=True):
         x (~chainer.Variable): Input variable.
         use_cudnn (bool): If True and CuDNN is enabled, then this function uses
             CuDNN as the core implementation.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Softmax(use_cudnn)(x)
+    return Softmax(use_cudnn, name=name)(x)

--- a/chainer/functions/activation/softplus.py
+++ b/chainer/functions/activation/softplus.py
@@ -9,9 +9,11 @@ class Softplus(function.Function):
 
     """Softplus function."""
 
-    def __init__(self, beta=1.0):
+    def __init__(self, beta=1.0, name=None):
         self.beta = numpy.float32(beta)
         self.beta_inv = numpy.float32(1.0 / beta)
+
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -57,7 +59,7 @@ class Softplus(function.Function):
         return gx,
 
 
-def softplus(x, beta=1.0):
+def softplus(x, beta=1.0, name=None):
     """Elementwise softplus function.
 
     This function is expressed as
@@ -67,9 +69,10 @@ def softplus(x, beta=1.0):
     Args:
         x (~chainer.Variable): Input variable.
         beta (float): Parameter :math:`\\beta`.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Softplus(beta=beta)(x)
+    return Softplus(beta=beta, name=name)(x)

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -15,8 +15,9 @@ class Tanh(function.Function):
 
     """Hyperbolic tangent function."""
 
-    def __init__(self, use_cudnn=True):
+    def __init__(self, use_cudnn=True, name=None):
         self.use_cudnn = use_cudnn
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -60,16 +61,17 @@ class Tanh(function.Function):
         return gx,
 
 
-def tanh(x, use_cudnn=True):
+def tanh(x, use_cudnn=True, name=None):
     """Elementwise hyperbolic tangent function.
 
     Args:
         x (~chainer.Variable): Input variable.
         use_cudnn (bool): If True and CuDNN is enabled, then this function uses
             CuDNN as the core implementation.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Tanh(use_cudnn)(x)
+    return Tanh(use_cudnn, name=name)(x)

--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -10,8 +10,9 @@ class Concat(function.Function):
     """Concatenate multiple tensors towards specified axis."""
 
     # concat along the channel dimension by default
-    def __init__(self, axis=1):
+    def __init__(self, axis=1, name=None):
         self.axis = axis
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
@@ -42,15 +43,16 @@ class Concat(function.Function):
         return xp.split(gy[0], sizes, axis=self.axis)
 
 
-def concat(xs, axis=1):
+def concat(xs, axis=1, name=None):
     """Concatenates given variables along an axis.
 
     Args:
         xs (tuple of Variables): Variables to be concatenated.
         axis (int): Axis that the input arrays are concatenated along.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Concat(axis=axis)(*xs)
+    return Concat(axis=axis, name=name)(*xs)

--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -7,8 +7,9 @@ class Copy(function.Function):
 
     """Copy an input cupy.ndarray onto another device."""
 
-    def __init__(self, out_device):
+    def __init__(self, out_device, name=None):
         self.out_device = out_device
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(
@@ -28,7 +29,7 @@ class Copy(function.Function):
         return cuda.copy(gy[0], out_device=cuda.get_device(x[0])),
 
 
-def copy(x, dst):
+def copy(x, dst, name=None):
     """Copies the input variable onto the specified device.
 
     This function copies the array of input variable onto the device specified
@@ -38,9 +39,10 @@ def copy(x, dst):
     Args:
         x (~chainer.Variable): Variable to be copied.
         dst: Target device specifier.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Copy(dst)(x)
+    return Copy(dst, name=name)(x)

--- a/chainer/functions/array/reshape.py
+++ b/chainer/functions/array/reshape.py
@@ -13,11 +13,12 @@ class Reshape(function.Function):
 
     """Reshapes an input array without copy."""
 
-    def __init__(self, shape):
+    def __init__(self, shape, name=None):
         cnt = _count_unknown_dims(shape)
         assert cnt == 0 or cnt == 1
 
         self.shape = shape
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(
@@ -47,16 +48,17 @@ class Reshape(function.Function):
         return gy[0].reshape(x[0].shape),
 
 
-def reshape(x, shape):
+def reshape(x, shape, name=None):
     """Reshapes an input variable without copy.
 
     Args:
         x (~chainer.Variable): Input variable.
         shape (tuple of ints): Target shape.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Variable that holds a reshaped version of the input
             variable.
 
     """
-    return Reshape(shape)(x)
+    return Reshape(shape, name=name)(x)

--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -11,11 +11,12 @@ class SplitAxis(function.Function):
 
     """Function that splits multiple arrays towards the specified axis."""
 
-    def __init__(self, indices_or_sections, axis):
+    def __init__(self, indices_or_sections, axis, name=None):
         if not isinstance(indices_or_sections, (int, collections.Iterable)):
             raise TypeError('indices_or_sections must be integer or 1-D array')
         self.indices_or_sections = indices_or_sections
         self.axis = axis
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -58,7 +59,7 @@ class SplitAxis(function.Function):
             return xp.concatenate(gys, axis=self.axis),
 
 
-def split_axis(x, indices_or_sections, axis):
+def split_axis(x, indices_or_sections, axis, name=None):
     """Splits given variables along an axis.
 
     Args:
@@ -68,6 +69,7 @@ def split_axis(x, indices_or_sections, axis):
             If it is a 1-D array of sorted integers, it
             indicates the positions where the array is split.
         axis (int): Axis that the input array is split along.
+        name (str): Function name
 
     Returns:
         ``tuple`` or ``Variable``: Tuple of :class:`~chainer.Variable` objects
@@ -80,4 +82,4 @@ def split_axis(x, indices_or_sections, axis):
         (i.e. `axis`-th value of its shape is zero).
 
     """
-    return SplitAxis(indices_or_sections, axis)(x)
+    return SplitAxis(indices_or_sections, axis, name=name)(x)

--- a/chainer/functions/array/swapaxes.py
+++ b/chainer/functions/array/swapaxes.py
@@ -5,9 +5,10 @@ from chainer.utils import type_check
 class Swapaxes(function.Function):
     """Swap two axes of an array."""
 
-    def __init__(self, axis1, axis2):
+    def __init__(self, axis1, axis2, name=None):
         self.axis1 = axis1
         self.axis2 = axis2
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1,)
@@ -27,16 +28,17 @@ class Swapaxes(function.Function):
         return gx,
 
 
-def swapaxes(x, axis1, axis2):
+def swapaxes(x, axis1, axis2, name=None):
     """Swap two axes of a variable.
 
     Args:
         x (~chainer.Variable): Input variable.
         axis1 (int): The first axis to swap.
         axis2 (int): The second axis to swap.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Variable whose axes are swapped.
 
     """
-    return Swapaxes(axis1, axis2)(x)
+    return Swapaxes(axis1, axis2, name=name)(x)

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -7,8 +7,9 @@ from chainer.utils import type_check
 class Transpose(function.Function):
     """Permute the dimensions of an array."""
 
-    def __init__(self, axes):
+    def __init__(self, axes, name=None):
         self.axes = tuple(ax % len(axes) for ax in axes)
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1,)
@@ -29,16 +30,17 @@ class Transpose(function.Function):
         return gx,
 
 
-def transpose(x, axes=None):
+def transpose(x, axes=None, name=None):
     """Permute the dimensions of an input variable without copy.
 
     Args:
         x (~chainer.Variable): Input variable.
         axes (tuple of ints): By default, reverse the dimensions,
             otherwise permute the axes according to the values given.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Variable whose axes are permuted.
 
     """
-    return Transpose(axes)(x)
+    return Transpose(axes, name=name)(x)

--- a/chainer/functions/caffe/caffe_function.py
+++ b/chainer/functions/caffe/caffe_function.py
@@ -91,6 +91,7 @@ class CaffeFunction(function.Function):
 
     Args:
         model_path (str): Path to the binary-proto model file of Caffe.
+        name (str): Function name
 
     Attributes:
         fs (FunctionSet): A set of functions corresponding to parameterized
@@ -99,7 +100,7 @@ class CaffeFunction(function.Function):
         forwards (dict): A mapping from layer names to corresponding functions.
 
     """
-    def __init__(self, model_path):
+    def __init__(self, model_path, name=None):
         if not available:
             raise RuntimeError('CaffeFunction is not supported on Python 3')
 
@@ -111,6 +112,7 @@ class CaffeFunction(function.Function):
         self.forwards = {}
         self.split_map = {}
         self.layers = []
+        self.name = name
 
         if net.layer:
             for layer in net.layer:

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -70,6 +70,7 @@ class Bilinear(function.Function):
             and ``(output_size,)``, respectively. If ``None``, :math:`V^1`
             and :math:`V^2` is initialized by scaled centered Gaussian
             distributions and :math:`b` is set to :math:`0`.
+        name (str): Function name
 
     See:
         `Reasoning With Neural Tensor Networks for Knowledge Base Completion
@@ -78,7 +79,7 @@ class Bilinear(function.Function):
     """
 
     def __init__(self, left_size, right_size, out_size, nobias=False,
-                 initialW=None, initial_bias=None):
+                 initialW=None, initial_bias=None, name=None):
 
         self.W = None
         self.gW = None
@@ -91,6 +92,8 @@ class Bilinear(function.Function):
 
         self.in_sizes = (left_size, right_size)
         self.nobias = nobias
+
+        self.name = name
 
         if initialW is not None:
             assert initialW.shape == (

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -45,6 +45,7 @@ class Convolution2D(function.Function):
         initial_bias (1-D array): Initial bias value. If ``None``, then this
             function uses to initialize ``bias``.
         dtype (numpy.dtype): Type to use in computing.
+        name (str): Function name
 
     This function holds at most two parameter arrays: ``W`` and ``b``, which
     indicate the filter weight and the bias vector, respectively.
@@ -87,9 +88,8 @@ class Convolution2D(function.Function):
     def __init__(self, in_channels, out_channels, ksize, stride=1, pad=0,
                  wscale=1, bias=0, nobias=False, use_cudnn=True,
                  initialW=None, initial_bias=None,
-                 dtype=numpy.float32):
+                 dtype=numpy.float32, name=None):
         self.dtype = numpy.dtype(dtype)
-
         ksize = _pair(ksize)
         stride = _pair(stride)
         pad = _pair(pad)
@@ -105,6 +105,8 @@ class Convolution2D(function.Function):
         self.gW = None
         self.b = None
         self.gb = None
+
+        self.name = name
 
         if initialW is not None:
             assert initialW.shape == \
@@ -299,15 +301,17 @@ class NonparameterizedConvolution2D(function.Function):
         pad (int or (int, int)): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         use_cudnn (bool): If True, then this function uses CuDNN if available.
+        name (str): Function name
 
     .. seealso:: :class:`Convolution2D`
 
     """
-    def __init__(self, stride=1, pad=0, use_cudnn=True):
+    def __init__(self, stride=1, pad=0, use_cudnn=True, name=None):
         self.stride = stride
         self.pad = pad
 
         self.use_cudnn = use_cudnn
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(
@@ -359,7 +363,7 @@ class NonparameterizedConvolution2D(function.Function):
         return (gx[0], func.gW, func.gb)
 
 
-def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True):
+def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True, name=None):
     """Two-dimensional convolution function.
 
     Args:
@@ -371,6 +375,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True):
         pad (int or (int, int)): Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         use_cudnn (bool): If True, then this function uses CuDNN if available.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -380,7 +385,7 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True):
     """
     if b is None:
         return NonparameterizedConvolution2D(
-            stride=stride, pad=pad, use_cudnn=use_cudnn)(x, W)
+            stride=stride, pad=pad, use_cudnn=use_cudnn, name=name)(x, W)
     else:
         return NonparameterizedConvolution2D(
-            stride=stride, pad=pad, use_cudnn=use_cudnn)(x, W, b)
+            stride=stride, pad=pad, use_cudnn=use_cudnn, name=name)(x, W, b)

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -19,6 +19,7 @@ class EmbedID(function.Function):
         in_size (int): Number of different identifiers (a.k.a. vocabulary
             size).
         out_size (int): Size of embedding vector.
+        name (str): Function name
 
     .. note::
 
@@ -29,9 +30,10 @@ class EmbedID(function.Function):
     parameter_names = ('W',)
     gradient_names = ('gW',)
 
-    def __init__(self, in_size, out_size):
+    def __init__(self, in_size, out_size, name=None):
         self.W = numpy.random.randn(in_size, out_size).astype(numpy.float32)
         self.gW = numpy.full_like(self.W, numpy.nan)
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)

--- a/chainer/functions/connection/inception.py
+++ b/chainer/functions/connection/inception.py
@@ -30,6 +30,7 @@ class Inception(function.Function):
         proj5 (int): Projection size of 5x5 convolution path.
         out5 (int): Output size of 5x5 convolution path.
         proj_pool (int): Projection size of max pooling path.
+        name (str): Function name
 
     Returns:
         Variable: Output variable. Its array has the same spatial size and the
@@ -44,7 +45,8 @@ class Inception(function.Function):
 
     """
 
-    def __init__(self, in_channels, out1, proj3, out3, proj5, out5, proj_pool):
+    def __init__(self, in_channels, out1, proj3, out3, proj5, out5,
+                 proj_pool, name=None):
         self.f = function_set.FunctionSet(
             conv1=convolution_2d.Convolution2D(in_channels, out1, 1),
             proj3=convolution_2d.Convolution2D(in_channels, proj3, 1),
@@ -53,6 +55,7 @@ class Inception(function.Function):
             conv5=convolution_2d.Convolution2D(proj5, out5, 5, pad=2),
             projp=convolution_2d.Convolution2D(in_channels, proj_pool, 1),
         )
+        self.name = name
 
     def __call__(self, x):
         out1 = self.f.conv1(x)

--- a/chainer/functions/connection/inceptionbn.py
+++ b/chainer/functions/connection/inceptionbn.py
@@ -29,12 +29,13 @@ class InceptionBN(function.Function):
         pooltype (str): Pooling type. It must be either ``'max'`` or ``'avg'``.
         proj_pool (bool): If True, do projection in the pooling path.
         stride (int): Stride parameter of the last convolution of each path.
+        name (str): Function name
 
     .. seealso:: :class:`Inception`
 
     """
     def __init__(self, in_channels, out1, proj3, out3, proj33, out33,
-                 pooltype, proj_pool=None, stride=1):
+                 pooltype, proj_pool=None, stride=1, name=None):
         if out1 > 0:
             assert stride == 1
             assert proj_pool is not None
@@ -54,8 +55,9 @@ class InceptionBN(function.Function):
             conv3n=batch_normalization.BatchNormalization(out3),
             proj33n=batch_normalization.BatchNormalization(proj33),
             conv33an=batch_normalization.BatchNormalization(out33),
-            conv33bn=batch_normalization.BatchNormalization(out33),
+            conv33bn=batch_normalization.BatchNormalization(out33)
         )
+        self.name = name
 
         if out1 > 0:
             self.f.conv1 = convolution_2d.Convolution2D(

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -44,6 +44,7 @@ class Linear(function.Function):
             function uses to initialize ``wscale``.
         initial_bias (1-D array): Initial bias value. If ``None``, then this
             function uses to initialize ``bias``.
+        name (str): Function name
 
     .. note::
 
@@ -53,11 +54,12 @@ class Linear(function.Function):
 
     """
     def __init__(self, in_size, out_size, wscale=1, bias=0, nobias=False,
-                 initialW=None, initial_bias=None):
+                 initialW=None, initial_bias=None, name=None):
         self.W = None
         self.gW = None
         self.b = None
         self.gb = None
+        self.name = name
 
         if initialW is not None:
             assert initialW.shape == (out_size, in_size)
@@ -174,13 +176,14 @@ class NonparameterizedLinear(function.Function):
         return (gx[0], func.gW, func.gb)
 
 
-def linear(x, W, b=None):
+def linear(x, W, b=None, name=None):
     """Nonparameterized linear function.
 
     Args:
         x (~chainer.Variable): Input variable.
         W (~chainer.Variable): Weight variable.
         b (~chainer.Variable): Bias variable (optional).
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -189,6 +192,6 @@ def linear(x, W, b=None):
 
     """
     if b is None:
-        return NonparameterizedLinear()(x, W)
+        return NonparameterizedLinear(name=name)(x, W)
     else:
-        return NonparameterizedLinear()(x, W, b)
+        return NonparameterizedLinear(name=name)(x, W, b)

--- a/chainer/functions/connection/parameter.py
+++ b/chainer/functions/connection/parameter.py
@@ -13,14 +13,16 @@ class Parameter(function.Function):
 
     Args:
         array: Initial parameter array.
+        name (str): Function name
 
     """
     parameter_names = 'W',
     gradient_names = 'gW',
 
-    def __init__(self, array):
+    def __init__(self, array, name=None):
         self.W = array
         self.gW = numpy.full_like(array, numpy.nan)
+        self.name = name
 
     def __call__(self, volatile=False):
         ret = super(Parameter, self).__call__()

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -29,13 +29,14 @@ class Accuracy(function.Function):
         return xp.asarray((pred == t).mean(dtype='f')),
 
 
-def accuracy(y, t):
+def accuracy(y, t, name=None):
     """Computes muticlass classification accuracy of the minibatch.
 
     Args:
         y (Variable): Variable holding a matrix whose (i, j)-th element
             indicates the score of the class j at the i-th example.
         t (Variable): Variable holding an int32 vector of groundtruth labels.
+        name (str): Function name
 
     Returns:
         Variable: A variable holding a scalar array of the accuracy.
@@ -43,4 +44,4 @@ def accuracy(y, t):
     .. note:: This function is non-differentiable.
 
     """
-    return Accuracy()(y, t)
+    return Accuracy(name=name)(y, t)

--- a/chainer/functions/loss/cross_covariance.py
+++ b/chainer/functions/loss/cross_covariance.py
@@ -10,10 +10,12 @@ class CrossCovariance(function.Function):
 
     """Cross-covariance loss."""
 
-    def __init__(self):
+    def __init__(self, name=None):
         self.y_centered = None
         self.z_centered = None
         self.covariance = None
+
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -51,7 +53,7 @@ class CrossCovariance(function.Function):
         return gy, gz
 
 
-def cross_covariance(y, z):
+def cross_covariance(y, z, name=None):
     """Computes the sum-squared cross-covariance penalty between ``y`` and ``z``
 
     Args:
@@ -59,6 +61,7 @@ def cross_covariance(y, z):
             corresponds to the batches
         z (Variable): Variable holding a matrix where the first dimension
             corresponds to the batches
+        name (str): Function name
 
     Returns:
         Variable: A variable holding a scalar of the cross covariance loss.
@@ -69,4 +72,4 @@ def cross_covariance(y, z):
        See http://arxiv.org/abs/1412.6583v3 for details.
 
     """
-    return CrossCovariance()(y, z)
+    return CrossCovariance(name=name)(y, z)

--- a/chainer/functions/loss/hierarchical_softmax.py
+++ b/chainer/functions/loss/hierarchical_softmax.py
@@ -92,6 +92,7 @@ class BinaryHierarchicalSoftmax(function.Function):
     Args:
         in_size (int): Dimension of input vectors.
         tree: A binary tree made with tuples like `((1, 2), 3)`.
+        name (str): Function name
 
     See: Hierarchical Probabilistic Neural Network Language Model [Morin+,
     AISTAT2005].
@@ -101,7 +102,7 @@ class BinaryHierarchicalSoftmax(function.Function):
     parameter_names = ('W',)
     gradient_names = ('gW',)
 
-    def __init__(self, in_size, tree):
+    def __init__(self, in_size, tree, name=None):
         parser = TreeParser()
         parser.parse(tree)
         paths = parser.get_paths()
@@ -122,6 +123,8 @@ class BinaryHierarchicalSoftmax(function.Function):
         self.W = numpy.random.uniform(
             -1, 1, (parser.size(), in_size)).astype(numpy.float32)
         self.gW = numpy.full_like(self.W, numpy.nan)
+
+        self.name = name
 
     @staticmethod
     def create_huffman_tree(word_counts):

--- a/chainer/functions/loss/mean_squared_error.py
+++ b/chainer/functions/loss/mean_squared_error.py
@@ -34,11 +34,11 @@ class MeanSquaredError(function.Function):
         return gx0, -gx0
 
 
-def mean_squared_error(x0, x1):
+def mean_squared_error(x0, x1, name=None):
     """Mean squared error function.
 
     This function computes mean squared error between two variables. The mean
     is taken over the minibatch. Note that the error is not scaled by 1/2.
 
     """
-    return MeanSquaredError()(x0, x1)
+    return MeanSquaredError(name=name)(x0, x1)

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -45,6 +45,7 @@ class NegativeSampling(function.Function):
         counts (int list): Number of each identifiers.
         sample_size (int): Number of negative samples.
         power (float): Power factor :math:`\\alpha`.
+        name (str): Function name
 
     See: `Distributed Representations of Words and Phrases and their\
          Compositionality <http://arxiv.org/abs/1310.4546>`_
@@ -53,7 +54,7 @@ class NegativeSampling(function.Function):
     parameter_names = ('W',)
     gradient_names = ('gW',)
 
-    def __init__(self, in_size, counts, sample_size, power=0.75):
+    def __init__(self, in_size, counts, sample_size, power=0.75, name=None):
         self.sample_size = sample_size
         p = numpy.array(counts, numpy.float32)
         p = numpy.power(p, p.dtype.type(power))
@@ -62,6 +63,8 @@ class NegativeSampling(function.Function):
         vocab_size = len(counts)
         self.W = numpy.zeros((vocab_size, in_size)).astype(numpy.float32)
         self.gW = numpy.full_like(self.W, numpy.nan)
+
+        self.name = name
 
     def _make_samples(self, t):
         if hasattr(self, 'samples'):

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -10,8 +10,9 @@ class SigmoidCrossEntropy(function.Function):
 
     """Sigmoid activation followed by a sigmoid cross entropy loss."""
 
-    def __init__(self, use_cudnn=True):
+    def __init__(self, use_cudnn=True, name=None):
         self.use_cudnn = use_cudnn
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -55,7 +56,7 @@ class SigmoidCrossEntropy(function.Function):
         return gx, None
 
 
-def sigmoid_cross_entropy(x, t, use_cudnn=True):
+def sigmoid_cross_entropy(x, t, use_cudnn=True, name=None):
     """Computes cross entropy loss for sigmoid activations.
 
     Args:
@@ -64,6 +65,7 @@ def sigmoid_cross_entropy(x, t, use_cudnn=True):
             at the i-th example.
         t (Variable): A variable object holding an int32 vector of groundtruth
             binary labels.
+        name (str): Function name
 
     Returns:
         Variable: A variable object holding a scalar array of the cross entropy
@@ -74,4 +76,4 @@ def sigmoid_cross_entropy(x, t, use_cudnn=True):
        This function is differentiable only by ``x``.
 
     """
-    return SigmoidCrossEntropy(use_cudnn)(x, t)
+    return SigmoidCrossEntropy(use_cudnn, name=name)(x, t)

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -13,9 +13,10 @@ class SoftmaxCrossEntropy(function.Function):
 
     ignore_label = -1
 
-    def __init__(self, use_cudnn=True, normalize=True):
+    def __init__(self, use_cudnn=True, normalize=True, name=None):
         self.use_cudnn = use_cudnn
         self.normalize = normalize
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -123,7 +124,7 @@ class SoftmaxCrossEntropy(function.Function):
         return gx, None
 
 
-def softmax_cross_entropy(x, t, use_cudnn=True, normalize=True):
+def softmax_cross_entropy(x, t, use_cudnn=True, normalize=True, name=None):
     """Computes cross entropy loss for pre-softmax activations.
 
     Args:
@@ -140,6 +141,7 @@ def softmax_cross_entropy(x, t, use_cudnn=True, normalize=True):
             determines the normalization constant. If true, this function
             normalizes the cross entropy loss across all instances. If else,
             it only normalizes along a batch size.
+        name (str): Function name
 
     Returns:
         Variable: A variable holding a scalar array of the cross entropy loss.
@@ -149,4 +151,4 @@ def softmax_cross_entropy(x, t, use_cudnn=True, normalize=True):
        This function is differentiable only by ``x``.
 
     """
-    return SoftmaxCrossEntropy(use_cudnn, normalize)(x, t)
+    return SoftmaxCrossEntropy(use_cudnn, normalize, name=name)(x, t)

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -102,10 +102,14 @@ class Add(function.Function):
         return gy[0], gy[0]
 
 
-class AddConstant(function.Function):
+class MathConstantFunction(function.Function):
 
-    def __init__(self, value):
+    def __init__(self, value, name=None):
         self.value = value
+        self.name = name
+
+
+class AddConstant(MathConstantFunction):
 
     @property
     def label(self):
@@ -156,10 +160,7 @@ def sub(lhs, rhs):  # lhs - rhs
     return AddConstant(-rhs)(lhs)
 
 
-class SubFromConstant(function.Function):
-
-    def __init__(self, value):
-        self.value = value
+class SubFromConstant(MathConstantFunction):
 
     @property
     def label(self):
@@ -204,10 +205,7 @@ class Mul(function.Function):
         return utils.force_array(gy[0] * x[1]), utils.force_array(gy[0] * x[0])
 
 
-class MulConstant(function.Function):
-
-    def __init__(self, value):
-        self.value = value
+class MulConstant(MathConstantFunction):
 
     @property
     def label(self):
@@ -270,10 +268,7 @@ def div(lhs, rhs):  # lhs / rhs
     return MulConstant(1. / rhs)(lhs)
 
 
-class DivFromConstant(function.Function):
-
-    def __init__(self, value):
-        self.value = value
+class DivFromConstant(MathConstantFunction):
 
     @property
     def label(self):
@@ -342,10 +337,7 @@ class PowVarVar(function.Function):
             ''', 'pow_var_var_bwd')(x[0], x[1], gy[0])
 
 
-class PowVarConst(function.Function):
-
-    def __init__(self, value):
-        self.value = value
+class PowVarConst(MathConstantFunction):
 
     @property
     def label(self):
@@ -380,10 +372,7 @@ def pow(lhs, rhs):  # lhs ** rhs
     return PowVarConst(rhs)(lhs)
 
 
-class PowConstVar(function.Function):
-
-    def __init__(self, value):
-        self.value = value
+class PowConstVar(MathConstantFunction):
 
     @property
     def label(self):

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -119,9 +119,11 @@ def _get_check_index(trans, right, row_idx=0, col_idx=1):
 
 
 class MatMul(function.Function):
-    def __init__(self, transa=False, transb=False):
+
+    def __init__(self, transa=False, transb=False, name=None):
         self.transa = transa
         self.transb = transb
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -156,7 +158,7 @@ class MatMul(function.Function):
         return gx0, gx1
 
 
-def matmul(a, b, transa=False, transb=False):
+def matmul(a, b, transa=False, transb=False, name=None):
     """Computes the matrix multiplication of two arrays.
 
     Args:
@@ -167,18 +169,21 @@ def matmul(a, b, transa=False, transb=False):
             Its array is treated as a matrix in the same way as ``a``'s array.
         transa (bool): If true, transpose a.
         transb (bool): If true, transpose b.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: The result of the matrix multiplication as a 2-D
             array.
     """
-    return MatMul(transa=transa, transb=transb)(a, b)
+    return MatMul(transa=transa, transb=transb, name=name)(a, b)
 
 
 class BatchMatMul(function.Function):
-    def __init__(self, transa=False, transb=False):
+
+    def __init__(self, transa=False, transb=False, name=None):
         self.transa = transa
         self.transb = transb
+        self.name = name
 
     def _output_shape(self, a, b):
         batch_size = a.shape[0]
@@ -255,7 +260,7 @@ class BatchMatMul(function.Function):
         return ga, gb
 
 
-def batch_matmul(a, b, transa=False, transb=False):
+def batch_matmul(a, b, transa=False, transb=False, name=None):
     """Computes the batch matrix multiplications of two sets of arrays.
 
     Args:
@@ -266,9 +271,10 @@ def batch_matmul(a, b, transa=False, transb=False):
             Its array is treated as matrices in the same way as ``a``'s array.
         transa (bool): If true, transpose each matrix in a.
         transb (bool): If true, transpose each matrix in b.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: The result of the batch matrix multiplications as a
             3-D array.
     """
-    return BatchMatMul(transa=transa, transb=transb)(a, b)
+    return BatchMatMul(transa=transa, transb=transb, name=name)(a, b)

--- a/chainer/functions/math/sum.py
+++ b/chainer/functions/math/sum.py
@@ -8,7 +8,7 @@ from chainer.utils import type_check
 class Sum(function.Function):
     """Sum of array elements over a given axis."""
 
-    def __init__(self, axis=None):
+    def __init__(self, axis=None, name=None):
         if axis is None:
             self.axis = None
         elif isinstance(axis, int):
@@ -20,6 +20,8 @@ class Sum(function.Function):
             self.axis = axis
         else:
             raise TypeError('None, int or tuple of int are required')
+
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(
@@ -62,7 +64,7 @@ class Sum(function.Function):
         return gx,
 
 
-def sum(x, axis=None):
+def sum(x, axis=None, name=None):
     """Sum of array elements over a given axis.
 
     Args:
@@ -70,9 +72,10 @@ def sum(x, axis=None):
         axis (None, int, or tuple of int): Axis which a sum is performed.
             The default (axis = None) is perform a sum over all the dimensions
             of the input array.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Sum(axis)(x)
+    return Sum(axis, name=name)(x)

--- a/chainer/functions/math/trigonometric.py
+++ b/chainer/functions/math/trigonometric.py
@@ -32,9 +32,9 @@ class Sin(function.Function):
         return gx,
 
 
-def sin(x):
+def sin(x, name=None):
     """Elementwise sin function."""
-    return Sin()(x)
+    return Sin(name=name)(x)
 
 
 class Cos(function.Function):
@@ -64,6 +64,6 @@ class Cos(function.Function):
         return gx,
 
 
-def cos(x):
+def cos(x, name=None):
     """Elementwise cos function."""
-    return Cos()(x)
+    return Cos(name=name)(x)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -7,8 +7,9 @@ class Dropout(function.Function):
 
     """Dropout regularization."""
 
-    def __init__(self, dropout_ratio):
+    def __init__(self, dropout_ratio, name=None):
         self.dropout_ratio = dropout_ratio
+        self.name = name
 
     def check_type_forwrad(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -26,7 +27,7 @@ class Dropout(function.Function):
         return gy[0] * self.mask,
 
 
-def dropout(x, ratio=.5, train=True):
+def dropout(x, ratio=.5, train=True, name=None):
     """Drops elements of input variable randomly.
 
     This function drops input elements randomly with probability ``ratio`` and
@@ -37,6 +38,7 @@ def dropout(x, ratio=.5, train=True):
         x (~chainer.Variable): Input variable.
         ratio (float): Dropout ratio.
         train (bool): If True, executes dropout. Otherwise, does nothing.
+        name: Function name
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -46,5 +48,5 @@ def dropout(x, ratio=.5, train=True):
 
     """
     if train:
-        return Dropout(ratio)(x)
+        return Dropout(ratio, name=name)(x)
     return x

--- a/chainer/functions/noise/gaussian.py
+++ b/chainer/functions/noise/gaussian.py
@@ -13,8 +13,9 @@ class Gaussian(function.Function):
     as inputs, and draw a sample from a gaussian distribution.
     """
 
-    def __init__(self):
+    def __init__(self, name=None):
         self.eps = None
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
@@ -55,7 +56,7 @@ class Gaussian(function.Function):
         return g, g * self.noise * g.dtype.type(0.5),
 
 
-def gaussian(mean, ln_var):
+def gaussian(mean, ln_var, name=None):
     """Gaussian sampling function.
 
     It takes mean :math:`\\mu` and logarithm of variance
@@ -67,9 +68,10 @@ def gaussian(mean, ln_var):
             :math:`\\mu`.
         ln_var (~chainer.Variable): Input variable representing logarithm of
             variance :math:`\\log(\\sigma^2)`.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
 
     """
-    return Gaussian()(mean, ln_var)
+    return Gaussian(name=name)(mean, ln_var)

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -15,6 +15,7 @@ class BatchNormalization(function.Function):
         decay (float): Decay rate of moving average.
         eps (float): Epsilon value for numerical stability.
         dtype (numpy.dtype): Type to use in computing.
+        name (str): Function name
 
     See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
           Internal Covariate Shift <http://arxiv.org/abs/1502.03167>`_
@@ -23,7 +24,8 @@ class BatchNormalization(function.Function):
     parameter_names = ('gamma',  'beta')
     gradient_names = ('ggamma', 'gbeta')
 
-    def __init__(self, size, decay=0.9, eps=1e-5, dtype=numpy.float32):
+    def __init__(self, size, decay=0.9, eps=1e-5,
+                 dtype=numpy.float32, name=None):
         if isinstance(size, tuple):
             self.size = size
         elif isinstance(size, int):
@@ -45,6 +47,8 @@ class BatchNormalization(function.Function):
         self.decay = decay
         self.N = [0]  # as a reference
         self.eps = eps
+
+        self.name = name
 
     def __call__(self, x, test=False, finetune=False):
         """Invokes the forward propagation of BatchNormalization.

--- a/chainer/functions/normalization/local_response_normalization.py
+++ b/chainer/functions/normalization/local_response_normalization.py
@@ -36,11 +36,12 @@ class LocalResponseNormalization(function.Function):
 
     """Cross-channel normalization function used in AlexNet."""
 
-    def __init__(self, n=5, k=2, alpha=1e-4, beta=.75):
+    def __init__(self, n=5, k=2, alpha=1e-4, beta=.75, name=None):
         self.n = n
         self.k = k
         self.alpha = alpha
         self.beta = beta
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
@@ -102,7 +103,7 @@ class LocalResponseNormalization(function.Function):
         return gx,
 
 
-def local_response_normalization(x, n=5, k=2, alpha=1e-4, beta=.75):
+def local_response_normalization(x, n=5, k=2, alpha=1e-4, beta=.75, name=None):
     """Local response normalization across neighboring channels.
 
     This function implements normalization across channels. Let :math:`x` an
@@ -120,6 +121,7 @@ def local_response_normalization(x, n=5, k=2, alpha=1e-4, beta=.75):
         k (float): Smoothing parameter.
         alpha (float): Normalizer scaling parameter.
         beta (float): Normalizer power parameter.
+        name (str): Function name
 
     Returns:
         Variable: Output variable.
@@ -128,4 +130,4 @@ def local_response_normalization(x, n=5, k=2, alpha=1e-4, beta=.75):
     Neural Networks <http://www.cs.toronto.edu/~fritz/absps/imagenet.pdf>`_
 
     """
-    return LocalResponseNormalization(n, k, alpha, beta)(x)
+    return LocalResponseNormalization(n, k, alpha, beta, name=name)(x)

--- a/chainer/functions/pooling/average_pooling_2d.py
+++ b/chainer/functions/pooling/average_pooling_2d.py
@@ -107,7 +107,8 @@ class AveragePooling2D(pooling_2d.Pooling2D):
             libcudnn.CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
 
 
-def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
+def average_pooling_2d(x, ksize, stride=None, pad=0,
+                       use_cudnn=True, name=None):
     """Spatial average pooling function.
 
     This function acts similarly to :class:`~functions.Convolution2D`, but
@@ -125,6 +126,7 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
         use_cudnn (bool): If True and CuDNN is enabled, then this function
             uses CuDNN as the core implementation.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -135,4 +137,4 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
        :func:`max_pooling_2d`. Average pooling runs in non-cover-all mode.
 
     """
-    return AveragePooling2D(ksize, stride, pad, False, use_cudnn)(x)
+    return AveragePooling2D(ksize, stride, pad, False, use_cudnn, name=name)(x)

--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -138,7 +138,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
 
 
 def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
-                   use_cudnn=True):
+                   use_cudnn=True, name=None):
     """Spatial max pooling function.
 
     This function acts similarly to :class:`~functions.Convolution2D`, but
@@ -158,9 +158,10 @@ def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
             output pixels. It may make the output size larger.
         use_cudnn (bool): If True and CuDNN is enabled, then this function
             uses CuDNN as the core implementation.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Ouptut variable.
 
     """
-    return MaxPooling2D(ksize, stride, pad, cover_all, use_cudnn)(x)
+    return MaxPooling2D(ksize, stride, pad, cover_all, use_cudnn, name=name)(x)

--- a/chainer/functions/pooling/pooling_2d.py
+++ b/chainer/functions/pooling/pooling_2d.py
@@ -24,7 +24,7 @@ class Pooling2D(function.Function):
     """Base class of pooling function over a set of 2d planes."""
 
     def __init__(self, ksize, stride=None, pad=0, cover_all=True,
-                 use_cudnn=True):
+                 use_cudnn=True, name=None):
         if stride is None:
             stride = ksize
 
@@ -34,6 +34,8 @@ class Pooling2D(function.Function):
 
         self.cover_all = cover_all
         self.use_cudnn = use_cudnn
+
+        self.name = name
 
     def check_type_forward(self, in_types):
         type_check.expect(

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -11,9 +11,11 @@ class SpatialPyramidPooling2D(function.Function):
 
     """Spatial pyramid pooling over a set of 2d planes."""
 
-    def __init__(self, x_shape, pyramid_height, pooling_class, use_cudnn=True):
+    def __init__(self, x_shape, pyramid_height, pooling_class,
+                 use_cudnn=True, name=None):
         bottom_c, bottom_h, bottom_w = x_shape
         self.pyramid_height = pyramid_height
+        self.name = name
 
         # create pooling functions for different pyramid levels
         out_dim = 0
@@ -65,7 +67,7 @@ class SpatialPyramidPooling2D(function.Function):
 
 
 def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
-                               use_cudnn=True):
+                               use_cudnn=True, name=None):
     """Spatial pyramid pooling function.
 
     It outputs a fixed-length vector regardless of input feature map size.
@@ -102,6 +104,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
             Only MaxPooling2D class can be available for now.
         use_cudnn (bool): If True and CuDNN is enabled, then this function
             uses CuDNN as the core implementation.
+        name (str): Function name
 
     Returns:
         ~chainer.Variable: Ouptut variable. The shape of the output variable
@@ -118,4 +121,5 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
     """
 
     return SpatialPyramidPooling2D(x.data.shape[1:], pyramid_height,
-                                   pooling_class, use_cudnn=use_cudnn)(x)
+                                   pooling_class, use_cudnn=use_cudnn,
+                                   name=name)(x)

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,5 +1,6 @@
 import numpy
 
+
 from chainer.utils import walker_alias
 
 WalkerAlias = walker_alias.WalkerAlias

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -432,10 +432,11 @@ class InvalidType(Exception):
     """Raised when types of data for forward/backward are invalid.
 
     """
-    def __init__(self, expect, actual):
-        msg = 'Expect: {0}\nActual: {1}'.format(expect, actual)
-        super(InvalidType, self).__init__(msg)
+    def __init__(self, expect, actual, msg=None):
 
+        if msg is None:
+            msg = 'Expect: {0}\nActual: {1}'.format(expect, actual)
+        super(InvalidType, self).__init__(msg)
         self.expect = expect
         self.actual = actual
 

--- a/tests/chainer_tests/test_function.py
+++ b/tests/chainer_tests/test_function.py
@@ -390,5 +390,13 @@ class TestSplit(unittest.TestCase):
         self.check_backward_one(cuda.to_gpu(self.x),
                                 cuda.to_cpu(self.g1))
 
+    def test_name(self):
+        import inspect
+        for func in F.__dict__:
+            func = getattr(F, func)
+            if inspect.isclass(func) and issubclass(func, chainer.Function):
+                argspec = inspect.getargspec(func.__init__)
+                self.assertTrue('name' in argspec.args)
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_function_set.py
+++ b/tests/chainer_tests/test_function_set.py
@@ -335,4 +335,15 @@ class TestFunctionSet(TestFunctionSetBase):
     def test_gradients_setter_invalid_2_gpu(self):
         self._check_setter_invalid(self.fs, -1, cuda.cupy, 'gradients')
 
+
+class TestFunctionSetValidation(unittest.TestCase):
+
+    def test_not_function(self):
+        with self.assertRaises(ValueError):
+            chainer.FunctionSet(
+                a=lambda x: x,
+                b=F.Linear(3, 2)
+            )
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Recently added type-checking is very useful, but it looks not easy to read. This PR intends to make it more understandable by showing where the error is raised.

Assuming the following model (derived from MNIST example).

```
model = chainer.FunctionSet(l1=F.Linear(784, n_units),
                            l2=F.Linear(n_units + 5, n_units),  # dimensionality mismatch
                            l3=F.Linear(n_units, 10))
```
#### Current error

```
chainer.utils.type_check.InvalidType: Expect: in_types[0].shape[1] == W.shape[1]
Actual: 1000 != 1005
```
#### After this PR

```
chainer.utils.type_check.InvalidType: 
Invalid Operation is performed in: Linear (l2) (Forward)

Expect: in_types[0].shape[1] == W.shape[1]
Actual: 1000 != 1005
```

If base idea looks OK, I'll work on:
- [x] Add `name` property to all functions.
  - [x] Add `name` attribute to `Function` and `FunctionSet`. `FunctionSet` will automatically attach `name` to given functions based on its key.
  - [x] Add `name` to functions which has own `__init__` method
- ~~Define `Function` and `FunctionSet` string representations~~
- [x] Tests
