### PR TITLE
Extract timer functionality from TimerHook

### DIFF
--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -40,6 +40,10 @@ class TimerHook(function_.FunctionHook):
         self._preprocess()
 
     def _postprocess(self, function):
+        # For backward compatibility
+        if self.xp is numpy:
+            self.stop = self.timer.stop_times[-1]
+
         self.timer.stop()
         self.call_history.append((function, self.timer.total_time()))
 

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -48,11 +48,13 @@ class TimerHook(function_.FunctionHook):
         self.call_history.append((function, self.timer.total_time()))
 
     def forward_postprocess(self, function, in_data):
-        self.xp = cuda.get_array_module(*in_data)
+        xp = cuda.get_array_module(*in_data)
+        assert xp is self.xp
         self._postprocess(function)
 
     def backward_postprocess(self, function, in_data, out_grad):
-        self.xp = cuda.get_array_module(*(in_data + out_grad))
+        xp = cuda.get_array_module(*(in_data + out_grad))
+        assert xp is self.xp
         self._postprocess(function)
 
     def total_time(self):

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -40,12 +40,12 @@ class TimerHook(function_.FunctionHook):
         self._preprocess()
 
     def _postprocess(self, function):
+        self.timer.stop()
+        self.call_history.append((function, self.timer.total_time()))
+
         # For backward compatibility
         if self.xp is numpy:
             self.stop = self.timer.stop_times[-1]
-
-        self.timer.stop()
-        self.call_history.append((function, self.timer.total_time()))
 
     def forward_postprocess(self, function, in_data):
         xp = cuda.get_array_module(*in_data)

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,8 +1,12 @@
 import numpy
 
 from chainer.utils import walker_alias
+from chainer.utils import timer
 
 WalkerAlias = walker_alias.WalkerAlias
+get_timer = timer.get_timer
+CPUTimer = timer.CPUTimer
+GPUTimer = timer.GPUTimer
 
 
 def force_array(x):

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,7 +1,7 @@
 import numpy
 
-from chainer.utils import walker_alias
 from chainer.utils import timer
+from chainer.utils import walker_alias
 
 WalkerAlias = walker_alias.WalkerAlias
 get_timer = timer.get_timer

--- a/chainer/utils/timer.py
+++ b/chainer/utils/timer.py
@@ -94,6 +94,9 @@ class CPUTimer(Timer):
 class GPUTimer(object):
 
     def __init__(self, blocking_method='non_block'):
+        if not cuda.available:
+            raise RuntimeError('CUDA must be available to use GPUTimer.')
+
         if not (blocking_method == 'non_block' or
                 blocking_method == 'block_first_time' or
                 blocking_method == 'block_every_time'):

--- a/chainer/utils/timer.py
+++ b/chainer/utils/timer.py
@@ -8,8 +8,11 @@ import numpy
 def get_timer(xp, *args, **kwargs):
     if xp is numpy:
         return CPUTimer(*args, **kwargs)
-    else:
+    elif xp is cuda.cupy:
         return GPUTimer(*args, **kwargs)
+    else:
+        raise ValueError('xp should be either NumPy or CuPy. '
+                         'Actually it is {}'.format(xp))
 
 
 class Timer(object):

--- a/chainer/utils/timer.py
+++ b/chainer/utils/timer.py
@@ -14,9 +14,6 @@ def get_timer(xp, *args, **kwargs):
 
 class Timer(object):
 
-    def __init__(self):
-        raise RuntimeError('This class should not be instantiated.')
-
     @property
     def xp(self):
         raise NotImplementedError

--- a/chainer/utils/timer.py
+++ b/chainer/utils/timer.py
@@ -46,12 +46,13 @@ class Timer(object):
         raise NotImplementedError
 
     def mean(self):
-        if self.count() == 0:
+        count = self.count()
+        if count == 0:
             raise ValueError('Cannot calculate the mean elapsed time '
                              'because this timer has never '
                              'measure elapsed times.')
         else:
-            return self.total_time() / self.count()
+            return self.total_time() / count
 
 
 class CPUTimer(Timer):

