### PR TITLE
Implement Eve

### DIFF
--- a/chainer/optimizers/__init__.py
+++ b/chainer/optimizers/__init__.py
@@ -1,6 +1,7 @@
 from chainer.optimizers import ada_delta
 from chainer.optimizers import ada_grad
 from chainer.optimizers import adam
+from chainer.optimizers import eve
 from chainer.optimizers import momentum_sgd
 from chainer.optimizers import nesterov_ag
 from chainer.optimizers import rmsprop
@@ -11,6 +12,7 @@ from chainer.optimizers import smorms3
 AdaDelta = ada_delta.AdaDelta
 AdaGrad = ada_grad.AdaGrad
 Adam = adam.Adam
+Eve = eve.Eve
 MomentumSGD = momentum_sgd.MomentumSGD
 NesterovAG = nesterov_ag.NesterovAG
 RMSprop = rmsprop.RMSprop

--- a/chainer/optimizers/eve.py
+++ b/chainer/optimizers/eve.py
@@ -17,14 +17,14 @@ class Eve(optimizer.GradientMethod):
     """
 
     def __init__(self, alpha=0.001, beta1=0.9, beta2=0.999, beta3=0.999,
-                 eps=1e-8, k=0.1, K=10):
+                 eps=1e-8, lower_threshold=0.1, upper_threshold=10):
         self.alpha = alpha
         self.beta1 = beta1
         self.beta2 = beta2
         self.beta3 = beta3
         self.eps = eps
-        self.k = k
-        self.K = K
+        self.lower_threshold = lower_threshold
+        self.upper_threshold = upper_threshold
 
     def init_state(self, param, state):
         xp = cuda.get_array_module(param.data)
@@ -39,11 +39,11 @@ class Eve(optimizer.GradientMethod):
         if self.t > 1:
             old_f = float(cuda.to_cpu(state['f']))
             if self.loss < old_f:
-                delta = self.k + 1.
-                Delta = self.K + 1.
+                delta = self.lower_threshold + 1.
+                Delta = self.upper_threshold + 1.
             else:
-                delta = 1. / (self.K + 1.)
-                Delta = 1. / (self.k + 1.)
+                delta = 1. / (self.upper_threshold + 1.)
+                Delta = 1. / (self.lower_threshold + 1.)
             c = min(max(delta, self.loss / old_f), Delta)
             new_f = c * self.loss
             r = abs(new_f - old_f) / min(new_f, old_f)

--- a/chainer/optimizers/eve.py
+++ b/chainer/optimizers/eve.py
@@ -1,0 +1,88 @@
+import math
+
+import numpy
+
+from chainer import cuda
+from chainer import optimizer
+
+
+class Eve(optimizer.GradientMethod):
+
+    """Eve optimization algorithm.
+
+    See: https://arxiv.org/abs/1611.01505
+
+    You must speficify ``lossfun`` when you call its ``update`` method so that
+    it can utilize loss values in optimization.
+    """
+
+    def __init__(self, alpha=0.001, beta1=0.9, beta2=0.999, beta3=0.999,
+                 eps=1e-8, k=0.1, K=10):
+        self.alpha = alpha
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.beta3 = beta3
+        self.eps = eps
+        self.k = k
+        self.K = K
+
+    def init_state(self, param, state):
+        xp = cuda.get_array_module(param.data)
+        with cuda.get_device(param.data):
+            state['m'] = xp.zeros_like(param.data)
+            state['v'] = xp.zeros_like(param.data)
+            state['d'] = xp.ones(1, dtype=param.data.dtype)
+            state['f'] = xp.zeros(1, dtype=param.data.dtype)
+
+    def _update_d_and_f(self, state):
+        d, f = state['d'], state['f']
+        if self.t > 1:
+            old_f = float(cuda.to_cpu(state['f']))
+            if self.loss < old_f:
+                delta = self.k + 1.
+                Delta = self.K + 1.
+            else:
+                delta = 1. / (self.K + 1.)
+                Delta = 1. / (self.k + 1.)
+            c = min(max(delta, self.loss / old_f), Delta)
+            new_f = c * self.loss
+            r = abs(new_f - old_f) / min(new_f, old_f)
+            d += (1 - self.beta3) * (r - d)
+            f[:] = new_f
+        else:
+            f[:] = self.loss
+
+    def update_one_cpu(self, param, state):
+        m, v, d = state['m'], state['v'], state['d']
+        grad = param.grad
+
+        self._update_d_and_f(state)
+        m += (1. - self.beta1) * (grad - m)
+        v += (1. - self.beta2) * (grad * grad - v)
+        param.data -= self.lr * m / (d * numpy.sqrt(v) + self.eps)
+
+    def update_one_gpu(self, param, state):
+        self._update_d_and_f(state)
+        cuda.elementwise(
+            'T grad, T lr, T one_minus_beta1, T one_minus_beta2, T eps, T d',
+            'T param, T m, T v',
+            '''m += one_minus_beta1 * (grad - m);
+               v += one_minus_beta2 * (grad * grad - v);
+               param -= lr * m / (d * sqrt(v) + eps);''',
+            'eve')(param.grad, self.lr, 1 - self.beta1, 1 - self.beta2,
+                   self.eps, float(state['d']), param.data, state['m'],
+                   state['v'])
+
+    @property
+    def lr(self):
+        fix1 = 1. - self.beta1 ** self.t
+        fix2 = 1. - self.beta2 ** self.t
+        return self.alpha * math.sqrt(fix2) / fix1
+
+    def update(self, lossfun=None, *args, **kwds):
+        # Overwrites GradientMethod.update in order to get loss values
+        if lossfun is None:
+            raise RuntimeError('Eve.update requires lossfun to be specified')
+        loss_var = lossfun(*args, **kwds)
+        self.loss = float(loss_var.data)
+        super(Eve, self).update(lossfun=lambda: loss_var)

--- a/chainer/optimizers/eve.py
+++ b/chainer/optimizers/eve.py
@@ -38,14 +38,14 @@ class Eve(optimizer.GradientMethod):
         d, f = state['d'], state['f']
         if self.t > 1:
             old_f = float(cuda.to_cpu(state['f']))
-            if self.loss < old_f:
+            if self.loss > old_f:
                 delta = self.lower_threshold + 1.
                 Delta = self.upper_threshold + 1.
             else:
                 delta = 1. / (self.upper_threshold + 1.)
                 Delta = 1. / (self.lower_threshold + 1.)
             c = min(max(delta, self.loss / old_f), Delta)
-            new_f = c * self.loss
+            new_f = c * old_f
             r = abs(new_f - old_f) / min(new_f, old_f)
             d += (1 - self.beta3) * (r - d)
             f[:] = new_f

--- a/docs/source/reference/optimizers.rst
+++ b/docs/source/reference/optimizers.rst
@@ -6,6 +6,7 @@ Optimizers
 .. autoclass:: AdaDelta
 .. autoclass:: AdaGrad
 .. autoclass:: Adam
+.. autoclass:: Eve
 .. autoclass:: MomentumSGD
 .. autoclass:: NesterovAG
 .. autoclass:: RMSprop

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -153,6 +153,15 @@ class TestAdam(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64]
 }))
+class TestEve(OptimizerTestBase, unittest.TestCase):
+
+    def create(self):
+        return optimizers.Eve(0.1)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+}))
 class TestMomentumSGD(OptimizerTestBase, unittest.TestCase):
 
     def create(self):
@@ -202,15 +211,6 @@ class TestSMORMS3(OptimizerTestBase, unittest.TestCase):
 
     def create(self):
         return optimizers.SMORMS3(0.1)
-
-
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
-}))
-class TestEve(OptimizerTestBase, unittest.TestCase):
-
-    def create(self):
-        return optimizers.Eve(0.1)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -57,9 +57,7 @@ class LinearModel(object):
                                  self.dtype)
             model.cleargrads()
             y = model(x)
-            loss = F.softmax_cross_entropy(y, t)
-            loss.backward()
-            optimizer.update()
+            optimizer.update(F.softmax_cross_entropy, y, t)
 
         x_test, t_test = _make_dataset(self.BATCH_SIZE, self.UNIT_NUM, gpu,
                                        self.dtype)
@@ -204,6 +202,15 @@ class TestSMORMS3(OptimizerTestBase, unittest.TestCase):
 
     def create(self):
         return optimizers.SMORMS3(0.1)
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+}))
+class TestEve(OptimizerTestBase, unittest.TestCase):
+
+    def create(self):
+        return optimizers.Eve(0.1)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR will add a new optimizer Eve #1846 .

Since Eve requires loss values to compute step sizes, `GradientMethod.update` is overwritten to get the outputs of `lossfun`. It will raise an error if `lossfun` is not specified. Tests for optimizers are also modified to use `lossfun`.

I found it is better than Adam when applied to `examples/mnist/train_mnist.py` with default parameters:
Eve
```
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy
1           0.193573    0.0952835             0.9419         0.9696
2           0.0725242   0.0800335             0.977466       0.9765
3           0.0345596   0.06424               0.988915       0.981
4           0.013741    0.0567913             0.995832       0.9843
5           0.00571857  0.0562762             0.998649       0.985
6           0.00299029  0.053972              0.999333       0.9859
7           0.00175658  0.0581067             0.99965        0.9857
8           0.00100978  0.0592461             0.999917       0.9856
9           0.000664501  0.0626751             0.999933       0.9861
10          0.000589156  0.0727927             0.999933       0.9853
11          0.0013305   0.0659082             0.999733       0.9859
12          0.00049436  0.0670607             0.999883       0.9865
13          0.000336688  0.0687204             0.99995        0.9858
14          0.00010929  0.0690714             1              0.986
15          6.87041e-05  0.0699605             1              0.9865
16          5.16802e-05  0.0734176             1              0.986
17          3.75787e-05  0.0766912             1              0.9856
18          0.0028124   0.0766279             0.999183       0.985
19          0.000150661  0.0755002             1              0.9855
20          7.40332e-05  0.076406              1              0.9857
```
Adam
```
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy
1           0.192746    0.118016              0.9411         0.9631
2           0.0727157   0.093093              0.977249       0.97
3           0.0501551   0.0860783             0.983615       0.9738
4           0.0367548   0.0736718             0.988399       0.9783
5           0.0272907   0.0791892             0.990932       0.9786
6           0.0258209   0.0827545             0.991516       0.9796
7           0.0203185   0.0644044             0.993332       0.9828
8           0.0177427   0.0757816             0.994432       0.9822
9           0.0161435   0.0873263             0.994815       0.9803
10          0.0139228   0.0853089             0.995249       0.9811
11          0.01513     0.081602              0.995066       0.983
12          0.0108932   0.0992509             0.996665       0.9789
13          0.0152876   0.0997881             0.995049       0.9811
14          0.0105591   0.0815175             0.996832       0.9841
15          0.00797358  0.0912213             0.997833       0.983
16          0.0113328   0.102879              0.996566       0.9801
17          0.0126291   0.087415              0.996166       0.9836
18          0.00641422  0.0877847             0.998116       0.9839
19          0.00915058  0.117586              0.997432       0.9811
20          0.00941298  0.126669              0.997215       0.9775
```