### PR TITLE
Run from AWS Marketplace install section

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -233,6 +233,12 @@ Or, run the interpreter directly::
   $ nvidia-docker run -it chainer/chainer /usr/bin/python
 
 
+Run Chainer from AWS Marketplace
+--------------------------------
+
+Bitfusion provides an EC2 AMI pre-installed with Nvidia drivers, CUDA, cuDNN, Chainer, Jupyter, and more.  `Launch <https://aws.amazon.com/marketplace/pp/B01KKDQD84/ref=_ptnr_referral_docs_chainer>`_ an instance from the AWS Marketplace.
+
+
 What "recommend" means?
 -----------------------
 


### PR DESCRIPTION
Section added on running an AMI from AWS Marketplace. Similar sections w/ links are on TensorFlow and Torch docs and the respective communities have been very positive about it.