--- a/chainer/utils/timer.py
+++ b/chainer/utils/timer.py
@@ -1,0 +1,163 @@
+import time
+
+from chainer import cuda
+
+import numpy
+
+
+def get_timer(xp, *args, **kwargs):
+    if xp is numpy:
+        return CPUTimer(*args, **kwargs)
+    else:
+        return GPUTimer(*args, **kwargs)
+
+
+class Timer(object):
+
+    def __init__(self):
+        raise RuntimeError('This class should not be instantiated.')
+
+    @property
+    def xp(self):
+        raise NotImplementedError
+
+    def reset(self):
+        raise NotImplementedError
+
+    def start(self):
+        raise NotImplementedError
+
+    def stop(self):
+        raise NotImplementedError
+
+    def __enter__(self, *args, **kwargs):
+        self.reset()
+        self.start()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.stop()
+        return self
+
+    def total_time(self):
+        raise NotImplementedError
+
+    def count(self):
+        raise NotImplementedError
+
+    def mean(self):
+        if self.count() == 0:
+            raise ValueError('Cannot calculate the mean elapsed time '
+                             'because this timer has never '
+                             'measure elapsed times.')
+        else:
+            return self.total_time() / self.count()
+
+
+class CPUTimer(Timer):
+
+    def __init__(self):
+        self.reset()
+
+    @property
+    def xp(self):
+        return numpy
+
+    def reset(self):
+        self.elapsed_times = []
+        self.start_times = []
+        self.stop_times = []
+        self.running = False
+
+    def start(self):
+        if self.running:
+            return
+        self.start_times.append(time.time())
+        self.running = True
+
+    def stop(self):
+        if not self.running:
+            return
+        self.stop_times.append(time.time())
+        self.running = False
+
+    def total_time(self):
+        self.elapsed_times = list(stop - start for start, stop
+                                  in zip(self.start_times, self.stop_times))
+        return sum(self.elapsed_times)
+
+    def count(self):
+        return len(self.stop)
+
+
+class GPUTimer(object):
+
+    def __init__(self, blocking_method='non_block'):
+        if not (blocking_method == 'non_block' or
+                blocking_method == 'block_first_time' or
+                blocking_method == 'block_every_time'):
+            raise ValueError(
+                'Invalid blocking method:{}'.format(blocking_method))
+        self.blocking_method = blocking_method
+        self.reset()
+
+    @property
+    def xp(self):
+        return cuda.cupy
+
+    def reset(self):
+        self.running = False
+        self.start_events = []
+        self.stop_events = []
+        self.elapsed_times = None
+        self.synchronized = False
+
+    def start(self):
+        if self.running:
+            return
+
+        if self._synchronized:
+            raise RuntimeError('Thit timer is already synchronized. '
+                               'Please reset the timer first.')
+
+        start = cuda.Event()
+        stop = cuda.Event()
+
+        start.record()
+
+        if ((self.blocking_method == 'block_first_time' and
+             not self.start_events) or
+            (self.blocking_method == 'block_every_time')):
+            start.synchronize()
+
+        self.start_events.append(start)
+        self.stop_events.append(stop)
+        self.running = True
+
+    def stop(self):
+        if not self.running:
+            return
+
+        self.stop_events[-1].record()
+        self.running = False
+
+    def synchronize(self):
+        if self.running:
+            raise RuntimeError('Timer is running.')
+        if self._synchronized:
+            return
+
+        if len(self.stop_events) > 0:
+            self.stop_events[-1].synchronize()
+        self.synchronized = True
+        self.elapsed_times = map(
+            cuda.cupy.cuda.get_elapsed_time(start, stop) / 1000
+            for start, stop in zip(self.start_events, self.stop_events))
+
+    def total_time(self):
+        self.synchronize()
+        return sum(self.elapsed_times)
+
+    def count(self):
+        """Returns number of measurements that is already finish recording."""
+        return len(self.stop_events)

--- a/chainer/utils/timer.py
+++ b/chainer/utils/timer.py
@@ -88,7 +88,7 @@ class CPUTimer(Timer):
         return sum(self.elapsed_times)
 
     def count(self):
-        return len(self.stop)
+        return len(self.stop_times)
 
 
 class GPUTimer(object):

--- a/tests/chainer_tests/utils_tests/test_timer.py
+++ b/tests/chainer_tests/utils_tests/test_timer.py
@@ -85,7 +85,8 @@ class TimerTestBase(object):
         self.timer.start()
         time.sleep(0.1)
         self.timer.stop()
-        numpy.testing.assert_allclose(self.timer.total_time(), 0.1, atol=0.01, rtol=1.5)
+        numpy.testing.assert_allclose(self.timer.total_time(),
+                                      0.1, atol=0.01, rtol=1.5)
 
 
 class TestCPUTimer(TimerTestBase, unittest.TestCase):
@@ -102,11 +103,13 @@ class TestCPUTimer(TimerTestBase, unittest.TestCase):
         self.timer.start()
         time.sleep(0.1)
         self.timer.stop()
-        numpy.testing.assert_allclose(self.timer.total_time(), 0.1, atol=0.01, rtol=1.5)
+        numpy.testing.assert_allclose(self.timer.total_time(),
+                                      0.1, atol=0.01, rtol=1.5)
         self.timer.start()
         time.sleep(0.1)
         self.timer.stop()
