### PR TITLE
skip gpu tests if not cuda.available

### DIFF
--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -1,6 +1,18 @@
 from nose.plugins import attrib
+from unittest import skip
+from chainer import cuda
 
-gpu = attrib.attr('gpu')
+
+if cuda.available:
+    gpu = attrib.attr('gpu')
+else:
+    _gpu = attrib.attr('gpu')
+
+    def _skip_attr(op):
+        # join decorator skip and attrib.attr
+        return skip('gpu not aviable')(_gpu(op))
+    gpu = _skip_attr
+    
 cudnn = attrib.attr('gpu', 'cudnn')
 slow = attrib.attr('slow')
 


### PR DESCRIPTION
This PR is only a suggestion.

When I launch testcases from pycharm on a computer without cuda the gpu testcases raise exceptions, that cupy is not correctly installed. 

In my mind it is better to skip these testcases. Since there is already such a flag, the decorator can be overloaded.