### PR TITLE
Fix the types of input argument functions in the document

### DIFF
--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -56,7 +56,7 @@ def clipped_relu(x, z=20.0):
     = \\min(\\max(0, x), z)`, where :math:`z(>0)` is a clipping value.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         z (float): Clipping value. (default = 20.0)
 
     Returns:

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -56,7 +56,8 @@ def clipped_relu(x, z=20.0):
     = \\min(\\max(0, x), z)`, where :math:`z(>0)` is a clipping value.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         z (float): Clipping value. (default = 20.0)
 
     Returns:

--- a/chainer/functions/activation/crelu.py
+++ b/chainer/functions/activation/crelu.py
@@ -52,7 +52,8 @@ def crelu(x, axis=1):
     See: http://arxiv.org/abs/1603.05201
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         axis (int): Axis that the output values are concatenated along
 
     Returns:

--- a/chainer/functions/activation/crelu.py
+++ b/chainer/functions/activation/crelu.py
@@ -52,7 +52,7 @@ def crelu(x, axis=1):
     See: http://arxiv.org/abs/1603.05201
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         axis (int): Axis that the output values are concatenated along
 
     Returns:

--- a/chainer/functions/activation/elu.py
+++ b/chainer/functions/activation/elu.py
@@ -62,7 +62,8 @@ def elu(x, alpha=1.0):
     See: http://arxiv.org/abs/1511.07289
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         alpha (float): Parameter :math:`\\alpha`.
 
     Returns:

--- a/chainer/functions/activation/elu.py
+++ b/chainer/functions/activation/elu.py
@@ -62,7 +62,7 @@ def elu(x, alpha=1.0):
     See: http://arxiv.org/abs/1511.07289
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         alpha (float): Parameter :math:`\\alpha`.
 
     Returns:

--- a/chainer/functions/activation/hard_sigmoid.py
+++ b/chainer/functions/activation/hard_sigmoid.py
@@ -59,7 +59,7 @@ def hard_sigmoid(x):
         \\end{array} \\right.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/activation/hard_sigmoid.py
+++ b/chainer/functions/activation/hard_sigmoid.py
@@ -59,7 +59,8 @@ def hard_sigmoid(x):
         \\end{array} \\right.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -47,7 +47,7 @@ def leaky_relu(x, slope=0.2):
     is a configurable slope value.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         slope (float): Slope value :math:`a`.
 
     Returns:

--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -47,7 +47,8 @@ def leaky_relu(x, slope=0.2):
     is a configurable slope value.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+           Input variable.
         slope (float): Slope value :math:`a`.
 
     Returns:

--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -109,7 +109,7 @@ def log_softmax(x, use_cudnn=True):
         ``log_softmax`` method is more stable.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         use_cudnn (bool): If ``True``, cuDNN is enabled and cuDNN ver. 3 or
             later is used, then this function uses cuDNN as the core
             implementation.

--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -109,7 +109,8 @@ def log_softmax(x, use_cudnn=True):
         ``log_softmax`` method is more stable.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         use_cudnn (bool): If ``True``, cuDNN is enabled and cuDNN ver. 3 or
             later is used, then this function uses cuDNN as the core
             implementation.

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -190,10 +190,10 @@ def lstm(c_prev, x):
     applying the function.
 
     Args:
-        c_prev (~chainer.Variable): Variable that holds the previous cell
+        c_prev (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the previous cell
             state. The cell state should be a zero array or the output of the
             previous call of LSTM.
-        x (~chainer.Variable): Variable that holds the incoming signal. It must
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the incoming signal. It must
             have the second dimension four times of that of the cell state,
 
     Returns:

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -190,10 +190,12 @@ def lstm(c_prev, x):
     applying the function.
 
     Args:
-        c_prev (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the previous cell
+        c_prev (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable that holds the previous cell
             state. The cell state should be a zero array or the output of the
             previous call of LSTM.
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the incoming signal. It must
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable that holds the incoming signal. It must
             have the second dimension four times of that of the cell state,
 
     Returns:

--- a/chainer/functions/activation/maxout.py
+++ b/chainer/functions/activation/maxout.py
@@ -24,7 +24,7 @@ def maxout(x, pool_size, axis=1):
     >>> y = maxout(x, pool_size)
 
     Args:
-       x (~chainer.Variable): Input variable. Its first dimension is assumed
+       x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. Its first dimension is assumed
             to be the *minibatch dimension*. The other dimensions are treated
             as one concatenated dimension.
     Returns:

--- a/chainer/functions/activation/maxout.py
+++ b/chainer/functions/activation/maxout.py
@@ -24,7 +24,8 @@ def maxout(x, pool_size, axis=1):
     >>> y = maxout(x, pool_size)
 
     Args:
-       x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. Its first dimension is assumed
+       x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable. Its first dimension is assumed
             to be the *minibatch dimension*. The other dimensions are treated
             as one concatenated dimension.
     Returns:

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -92,9 +92,9 @@ def prelu(x, W):
     is arbitrary non-negative integer.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
             Its first argument is assumed to be the minibatch dimension.
-        W (~chainer.Variable): Weight variable.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable.
 
     Returns:
         ~chainer.Variable: Output variable

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -92,9 +92,11 @@ def prelu(x, W):
     is arbitrary non-negative integer.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
             Its first argument is assumed to be the minibatch dimension.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight variable.
 
     Returns:
         ~chainer.Variable: Output variable

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -58,7 +58,7 @@ def relu(x, use_cudnn=True):
     """Rectified Linear Unit function :math:`f(x)=\\max(0, x)`.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -58,7 +58,8 @@ def relu(x, use_cudnn=True):
     """Rectified Linear Unit function :math:`f(x)=\\max(0, x)`.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -61,7 +61,8 @@ def sigmoid(x, use_cudnn=True):
     """Elementwise sigmoid logistic function :math:`f(x)=(1 + \\exp(-x))^{-1}`.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -61,7 +61,7 @@ def sigmoid(x, use_cudnn=True):
     """Elementwise sigmoid logistic function :math:`f(x)=(1 + \\exp(-x))^{-1}`.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/activation/slstm.py
+++ b/chainer/functions/activation/slstm.py
@@ -218,15 +218,15 @@ def slstm(c_prev1, c_prev2, x1, x2):
     The function returns :math:`c` and :math:`h` as a tuple.
 
     Args:
-        c_prev1 (~chainer.Variable): Variable that holds the previous cell
+        c_prev1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the previous cell
             state of the first child node. The cell state should be a zero
             array or the output of the  previous call of LSTM.
-        c_prev2 (~chainer.Variable): Variable that holds the previous cell
+        c_prev2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the previous cell
             state of the second child node.
-        x1 (~chainer.Variable): Variable that holds the incoming signal from
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the incoming signal from
             the first child node. It must have the second dimension four times
             of that of the cell state,
-        x2 (~chainer.Variable): Variable that holds the incoming signal from
+        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the incoming signal from
             the second child node.
 
     Returns:

--- a/chainer/functions/activation/slstm.py
+++ b/chainer/functions/activation/slstm.py
@@ -218,15 +218,19 @@ def slstm(c_prev1, c_prev2, x1, x2):
     The function returns :math:`c` and :math:`h` as a tuple.
 
     Args:
-        c_prev1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the previous cell
+        c_prev1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable that holds the previous cell
             state of the first child node. The cell state should be a zero
             array or the output of the  previous call of LSTM.
-        c_prev2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the previous cell
+        c_prev2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable that holds the previous cell
             state of the second child node.
-        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the incoming signal from
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable that holds the incoming signal from
             the first child node. It must have the second dimension four times
             of that of the cell state,
-        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable that holds the incoming signal from
+        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable that holds the incoming signal from
             the second child node.
 
     Returns:

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -84,7 +84,7 @@ def softmax(x, use_cudnn=True):
     :math:`p(x) = {\\exp(f(x)) \\over \\sum_{x_2} \\exp(f(x))}`.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -84,7 +84,8 @@ def softmax(x, use_cudnn=True):
     :math:`p(x) = {\\exp(f(x)) \\over \\sum_{x_2} \\exp(f(x))}`.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/activation/softplus.py
+++ b/chainer/functions/activation/softplus.py
@@ -65,7 +65,8 @@ def softplus(x, beta=1.0):
     where :math:`\\beta` is a parameter.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         beta (float): Parameter :math:`\\beta`.
 
     Returns:

--- a/chainer/functions/activation/softplus.py
+++ b/chainer/functions/activation/softplus.py
@@ -65,7 +65,7 @@ def softplus(x, beta=1.0):
     where :math:`\\beta` is a parameter.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         beta (float): Parameter :math:`\\beta`.
 
     Returns:

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -56,7 +56,8 @@ def tanh(x, use_cudnn=True):
     """Elementwise hyperbolic tangent function.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -56,7 +56,7 @@ def tanh(x, use_cudnn=True):
     """Elementwise hyperbolic tangent function.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.
 

--- a/chainer/functions/array/broadcast.py
+++ b/chainer/functions/array/broadcast.py
@@ -106,7 +106,7 @@ def broadcast_to(x, shape):
     """Broadcast a given variable to a given shape.
 
     Args:
-        x (~chainer.Variable): Variable to be broadcasted.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable to be broadcasted.
         shape (tuple of int): The shape of the output variable.
 
     Returns:

--- a/chainer/functions/array/broadcast.py
+++ b/chainer/functions/array/broadcast.py
@@ -106,7 +106,8 @@ def broadcast_to(x, shape):
     """Broadcast a given variable to a given shape.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable to be broadcasted.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable to be broadcasted.
         shape (tuple of int): The shape of the output variable.
 
     Returns:

--- a/chainer/functions/array/cast.py
+++ b/chainer/functions/array/cast.py
@@ -26,7 +26,7 @@ def cast(x, typ):
     """Cast an input variable to a given type.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         typ (str of dtype): Typecode or data type to cast.
 
     Returns:

--- a/chainer/functions/array/cast.py
+++ b/chainer/functions/array/cast.py
@@ -26,7 +26,8 @@ def cast(x, typ):
     """Cast an input variable to a given type.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         typ (str of dtype): Typecode or data type to cast.
 
     Returns:

--- a/chainer/functions/array/concat.py
+++ b/chainer/functions/array/concat.py
@@ -54,7 +54,8 @@ def concat(xs, axis=1):
     """Concatenates given variables along an axis.
 
     Args:
-        xs (tuple of Variables): Variables to be concatenated.
+        xs (tuple of Variables, or numpy.arrays or cupy.arrays):
+        Variables to be concatenated.
         axis (int): Axis that the input arrays are concatenated along.
 
     Returns:

--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -57,7 +57,8 @@ def copy(x, dst):
     and from device to host.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable to be copied.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable to be copied.
         dst: Target device specifier.
 
     Returns:

--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -57,7 +57,7 @@ def copy(x, dst):
     and from device to host.
 
     Args:
-        x (~chainer.Variable): Variable to be copied.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable to be copied.
         dst: Target device specifier.
 
     Returns:

--- a/chainer/functions/array/expand_dims.py
+++ b/chainer/functions/array/expand_dims.py
@@ -30,7 +30,7 @@ def expand_dims(x, axis):
     """Expands dimensions of an input variable without copy.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         axis (int): Position where new axis is to be inserted.
 
     Returns:

--- a/chainer/functions/array/expand_dims.py
+++ b/chainer/functions/array/expand_dims.py
@@ -30,7 +30,8 @@ def expand_dims(x, axis):
     """Expands dimensions of an input variable without copy.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         axis (int): Position where new axis is to be inserted.
 
     Returns:

--- a/chainer/functions/array/flatten.py
+++ b/chainer/functions/array/flatten.py
@@ -16,7 +16,8 @@ def flatten(x):
     """Flatten a given array.
 
     Args:
-        x (~chainer.Varaiable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -53,7 +53,8 @@ def get_item(x, slices):
     """Extract elements from array with specified shape, axes and offsets.
 
     Args:
-        x (tuple of Variables): Variable to be sliced.
+        x (tuple of Variables, numpy.ndarray or cupy.ndarraty):
+            Variable to be sliced.
         slices (int, slice, None or Ellipsis or tuple of them): Basic slicing
             to slice a variable. It supports ``int``, ``slice``, ``newaxis``
             (equivalent to ``None``) and ``Ellipsis``.

--- a/chainer/functions/array/hstack.py
+++ b/chainer/functions/array/hstack.py
@@ -53,7 +53,8 @@ def hstack(xs):
     """Concatenate variables horizontally (column wise).
 
     Args:
-        xs (list of chainer.Variable): Variables to be concatenated.
+        xs (tuple of chainer.Variable, numpy.ndarray or cupy.ndarray):
+            Variables to be concatenated.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/array/permutate.py
+++ b/chainer/functions/array/permutate.py
@@ -92,8 +92,10 @@ def permutate(x, indices, axis=0, inv=False):
     That means ``y[indices[i]] = x[i]``.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable to permutate.
-        indices (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Indices to extract from the variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable to permutate.
+        indices (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Indices to extract from the variable.
         axis (int): Axis that the input array is permutate along.
         inv (bool): If ``True``, ``indices`` is treated as its inverse.
 

--- a/chainer/functions/array/permutate.py
+++ b/chainer/functions/array/permutate.py
@@ -92,8 +92,8 @@ def permutate(x, indices, axis=0, inv=False):
     That means ``y[indices[i]] = x[i]``.
 
     Args:
-        x (~chainer.Variable): Variable to permutate.
-        indices (~chainer.Variable): Indices to extract from the variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable to permutate.
+        indices (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Indices to extract from the variable.
         axis (int): Axis that the input array is permutate along.
         inv (bool): If ``True``, ``indices`` is treated as its inverse.
 

--- a/chainer/functions/array/reshape.py
+++ b/chainer/functions/array/reshape.py
@@ -51,7 +51,8 @@ def reshape(x, shape):
     """Reshapes an input variable without copy.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         shape (tuple of ints): Target shape.
 
     Returns:

--- a/chainer/functions/array/reshape.py
+++ b/chainer/functions/array/reshape.py
@@ -51,7 +51,7 @@ def reshape(x, shape):
     """Reshapes an input variable without copy.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         shape (tuple of ints): Target shape.
 
     Returns:

--- a/chainer/functions/array/rollaxis.py
+++ b/chainer/functions/array/rollaxis.py
@@ -57,7 +57,8 @@ def rollaxis(x, axis, start=0):
     """Roll the axis backwards to the given position.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         axis (int): The axis to roll backwards.
         start (int): The place to which the axis is moved.
 

--- a/chainer/functions/array/rollaxis.py
+++ b/chainer/functions/array/rollaxis.py
@@ -57,7 +57,7 @@ def rollaxis(x, axis, start=0):
     """Roll the axis backwards to the given position.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         axis (int): The axis to roll backwards.
         start (int): The place to which the axis is moved.
 

--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -71,8 +71,10 @@ def select_item(x, t):
     ``y[i] == x[i, t[i]]`` for all ``i``.
 
     Args:
-        x (Variable): Variable storing arrays.
-        t (Variable): Variable storing index numbers.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable storing arrays.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable storing index numbers.
 
     Returns:
         ~chainer.Variable: Variable that holds ``t``-th element of ``x``.

--- a/chainer/functions/array/separate.py
+++ b/chainer/functions/array/separate.py
@@ -12,7 +12,8 @@ def separate(x, axis=0):
     This function is an inverse of :func:`chainer.functions.stack`.
 
     Args:
-        x (chainer.Variable): Variable to be separated.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable to be separated.
         axis (int): Axis along which variables are separated.
 
     Returns:

--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -66,7 +66,8 @@ def split_axis(x, indices_or_sections, axis, force_tuple=False):
     """Splits given variables along an axis.
 
     Args:
-        x (tuple of Variables): Variables to be split.
+        x (tuple of Variables, numpy.ndarray, cupy.ndarray):
+            Variables to be split.
         indices_or_sections (int or 1-D array): If this argument is an integer,
             N, the array will be divided into N equal arrays along axis.
             If it is a 1-D array of sorted integers, it

--- a/chainer/functions/array/stack.py
+++ b/chainer/functions/array/stack.py
@@ -6,7 +6,8 @@ def stack(xs, axis=0):
     """Concatenate variables along a new axis.
 
     Args:
-        xs (list of chainer.Variable): Variables to be concatenated.
+        xs (tuple of chainer.Variables, numpy.ndarrays or cupy.ndarrays):
+            Variables to be concatenated.
         axis (int): Axis of result along which variables are stacked.
 
     Returns:

--- a/chainer/functions/array/swapaxes.py
+++ b/chainer/functions/array/swapaxes.py
@@ -31,7 +31,7 @@ def swapaxes(x, axis1, axis2):
     """Swap two axes of a variable.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         axis1 (int): The first axis to swap.
         axis2 (int): The second axis to swap.
 

--- a/chainer/functions/array/swapaxes.py
+++ b/chainer/functions/array/swapaxes.py
@@ -31,7 +31,8 @@ def swapaxes(x, axis1, axis2):
     """Swap two axes of a variable.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         axis1 (int): The first axis to swap.
         axis2 (int): The second axis to swap.
 

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -36,7 +36,8 @@ def transpose(x, axes=None):
     """Permute the dimensions of an input variable without copy.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         axes (tuple of ints): By default, reverse the dimensions,
             otherwise permute the axes according to the values given.
 

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -36,7 +36,7 @@ def transpose(x, axes=None):
     """Permute the dimensions of an input variable without copy.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         axes (tuple of ints): By default, reverse the dimensions,
             otherwise permute the axes according to the values given.
 

--- a/chainer/functions/array/transpose_sequence.py
+++ b/chainer/functions/array/transpose_sequence.py
@@ -90,7 +90,8 @@ def transpose_sequence(xs):
     :class:`~chainer.Variable`.
 
     Args:
-        xs (list of ~chainer.Variable): Variables to transpose.
+        xs (tpule of chainer.Variable, numpy.array or cupy.ndarray):
+            Variables to transpose.
 
     Returns:
         tuple or Variable: Transposed list.

--- a/chainer/functions/array/transpose_sequence.py
+++ b/chainer/functions/array/transpose_sequence.py
@@ -90,7 +90,7 @@ def transpose_sequence(xs):
     :class:`~chainer.Variable`.
 
     Args:
-        xs (tpule of chainer.Variable, numpy.array or cupy.ndarray):
+        xs (tpule of chainer.Variable, numpy.ndarray or cupy.ndarray):
             Variables to transpose.
 
     Returns:

--- a/chainer/functions/array/vstack.py
+++ b/chainer/functions/array/vstack.py
@@ -49,7 +49,8 @@ def vstack(xs):
     """Concatenate variables vertically (row wise).
 
     Args:
-        xs (list of chainer.Variable): Variables to be concatenated.
+        xs (tuple of chainer.Variables, numpy.ndarray, or cupy.ndarray):
+            Variables to be concatenated.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/array/where.py
+++ b/chainer/functions/array/where.py
@@ -40,10 +40,13 @@ def where(condition, x, y):
     All ``condition``, ``x``, and ``y`` must have the same shape.
 
     Args:
-        condition (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable containing the condition.
+        condition (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable containing the condition.
             Only boolean array is permitted.
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable chosen when ``condition`` is ``True``.
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable chosen when ``condition`` is ``False``.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable chosen when ``condition`` is ``True``.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable chosen when ``condition`` is ``False``.
 
     Returns:
         ~chainer.Variable: Variable containing chosen values.

--- a/chainer/functions/array/where.py
+++ b/chainer/functions/array/where.py
@@ -40,10 +40,10 @@ def where(condition, x, y):
     All ``condition``, ``x``, and ``y`` must have the same shape.
 
     Args:
-        condition (~chainer.Variable): Variable containing the condition.
+        condition (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable containing the condition.
             Only boolean array is permitted.
-        x (~chainer.Variable): Variable chosen when ``condition`` is ``True``.
-        y (~chainer.Variable): Variable chosen when ``condition`` is ``False``.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable chosen when ``condition`` is ``True``.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable chosen when ``condition`` is ``False``.
 
     Returns:
         ~chainer.Variable: Variable containing chosen values.

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -151,12 +151,12 @@ def bilinear(e1, e2, W, V1=None, V2=None, b=None):
        (concatenation of matrices) by :math:`V`.
 
     Args:
-        e1 (~chainer.Variable): Left input variable.
-        e2 (~chainer.Variable): Right input variable.
-        W (~chainer.Variable): Quadratic weight variable.
-        V1 (~chainer.Variable): Left coefficient variable.
-        V2 (~chainer.Variable): Right coefficient variable.
-        b (~chainer.Variable): Bias variable.
+        e1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Left input variable.
+        e2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Right input variable.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Quadratic weight variable.
+        V1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Left coefficient variable.
+        V2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Right coefficient variable.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -151,12 +151,18 @@ def bilinear(e1, e2, W, V1=None, V2=None, b=None):
        (concatenation of matrices) by :math:`V`.
 
     Args:
-        e1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Left input variable.
-        e2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Right input variable.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Quadratic weight variable.
-        V1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Left coefficient variable.
-        V2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Right coefficient variable.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable.
+        e1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Left input variable.
+        e2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Right input variable.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Quadratic weight variable.
+        V1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Left coefficient variable.
+        V2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Right coefficient variable.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -269,10 +269,10 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
       respectively.
 
     Args:
-        x (~chainer.Variable): Input variable of shape :math:`(n, c_I, h, w)`.
-        W (~chainer.Variable): Weight variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape :math:`(n, c_I, h, w)`.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
             :math:`(c_O, c_I, k_H, k_W)`.
-        b (~chainer.Variable): Bias variable of length :math:`c_O` (optional).
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable of length :math:`c_O` (optional).
         stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
         pad (int or pair of ints): Spatial padding width for input arrays.

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -269,10 +269,13 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, use_cudnn=True,
       respectively.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape :math:`(n, c_I, h, w)`.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable of shape :math:`(n, c_I, h, w)`.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight variable of shape
             :math:`(c_O, c_I, k_H, k_W)`.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable of length :math:`c_O` (optional).
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias variable of length :math:`c_O` (optional).
         stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
         pad (int or pair of ints): Spatial padding width for input arrays.

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -308,11 +308,14 @@ def convolution_nd(x, W, b=None, stride=1, pad=0, use_cudnn=True,
       respectively.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable of shape
             :math:`(n, c_I, d_1, d_2, ..., d_N)`.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight variable of shape
             :math:`(c_O, c_I, k_1, k_2, ..., k_N)`.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): One-dimensional bias variable with length
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            One-dimensional bias variable with length
             :math:`c_O` (optional).
         stride (int or tuple of ints): Stride of filter applications
             :math:`(s_1, s_2, ..., s_N)`. ``stride=s`` is equivalent to

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -308,11 +308,11 @@ def convolution_nd(x, W, b=None, stride=1, pad=0, use_cudnn=True,
       respectively.
 
     Args:
-        x (~chainer.Variable): Input variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape
             :math:`(n, c_I, d_1, d_2, ..., d_N)`.
-        W (~chainer.Variable): Weight variable of shape
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
             :math:`(c_O, c_I, k_1, k_2, ..., k_N)`.
-        b (~chainer.Variable): One-dimensional bias variable with length
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): One-dimensional bias variable with length
             :math:`c_O` (optional).
         stride (int or tuple of ints): Stride of filter applications
             :math:`(s_1, s_2, ..., s_N)`. ``stride=s`` is equivalent to

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -283,10 +283,10 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
     the filter weight ``W``, and the bias vector ``b``.
 
     Args:
-        x (~chainer.Variable): Input variable of shape :math:`(n, c_I, h, w)`.
-        W (~chainer.Variable): Weight variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape :math:`(n, c_I, h, w)`.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
             :math:`(c_I, c_O, k_H, k_W)`.
-        b (~chainer.Variable): Bias variable of length :math:`c_O` (optional).
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable of length :math:`c_O` (optional).
         stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
         pad (int or pair of ints): Spatial padding width for input arrays.

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -283,10 +283,13 @@ def deconvolution_2d(x, W, b=None, stride=1, pad=0,
     the filter weight ``W``, and the bias vector ``b``.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape :math:`(n, c_I, h, w)`.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable of shape :math:`(n, c_I, h, w)`.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight variable of shape
             :math:`(c_I, c_O, k_H, k_W)`.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable of length :math:`c_O` (optional).
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias variable of length :math:`c_O` (optional).
         stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
         pad (int or pair of ints): Spatial padding width for input arrays.

--- a/chainer/functions/connection/dilated_convolution_2d.py
+++ b/chainer/functions/connection/dilated_convolution_2d.py
@@ -333,10 +333,13 @@ def dilated_convolution_2d(x, W, b=None, stride=1, pad=0, dilate=1,
       respectively.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape :math:`(n, c_I, h, w)`.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable of shape :math:`(n, c_I, h, w)`.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight variable of shape
             :math:`(c_O, c_I, k_H, k_W)`.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable of length :math:`c_O` (optional).
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias variable of length :math:`c_O` (optional).
         stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
         pad (int or pair of ints): Spatial padding width for input arrays.

--- a/chainer/functions/connection/dilated_convolution_2d.py
+++ b/chainer/functions/connection/dilated_convolution_2d.py
@@ -333,10 +333,10 @@ def dilated_convolution_2d(x, W, b=None, stride=1, pad=0, dilate=1,
       respectively.
 
     Args:
-        x (~chainer.Variable): Input variable of shape :math:`(n, c_I, h, w)`.
-        W (~chainer.Variable): Weight variable of shape
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable of shape :math:`(n, c_I, h, w)`.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape
             :math:`(c_O, c_I, k_H, k_W)`.
-        b (~chainer.Variable): Bias variable of length :math:`c_O` (optional).
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable of length :math:`c_O` (optional).
         stride (int or pair of ints): Stride of filter applications.
             ``stride=s`` and ``stride=(s, s)`` are equivalent.
         pad (int or pair of ints): Spatial padding width for input arrays.

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -91,8 +91,8 @@ def embed_id(x, W, ignore_label=None):
     This function is only differentiable on the input ``W``.
 
     Args:
-        x (~chainer.Variable): Batch vectors of IDs.
-        W (~chainer.Variable): Representation of each ID (a.k.a.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch vectors of IDs.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Representation of each ID (a.k.a.
             word embeddings).
         ignore_label (int or None): If ``ignore_label`` is an int value,
             ``i``-th column of return value is filled with ``0``.

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -91,8 +91,10 @@ def embed_id(x, W, ignore_label=None):
     This function is only differentiable on the input ``W``.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch vectors of IDs.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Representation of each ID (a.k.a.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch vectors of IDs.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Representation of each ID (a.k.a.
             word embeddings).
         ignore_label (int or None): If ``ignore_label`` is an int value,
             ``i``-th column of return value is filled with ``0``.

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -61,11 +61,14 @@ def linear(x, W, b=None):
     :math:`Y = xW^\\top + b`.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. Its first dimension is assumed
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable. Its first dimension is assumed
             to be the *minibatch dimension*. The other dimensions are treated
             as concatenated one dimension whose size must be ``N``.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape ``(M, N)``.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable (optional) of shape ``(M,)``.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight variable of shape ``(M, N)``.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias variable (optional) of shape ``(M,)``.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -61,11 +61,11 @@ def linear(x, W, b=None):
     :math:`Y = xW^\\top + b`.
 
     Args:
-        x (~chainer.Variable): Input variable. Its first dimension is assumed
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. Its first dimension is assumed
             to be the *minibatch dimension*. The other dimensions are treated
             as concatenated one dimension whose size must be ``N``.
-        W (~chainer.Variable): Weight variable of shape ``(M, N)``.
-        b (~chainer.Variable): Bias variable (optional) of shape ``(M,)``.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight variable of shape ``(M, N)``.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias variable (optional) of shape ``(M,)``.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -59,9 +59,11 @@ def accuracy(y, t, ignore_label=None):
     """Computes muticlass classification accuracy of the minibatch.
 
     Args:
-        y (Variable): Variable holding a matrix whose (i, j)-th element
+        y (chainer.Variable, numpy.ndarray, or cupy.ndarray):
+            Variable holding a matrix whose (i, j)-th element
             indicates the score of the class j at the i-th example.
-        t (Variable): Variable holding an int32 vector of ground truth labels.
+        t (chainer.Variable, numpy.ndarray, or cupy.ndarray):
+            Variable holding an int32 vector of ground truth labels.
         ignore_label (int or None): Skip calculating accuracy
             if the true label is ``ignore_label``.
 

--- a/chainer/functions/evaluation/binary_accuracy.py
+++ b/chainer/functions/evaluation/binary_accuracy.py
@@ -36,9 +36,11 @@ def binary_accuracy(y, t):
     """Computes binary classification accuracy of the minibatch.
 
     Args:
-        y (Variable): Variable holding a matrix whose i-th element
+        y (chainer.Variable, numpy.ndarray, or cupy.ndarray):
+            Variable holding a matrix whose i-th element
             indicates the score of positive at the i-th example.
-        t (Variable): Variable holding an int32 vector of ground truth labels.
+        t (chainer.Variable, numpy.ndarray, or cupy.ndarray):
+            Variable holding an int32 vector of ground truth labels.
             If ``t[i] == -1``, corresponding ``x[i]`` is ignored.
             Accuracy is zero if all ground truth labels are ``-1``.
 

--- a/chainer/functions/evaluation/classification_summary.py
+++ b/chainer/functions/evaluation/classification_summary.py
@@ -96,8 +96,10 @@ def classification_summary(y, t, label_num=None, beta=1.0, ignore_label=-1):
     arrays do not contain correct quantities.
 
     Args:
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable holding a vector of scores.
-        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable holding a vector of
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable holding a vector of scores.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable holding a vector of
         ground truth labels.
         label_num (int): The number of classes.
         beta (float): The parameter which determines the weight of

--- a/chainer/functions/evaluation/classification_summary.py
+++ b/chainer/functions/evaluation/classification_summary.py
@@ -96,8 +96,8 @@ def classification_summary(y, t, label_num=None, beta=1.0, ignore_label=-1):
     arrays do not contain correct quantities.
 
     Args:
-        y (~chainer.Variable): Variable holding a vector of scores.
-        t (~chainer.Variable): Variable holding a vector of
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable holding a vector of scores.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Variable holding a vector of
         ground truth labels.
         label_num (int): The number of classes.
         beta (float): The parameter which determines the weight of

--- a/chainer/functions/loss/black_out.py
+++ b/chainer/functions/loss/black_out.py
@@ -28,10 +28,10 @@ def black_out(x, t, W, samples):
        \\sum_{s \\in samples} \\exp(W_s^\\top x)}.
 
     Args:
-        x (~chainer.Variable): Batch of input vectors.
-        t (~chainer.Variable): Vector of ground truth labels.
-        W (~chainer.Variable): Weight matrix.
-        samples (~chainer.Variable): Negative samples.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Vector of ground truth labels.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight matrix.
+        samples (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Negative samples.
 
     Returns:
         ~chainer.Variable: Loss value.

--- a/chainer/functions/loss/black_out.py
+++ b/chainer/functions/loss/black_out.py
@@ -28,10 +28,14 @@ def black_out(x, t, W, samples):
        \\sum_{s \\in samples} \\exp(W_s^\\top x)}.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
-        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Vector of ground truth labels.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight matrix.
-        samples (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Negative samples.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch of input vectors.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Vector of ground truth labels.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight matrix.
+        samples (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Negative samples.
 
     Returns:
         ~chainer.Variable: Loss value.

--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -85,12 +85,12 @@ def contrastive(x0, x1, y, margin=1):
     x1.
 
     Args:
-        x0 (~chainer.Variable): The first input variable. The shape should be
+        x0 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The first input variable. The shape should be
             (N, K), where N denotes the mini-batch size, and K denotes the
             dimension of x0.
-        x1 (~chainer.Variable): The second input variable. The shape should be
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The second input variable. The shape should be
             the same as x0.
-        y (~chainer.Variable): Labels. All values should be 0 or 1. The shape
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Labels. All values should be 0 or 1. The shape
             should be ``(N,)``, where N denotes the mini-batch size.
         margin (float): A parameter for contrastive loss. It should be positive
             value.

--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -85,12 +85,15 @@ def contrastive(x0, x1, y, margin=1):
     x1.
 
     Args:
-        x0 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The first input variable. The shape should be
+        x0 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The first input variable. The shape should be
             (N, K), where N denotes the mini-batch size, and K denotes the
             dimension of x0.
-        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The second input variable. The shape should be
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The second input variable. The shape should be
             the same as x0.
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Labels. All values should be 0 or 1. The shape
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Labels. All values should be 0 or 1. The shape
             should be ``(N,)``, where N denotes the mini-batch size.
         margin (float): A parameter for contrastive loss. It should be positive
             value.

--- a/chainer/functions/loss/crf1d.py
+++ b/chainer/functions/loss/crf1d.py
@@ -24,13 +24,16 @@ def crf1d(cost, xs, ys):
     normalizing constant called partition function.
 
     Args:
-        cost (Variable): A :math:`K \\times K` matrix which holds transition
+        cost (chainer.Variable, numpy.ndarray or cupy.ndarray):
+            A :math:`K \\times K` matrix which holds transition
             cost between two labels, where :math:`K` is the number of labels.
-        xs (list of Variable): Input feature vector for each label. Each
+        xs (tuple of Variables, numpy.ndarrays or cupy.ndarrays):
+            Input feature vector for each label. Each
             :class:`~chainer.Variable` holds a :math:`B \\times K`
             matrix, where :math:`B` is mini-batch size, :math:`K` is the number
             of labels.
-        ys (list of Variable): Expected output labels. Each
+        ys (tuple of Variables, numpy.ndarrays or cupy.ndarray):
+            Expected output labels. Each
             :class:`~chainer.Variable` holds a :math:`B` integer vector.
 
     Returns:

--- a/chainer/functions/loss/cross_covariance.py
+++ b/chainer/functions/loss/cross_covariance.py
@@ -55,9 +55,11 @@ def cross_covariance(y, z):
     """Computes the sum-squared cross-covariance penalty between ``y`` and ``z``
 
     Args:
-        y (Variable): Variable holding a matrix where the first dimension
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable holding a matrix where the first dimension
             corresponds to the batches
-        z (Variable): Variable holding a matrix where the first dimension
+        z (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Variable holding a matrix where the first dimension
             corresponds to the batches
 
     Returns:

--- a/chainer/functions/loss/hinge.py
+++ b/chainer/functions/loss/hinge.py
@@ -114,9 +114,11 @@ def hinge(x, t, norm='L1'):
             \\end{array} \\right.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The shape of ``x`` should be
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable. The shape of ``x`` should be
             (:math:`N`, :math:`K`).
-        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The :math:`N`-dimensional label vector
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The :math:`N`-dimensional label vector
             :math:`{\\bf l}` with values
             :math:`l_n \in \{0, 1, 2, \dots, K-1\}`. The shape of ``t`` should
             be (:math:`N`,).

--- a/chainer/functions/loss/hinge.py
+++ b/chainer/functions/loss/hinge.py
@@ -114,9 +114,9 @@ def hinge(x, t, norm='L1'):
             \\end{array} \\right.
 
     Args:
-        x (~chainer.Variable): Input variable. The shape of ``x`` should be
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The shape of ``x`` should be
             (:math:`N`, :math:`K`).
-        t (~chainer.Variable): The :math:`N`-dimensional label vector
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The :math:`N`-dimensional label vector
             :math:`{\\bf l}` with values
             :math:`l_n \in \{0, 1, 2, \dots, K-1\}`. The shape of ``t`` should
             be (:math:`N`,).

--- a/chainer/functions/loss/huber_loss.py
+++ b/chainer/functions/loss/huber_loss.py
@@ -51,9 +51,9 @@ def huber_loss(x, t, delta):
             \\end{array} \\right.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
             The shape of ``x`` should be (:math:`N`, :math:`K`).
-        t (~chainer.Variable): Target variable for regression.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Target variable for regression.
             The shape of ``t`` should be (:math:`N`, :math:`K`).
         delta (float): Constant variable for huber loss function
             as used in definition.

--- a/chainer/functions/loss/huber_loss.py
+++ b/chainer/functions/loss/huber_loss.py
@@ -51,9 +51,11 @@ def huber_loss(x, t, delta):
             \\end{array} \\right.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
             The shape of ``x`` should be (:math:`N`, :math:`K`).
-        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Target variable for regression.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Target variable for regression.
             The shape of ``t`` should be (:math:`N`, :math:`K`).
         delta (float): Constant variable for huber loss function
             as used in definition.

--- a/chainer/functions/loss/mean_squared_error.py
+++ b/chainer/functions/loss/mean_squared_error.py
@@ -40,5 +40,15 @@ def mean_squared_error(x0, x1):
     This function computes mean squared error between two variables. The mean
     is taken over the minibatch. Note that the error is not scaled by 1/2.
 
+    Args:
+        x0 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: A variable object holding a scalar array of the
+            mean squared loss.
+
     """
     return MeanSquaredError()(x0, x1)

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -205,9 +205,9 @@ def negative_sampling(x, t, W, sampler, sample_size):
     a hyper-parameter, and :math:`Z` is the normalization constant.
 
     Args:
-        x (~chainer.Variable): Batch of input vectors.
-        t (~chainer.Variable): Vector of ground truth labels.
-        W (~chainer.Variable): Weight matrix.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Vector of ground truth labels.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight matrix.
         sampler (~types.FunctionType): Sampling function. It takes a shape and
             returns an integer array of the shape. Each element of this array
             is a sample from the word distribution.

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -205,9 +205,12 @@ def negative_sampling(x, t, W, sampler, sample_size):
     a hyper-parameter, and :math:`Z` is the normalization constant.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
-        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Vector of ground truth labels.
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight matrix.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch of input vectors.
+        t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Vector of ground truth labels.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight matrix.
         sampler (~types.FunctionType): Sampling function. It takes a shape and
             returns an integer array of the shape. Each element of this array
             is a sample from the word distribution.

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -57,10 +57,12 @@ def sigmoid_cross_entropy(x, t, use_cudnn=True, normalize=True):
     """Computes cross entropy loss for pre-sigmoid activations.
 
     Args:
-        x (Variable): A variable object holding a matrix whose (i, j)-th
+        x (chainer.Variable, :class:`numpy.ndarray` or cupy.ndarray):
+            A variable object holding a matrix whose (i, j)-th
             element indicates the unnormalized log probability of the j-th unit
             at the i-th example.
-        t (Variable): Variable holding an int32 vector of ground truth labels.
+        t (chainer.Variable, :class:`numpy.ndarray` or cupy.ndarray):
+            Variable holding an int32 vector of ground truth labels.
             If ``t[i] == -1``, corresponding ``x[i]`` is ignored.
             Loss is zero if all ground truth labels are ``-1``.
         normalize (bool): Variable holding a boolean value which

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -145,14 +145,16 @@ def softmax_cross_entropy(
     """Computes cross entropy loss for pre-softmax activations.
 
     Args:
-        x (Variable): Variable holding a multidimensional array whose element
+        x (chainer.Variable, :class:`numpy.ndarray`, or cupy.ndarray):
+            Variable holding a multidimensional array whose element
             indicates unnormalized log probability: the first axis of the
             variable represents the number of samples, and the second axis
             represents the number of classes. While this function computes
             a usual softmax cross entropy if the number of dimensions is equal
             to 2, it computes a cross entropy of the replicated softmax if the
             number of dimensions is greater than 2.
-        t (Variable): Variable holding an int32 vector of ground truth labels.
+        t (chainer.Variable, :class:`numpy.ndarray`, or cupy.ndarray):
+            Variable holding an int32 vector of ground truth labels.
             If ``t[i] == -1``, corresponding ``x[i]`` is ignored.
         normalize (bool): If true, this function normalizes the cross entropy
             loss across all instances. If false, it only normalizes along

--- a/chainer/functions/loss/triplet.py
+++ b/chainer/functions/loss/triplet.py
@@ -75,12 +75,15 @@ def triplet(anchor, positive, negative, margin=0.2):
     where :math:`d(x_i, y_i) = \\| {\\bf x}_i - {\\bf y}_i \\|_2^2`.
 
     Args:
-        anchor (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The anchor example variable. The shape
+        anchor (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The anchor example variable. The shape
             should be :math:`(N, K)`, where :math:`N` denotes the minibatch
             size, and :math:`K` denotes the dimension of the anchor.
-        positive (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The positive example variable. The shape
+        positive (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The positive example variable. The shape
             should be the same as anchor.
-        negative (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The negative example variable. The shape
+        negative (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The negative example variable. The shape
             should be the same as anchor.
         margin (float): A parameter for triplet loss. It should be a positive
             value.

--- a/chainer/functions/loss/triplet.py
+++ b/chainer/functions/loss/triplet.py
@@ -75,12 +75,12 @@ def triplet(anchor, positive, negative, margin=0.2):
     where :math:`d(x_i, y_i) = \\| {\\bf x}_i - {\\bf y}_i \\|_2^2`.
 
     Args:
-        anchor (~chainer.Variable): The anchor example variable. The shape
+        anchor (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The anchor example variable. The shape
             should be :math:`(N, K)`, where :math:`N` denotes the minibatch
             size, and :math:`K` denotes the dimension of the anchor.
-        positive (~chainer.Variable): The positive example variable. The shape
+        positive (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The positive example variable. The shape
             should be the same as anchor.
-        negative (~chainer.Variable): The negative example variable. The shape
+        negative (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): The negative example variable. The shape
             should be the same as anchor.
         margin (float): A parameter for triplet loss. It should be a positive
             value.

--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -22,9 +22,9 @@ def gaussian_kl_divergence(mean, ln_var):
     and :math:`I` is an identity matrix.
 
     Args:
-        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing mean of given
+        mean (~chainer.Variable): A variable representing mean of given
             gaussian distribution, :math:`\\mu`.
-        ln_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing logarithm of
+        ln_var (~chainer.Variable): A variable representing logarithm of
             variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
 
     Returns:
@@ -60,8 +60,8 @@ def bernoulli_nll(x, y):
        directly.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing the parameter of
+        x (~chainer.Variable): Input variable.
+        y (~chainer.Variable): A variable representing the parameter of
             Bernoulli distribution.
 
     Returns:
@@ -91,10 +91,10 @@ def gaussian_nll(x, mean, ln_var):
     matrix where :math:`S_{ii} = \\sigma_i^2`.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
-        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing mean of a Gaussian
+        x (~chainer.Variable): Input variable.
+        mean (~chainer.Variable): A variable representing mean of a Gaussian
             distribution, :math:`\\mu`.
-        ln_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing logarithm of
+        ln_var (~chainer.Variable): A variable representing logarithm of
             variance of a Gaussian distribution, :math:`\\log(\\sigma^2)`.
 
     Returns:

--- a/chainer/functions/loss/vae.py
+++ b/chainer/functions/loss/vae.py
@@ -22,9 +22,9 @@ def gaussian_kl_divergence(mean, ln_var):
     and :math:`I` is an identity matrix.
 
     Args:
-        mean (~chainer.Variable): A variable representing mean of given
+        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing mean of given
             gaussian distribution, :math:`\\mu`.
-        ln_var (~chainer.Variable): A variable representing logarithm of
+        ln_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing logarithm of
             variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
 
     Returns:
@@ -60,8 +60,8 @@ def bernoulli_nll(x, y):
        directly.
 
     Args:
-        x (~chainer.Variable): Input variable.
-        y (~chainer.Variable): A variable representing the parameter of
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing the parameter of
             Bernoulli distribution.
 
     Returns:
@@ -91,10 +91,10 @@ def gaussian_nll(x, mean, ln_var):
     matrix where :math:`S_{ii} = \\sigma_i^2`.
 
     Args:
-        x (~chainer.Variable): Input variable.
-        mean (~chainer.Variable): A variable representing mean of a Gaussian
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing mean of a Gaussian
             distribution, :math:`\\mu`.
-        ln_var (~chainer.Variable): A variable representing logarithm of
+        ln_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A variable representing logarithm of
             variance of a Gaussian distribution, :math:`\\log(\\sigma^2)`.
 
     Returns:

--- a/chainer/functions/math/batch_l2_norm_squared.py
+++ b/chainer/functions/math/batch_l2_norm_squared.py
@@ -49,7 +49,8 @@ def batch_l2_norm_squared(x):
     along batch axis is done.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The first dimension is assumed
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable. The first dimension is assumed
             to be the *minibatch dimension*. If x has more than two dimensions
             all but the first dimension are flattened to one dimension.
 

--- a/chainer/functions/math/batch_l2_norm_squared.py
+++ b/chainer/functions/math/batch_l2_norm_squared.py
@@ -49,7 +49,7 @@ def batch_l2_norm_squared(x):
     along batch axis is done.
 
     Args:
-        x (~chainer.Variable): Input variable. The first dimension is assumed
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The first dimension is assumed
             to be the *minibatch dimension*. If x has more than two dimensions
             all but the first dimension are flattened to one dimension.
 

--- a/chainer/functions/math/bias.py
+++ b/chainer/functions/math/bias.py
@@ -26,8 +26,10 @@ def bias(x, y, axis=1):
     Note that how the ``axis`` indicates to which axis of ``x`` we apply ``y``.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to be summed.
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to sum, broadcasted.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable to be summed.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable to sum, broadcasted.
         axis (int): The first axis of ``x`` along which ``y`` is applied.
 
     Returns:

--- a/chainer/functions/math/bias.py
+++ b/chainer/functions/math/bias.py
@@ -26,8 +26,8 @@ def bias(x, y, axis=1):
     Note that how the ``axis`` indicates to which axis of ``x`` we apply ``y``.
 
     Args:
-        x (~chainer.Variable): Input variable to be summed.
-        y (~chainer.Variable): Input variable to sum, broadcasted.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to be summed.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to sum, broadcasted.
         axis (int): The first axis of ``x`` along which ``y`` is applied.
 
     Returns:

--- a/chainer/functions/math/ceil.py
+++ b/chainer/functions/math/ceil.py
@@ -31,7 +31,8 @@ def ceil(x):
     .. math::
        y_i = \\lceil x_i \\rceil
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/ceil.py
+++ b/chainer/functions/math/ceil.py
@@ -31,7 +31,7 @@ def ceil(x):
     .. math::
        y_i = \\lceil x_i \\rceil
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/clip.py
+++ b/chainer/functions/math/clip.py
@@ -50,7 +50,8 @@ def clip(x, x_min, x_max):
     clipped to the interval edges.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to be clipped.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable to be clipped.
         x_min (float): Minimum value.
         x_max (float): Maximum value.
 

--- a/chainer/functions/math/clip.py
+++ b/chainer/functions/math/clip.py
@@ -50,7 +50,7 @@ def clip(x, x_min, x_max):
     clipped to the interval edges.
 
     Args:
-        x (~chainer.Variable): Input variable to be clipped.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to be clipped.
         x_min (float): Minimum value.
         x_max (float): Maximum value.
 

--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -86,9 +86,10 @@ def batch_det(a):
     """Computes the determinant of a batch of square matrices.
 
     Args:
-        a (Variable): Input array to compute the determinant for.
-        The first dimension should iterate over each matrix and be
-        of the batchsize.
+        a (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input array to compute the determinant for.
+            The first dimension should iterate over each matrix and be
+            of the batchsize.
 
     Returns:
         ~chainer.Variable: vector of determinants for every matrix
@@ -102,7 +103,8 @@ def det(a):
     """Computes the determinant of a single square matrix.
 
     Args:
-        a (Variable): Input array to compute the determinant for.
+        a (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input array to compute the determinant for.
 
     Returns:
         ~chainer.Variable: Scalar determinant of the matrix a.

--- a/chainer/functions/math/exponential.py
+++ b/chainer/functions/math/exponential.py
@@ -87,7 +87,8 @@ def log2(x):
        y_i = \\log_2 x_i.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -124,7 +125,8 @@ def log10(x):
        y_i = \\log_10 x_i.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/exponential.py
+++ b/chainer/functions/math/exponential.py
@@ -87,7 +87,7 @@ def log2(x):
        y_i = \\log_2 x_i.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -124,7 +124,7 @@ def log10(x):
        y_i = \\log_10 x_i.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/exponential.py
+++ b/chainer/functions/math/exponential.py
@@ -29,7 +29,18 @@ class Exp(function.Function):
 
 
 def exp(x):
-    """Elementwise exponential function."""
+    """Elementwise exponential function.
+
+    .. math::
+       y_i = \\exp x_i.
+
+    Args:
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Exp()(x)
 
 
@@ -54,7 +65,18 @@ class Log(function.Function):
 
 
 def log(x):
-    """Elementwise natural logarithm function."""
+    """Elementwise natural logarithm function.
+
+    .. math::
+       y_i = \\log_e x_i.
+
+    Args:
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Log()(x)
 
 

--- a/chainer/functions/math/exponential_m1.py
+++ b/chainer/functions/math/exponential_m1.py
@@ -29,5 +29,13 @@ class Expm1(function.Function):
 
 
 def expm1(x):
-    """Elementwise exponential minus one function."""
+    """Elementwise exponential minus one function.
+
+    Args:
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Expm1()(x)

--- a/chainer/functions/math/floor.py
+++ b/chainer/functions/math/floor.py
@@ -32,7 +32,8 @@ def floor(x):
        y_i = \\lfloor x_i \\rfloor
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/floor.py
+++ b/chainer/functions/math/floor.py
@@ -32,7 +32,7 @@ def floor(x):
        y_i = \\lfloor x_i \\rfloor
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/hyperbolic.py
+++ b/chainer/functions/math/hyperbolic.py
@@ -34,7 +34,8 @@ def cosh(x):
        y_i = \\cosh x_i.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -72,7 +73,8 @@ def sinh(x):
        y_i = \\sinh x_i.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/hyperbolic.py
+++ b/chainer/functions/math/hyperbolic.py
@@ -34,7 +34,7 @@ def cosh(x):
        y_i = \\cosh x_i.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -72,7 +72,7 @@ def sinh(x):
        y_i = \\sinh x_i.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/identity.py
+++ b/chainer/functions/math/identity.py
@@ -16,5 +16,15 @@ class Identity(function.Function):
 
 
 def identity(*inputs):
-    """Just returns input variables."""
+    """Just returns input variables.
+
+
+    Args:
+        inputs (tuple of chainer.Variables, :class:`numpy.ndarray`s
+        or cupy.ndarrays):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Identity()(*inputs)

--- a/chainer/functions/math/inv.py
+++ b/chainer/functions/math/inv.py
@@ -110,7 +110,8 @@ def inv(a):
     """Computes the inverse of of square matrix.
 
     Args:
-        a (Variable): Input array to compute the determinant for. Shape of
+        a (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input array to compute the determinant for. Shape of
             the array should be ``(n, n)`` where ``n`` is the dimensionality of
             a square matrix.
 
@@ -124,7 +125,8 @@ def batch_inv(a):
     """Computes the inverse of a batch of square matrices.
 
     Args:
-        a (Variable): Input array to compute the determinant for. Shape of
+        a (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input array to compute the determinant for. Shape of
             the array should be ``(m, n, n)`` where m is the number of matrices
             in the batch, and ``n`` is the dimensionality of a square matrix.
 

--- a/chainer/functions/math/linear_interpolate.py
+++ b/chainer/functions/math/linear_interpolate.py
@@ -63,9 +63,9 @@ def linear_interpolate(p, x, y):
         f(p, x, y) = p x + (1 - p) y.
 
     Args:
-        p (~chainer.Variable): Input variable.
-        x (~chainer.Variable): Input variable.
-        y (~chainer.Variable): Input variable.
+        p (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/linear_interpolate.py
+++ b/chainer/functions/math/linear_interpolate.py
@@ -63,9 +63,12 @@ def linear_interpolate(p, x, y):
         f(p, x, y) = p x + (1 - p) y.
 
     Args:
-        p (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        p (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/logarithm_1p.py
+++ b/chainer/functions/math/logarithm_1p.py
@@ -27,5 +27,13 @@ class Log1p(function.Function):
 
 
 def log1p(x):
-    """Elementwise natural logarithm plus one function."""
+    """Elementwise natural logarithm plus one function.
+
+    Args:
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Log1p()(x)

--- a/chainer/functions/math/logsumexp.py
+++ b/chainer/functions/math/logsumexp.py
@@ -75,7 +75,7 @@ def logsumexp(x, axis=None):
        y_i = \\log\\left(\\sum_j \\exp(x_{ij})\\right)
 
     Args:
-        x (~chainer.Variable): Elements to log-sum-exp.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Elements to log-sum-exp.
         axis (None, int, or tuple of int): Axis which a sum is performed.
             The default (axis = None) is perform a sum over all the dimensions
             of the input array.

--- a/chainer/functions/math/logsumexp.py
+++ b/chainer/functions/math/logsumexp.py
@@ -75,7 +75,8 @@ def logsumexp(x, axis=None):
        y_i = \\log\\left(\\sum_j \\exp(x_{ij})\\right)
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Elements to log-sum-exp.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Elements to log-sum-exp.
         axis (None, int, or tuple of int): Axis which a sum is performed.
             The default (axis = None) is perform a sum over all the dimensions
             of the input array.

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -162,12 +162,14 @@ def matmul(a, b, transa=False, transb=False):
     """Computes the matrix multiplication of two arrays.
 
     Args:
-        a (Variable): The left operand of the matrix multiplication.
+        a (chainer.Variable, or :class:`numpy.ndarray` or cupy.ndarray):
+            The left operand of the matrix multiplication.
             A 1-D array of shape ``(N,)`` is considered as an
             :math:`N \\times 1` matrix.
             A 2-D array of shape ``(M, N)`` is considered as an
             :math:`M \\times N` matrix.
-        b (Variable): The right operand of the matrix multiplication.
+        b (chainer.Variable, or :class:`numpy.ndarray` or cupy.ndarray):
+            The right operand of the matrix multiplication.
             Its array is treated as a matrix in the same way as ``a``'s array.
         transa (bool): If ``True``, transpose a.
         transb (bool): If ``True``, transpose b.
@@ -262,12 +264,14 @@ def batch_matmul(a, b, transa=False, transb=False):
     """Computes the batch matrix multiplications of two sets of arrays.
 
     Args:
-        a (Variable): The left operand of the batch matrix multiplications.
+        a (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The left operand of the batch matrix multiplications.
             A 2-D array of shape ``(B, N)`` is considered as B
             :math:`N \\times 1` matrices.
             A 3-D array of shape ``(B, M, N)`` is considered as B
             :math:`M \\times N` matrices.
-        b (Variable): The right operand of the batch matrix multiplications.
+        b (chainer.Variableor :class:`numpy.ndarray` or cupy.ndarray):
+            The right operand of the batch matrix multiplications.
             Its array is treated as matrices in the same way as ``a``'s array.
         transa (bool): If ``True``, transpose each matrix in a.
         transb (bool): If ``True``, transpose each matrix in b.

--- a/chainer/functions/math/maximum.py
+++ b/chainer/functions/math/maximum.py
@@ -51,8 +51,10 @@ def maximum(x1, x2):
     """Element-wise maximum of input variables.
 
     Args:
-        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
-        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variables to be compared.
+        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variables to be compared.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/maximum.py
+++ b/chainer/functions/math/maximum.py
@@ -51,8 +51,8 @@ def maximum(x1, x2):
     """Element-wise maximum of input variables.
 
     Args:
-        x1 (~chainer.Variable): Input variables to be compared.
-        x2 (~chainer.Variable): Input variables to be compared.
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
+        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/minimum.py
+++ b/chainer/functions/math/minimum.py
@@ -51,8 +51,10 @@ def minimum(x1, x2):
     """Element-wise minimum of input variables.
 
     Args:
-        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
-        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variables to be compared.
+        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variables to be compared.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/minimum.py
+++ b/chainer/functions/math/minimum.py
@@ -51,8 +51,8 @@ def minimum(x1, x2):
     """Element-wise minimum of input variables.
 
     Args:
-        x1 (~chainer.Variable): Input variables to be compared.
-        x2 (~chainer.Variable): Input variables to be compared.
+        x1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
+        x2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variables to be compared.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/minmax.py
+++ b/chainer/functions/math/minmax.py
@@ -128,7 +128,7 @@ def max(x, axis=None, keepdims=False):
     """Maximum of array elements over a given axis.
 
     Args:
-        x (~chainer.Variable): Array to be maximized.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to be maximized.
         axis (None, int, or tuple of int): Axis over which a max is performed.
             The default (axis = None) is perform a max over all the dimensions
             of the input array.
@@ -143,7 +143,7 @@ def min(x, axis=None, keepdims=False):
     """Minimum of array elements over a given axis.
 
     Args:
-        x (~chainer.Variable): Array to be minimized.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to be minimized.
         axis (None, int, or tuple of int): Axis over which a min is performed.
             The default (axis = None) is perform a min over all the dimensions
             of the input array.
@@ -158,7 +158,7 @@ def argmax(x, axis=None):
     """Returns index which holds maximum of array elements over a given axis.
 
     Args:
-        x (~chainer.Variable): Array to find maximum elements.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to find maximum elements.
         axis (None or int): Axis over which a max is performed.
             The default (axis = None) is perform a max over all the dimensions
             of the input array.
@@ -173,7 +173,7 @@ def argmin(x, axis=None):
     """Returns index which holds minimum of array elements over a given axis.
 
     Args:
-        x (~chainer.Variable): Array to find minimum elements.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to find minimum elements.
         axis (None or int): Axis over which a min is performed.
             The default (axis = None) is perform a min over all the dimensions
             of the input array.

--- a/chainer/functions/math/minmax.py
+++ b/chainer/functions/math/minmax.py
@@ -128,7 +128,8 @@ def max(x, axis=None, keepdims=False):
     """Maximum of array elements over a given axis.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to be maximized.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Array to be maximized.
         axis (None, int, or tuple of int): Axis over which a max is performed.
             The default (axis = None) is perform a max over all the dimensions
             of the input array.
@@ -143,7 +144,8 @@ def min(x, axis=None, keepdims=False):
     """Minimum of array elements over a given axis.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to be minimized.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Array to be minimized.
         axis (None, int, or tuple of int): Axis over which a min is performed.
             The default (axis = None) is perform a min over all the dimensions
             of the input array.
@@ -158,7 +160,8 @@ def argmax(x, axis=None):
     """Returns index which holds maximum of array elements over a given axis.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to find maximum elements.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Array to find maximum elements.
         axis (None or int): Axis over which a max is performed.
             The default (axis = None) is perform a max over all the dimensions
             of the input array.
@@ -173,7 +176,8 @@ def argmin(x, axis=None):
     """Returns index which holds minimum of array elements over a given axis.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Array to find minimum elements.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Array to find minimum elements.
         axis (None or int): Axis over which a min is performed.
             The default (axis = None) is perform a min over all the dimensions
             of the input array.

--- a/chainer/functions/math/scale.py
+++ b/chainer/functions/math/scale.py
@@ -26,8 +26,10 @@ def scale(x, y, axis=1):
     Note that how the ``axis`` indicates to which axis of ``x`` we apply ``y``.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to be scaled.
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to scale, broadcasted.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable to be scaled.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable to scale, broadcasted.
         axis (int): The first axis of ``x`` along which ``y`` is applied.
 
     Returns:

--- a/chainer/functions/math/scale.py
+++ b/chainer/functions/math/scale.py
@@ -26,8 +26,8 @@ def scale(x, y, axis=1):
     Note that how the ``axis`` indicates to which axis of ``x`` we apply ``y``.
 
     Args:
-        x (~chainer.Variable): Input variable to be scaled.
-        y (~chainer.Variable): Input variable to scale, broadcasted.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to be scaled.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable to scale, broadcasted.
         axis (int): The first axis of ``x`` along which ``y`` is applied.
 
     Returns:

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -39,7 +39,7 @@ def sqrt(x):
     respect to underlying numpy and cupy specification.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -54,7 +54,7 @@ def rsqrt(x):
        y_i = {1 \\over \\sqrt x_i}.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -39,7 +39,8 @@ def sqrt(x):
     respect to underlying numpy and cupy specification.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -54,7 +55,8 @@ def rsqrt(x):
        y_i = {1 \\over \\sqrt x_i}.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/math/sum.py
+++ b/chainer/functions/math/sum.py
@@ -66,7 +66,8 @@ def sum(x, axis=None):
     """Sum of array elements over a given axis.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Elements to sum.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Elements to sum.
         axis (None, int, or tuple of int): Axis which a sum is performed.
             The default (axis = None) is perform a sum over all the dimensions
             of the input array.

--- a/chainer/functions/math/sum.py
+++ b/chainer/functions/math/sum.py
@@ -66,7 +66,7 @@ def sum(x, axis=None):
     """Sum of array elements over a given axis.
 
     Args:
-        x (~chainer.Variable): Elements to sum.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Elements to sum.
         axis (None, int, or tuple of int): Axis which a sum is performed.
             The default (axis = None) is perform a sum over all the dimensions
             of the input array.

--- a/chainer/functions/math/trigonometric.py
+++ b/chainer/functions/math/trigonometric.py
@@ -33,7 +33,15 @@ class Sin(function.Function):
 
 
 def sin(x):
-    """Elementwise sin function."""
+    """Elementwise sin function.
+
+    Args:
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Sin()(x)
 
 
@@ -65,7 +73,15 @@ class Cos(function.Function):
 
 
 def cos(x):
-    """Elementwise cos function."""
+    """Elementwise cos function.
+
+    Args:
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Cos()(x)
 
 
@@ -93,5 +109,13 @@ class Tan(function.Function):
 
 
 def tan(x):
-    """Elementwise tan function."""
+    """Elementwise tan function.
+
+    Args:
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+    """
     return Tan()(x)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -39,7 +39,8 @@ def dropout(x, ratio=.5, train=True):
     mode, it does nothing and just returns ``x``.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         ratio (float): Dropout ratio.
         train (bool): If ``True``, executes dropout. Otherwise, does nothing.
 

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -39,7 +39,7 @@ def dropout(x, ratio=.5, train=True):
     mode, it does nothing and just returns ``x``.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         ratio (float): Dropout ratio.
         train (bool): If ``True``, executes dropout. Otherwise, does nothing.
 

--- a/chainer/functions/noise/gaussian.py
+++ b/chainer/functions/noise/gaussian.py
@@ -63,9 +63,11 @@ def gaussian(mean, ln_var):
     :math:`N(\\mu, \\sigma)`.
 
     Args:
-        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable representing mean
+        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable representing mean
             :math:`\\mu`.
-        ln_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable representing logarithm of
+        ln_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable representing logarithm of
             variance :math:`\\log(\\sigma^2)`.
 
     Returns:

--- a/chainer/functions/noise/gaussian.py
+++ b/chainer/functions/noise/gaussian.py
@@ -63,9 +63,9 @@ def gaussian(mean, ln_var):
     :math:`N(\\mu, \\sigma)`.
 
     Args:
-        mean (~chainer.Variable): Input variable representing mean
+        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable representing mean
             :math:`\\mu`.
-        ln_var (~chainer.Variable): Input variable representing logarithm of
+        ln_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable representing logarithm of
             variance :math:`\\log(\\sigma^2)`.
 
     Returns:

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -289,9 +289,12 @@ def batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None,
     corresponding Link class for an example of how to do this.
 
     Args:
-        x (Variable): The input variable.
-        gamma (Variable): The scaling parameter of normalized data.
-        beta (Variable): The shifting parameter of scaled normalized data.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The input variable.
+        gamma (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The scaling parameter of normalized data.
+        beta (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The shifting parameter of scaled normalized data.
         eps (float): Epsilon value for numerical stability.
         running_mean (array): The running average of the mean. This is a
             running average of the mean over several mini-batches using
@@ -329,11 +332,16 @@ def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5,
     statistics cannot be used for prediction consistency.
 
     Args:
-        x (Variable): The input variable.
-        gamma (Variable): The scaling parameter of normalized data.
-        beta (Variable): The shifting parameter of scaled normalized data.
-        mean (Variable): The shifting parameter of input.
-        var (Variable): The square of scaling parameter of input.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The input variable.
+        gamma (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The scaling parameter of normalized data.
+        beta (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The shifting parameter of scaled normalized data.
+        mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The shifting parameter of input.
+        var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            The square of scaling parameter of input.
         eps (float): Epsilon value for numerical stability.
         use_cudnn (bool): If ``True`` and cuDNN is enabled, then this function
             uses cuDNN as the core implementation.

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -102,7 +102,7 @@ def normalize(x, eps=1e-5):
     :math:`eps` is used to avoid division by zero when :math:`x_i=0`
 
     Args:
-        x (~chainer.Variable): Two dimensional output variable. The first
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Two dimensional output variable. The first
             dimension is assumed to be the mini-batch dimension.
         eps (float): Epsilon value for numerical stability.
 

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -102,7 +102,8 @@ def normalize(x, eps=1e-5):
     :math:`eps` is used to avoid division by zero when :math:`x_i=0`
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Two dimensional output variable. The first
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Two dimensional output variable. The first
             dimension is assumed to be the mini-batch dimension.
         eps (float): Epsilon value for numerical stability.
 

--- a/chainer/functions/normalization/local_response_normalization.py
+++ b/chainer/functions/normalization/local_response_normalization.py
@@ -115,7 +115,8 @@ def local_response_normalization(x, n=5, k=2, alpha=1e-4, beta=.75):
               x_j^2 \\right)^\\beta}.
 
     Args:
-        x (Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         n (int): Normalization window width.
         k (float): Smoothing parameter.
         alpha (float): Normalizer scaling parameter.

--- a/chainer/functions/pooling/average_pooling_2d.py
+++ b/chainer/functions/pooling/average_pooling_2d.py
@@ -115,7 +115,8 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
     without any parameter instead of computing the inner products.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int or pair of ints or None): Stride of pooling applications.

--- a/chainer/functions/pooling/average_pooling_2d.py
+++ b/chainer/functions/pooling/average_pooling_2d.py
@@ -115,7 +115,7 @@ def average_pooling_2d(x, ksize, stride=None, pad=0, use_cudnn=True):
     without any parameter instead of computing the inner products.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int or pair of ints or None): Stride of pooling applications.

--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -153,7 +153,8 @@ def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
     without any parameter instead of computing the inner products.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int or pair of ints or None): Stride of pooling applications.

--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -153,7 +153,7 @@ def max_pooling_2d(x, ksize, stride=None, pad=0, cover_all=True,
     without any parameter instead of computing the inner products.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int or pair of ints or None): Stride of pooling applications.

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -320,9 +320,11 @@ def roi_pooling_2d(x, rois, outh, outw, spatial_scale):
     with the region of interest.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The shape is expected to be
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable. The shape is expected to be
             4 dimentional: (n: batch, c: channel, h, height, w: width).
-        rois (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input roi variable. The shape is expected to
+        rois (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input roi variable. The shape is expected to
             be (n: data size, 5), and each datum is set as below:
             (batch_index, x_min, y_min, x_max, y_max).
         outh (int): Height of output image after pooled.

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -320,9 +320,9 @@ def roi_pooling_2d(x, rois, outh, outw, spatial_scale):
     with the region of interest.
 
     Args:
-        x (~chainer.Variable): Input variable. The shape is expected to be
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The shape is expected to be
             4 dimentional: (n: batch, c: channel, h, height, w: width).
-        rois (~chainer.Variable): Input roi variable. The shape is expected to
+        rois (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input roi variable. The shape is expected to
             be (n: data size, 5), and each datum is set as below:
             (batch_index, x_min, y_min, x_max, y_max).
         outh (int): Height of output image after pooled.

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -95,7 +95,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
     <http://arxiv.org/abs/1406.4729>`_.
 
     Args:
-        x (~chainer.Variable): Input variable. The shape of ``x`` should be
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The shape of ``x`` should be
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): the number of pyramid levels
         pooling_class (MaxPooling2D or AveragePooling2D):

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -95,7 +95,8 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class,
     <http://arxiv.org/abs/1406.4729>`_.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable. The shape of ``x`` should be
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable. The shape of ``x`` should be
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): the number of pyramid levels
         pooling_class (MaxPooling2D or AveragePooling2D):

--- a/chainer/functions/pooling/unpooling_2d.py
+++ b/chainer/functions/pooling/unpooling_2d.py
@@ -72,7 +72,8 @@ def unpooling_2d(x, ksize, stride=None, pad=0, outsize=None, cover_all=True):
     computing the inner products.
 
     Args:
-        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int, pair of ints or None): Stride of pooling applications.

--- a/chainer/functions/pooling/unpooling_2d.py
+++ b/chainer/functions/pooling/unpooling_2d.py
@@ -72,7 +72,7 @@ def unpooling_2d(x, ksize, stride=None, pad=0, outsize=None, cover_all=True):
     computing the inner products.
 
     Args:
-        x (~chainer.Variable): Input variable.
+        x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         ksize (int or pair of ints): Size of pooling window. ``ksize=k`` and
             ``ksize=(k, k)`` are equivalent.
         stride (int, pair of ints or None): Stride of pooling applications.

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -108,7 +108,8 @@ def forget(func, *xs):
             :class:`~chainer.Variable` object(s) and to return a
             :class:`~chainer.Variable` object or a tuple of
             :class:`~chainer.Variable` objects.
-        xs (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Argument variables of the function.
+        xs (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Argument variables of the function.
 
     Returns:
         ~chainer.Variable: A variable ``func`` returns. If it returns a tuple,

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -108,7 +108,7 @@ def forget(func, *xs):
             :class:`~chainer.Variable` object(s) and to return a
             :class:`~chainer.Variable` object or a tuple of
             :class:`~chainer.Variable` objects.
-        xs (~chainer.Variable): Argument variables of the function.
+        xs (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Argument variables of the function.
 
     Returns:
         ~chainer.Variable: A variable ``func`` returns. If it returns a tuple,

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -108,7 +108,8 @@ def forget(func, *xs):
             :class:`~chainer.Variable` object(s) and to return a
             :class:`~chainer.Variable` object or a tuple of
             :class:`~chainer.Variable` objects.
-        xs (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+        xs (tuple of chainer.Variables or :class:`numpy.ndarray`s
+            or cupy.ndarrays):
             Argument variables of the function.
 
     Returns:

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -81,7 +81,7 @@ class Maxout(link.Chain):
         """Applies the maxout layer.
 
         Args:
-            x (~chainer.Variable): Batch of input vectors.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
 
         Returns:
             ~chainer.Variable: Output of the maxout layer.

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -81,7 +81,8 @@ class Maxout(link.Chain):
         """Applies the maxout layer.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch of input vectors.
 
         Returns:
             ~chainer.Variable: Output of the maxout layer.

--- a/chainer/links/activation/prelu.py
+++ b/chainer/links/activation/prelu.py
@@ -17,7 +17,8 @@ class PReLU(link.Link):
     .. seealso:: :func:`chainer.functions.prelu`
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Coefficient of parametric ReLU.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Coefficient of parametric ReLU.
 
     """
 
@@ -29,7 +30,8 @@ class PReLU(link.Link):
         """Applies the parametric ReLU activation function.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
         Returns:
             ~chainer.Variable: Output of the parametric ReLU function.

--- a/chainer/links/activation/prelu.py
+++ b/chainer/links/activation/prelu.py
@@ -17,7 +17,7 @@ class PReLU(link.Link):
     .. seealso:: :func:`chainer.functions.prelu`
 
     Attributes:
-        W (~chainer.Variable): Coefficient of parametric ReLU.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Coefficient of parametric ReLU.
 
     """
 
@@ -29,7 +29,7 @@ class PReLU(link.Link):
         """Applies the parametric ReLU activation function.
 
         Args:
-            x (~chainer.Variable): Input variable.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
         Returns:
             ~chainer.Variable: Output of the parametric ReLU function.

--- a/chainer/links/connection/bias.py
+++ b/chainer/links/connection/bias.py
@@ -22,7 +22,7 @@ class Bias(link.Link):
     .. seealso:: See :func:`~chainer.functions.bias` for details.
 
     Attributes:
-        b (~chainer.Variable): Bias parameter if ``shape`` is given. Otherwise,
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter if ``shape`` is given. Otherwise,
             no attributes.
 
     """

--- a/chainer/links/connection/bias.py
+++ b/chainer/links/connection/bias.py
@@ -22,7 +22,8 @@ class Bias(link.Link):
     .. seealso:: See :func:`~chainer.functions.bias` for details.
 
     Attributes:
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter if ``shape`` is given. Otherwise,
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias parameter if ``shape`` is given. Otherwise,
             no attributes.
 
     """

--- a/chainer/links/connection/bilinear.py
+++ b/chainer/links/connection/bilinear.py
@@ -41,11 +41,15 @@ class Bilinear(link.Link):
     .. seealso:: See :func:`chainer.functions.bilinear` for details.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bilinear weight parameter.
-        V1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Linear weight parameter for the first argument.
-        V2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Linear weight parameter for the second
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bilinear weight parameter.
+        V1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Linear weight parameter for the first argument.
+        V2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Linear weight parameter for the second
             argument.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias parameter.
 
     """
 
@@ -91,8 +95,10 @@ class Bilinear(link.Link):
         """Applies the bilinear function to inputs and the internal parameters.
 
         Args:
-            e1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Left input.
-            e2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Right input.
+            e1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Left input.
+            e2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Right input.
 
         Returns:
             ~chainer.Variable: Output variable.

--- a/chainer/links/connection/bilinear.py
+++ b/chainer/links/connection/bilinear.py
@@ -41,11 +41,11 @@ class Bilinear(link.Link):
     .. seealso:: See :func:`chainer.functions.bilinear` for details.
 
     Attributes:
-        W (~chainer.Variable): Bilinear weight parameter.
-        V1 (~chainer.Variable): Linear weight parameter for the first argument.
-        V2 (~chainer.Variable): Linear weight parameter for the second
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bilinear weight parameter.
+        V1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Linear weight parameter for the first argument.
+        V2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Linear weight parameter for the second
             argument.
-        b (~chainer.Variable): Bias parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
 
     """
 
@@ -91,8 +91,8 @@ class Bilinear(link.Link):
         """Applies the bilinear function to inputs and the internal parameters.
 
         Args:
-            e1 (~chainer.Variable): Left input.
-            e2 (~chainer.Variable): Right input.
+            e1 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Left input.
+            e2 (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Right input.
 
         Returns:
             ~chainer.Variable: Output variable.

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -42,8 +42,10 @@ class Convolution2D(link.Link):
        two-dimensional convolution.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias parameter.
 
     """
 
@@ -88,7 +90,8 @@ class Convolution2D(link.Link):
         """Applies the convolution layer.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input image.
 
         Returns:
             ~chainer.Variable: Output of the convolution.

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -42,8 +42,8 @@ class Convolution2D(link.Link):
        two-dimensional convolution.
 
     Attributes:
-        W (~chainer.Variable): Weight parameter.
-        b (~chainer.Variable): Bias parameter.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
 
     """
 
@@ -88,7 +88,7 @@ class Convolution2D(link.Link):
         """Applies the convolution layer.
 
         Args:
-            x (~chainer.Variable): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
 
         Returns:
             ~chainer.Variable: Output of the convolution.

--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -46,8 +46,10 @@ class ConvolutionND(link.Link):
         two-dimensional convolution.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter. If ``initial_bias`` is ``None``,
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias parameter. If ``initial_bias`` is ``None``,
             set to ``None``.
 
     """
@@ -75,7 +77,8 @@ class ConvolutionND(link.Link):
         """Applies N-dimensional convolution layer.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input image.
 
         Returns:
             ~chainer.Variable: Output of convolution.

--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -46,8 +46,8 @@ class ConvolutionND(link.Link):
         two-dimensional convolution.
 
     Attributes:
-        W (~chainer.Variable): Weight parameter.
-        b (~chainer.Variable): Bias parameter. If ``initial_bias`` is ``None``,
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter. If ``initial_bias`` is ``None``,
             set to ``None``.
 
     """
@@ -75,7 +75,7 @@ class ConvolutionND(link.Link):
         """Applies N-dimensional convolution layer.
 
         Args:
-            x (~chainer.Variable): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
 
         Returns:
             ~chainer.Variable: Output of convolution.

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -44,8 +44,8 @@ class DilatedConvolution2D(link.Link):
        for the definition of two-dimensional dilated convolution.
 
     Attributes:
-        W (~chainer.Variable): Weight parameter.
-        b (~chainer.Variable): Bias parameter.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
 
     """
 
@@ -88,7 +88,7 @@ class DilatedConvolution2D(link.Link):
         """Applies the convolution layer.
 
         Args:
-            x (~chainer.Variable): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
 
         Returns:
             ~chainer.Variable: Output of the convolution.

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -44,8 +44,10 @@ class DilatedConvolution2D(link.Link):
        for the definition of two-dimensional dilated convolution.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias parameter.
 
     """
 
@@ -88,7 +90,8 @@ class DilatedConvolution2D(link.Link):
         """Applies the convolution layer.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input image.
 
         Returns:
             ~chainer.Variable: Output of the convolution.

--- a/chainer/links/connection/embed_id.py
+++ b/chainer/links/connection/embed_id.py
@@ -24,7 +24,7 @@ class EmbedID(link.Link):
     .. seealso:: :func:`chainer.functions.embed_id`
 
     Attributes:
-        W (~chainer.Variable): Embedding parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Embedding parameter matrix.
 
     """
 
@@ -41,7 +41,7 @@ class EmbedID(link.Link):
         """Extracts the word embedding of given IDs.
 
         Args:
-            x (~chainer.Variable): Batch vectors of IDs.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch vectors of IDs.
 
         Returns:
             ~chainer.Variable: Batch of corresponding embeddings.

--- a/chainer/links/connection/embed_id.py
+++ b/chainer/links/connection/embed_id.py
@@ -24,7 +24,8 @@ class EmbedID(link.Link):
     .. seealso:: :func:`chainer.functions.embed_id`
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Embedding parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Embedding parameter matrix.
 
     """
 
@@ -41,7 +42,8 @@ class EmbedID(link.Link):
         """Extracts the word embedding of given IDs.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch vectors of IDs.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch vectors of IDs.
 
         Returns:
             ~chainer.Variable: Batch of corresponding embeddings.

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -123,7 +123,7 @@ class StatefulGRU(GRUBase):
             default initialization.
 
     Attributes:
-        h(~chainer.Variable): Hidden vector that indicates the state of
+        h(chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Hidden vector that indicates the state of
             :class:`~chainer.links.StatefulGRU`.
 
     .. seealso:: :class:`~chainer.functions.GRU`

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -123,7 +123,8 @@ class StatefulGRU(GRUBase):
             default initialization.
 
     Attributes:
-        h(chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Hidden vector that indicates the state of
+        h(chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Hidden vector that indicates the state of
             :class:`~chainer.links.StatefulGRU`.
 
     .. seealso:: :class:`~chainer.functions.GRU`

--- a/chainer/links/connection/highway.py
+++ b/chainer/links/connection/highway.py
@@ -65,7 +65,8 @@ class Highway(link.Chain):
         """Computes the output of the Highway module.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
         Returns:
             Variable: Output variable. Its array has the same spatial size and
             the same minibatch size as the input array.

--- a/chainer/links/connection/highway.py
+++ b/chainer/links/connection/highway.py
@@ -65,7 +65,7 @@ class Highway(link.Chain):
         """Computes the output of the Highway module.
 
         Args:
-            x (~chainer.Variable): Input variable.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
         Returns:
             Variable: Output variable. Its array has the same spatial size and
             the same minibatch size as the input array.

--- a/chainer/links/connection/inception.py
+++ b/chainer/links/connection/inception.py
@@ -67,7 +67,7 @@ class Inception(link.Chain):
         """Computes the output of the Inception module.
 
         Args:
-            x (~chainer.Variable): Input variable.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
 
         Returns:
             Variable: Output variable. Its array has the same spatial size and

--- a/chainer/links/connection/inception.py
+++ b/chainer/links/connection/inception.py
@@ -67,7 +67,8 @@ class Inception(link.Chain):
         """Computes the output of the Inception module.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input variable.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input variable.
 
         Returns:
             Variable: Output variable. Its array has the same spatial size and

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -40,8 +40,8 @@ class Linear(link.Link):
     .. seealso:: :func:`~chainer.functions.linear`
 
     Attributes:
-        W (~chainer.Variable): Weight parameter.
-        b (~chainer.Variable): Bias parameter.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
 
     """
 
@@ -80,7 +80,7 @@ class Linear(link.Link):
         """Applies the linear layer.
 
         Args:
-            x (~chainer.Variable): Batch of input vectors.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
 
         Returns:
             ~chainer.Variable: Output of the linear layer.

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -40,8 +40,10 @@ class Linear(link.Link):
     .. seealso:: :func:`~chainer.functions.linear`
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter.
-        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Bias parameter.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter.
+        b (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Bias parameter.
 
     """
 
@@ -80,7 +82,8 @@ class Linear(link.Link):
         """Applies the linear layer.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of input vectors.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch of input vectors.
 
         Returns:
             ~chainer.Variable: Output of the linear layer.

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -60,9 +60,12 @@ class StatelessLSTM(LSTMBase):
         """Returns new cell state and updated output of LSTM.
 
         Args:
-            c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Cell states of LSTM units.
-            h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Output at the previous time step.
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new batch from the input sequence.
+            c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Cell states of LSTM units.
+            h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Output at the previous time step.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            A new batch from the input sequence.
 
         Returns:
             tuple of ~chainer.Variable: Returns ``(c_new, h_new)``, where
@@ -133,8 +136,10 @@ class LSTM(LSTMBase):
     Attributes:
         upward (~chainer.links.Linear): Linear layer of upward connections.
         lateral (~chainer.links.Linear): Linear layer of lateral connections.
-        c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Cell states of LSTM units.
-        h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Output at the previous time step.
+        c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Cell states of LSTM units.
+        h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Output at the previous time step.
 
     """
 
@@ -162,8 +167,10 @@ class LSTM(LSTMBase):
         It sets the :attr:`c` and :attr:`h` attributes.
 
         Args:
-            c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new cell states of LSTM units.
-            h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new output at the previous time step.
+            c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            A new cell states of LSTM units.
+            h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            A new output at the previous time step.
 
         """
         assert isinstance(c, chainer.Variable)
@@ -191,7 +198,8 @@ class LSTM(LSTMBase):
         """Updates the internal state and returns the LSTM outputs.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new batch from the input sequence.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            A new batch from the input sequence.
 
         Returns:
             ~chainer.Variable: Outputs of updated LSTM units.

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -60,9 +60,9 @@ class StatelessLSTM(LSTMBase):
         """Returns new cell state and updated output of LSTM.
 
         Args:
-            c (~chainer.Variable): Cell states of LSTM units.
-            h (~chainer.Variable): Output at the previous time step.
-            x (~chainer.Variable): A new batch from the input sequence.
+            c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Cell states of LSTM units.
+            h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Output at the previous time step.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new batch from the input sequence.
 
         Returns:
             tuple of ~chainer.Variable: Returns ``(c_new, h_new)``, where
@@ -133,8 +133,8 @@ class LSTM(LSTMBase):
     Attributes:
         upward (~chainer.links.Linear): Linear layer of upward connections.
         lateral (~chainer.links.Linear): Linear layer of lateral connections.
-        c (~chainer.Variable): Cell states of LSTM units.
-        h (~chainer.Variable): Output at the previous time step.
+        c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Cell states of LSTM units.
+        h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Output at the previous time step.
 
     """
 
@@ -162,8 +162,8 @@ class LSTM(LSTMBase):
         It sets the :attr:`c` and :attr:`h` attributes.
 
         Args:
-            c (~chainer.Variable): A new cell states of LSTM units.
-            h (~chainer.Variable): A new output at the previous time step.
+            c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new cell states of LSTM units.
+            h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new output at the previous time step.
 
         """
         assert isinstance(c, chainer.Variable)
@@ -191,7 +191,7 @@ class LSTM(LSTMBase):
         """Updates the internal state and returns the LSTM outputs.
 
         Args:
-            x (~chainer.Variable): A new batch from the input sequence.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new batch from the input sequence.
 
         Returns:
             ~chainer.Variable: Outputs of updated LSTM units.

--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -62,7 +62,8 @@ class MLPConvolution2D(link.ChainList):
         """Computes the output of the mlpconv layer.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input image.
 
         Returns:
             ~chainer.Variable: Output of the mlpconv layer.

--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -62,7 +62,7 @@ class MLPConvolution2D(link.ChainList):
         """Computes the output of the mlpconv layer.
 
         Args:
-            x (~chainer.Variable): Input image.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input image.
 
         Returns:
             ~chainer.Variable: Output of the mlpconv layer.

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -74,8 +74,10 @@ class NStepLSTM(link.ChainList):
         """Calculate all hidden states and cell states.
 
         Args:
-            hx (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Initial hidden states.
-            cx (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Initial cell states.
+            hx (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Initial hidden states.
+            cx (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Initial cell states.
             xs (list of ~chianer.Variable): List of input sequences.
                 Each element ``xs[i]`` is a :class:`chainer.Variable` holding
                 a sequence.

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -74,8 +74,8 @@ class NStepLSTM(link.ChainList):
         """Calculate all hidden states and cell states.
 
         Args:
-            hx (~chainer.Variable): Initial hidden states.
-            cx (~chainer.Variable): Initial cell states.
+            hx (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Initial hidden states.
+            cx (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Initial cell states.
             xs (list of ~chianer.Variable): List of input sequences.
                 Each element ``xs[i]`` is a :class:`chainer.Variable` holding
                 a sequence.

--- a/chainer/links/connection/parameter.py
+++ b/chainer/links/connection/parameter.py
@@ -15,7 +15,7 @@ class Parameter(link.Link):
         array: Initial parameter array.
 
     Attributes:
-        W (~chainer.Variable): Parameter variable.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Parameter variable.
 
     """
 

--- a/chainer/links/connection/parameter.py
+++ b/chainer/links/connection/parameter.py
@@ -15,7 +15,8 @@ class Parameter(link.Link):
         array: Initial parameter array.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Parameter variable.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Parameter variable.
 
     """
 

--- a/chainer/links/connection/peephole.py
+++ b/chainer/links/connection/peephole.py
@@ -45,8 +45,8 @@ class StatefulPeepholeLSTM(link.Chain):
                                         to the forget gate.
         peep_o (~chainer.links.Linear): Linear layer of peephole connections
                                         to the output gate.
-        c (~chainer.Variable): Cell states of LSTM units.
-        h (~chainer.Variable): Output at the current time step.
+        c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Cell states of LSTM units.
+        h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Output at the current time step.
 
     """
 
@@ -87,7 +87,7 @@ class StatefulPeepholeLSTM(link.Chain):
         """Updates the internal state and returns the LSTM outputs.
 
         Args:
-            x (~chainer.Variable): A new batch from the input sequence.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new batch from the input sequence.
 
         Returns:
             ~chainer.Variable: Outputs of updated LSTM units.

--- a/chainer/links/connection/peephole.py
+++ b/chainer/links/connection/peephole.py
@@ -45,8 +45,10 @@ class StatefulPeepholeLSTM(link.Chain):
                                         to the forget gate.
         peep_o (~chainer.links.Linear): Linear layer of peephole connections
                                         to the output gate.
-        c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Cell states of LSTM units.
-        h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Output at the current time step.
+        c (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Cell states of LSTM units.
+        h (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Output at the current time step.
 
     """
 
@@ -87,7 +89,8 @@ class StatefulPeepholeLSTM(link.Chain):
         """Updates the internal state and returns the LSTM outputs.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): A new batch from the input sequence.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            A new batch from the input sequence.
 
         Returns:
             ~chainer.Variable: Outputs of updated LSTM units.

--- a/chainer/links/connection/scale.py
+++ b/chainer/links/connection/scale.py
@@ -29,7 +29,8 @@ class Scale(link.Chain):
     .. seealso:: See :func:`~chainer.functions.scale` for details.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter if ``W_shape`` is given.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter if ``W_shape`` is given.
             Otherwise, no W attribute.
         bias (~chainer.links.Bias): Bias term if ``bias_term`` is True.
             Otherwise, no bias attribute.

--- a/chainer/links/connection/scale.py
+++ b/chainer/links/connection/scale.py
@@ -29,7 +29,7 @@ class Scale(link.Chain):
     .. seealso:: See :func:`~chainer.functions.scale` for details.
 
     Attributes:
-        W (~chainer.Variable): Weight parameter if ``W_shape`` is given.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter if ``W_shape`` is given.
             Otherwise, no W attribute.
         bias (~chainer.links.Bias): Bias term if ``bias_term`` is True.
             Otherwise, no bias attribute.

--- a/chainer/links/loss/black_out.py
+++ b/chainer/links/loss/black_out.py
@@ -19,7 +19,8 @@ class BlackOut(link.Link):
         sample_size (int): Number of negative samples.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter matrix.
 
     """
 
@@ -43,8 +44,10 @@ class BlackOut(link.Link):
         """Computes the loss value for given input and ground truth labels.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input of the weight matrix multiplication.
-            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of ground truth labels.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input of the weight matrix multiplication.
+            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch of ground truth labels.
 
         Returns:
             ~chainer.Variable: Loss value.

--- a/chainer/links/loss/black_out.py
+++ b/chainer/links/loss/black_out.py
@@ -19,7 +19,7 @@ class BlackOut(link.Link):
         sample_size (int): Number of negative samples.
 
     Attributes:
-        W (~chainer.Variable): Weight parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter matrix.
 
     """
 
@@ -43,8 +43,8 @@ class BlackOut(link.Link):
         """Computes the loss value for given input and ground truth labels.
 
         Args:
-            x (~chainer.Variable): Input of the weight matrix multiplication.
-            t (~chainer.Variable): Batch of ground truth labels.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input of the weight matrix multiplication.
+            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of ground truth labels.
 
         Returns:
             ~chainer.Variable: Loss value.

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -15,7 +15,8 @@ class CRF1d(link.Link):
     .. seealso:: :func:`~chainer.functions.crf1d` for more detail.
 
     Attributes:
-        cost (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Transition cost parameter.
+        cost (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Transition cost parameter.
     """
 
     def __init__(self, n_label):

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -15,7 +15,7 @@ class CRF1d(link.Link):
     .. seealso:: :func:`~chainer.functions.crf1d` for more detail.
 
     Attributes:
-        cost (~chainer.Variable): Transition cost parameter.
+        cost (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Transition cost parameter.
     """
 
     def __init__(self, n_label):

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -286,7 +286,7 @@ class BinaryHierarchicalSoftmax(link.Link):
         tree: A binary tree made with tuples like `((1, 2), 3)`.
 
     Attributes:
-        W (~chainer.Variable): Weight parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter matrix.
 
     See: Hierarchical Probabilistic Neural Network Language Model [Morin+,
     AISTAT2005].
@@ -349,8 +349,8 @@ class BinaryHierarchicalSoftmax(link.Link):
         """Computes the loss value for given input and ground truth labels.
 
         Args:
-            x (~chainer.Variable): Input to the classifier at each node.
-            t (~chainer.Variable): Batch of ground truth labels.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input to the classifier at each node.
+            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of ground truth labels.
 
         Returns:
             ~chainer.Variable: Loss value.

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -286,7 +286,8 @@ class BinaryHierarchicalSoftmax(link.Link):
         tree: A binary tree made with tuples like `((1, 2), 3)`.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter matrix.
 
     See: Hierarchical Probabilistic Neural Network Language Model [Morin+,
     AISTAT2005].
@@ -349,8 +350,10 @@ class BinaryHierarchicalSoftmax(link.Link):
         """Computes the loss value for given input and ground truth labels.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input to the classifier at each node.
-            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of ground truth labels.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input to the classifier at each node.
+            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch of ground truth labels.
 
         Returns:
             ~chainer.Variable: Loss value.

--- a/chainer/links/loss/negative_sampling.py
+++ b/chainer/links/loss/negative_sampling.py
@@ -23,7 +23,7 @@ class NegativeSampling(link.Link):
     .. seealso:: :func:`~chainer.functions.negative_sampling` for more detail.
 
     Attributes:
-        W (~chainer.Variable): Weight parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter matrix.
 
     """
 
@@ -51,8 +51,8 @@ class NegativeSampling(link.Link):
         """Computes the loss value for given input and ground truth labels.
 
         Args:
-            x (~chainer.Variable): Input of the weight matrix multiplication.
-            t (~chainer.Variable): Batch of ground truth labels.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input of the weight matrix multiplication.
+            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of ground truth labels.
 
         Returns:
             ~chainer.Variable: Loss value.

--- a/chainer/links/loss/negative_sampling.py
+++ b/chainer/links/loss/negative_sampling.py
@@ -23,7 +23,8 @@ class NegativeSampling(link.Link):
     .. seealso:: :func:`~chainer.functions.negative_sampling` for more detail.
 
     Attributes:
-        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Weight parameter matrix.
+        W (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Weight parameter matrix.
 
     """
 
@@ -51,8 +52,10 @@ class NegativeSampling(link.Link):
         """Computes the loss value for given input and ground truth labels.
 
         Args:
-            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Input of the weight matrix multiplication.
-            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Batch of ground truth labels.
+            x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Input of the weight matrix multiplication.
+            t (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Batch of ground truth labels.
 
         Returns:
             ~chainer.Variable: Loss value.

--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -20,9 +20,9 @@ class Classifier(link.Chain):
         predictor (~chainer.Link): Predictor network.
         lossfun (function): Loss function.
         accfun (function): Function that computes accuracy.
-        y (~chainer.Variable): Prediction for the last minibatch.
-        loss (~chainer.Variable): Loss value for the last minibatch.
-        accuracy (~chainer.Variable): Accuracy for the last minibatch.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Prediction for the last minibatch.
+        loss (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Loss value for the last minibatch.
+        accuracy (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Accuracy for the last minibatch.
         compute_accuracy (bool): If ``True``, compute accuracy on the forward
             computation. The default value is ``True``.
 

--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -20,9 +20,12 @@ class Classifier(link.Chain):
         predictor (~chainer.Link): Predictor network.
         lossfun (function): Loss function.
         accfun (function): Function that computes accuracy.
-        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Prediction for the last minibatch.
-        loss (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Loss value for the last minibatch.
-        accuracy (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Accuracy for the last minibatch.
+        y (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Prediction for the last minibatch.
+        loss (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Loss value for the last minibatch.
+        accuracy (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Accuracy for the last minibatch.
         compute_accuracy (bool): If ``True``, compute accuracy on the forward
             computation. The default value is ``True``.
 

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -49,10 +49,10 @@ class BatchNormalization(link.Link):
        :func:`~chainer.functions.fixed_batch_normalization`
 
     Attributes:
-        gamma (~chainer.Variable): Scaling parameter.
-        beta (~chainer.Variable): Shifting parameter.
-        avg_mean (~chainer.Variable): Population mean.
-        avg_var (~chainer.Variable): Population variance.
+        gamma (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Scaling parameter.
+        beta (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Shifting parameter.
+        avg_mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Population mean.
+        avg_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Population variance.
         N (int): Count of batches given for fine-tuning.
         decay (float): Decay rate of moving average. It is used on training.
         eps (float): Epsilon value for numerical stability. This value is added

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -49,10 +49,14 @@ class BatchNormalization(link.Link):
        :func:`~chainer.functions.fixed_batch_normalization`
 
     Attributes:
-        gamma (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Scaling parameter.
-        beta (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Shifting parameter.
-        avg_mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Population mean.
-        avg_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray): Population variance.
+        gamma (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Scaling parameter.
+        beta (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Shifting parameter.
+        avg_mean (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Population mean.
+        avg_var (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
+            Population variance.
         N (int): Count of batches given for fine-tuning.
         decay (float): Decay rate of moving average. It is used on training.
         eps (float): Epsilon value for numerical stability. This value is added


### PR DESCRIPTION
Fix #1653 

As I apply a simple rule to all links and functions, I need to check if the change is correct for each function and link. I also need to fix so that it obeys the 80-character rule.