-        numpy.testing.assert_allclose(self.timer.total_time(), 0.2, atol=0.02, rtol=1.5)
+        numpy.testing.assert_allclose(self.timer.total_time(),
+                                      0.2, atol=0.02, rtol=1.5)
 
 
 @testing.parameterize(
@@ -154,8 +157,8 @@ class TestGPUTimerSynchronization(unittest.TestCase):
 
     def test_synchronization(self):
         self.timer.start()
-        if (self.blocking_method == 'block_first_time'
-            or self.blocking_method == 'block_every_time'):
+        if ((self.blocking_method == 'block_first_time') or
+            (self.blocking_method == 'block_every_time')):
             self.mock.assert_called_with()
 
         self.mock.reset_mock()
@@ -171,33 +174,7 @@ class TestGPUTimerSynchronization(unittest.TestCase):
     {'blocking_method': 'block_every_time'}
 )
 @attr.gpu
-class TestGPUTimerSynchronization(unittest.TestCase):
-
-    def setUp(self):
-        self.timer = utils.GPUTimer(blocking_method=self.blocking_method)
-        self.mock = mock.Mock()
-        self.timer._need_synchronization_before_measurement = self.mock
-
-    def test_synchronization(self):
-        self.timer.start()
-        if (self.blocking_method == 'block_first_time'
-            or self.blocking_method == 'block_every_time'):
-            self.mock.assert_called_with()
-
-        self.mock.reset_mock()
-        self.timer.stop()
-        self.timer.start()
-        if self.blocking_method == 'block_every_time':
-            self.mock.assert_called_with()
-
-
-@testing.parameterize(
-    {'blocking_method': 'non_block'},
-    {'blocking_method': 'block_first_time'},
-    {'blocking_method': 'block_every_time'}
-)
-@attr.gpu
-class TestGPUTimerSynchronization(unittest.TestCase):
+class TestGPUTimerSynchronization2(unittest.TestCase):
 
     def setUp(self):
         self.timer = utils.GPUTimer(blocking_method=self.blocking_method)

--- a/tests/chainer_tests/utils_tests/test_timer.py
+++ b/tests/chainer_tests/utils_tests/test_timer.py
@@ -1,3 +1,4 @@
+import mock
 import time
 import unittest
 
@@ -18,13 +19,10 @@ class TestGetTimer(unittest.TestCase):
     @attr.gpu
     def test_gpu(self):
         timer = utils.get_timer(cuda.cupy)
-        selfassertIs(timer.xp, cuda.cupy)
+        self.assertIs(timer.xp, cuda.cupy)
 
 
-class TestCPUTimer(unittest.TestCase):
-
-    def setUp(self):
-        self.timer = utils.CPUTimer()
+class TimerTestBase(object):
 
     def test_interface(self):
         self.timer.xp
@@ -36,18 +34,6 @@ class TestCPUTimer(unittest.TestCase):
         self.timer.total_time()
         self.timer.count()
         self.timer.mean()
-
-    def test_normal_start_stop_times(self):
-        self.assertEqual(len(self.timer.start_times), 0)
-        self.assertEqual(len(self.timer.stop_times), 0)
-        self.timer.start()
-        self.timer.stop()
-        self.assertEqual(len(self.timer.start_times), 1)
-        self.assertEqual(len(self.timer.stop_times), 1)
-        self.timer.start()
-        self.timer.stop()
-        self.assertEqual(len(self.timer.start_times), 2)
-        self.assertEqual(len(self.timer.stop_times), 2)
 
     def test_running(self):
         self.assertFalse(self.timer.running)
@@ -60,19 +46,7 @@ class TestCPUTimer(unittest.TestCase):
         self.timer.stop()
         self.assertFalse(self.timer.running)
 
-    def test_duplicate_start(self):
-        self.timer.start()
-        self.timer.start()
-        self.timer.stop()
-        self.assertEqual(len(self.timer.start_times), 1)
-
-    def test_duplicate_stop(self):
-        self.timer.start()
-        self.timer.stop()
-        self.timer.stop()
-        self.assertEqual(len(self.timer.start_times), 1)
-
-    def count(self):
+    def test_count(self):
         self.assertEqual(self.timer.count(), 0)
         self.timer.start()
         self.assertEqual(self.timer.count(), 0)
@@ -83,7 +57,48 @@ class TestCPUTimer(unittest.TestCase):
         self.timer.stop()
         self.assertEqual(self.timer.count(), 2)
 
