### PR TITLE
AWS installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ $ nvidia-docker run -it chainer/chainer /bin/bash
 ```
 
 
+## Run from AWS Marketplace
+
+Bitfusion provides an EC2 AMI pre-installed with CUDA, cuDNN, Chainer, Jupyter, and more. [Launch](https://aws.amazon.com/marketplace/pp/B01KKDQD84/ref=_ptnr_referral_docs_chainer) an instance from the AWS Marketplace.
+
+
 ## Reference
 
 Tokui, S., Oono, K., Hido, S. and Clayton, J.,


### PR DESCRIPTION
Section added on running an AMI from AWS Marketplace. Similar links are on TensorFlow and Torch docs and the respective communities have been very positive about it.