-    def test_elapsed_times(self):
+    def test_normal_start_stop_times(self):
+        self.assertEqual(len(self.start_count), 0)
+        self.assertEqual(len(self.stop_count), 0)
+        self.timer.start()
+        self.timer.stop()
+        self.assertEqual(len(self.start_count), 1)
+        self.assertEqual(len(self.stop_count), 1)
+        self.timer.start()
+        self.timer.stop()
+        self.assertEqual(len(self.start_count), 2)
+        self.assertEqual(len(self.stop_count), 2)
+
+    def test_duplicate_start(self):
+        self.timer.start()
+        self.timer.start()
+        self.timer.stop()
+        self.assertEqual(len(self.start_count), 1)
+
+    def test_duplicate_stop(self):
+        self.timer.start()
+        self.timer.stop()
+        self.timer.stop()
+        self.assertEqual(len(self.start_count), 1)
+
+    def test_total_time(self):
+        self.timer.start()
+        time.sleep(0.1)
+        self.timer.stop()
+        numpy.testing.assert_allclose(self.timer.total_time(), 0.1, atol=0.01, rtol=1.5)
+
+
+class TestCPUTimer(TimerTestBase, unittest.TestCase):
+
+    def setUp(self):
+        self.timer = utils.CPUTimer()
+        self.start_count = self.timer.start_times
+        self.stop_count = self.timer.stop_times
+
+    def test_xp(self):
+        self.assertIs(numpy, self.timer.xp)
+
+    def test_total_time_twice(self):
         self.timer.start()
         time.sleep(0.1)
         self.timer.stop()
@@ -94,19 +109,104 @@ class TestCPUTimer(unittest.TestCase):
         numpy.testing.assert_allclose(self.timer.total_time(), 0.2, atol=0.02, rtol=1.5)
 
 
+@testing.parameterize(
+    {'blocking_method': 'non_block'},
+    {'blocking_method': 'block_first_time'},
+    {'blocking_method': 'block_every_time'}
+)
 @attr.gpu
-class TestGPUTimer(unittest.TestCase):
+class TestGPUTimer(TimerTestBase, unittest.TestCase):
 
     def setUp(self):
-        self.timer = utils.GPUTimer()
+        self.timer = utils.GPUTimer(blocking_method=self.blocking_method)
+        self.start_count = self.timer.start_events
+        self.stop_count = self.timer.stop_events
 
-    def test_interface(self):
-        self.timer.xp
-        self.timer.reset()
+    def test_xp(self):
+        self.assertIs(cuda.cupy, self.timer.xp)
+
+    def test_forbid_measurement_after_synchronization(self):
+        self.timer.synchronize()
+        with self.assertRaises(RuntimeError):
+            self.timer.start()
+
+
+@attr.gpu
+class TestGPUInvalid(unittest.TestCase):
+
+    def test_invalid_blocking(self):
+        with self.assertRaises(ValueError):
+            self.timer = utils.GPUTimer(blocking_method='invalid_argument')
+
+
+@testing.parameterize(
+    {'blocking_method': 'non_block'},
+    {'blocking_method': 'block_first_time'},
+    {'blocking_method': 'block_every_time'}
+)
+@attr.gpu
+class TestGPUTimerSynchronization(unittest.TestCase):
+
+    def setUp(self):
+        self.timer = utils.GPUTimer(blocking_method=self.blocking_method)
+        self.mock = mock.Mock()
+        self.timer._need_synchronization_before_measurement = self.mock
+
+    def test_synchronization(self):
         self.timer.start()
+        if (self.blocking_method == 'block_first_time'
+            or self.blocking_method == 'block_every_time'):
+            self.mock.assert_called_with()
+
+        self.mock.reset_mock()
         self.timer.stop()
-        with self.timer:
-            pass
+        self.timer.start()
+        if self.blocking_method == 'block_every_time':
+            self.mock.assert_called_with()
+
+
+@testing.parameterize(
+    {'blocking_method': 'non_block'},
+    {'blocking_method': 'block_first_time'},
+    {'blocking_method': 'block_every_time'}
+)
+@attr.gpu
+class TestGPUTimerSynchronization(unittest.TestCase):
+
+    def setUp(self):
+        self.timer = utils.GPUTimer(blocking_method=self.blocking_method)
+        self.mock = mock.Mock()
+        self.timer._need_synchronization_before_measurement = self.mock
+
+    def test_synchronization(self):
+        self.timer.start()
+        if (self.blocking_method == 'block_first_time'
+            or self.blocking_method == 'block_every_time'):
+            self.mock.assert_called_with()
+
+        self.mock.reset_mock()
+        self.timer.stop()
+        self.timer.start()
+        if self.blocking_method == 'block_every_time':
+            self.mock.assert_called_with()
+
+
+@testing.parameterize(
+    {'blocking_method': 'non_block'},
+    {'blocking_method': 'block_first_time'},
+    {'blocking_method': 'block_every_time'}
+)
+@attr.gpu
+class TestGPUTimerSynchronization(unittest.TestCase):
+
+    def setUp(self):
+        self.timer = utils.GPUTimer(blocking_method=self.blocking_method)
+        self.mock = mock.Mock()
+        self.timer.synchronize = self.mock
+
+    def test_synchronization(self):
         self.timer.total_time()
-        self.timer.count()
-        self.timer.mean()
+        self.mock.assert_called_with()
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_timer.py
+++ b/tests/chainer_tests/utils_tests/test_timer.py
@@ -1,0 +1,112 @@
+import time
+import unittest
+
+import numpy
+
+from chainer import cuda
+from chainer import testing
+from chainer.testing import attr
+from chainer import utils
+
+
+class TestGetTimer(unittest.TestCase):
+
+    def test_cpu(self):
+        timer = utils.get_timer(numpy)
+        self.assertIs(timer.xp, numpy)
+
+    @attr.gpu
+    def test_gpu(self):
+        timer = utils.get_timer(cuda.cupy)
+        selfassertIs(timer.xp, cuda.cupy)
+
+
+class TestCPUTimer(unittest.TestCase):
+
+    def setUp(self):
+        self.timer = utils.CPUTimer()
+
+    def test_interface(self):
+        self.timer.xp
+        self.timer.reset()
+        self.timer.start()
+        self.timer.stop()
+        with self.timer:
+            pass
+        self.timer.total_time()
+        self.timer.count()
+        self.timer.mean()
+
+    def test_normal_start_stop_times(self):
+        self.assertEqual(len(self.timer.start_times), 0)
+        self.assertEqual(len(self.timer.stop_times), 0)
+        self.timer.start()
+        self.timer.stop()
+        self.assertEqual(len(self.timer.start_times), 1)
+        self.assertEqual(len(self.timer.stop_times), 1)
+        self.timer.start()
+        self.timer.stop()
+        self.assertEqual(len(self.timer.start_times), 2)
+        self.assertEqual(len(self.timer.stop_times), 2)
+
+    def test_running(self):
+        self.assertFalse(self.timer.running)
+        self.timer.start()
+        self.assertTrue(self.timer.running)
+        self.timer.stop()
+        self.assertFalse(self.timer.running)
+        self.timer.start()
+        self.assertTrue(self.timer.running)
+        self.timer.stop()
+        self.assertFalse(self.timer.running)
+
+    def test_duplicate_start(self):
+        self.timer.start()
+        self.timer.start()
+        self.timer.stop()
+        self.assertEqual(len(self.timer.start_times), 1)
+
+    def test_duplicate_stop(self):
+        self.timer.start()
+        self.timer.stop()
+        self.timer.stop()
+        self.assertEqual(len(self.timer.start_times), 1)
+
+    def count(self):
+        self.assertEqual(self.timer.count(), 0)
+        self.timer.start()
+        self.assertEqual(self.timer.count(), 0)
+        self.timer.stop()
+        self.assertEqual(self.timer.count(), 1)
+        self.timer.start()
+        self.assertEqual(self.timer.count(), 1)
+        self.timer.stop()
+        self.assertEqual(self.timer.count(), 2)
+
+    def test_elapsed_times(self):
+        self.timer.start()
+        time.sleep(0.1)
+        self.timer.stop()
+        numpy.testing.assert_allclose(self.timer.total_time(), 0.1, atol=0.01, rtol=1.5)
+        self.timer.start()
+        time.sleep(0.1)
+        self.timer.stop()
+        numpy.testing.assert_allclose(self.timer.total_time(), 0.2, atol=0.02, rtol=1.5)
+
+
+@attr.gpu
+class TestGPUTimer(unittest.TestCase):
+
+    def setUp(self):
+        self.timer = utils.GPUTimer()
+
+    def test_interface(self):
+        self.timer.xp
+        self.timer.reset()
+        self.timer.start()
+        self.timer.stop()
+        with self.timer:
+            pass
+        self.timer.total_time()
+        self.timer.count()
+        self.timer.mean()


### PR DESCRIPTION
This PR extracts `Timer` class from `TimerHook` to make this functionality reusable. Specifically, I made an abstract `Timer` class, concrete realizations of this class (`CPUTimer` and `GPUTimer`), and factory method of `Timer` objects.
- [x] Unittests
- [ ] Document

Related to #1004
