### PR TITLE
Fix deadlock issue on multi-threaded application part2

### DIFF
--- a/cupy/cuda/cublas.pyx
+++ b/cupy/cuda/cublas.pyx
@@ -130,32 +130,37 @@ cpdef inline check_status(int status):
 
 cpdef size_t create() except *:
     cdef Handle handle
-    status = cublasCreate(&handle)
+    with nogil:
+        status = cublasCreate(&handle)
     check_status(status)
     return <size_t>handle
 
 
 cpdef void destroy(size_t handle) except *:
-    status = cublasDestroy(<Handle>handle)
+    with nogil:
+        status = cublasDestroy(<Handle>handle)
     check_status(status)
 
 
 cpdef int getVersion(size_t handle) except *:
     cdef int version
-    status = cublasGetVersion(<Handle>handle, &version)
+    with nogil:
+        status = cublasGetVersion(<Handle>handle, &version)
     check_status(status)
     return version
 
 
 cpdef int getPointerMode(size_t handle) except *:
     cdef PointerMode mode
-    status = cublasGetPointerMode(<Handle>handle, &mode)
+    with nogil:
+        status = cublasGetPointerMode(<Handle>handle, &mode)
     check_status(status)
     return mode
 
 
 cpdef setPointerMode(size_t handle, int mode):
-    status = cublasSetPointerMode(<Handle>handle, <PointerMode>mode)
+    with nogil:
+        status = cublasSetPointerMode(<Handle>handle, <PointerMode>mode)
     check_status(status)
 
 
@@ -164,13 +169,15 @@ cpdef setPointerMode(size_t handle, int mode):
 ###############################################################################
 
 cpdef setStream(size_t handle, size_t stream):
-    status = cublasSetStream(<Handle>handle, <driver.Stream>stream)
+    with nogil:
+        status = cublasSetStream(<Handle>handle, <driver.Stream>stream)
     check_status(status)
 
 
 cpdef size_t getStream(size_t handle) except *:
     cdef driver.Stream stream
-    status = cublasGetStream(<Handle>handle, &stream)
+    with nogil:
+        status = cublasGetStream(<Handle>handle, &stream)
     check_status(status)
     return <size_t>stream
 

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -313,7 +313,8 @@ class CuDNNError(RuntimeError):
 
     def __init__(self, int status):
         self.status = status
-        msg = cudnnGetErrorString(<Status>status)
+        with nogil:
+            msg = cudnnGetErrorString(<Status>status)
         super(CuDNNError, self).__init__('%s: %s' % (STATUS[status], msg))
 
 
@@ -328,7 +329,10 @@ cpdef inline check_status(int status):
 ###############################################################################
 
 cpdef size_t getVersion() except *:
-    return cudnnGetVersion()
+    cdef size_t version
+    with nogil:
+        version = cudnnGetVersion()
+    return version
 
 
 ###############################################################################
@@ -350,13 +354,15 @@ cpdef destroy(size_t handle):
 
 
 cpdef setStream(size_t handle, size_t stream):
-    status = cudnnSetStream(<Handle>handle, <driver.Stream>stream)
+    with nogil:
+        status = cudnnSetStream(<Handle>handle, <driver.Stream>stream)
     check_status(status)
 
 
 cpdef size_t getStream(size_t handle) except *:
     cdef driver.Stream stream
-    status = cudnnGetStream(<Handle>handle, &stream)
+    with nogil:
+        status = cudnnGetStream(<Handle>handle, &stream)
     check_status(status)
     return <size_t>stream
 
@@ -367,38 +373,43 @@ cpdef size_t getStream(size_t handle) except *:
 
 cpdef size_t createTensorDescriptor() except *:
     cdef TensorDescriptor descriptor
-    status = cudnnCreateTensorDescriptor(&descriptor)
+    with nogil:
+        status = cudnnCreateTensorDescriptor(&descriptor)
     check_status(status)
     return <size_t>descriptor
 
 
 cpdef setTensor4dDescriptor(size_t tensorDesc, int format, int dataType,
                             int n, int c, int h, int w):
-    status = cudnnSetTensor4dDescriptor(
-        <TensorDescriptor>tensorDesc, <TensorFormat>format,
-        <DataType>dataType, n, c, h, w)
+    with nogil:
+        status = cudnnSetTensor4dDescriptor(
+            <TensorDescriptor>tensorDesc, <TensorFormat>format,
+            <DataType>dataType, n, c, h, w)
     check_status(status)
 
 
 cpdef setTensor4dDescriptorEx(size_t tensorDesc, int dataType,
                               int n, int c, int h, int w, int nStride,
                               int cStride, int hStride, int wStride):
-    status = cudnnSetTensor4dDescriptorEx(
-        <TensorDescriptor>tensorDesc, <DataType>dataType, n, c, h, w,
-        nStride, cStride, hStride, wStride)
+    with nogil:
+        status = cudnnSetTensor4dDescriptorEx(
+            <TensorDescriptor>tensorDesc, <DataType>dataType, n, c, h, w,
+            nStride, cStride, hStride, wStride)
     check_status(status)
 
 
 cpdef setTensorNdDescriptor(size_t tensorDesc, int dataType, int nbDims,
                             size_t dimA, size_t strideA):
-    status = cudnnSetTensorNdDescriptor(
-        <TensorDescriptor>tensorDesc, <DataType>dataType, nbDims,
-        <int*>dimA, <int*>strideA)
+    with nogil:
+        status = cudnnSetTensorNdDescriptor(
+            <TensorDescriptor>tensorDesc, <DataType>dataType, nbDims,
+            <int*>dimA, <int*>strideA)
     check_status(status)
 
 
 cpdef destroyTensorDescriptor(size_t tensorDesc):
-    status = cudnnDestroyTensorDescriptor(<TensorDescriptor>tensorDesc)
+    with nogil:
+        status = cudnnDestroyTensorDescriptor(<TensorDescriptor>tensorDesc)
     check_status(status)
 
 
@@ -428,23 +439,26 @@ cpdef addTensor_v3(size_t handle, size_t alpha, size_t bDesc,
 
 cpdef size_t createFilterDescriptor() except *:
     cdef FilterDescriptor desc
-    status = cudnnCreateFilterDescriptor(&desc)
+    with nogil:
+        status = cudnnCreateFilterDescriptor(&desc)
     check_status(status)
     return <size_t>desc
 
 
 cpdef setFilter4dDescriptor_v3(
         size_t filterDesc, int dataType, int k, int c, int h, int w):
-    status = cudnnSetFilter4dDescriptor_v3(
-        <FilterDescriptor>filterDesc, <DataType>dataType, k, c, h, w)
+    with nogil:
+        status = cudnnSetFilter4dDescriptor_v3(
+            <FilterDescriptor>filterDesc, <DataType>dataType, k, c, h, w)
     check_status(status)
 
 
 cpdef setFilterNdDescriptor_v3(
         size_t filterDesc, int dataType, int nbDims, size_t filterDimA):
-    status = cudnnSetFilterNdDescriptor_v3(
-        <FilterDescriptor>filterDesc, <DataType>dataType, nbDims,
-        <int*>filterDimA)
+    with nogil:
+        status = cudnnSetFilterNdDescriptor_v3(
+            <FilterDescriptor>filterDesc, <DataType>dataType, nbDims,
+            <int*>filterDimA)
     check_status(status)
 
 
@@ -455,15 +469,17 @@ cpdef getFilterNdDescriptor(size_t wDesc, int nbDimsRequested):
     cdef vector.vector[int] filterDimA
     filterDimA.resize(nbDimsRequested)
 
-    status = cudnnGetFilterNdDescriptor_v5(
-        <FilterDescriptor>wDesc, nbDimsRequested, &dataType,
-        &format, &nbDims, &filterDimA[0])
+    with nogil:
+        status = cudnnGetFilterNdDescriptor_v5(
+            <FilterDescriptor>wDesc, nbDimsRequested, &dataType,
+            &format, &nbDims, &filterDimA[0])
     check_status(status)
     return (dataType, format, nbDims, tuple(filterDimA))
 
 
 cpdef destroyFilterDescriptor(size_t filterDesc):
-    status = cudnnDestroyFilterDescriptor(<FilterDescriptor>filterDesc)
+    with nogil:
+        status = cudnnDestroyFilterDescriptor(<FilterDescriptor>filterDesc)
     check_status(status)
 
 
@@ -473,7 +489,8 @@ cpdef destroyFilterDescriptor(size_t filterDesc):
 
 cpdef size_t createConvolutionDescriptor() except *:
     cdef ConvolutionDescriptor desc
-    status = cudnnCreateConvolutionDescriptor(&desc)
+    with nogil:
+        status = cudnnCreateConvolutionDescriptor(&desc)
     check_status(status)
     return <size_t>desc
 
@@ -481,34 +498,38 @@ cpdef size_t createConvolutionDescriptor() except *:
 cpdef setConvolution2dDescriptor(
         size_t convDesc, int pad_h, int pad_w, int u, int v, int upscalex,
         int upscaley, int mode):
-    status = cudnnSetConvolution2dDescriptor(
-        <ConvolutionDescriptor>convDesc, pad_h, pad_w, u, v, upscalex,
-        upscaley, <ConvolutionMode>mode)
+    with nogil:
+        status = cudnnSetConvolution2dDescriptor(
+            <ConvolutionDescriptor>convDesc, pad_h, pad_w, u, v, upscalex,
+            upscaley, <ConvolutionMode>mode)
     check_status(status)
 
 
 cpdef setConvolutionNdDescriptor_v2(
         size_t convDesc, int arrayLength, size_t padA, size_t filterStrideA,
         size_t upscaleA, int mode):
-    status = cudnnSetConvolutionNdDescriptor_v2(
-        <ConvolutionDescriptor>convDesc, arrayLength, <int*>padA,
-        <int*>filterStrideA, <int*>upscaleA, <ConvolutionMode>mode)
+    with nogil:
+        status = cudnnSetConvolutionNdDescriptor_v2(
+            <ConvolutionDescriptor>convDesc, arrayLength, <int*>padA,
+            <int*>filterStrideA, <int*>upscaleA, <ConvolutionMode>mode)
     check_status(status)
 
 
 cpdef setConvolutionNdDescriptor_v3(
         size_t convDesc, int arrayLength, size_t padA, size_t filterStrideA,
         size_t upscaleA, int mode, int dataType):
-    status = cudnnSetConvolutionNdDescriptor_v3(
-        <ConvolutionDescriptor>convDesc, arrayLength, <int*>padA,
-        <int*>filterStrideA, <int*>upscaleA, <ConvolutionMode>mode,
-        <DataType>dataType)
+    with nogil:
+        status = cudnnSetConvolutionNdDescriptor_v3(
+            <ConvolutionDescriptor>convDesc, arrayLength, <int*>padA,
+            <int*>filterStrideA, <int*>upscaleA, <ConvolutionMode>mode,
+            <DataType>dataType)
     check_status(status)
 
 
 cpdef destroyConvolutionDescriptor(size_t convDesc):
-    status = cudnnDestroyConvolutionDescriptor(
-        <ConvolutionDescriptor>convDesc)
+    with nogil:
+        status = cudnnDestroyConvolutionDescriptor(
+            <ConvolutionDescriptor>convDesc)
     check_status(status)
 
 
@@ -517,11 +538,12 @@ cpdef int getConvolutionForwardAlgorithm(
         size_t destDesc, ConvolutionFwdPreference preference,
         size_t memoryLimitInbytes) except *:
     cdef ConvolutionFwdAlgo algo
-    status = cudnnGetConvolutionForwardAlgorithm(
-        <Handle>handle, <TensorDescriptor>srcDesc,
-        <FilterDescriptor>filterDesc, <ConvolutionDescriptor>convDesc,
-        <TensorDescriptor>destDesc, <ConvolutionFwdPreference>preference,
-        memoryLimitInbytes, &algo)
+    with nogil:
+        status = cudnnGetConvolutionForwardAlgorithm(
+            <Handle>handle, <TensorDescriptor>srcDesc,
+            <FilterDescriptor>filterDesc, <ConvolutionDescriptor>convDesc,
+            <TensorDescriptor>destDesc, <ConvolutionFwdPreference>preference,
+            memoryLimitInbytes, &algo)
     check_status(status)
     return algo
 
@@ -530,10 +552,11 @@ cpdef size_t getConvolutionForwardWorkspaceSize(
         size_t handle, size_t srcDesc, size_t filterDesc, size_t convDesc,
         size_t destDesc, int algo) except *:
     cdef size_t sizeInBytes
-    status = cudnnGetConvolutionForwardWorkspaceSize(
-        <Handle>handle, <TensorDescriptor>srcDesc,
-        <FilterDescriptor>filterDesc, <ConvolutionDescriptor> convDesc,
-        <TensorDescriptor>destDesc, <ConvolutionFwdAlgo>algo, &sizeInBytes)
+    with nogil:
+        status = cudnnGetConvolutionForwardWorkspaceSize(
+            <Handle>handle, <TensorDescriptor>srcDesc,
+            <FilterDescriptor>filterDesc, <ConvolutionDescriptor> convDesc,
+            <TensorDescriptor>destDesc, <ConvolutionFwdAlgo>algo, &sizeInBytes)
     check_status(status)
     return sizeInBytes
 
@@ -569,12 +592,13 @@ cpdef int getConvolutionBackwardFilterAlgorithm(
         size_t filterDesc, ConvolutionBwdFilterPreference preference,
         size_t memoryLimitInbytes) except *:
     cdef ConvolutionBwdFilterAlgo algo
-    status = cudnnGetConvolutionBackwardFilterAlgorithm(
-        <Handle>handle, <TensorDescriptor>srcDesc,
-        <TensorDescriptor>diffDesc, <ConvolutionDescriptor>convDesc,
-        <FilterDescriptor>filterDesc,
-        <ConvolutionBwdFilterPreference>preference,
-        memoryLimitInbytes, &algo)
+    with nogil:
+        status = cudnnGetConvolutionBackwardFilterAlgorithm(
+            <Handle>handle, <TensorDescriptor>srcDesc,
+            <TensorDescriptor>diffDesc, <ConvolutionDescriptor>convDesc,
+            <FilterDescriptor>filterDesc,
+            <ConvolutionBwdFilterPreference>preference,
+            memoryLimitInbytes, &algo)
     check_status(status)
     return algo
 
@@ -582,11 +606,12 @@ cpdef size_t getConvolutionBackwardFilterWorkspaceSize(
         size_t handle, size_t srcDesc, size_t diffDesc, size_t convDesc,
         size_t filterDesc, int algo) except *:
     cdef size_t sizeInBytes
-    status = cudnnGetConvolutionBackwardFilterWorkspaceSize(
-        <Handle>handle, <TensorDescriptor>srcDesc,
-        <TensorDescriptor>diffDesc, <ConvolutionDescriptor> convDesc,
-        <FilterDescriptor>filterDesc, <ConvolutionBwdFilterAlgo>algo,
-        &sizeInBytes)
+    with nogil:
+        status = cudnnGetConvolutionBackwardFilterWorkspaceSize(
+            <Handle>handle, <TensorDescriptor>srcDesc,
+            <TensorDescriptor>diffDesc, <ConvolutionDescriptor> convDesc,
+            <FilterDescriptor>filterDesc, <ConvolutionBwdFilterAlgo>algo,
+            &sizeInBytes)
     check_status(status)
     return sizeInBytes
 
@@ -623,11 +648,13 @@ cpdef int getConvolutionBackwardDataAlgorithm(
         size_t gradDesc, size_t preference,
         size_t memoryLimitInbytes) except *:
     cdef ConvolutionBwdDataAlgo algo
-    status = cudnnGetConvolutionBackwardDataAlgorithm(
-        <Handle>handle, <FilterDescriptor>filterDesc,
-        <TensorDescriptor>diffDesc, <ConvolutionDescriptor>convDesc,
-        <TensorDescriptor>gradDesc, <ConvolutionBwdDataPreference>preference,
-        memoryLimitInbytes, &algo)
+    with nogil:
+        status = cudnnGetConvolutionBackwardDataAlgorithm(
+            <Handle>handle, <FilterDescriptor>filterDesc,
+            <TensorDescriptor>diffDesc, <ConvolutionDescriptor>convDesc,
+            <TensorDescriptor>gradDesc,
+            <ConvolutionBwdDataPreference>preference,
+            memoryLimitInbytes, &algo)
     check_status(status)
     return algo
 
@@ -635,11 +662,12 @@ cpdef size_t getConvolutionBackwardDataWorkspaceSize(
         size_t handle, size_t filterDesc, size_t diffDesc, size_t convDesc,
         size_t gradDesc, int algo) except *:
     cdef size_t sizeInBytes
-    status = cudnnGetConvolutionBackwardDataWorkspaceSize(
-        <Handle>handle, <FilterDescriptor>filterDesc,
-        <TensorDescriptor>diffDesc,
-        <ConvolutionDescriptor>convDesc, <TensorDescriptor>gradDesc,
-        <ConvolutionBwdDataAlgo>algo, &sizeInBytes)
+    with nogil:
+        status = cudnnGetConvolutionBackwardDataWorkspaceSize(
+            <Handle>handle, <FilterDescriptor>filterDesc,
+            <TensorDescriptor>diffDesc,
+            <ConvolutionDescriptor>convDesc, <TensorDescriptor>gradDesc,
+            <ConvolutionBwdDataAlgo>algo, &sizeInBytes)
     check_status(status)
     return sizeInBytes
 
@@ -677,7 +705,8 @@ cpdef convolutionBackwardData_v3(
 
 cpdef size_t createPoolingDescriptor() except *:
     cdef PoolingDescriptor desc
-    status = cudnnCreatePoolingDescriptor(&desc)
+    with nogil:
+        status = cudnnCreatePoolingDescriptor(&desc)
     check_status(status)
     return <size_t>desc
 
@@ -686,24 +715,27 @@ cpdef setPooling2dDescriptor_v3(
         size_t poolingDesc, int mode, int windowHeight, int windowWidth,
         int verticalPadding, int horizontalPadding, int verticalStride,
         int horizontalStride):
-    status = cudnnSetPooling2dDescriptor_v3(
-        <PoolingDescriptor>poolingDesc, <PoolingMode>mode,
-        windowHeight, windowWidth, verticalPadding, horizontalPadding,
-        verticalStride, horizontalStride)
+    with nogil:
+        status = cudnnSetPooling2dDescriptor_v3(
+            <PoolingDescriptor>poolingDesc, <PoolingMode>mode,
+            windowHeight, windowWidth, verticalPadding, horizontalPadding,
+            verticalStride, horizontalStride)
     check_status(status)
 
 
 cpdef setPoolingNdDescriptor_v3(
         size_t poolingDesc, int mode, int nbDims, size_t windowDimA,
         size_t paddingA, size_t strideA):
-    status = cudnnSetPoolingNdDescriptor_v3(
-        <PoolingDescriptor>poolingDesc, <PoolingMode>mode, nbDims,
-        <int*>windowDimA, <int*>paddingA, <int*>strideA)
+    with nogil:
+        status = cudnnSetPoolingNdDescriptor_v3(
+            <PoolingDescriptor>poolingDesc, <PoolingMode>mode, nbDims,
+            <int*>windowDimA, <int*>paddingA, <int*>strideA)
     check_status(status)
 
 
 cpdef destroyPoolingDescriptor(size_t poolingDesc):
-    status = cudnnDestroyPoolingDescriptor(<PoolingDescriptor>poolingDesc)
+    with nogil:
+        status = cudnnDestroyPoolingDescriptor(<PoolingDescriptor>poolingDesc)
     check_status(status)
 
 
@@ -738,9 +770,10 @@ cpdef poolingBackward(
 
 cpdef deriveBNTensorDescriptor(
         size_t derivedBnDesc, size_t xDesc, int mode):
-    status = cudnnDeriveBNTensorDescriptor(
-        <TensorDescriptor>derivedBnDesc, <TensorDescriptor>xDesc,
-        <BatchNormMode> mode)
+    with nogil:
+        status = cudnnDeriveBNTensorDescriptor(
+            <TensorDescriptor>derivedBnDesc, <TensorDescriptor>xDesc,
+            <BatchNormMode> mode)
     check_status(status)
 
 cpdef batchNormalizationForwardTraining(
@@ -859,20 +892,23 @@ cpdef activationBackward_v3(
 
 cpdef size_t createDropoutDescriptor() except *:
     cdef DropoutDescriptor desc
-    status = cudnnCreateDropoutDescriptor(&desc)
+    with nogil:
+        status = cudnnCreateDropoutDescriptor(&desc)
     check_status(status)
     return <size_t>desc
 
 
 cpdef destroyDropoutDescriptor(size_t dropoutDesc):
-    status = cudnnDestroyDropoutDescriptor(<DropoutDescriptor>dropoutDesc)
+    with nogil:
+        status = cudnnDestroyDropoutDescriptor(<DropoutDescriptor>dropoutDesc)
     check_status(status)
 
 
 cpdef size_t dropoutGetStatesSize(size_t handle) except *:
     cdef size_t sizeInBytes
-    status = cudnnDropoutGetStatesSize(
-        <Handle>handle, &sizeInBytes)
+    with nogil:
+        status = cudnnDropoutGetStatesSize(
+            <Handle>handle, &sizeInBytes)
     check_status(status)
     return sizeInBytes
 
@@ -880,9 +916,10 @@ cpdef size_t dropoutGetStatesSize(size_t handle) except *:
 cpdef setDropoutDescriptor(
         size_t dropoutDesc, size_t handle, float dropout,
         size_t states, size_t stateSizeInBytes, unsigned long long seed):
-    status = cudnnSetDropoutDescriptor(
-        <DropoutDescriptor>dropoutDesc, <Handle>handle, dropout,
-        <void*>states, stateSizeInBytes, seed)
+    with nogil:
+        status = cudnnSetDropoutDescriptor(
+            <DropoutDescriptor>dropoutDesc, <Handle>handle, dropout,
+            <void*>states, stateSizeInBytes, seed)
     check_status(status)
 
 
@@ -890,13 +927,15 @@ cpdef setDropoutDescriptor(
 
 cpdef size_t createRNNDescriptor() except *:
     cdef RNNDescriptor desc
-    status = cudnnCreateRNNDescriptor(&desc)
+    with nogil:
+        status = cudnnCreateRNNDescriptor(&desc)
     check_status(status)
     return <size_t>desc
 
 
 cpdef destroyRNNDescriptor(size_t rnnDesc):
-    status = cudnnDestroyRNNDescriptor(<RNNDescriptor>rnnDesc)
+    with nogil:
+        status = cudnnDestroyRNNDescriptor(<RNNDescriptor>rnnDesc)
     check_status(status)
 
 
@@ -904,19 +943,21 @@ cpdef setRNNDescriptor(
         size_t rnnDesc, int hiddenSize, int numLayers,
         size_t dropoutDesc, int inputMode, int direction, int mode,
         int dataType):
-    status = cudnnSetRNNDescriptor(
-        <RNNDescriptor>rnnDesc, hiddenSize, numLayers,
-        <DropoutDescriptor>dropoutDesc, <RNNInputMode>inputMode,
-        <DirectionMode>direction, <RNNMode>mode, <DataType>dataType)
+    with nogil:
+        status = cudnnSetRNNDescriptor(
+            <RNNDescriptor>rnnDesc, hiddenSize, numLayers,
+            <DropoutDescriptor>dropoutDesc, <RNNInputMode>inputMode,
+            <DirectionMode>direction, <RNNMode>mode, <DataType>dataType)
     check_status(status)
 
 
 cpdef getRNNWorkspaceSize(
         size_t handle, size_t rnnDesc, int seqLength, size_t xDesc):
     cdef size_t sizeInBytes
-    status = cudnnGetRNNWorkspaceSize(
-        <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
-        <TensorDescriptor*>xDesc, &sizeInBytes)
+    with nogil:
+        status = cudnnGetRNNWorkspaceSize(
+            <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
+            <TensorDescriptor*>xDesc, &sizeInBytes)
     check_status(status)
     return sizeInBytes
 
@@ -924,9 +965,10 @@ cpdef getRNNWorkspaceSize(
 cpdef getRNNTrainingReserveSize(
         size_t handle, size_t rnnDesc, int seqLength, size_t xDesc):
     cdef size_t sizeInBytes
-    status = cudnnGetRNNTrainingReserveSize(
-        <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
-        <TensorDescriptor*>xDesc, &sizeInBytes)
+    with nogil:
+        status = cudnnGetRNNTrainingReserveSize(
+            <Handle>handle, <RNNDescriptor>rnnDesc, seqLength,
+            <TensorDescriptor*>xDesc, &sizeInBytes)
     check_status(status)
     return sizeInBytes
 
@@ -934,9 +976,10 @@ cpdef getRNNTrainingReserveSize(
 cpdef getRNNParamsSize(
         size_t handle, size_t rnnDesc, size_t xDesc, int dataType):
     cdef size_t sizeInBytes
-    status = cudnnGetRNNParamsSize(
-        <Handle>handle, <RNNDescriptor>rnnDesc, <TensorDescriptor>xDesc,
-        &sizeInBytes, <DataType>dataType)
+    with nogil:
+        status = cudnnGetRNNParamsSize(
+            <Handle>handle, <RNNDescriptor>rnnDesc, <TensorDescriptor>xDesc,
+            &sizeInBytes, <DataType>dataType)
     check_status(status)
     return sizeInBytes
 
@@ -944,10 +987,11 @@ cpdef getRNNParamsSize(
 cpdef getRNNLinLayerMatrixParams(
         size_t handle, size_t rnnDesc, int layer, size_t xDesc, size_t wDesc,
         size_t w, int linLayerID, size_t linLayerMatDesc, size_t linLayerMat):
-    status = cudnnGetRNNLinLayerMatrixParams(
-        <Handle>handle, <RNNDescriptor>rnnDesc, layer,
-        <TensorDescriptor>xDesc, <FilterDescriptor>wDesc, <void*>w,
-        linLayerID, <FilterDescriptor>linLayerMatDesc, <void**>linLayerMat)
+    with nogil:
+        status = cudnnGetRNNLinLayerMatrixParams(
+            <Handle>handle, <RNNDescriptor>rnnDesc, layer,
+            <TensorDescriptor>xDesc, <FilterDescriptor>wDesc, <void*>w,
+            linLayerID, <FilterDescriptor>linLayerMatDesc, <void**>linLayerMat)
     check_status(status)
 
 
@@ -955,10 +999,12 @@ cpdef getRNNLinLayerBiasParams(
         size_t handle, size_t rnnDesc, int layer, size_t xDesc, size_t wDesc,
         size_t w, int linLayerID, size_t linLayerBiasDesc,
         size_t linLayerBias):
-    status = cudnnGetRNNLinLayerBiasParams(
-        <Handle>handle, <RNNDescriptor>rnnDesc, layer,
-        <TensorDescriptor>xDesc, <FilterDescriptor>wDesc, <void*>w,
-        linLayerID, <FilterDescriptor>linLayerBiasDesc, <void**>linLayerBias)
+    with nogil:
+        status = cudnnGetRNNLinLayerBiasParams(
+            <Handle>handle, <RNNDescriptor>rnnDesc, layer,
+            <TensorDescriptor>xDesc, <FilterDescriptor>wDesc, <void*>w,
+            linLayerID, <FilterDescriptor>linLayerBiasDesc,
+            <void**>linLayerBias)
     check_status(status)
 
 

--- a/cupy/cuda/curand.pyx
+++ b/cupy/cuda/curand.pyx
@@ -98,34 +98,41 @@ cpdef size_t createGenerator(int rng_type) except *:
 
 
 cpdef destroyGenerator(size_t generator):
-    status = curandDestroyGenerator(<Generator>generator)
+    with nogil:
+        status = curandDestroyGenerator(<Generator>generator)
     check_status(status)
 
 
 cpdef int getVersion() except *:
     cdef int version
-    status = curandGetVersion(&version)
+    with nogil:
+        status = curandGetVersion(&version)
     check_status(status)
     return version
 
 
 cpdef setStream(size_t generator, size_t stream):
-    status = curandSetStream(<Generator>generator, <driver.Stream>stream)
+    with nogil:
+        status = curandSetStream(<Generator>generator, <driver.Stream>stream)
     check_status(status)
 
 
 cpdef setPseudoRandomGeneratorSeed(size_t generator, unsigned long long seed):
-    status = curandSetPseudoRandomGeneratorSeed(<Generator>generator, seed)
+    with nogil:
+        status = curandSetPseudoRandomGeneratorSeed(<Generator>generator, seed)
     check_status(status)
 
 
 cpdef setGeneratorOffset(size_t generator, unsigned long long offset):
-    status = curandSetGeneratorOffset(<Generator>generator, offset)
+    with nogil:
+        status = curandSetGeneratorOffset(<Generator>generator, offset)
     check_status(status)
 
 
 cpdef setGeneratorOrdering(size_t generator, int order):
-    status = curandSetGeneratorOrdering(<Generator>generator, <Ordering>order)
+    with nogil:
+        status = curandSetGeneratorOrdering(
+            <Generator>generator, <Ordering>order)
     check_status(status)
 
 
@@ -134,26 +141,30 @@ cpdef setGeneratorOrdering(size_t generator, int order):
 ###############################################################################
 
 cpdef generate(size_t generator, size_t outputPtr, size_t num):
-    status = curandGenerate(
-        <Generator>generator, <unsigned int*>outputPtr, num)
+    with nogil:
+        status = curandGenerate(
+            <Generator>generator, <unsigned int*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateLongLong(size_t generator, size_t outputPtr, size_t num):
-    status = curandGenerateLongLong(
-        <Generator>generator, <unsigned long long*>outputPtr, num)
+    with nogil:
+        status = curandGenerateLongLong(
+            <Generator>generator, <unsigned long long*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateUniform(size_t generator, size_t outputPtr, size_t num):
-    status = curandGenerateUniform(
-        <Generator>generator, <float*>outputPtr, num)
+    with nogil:
+        status = curandGenerateUniform(
+            <Generator>generator, <float*>outputPtr, num)
     check_status(status)
 
 
 cpdef generateUniformDouble(size_t generator, size_t outputPtr, size_t num):
-    status = curandGenerateUniformDouble(
-        <Generator>generator, <double*>outputPtr, num)
+    with nogil:
+        status = curandGenerateUniformDouble(
+            <Generator>generator, <double*>outputPtr, num)
     check_status(status)
 
 
@@ -163,8 +174,9 @@ cpdef generateNormal(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateNormal can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
-    status = curandGenerateNormal(
-        <Generator>generator, <float*>outputPtr, n, mean, stddev)
+    with nogil:
+        status = curandGenerateNormal(
+            <Generator>generator, <float*>outputPtr, n, mean, stddev)
     check_status(status)
 
 
@@ -174,8 +186,9 @@ cpdef generateNormalDouble(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateNormalDouble can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
-    status = curandGenerateNormalDouble(
-        <Generator>generator, <double*>outputPtr, n, mean, stddev)
+    with nogil:
+        status = curandGenerateNormalDouble(
+            <Generator>generator, <double*>outputPtr, n, mean, stddev)
     check_status(status)
 
 
@@ -185,8 +198,9 @@ def generateLogNormal(size_t generator, size_t outputPtr, size_t n,
         msg = ('curandGenerateLogNormal can only generate even number of '
                'random variables simultaneously. See issue #390 for detail.')
         raise ValueError(msg)
-    status = curandGenerateLogNormal(
-        <Generator>generator, <float*>outputPtr, n, mean, stddev)
+    with nogil:
+        status = curandGenerateLogNormal(
+            <Generator>generator, <float*>outputPtr, n, mean, stddev)
     check_status(status)
 
 
@@ -197,13 +211,15 @@ cpdef generateLogNormalDouble(size_t generator, size_t outputPtr, size_t n,
                'of random variables simultaneously. See issue #390 for '
                'detail.')
         raise ValueError(msg)
-    status = curandGenerateLogNormalDouble(
-        <Generator>generator, <double*>outputPtr, n, mean, stddev)
+    with nogil:
+        status = curandGenerateLogNormalDouble(
+            <Generator>generator, <double*>outputPtr, n, mean, stddev)
     check_status(status)
 
 
 cpdef generatePoisson(size_t generator, size_t outputPtr, size_t n,
                       double lam):
-    status = curandGeneratePoisson(
-        <Generator>generator, <unsigned int*>outputPtr, n, lam)
+    with nogil:
+        status = curandGeneratePoisson(
+            <Generator>generator, <unsigned int*>outputPtr, n, lam)
     check_status(status)

--- a/cupy/cuda/driver.pyx
+++ b/cupy/cuda/driver.pyx
@@ -49,8 +49,9 @@ class CUDADriverError(RuntimeError):
         self.status = status
         cdef const char *name
         cdef const char *msg
-        cuGetErrorName(status, &name)
-        cuGetErrorString(status, &msg)
+        with nogil:
+            cuGetErrorName(status, &name)
+            cuGetErrorString(status, &msg)
         cdef bytes s_name = name, s_msg = msg
         super(CUDADriverError, self).__init__(
             '%s: %s' % (s_name.decode(), s_msg.decode()))

--- a/cupy/cuda/profiler.pyx
+++ b/cupy/cuda/profiler.pyx
@@ -28,9 +28,12 @@ cpdef void initialize(str config_file,
     """
     cdef bytes b_config_file = config_file.encode()
     cdef bytes b_output_file = output_file.encode()
-    status = cudaProfilerInitialize(<const char*>b_config_file,
-                                    <const char*>b_output_file,
-                                    <OutputMode>output_mode)
+    cdef const char* b_config_file_ptr = <const char*>b_config_file
+    cdef const char* b_output_file_ptr = <const char*>b_output_file
+    with nogil:
+        status = cudaProfilerInitialize(b_config_file_ptr,
+                                        b_output_file_ptr,
+                                        <OutputMode>output_mode)
     runtime.check_status(status)
 
 
@@ -42,7 +45,8 @@ cpdef void start() except *:
 
     See the CUDA document for detail.
     """
-    status = cudaProfilerStart()
+    with nogil:
+        status = cudaProfilerStart()
     runtime.check_status(status)
 
 
@@ -54,5 +58,6 @@ cpdef void stop() except *:
 
     See the CUDA document for detail.
     """
-    status = cudaProfilerStop()
+    with nogil:
+        status = cudaProfilerStop()
     runtime.check_status(status)

--- a/cupy/cuda/runtime.pyx
+++ b/cupy/cuda/runtime.pyx
@@ -118,8 +118,12 @@ class CUDARuntimeError(RuntimeError):
 
     def __init__(self, status):
         self.status = status
-        cdef bytes name = cudaGetErrorName(<Error>status)
-        cdef bytes msg = cudaGetErrorString(<Error>status)
+        cdef Error error = <Error>status
+        with nogil:
+            name_ptr = cudaGetErrorName(error)
+            msg_ptr = cudaGetErrorString(error)
+        cdef bytes name = name_ptr
+        cdef bytes msg = msg_ptr
         super(CUDARuntimeError, self).__init__(
             '%s: %s' % (name.decode(), msg.decode()))
 
@@ -136,14 +140,16 @@ cpdef inline check_status(int status):
 
 cpdef int driverGetVersion() except *:
     cdef int version
-    status = cudaDriverGetVersion(&version)
+    with nogil:
+        status = cudaDriverGetVersion(&version)
     check_status(status)
     return version
 
 
 cpdef int runtimeGetVersion() except *:
     cdef int version
-    status = cudaRuntimeGetVersion(&version)
+    with nogil:
+        status = cudaRuntimeGetVersion(&version)
     check_status(status)
     return version
 
@@ -154,27 +160,31 @@ cpdef int runtimeGetVersion() except *:
 
 cpdef int getDevice() except *:
     cdef int device
-    status = cudaGetDevice(&device)
+    with nogil:
+        status = cudaGetDevice(&device)
     check_status(status)
     return device
 
 
 cpdef int deviceGetAttribute(int attrib, int device) except *:
     cdef int ret
-    status = cudaDeviceGetAttribute(&ret, <DeviceAttr>attrib, device)
+    with nogil:
+        status = cudaDeviceGetAttribute(&ret, <DeviceAttr>attrib, device)
     check_status(status)
     return ret
 
 
 cpdef int getDeviceCount() except *:
     cdef int count
-    status = cudaGetDeviceCount(&count)
+    with nogil:
+        status = cudaGetDeviceCount(&count)
     check_status(status)
     return count
 
 
 cpdef setDevice(int device):
-    status = cudaSetDevice(device)
+    with nogil:
+        status = cudaSetDevice(device)
     check_status(status)
 
 
@@ -186,13 +196,15 @@ cpdef deviceSynchronize():
 
 cpdef int deviceCanAccessPeer(int device, int peerDevice) except *:
     cpdef int ret
-    status = cudaDeviceCanAccessPeer(&ret, device, peerDevice)
+    with nogil:
+        status = cudaDeviceCanAccessPeer(&ret, device, peerDevice)
     check_status(status)
     return ret
 
 
 cpdef deviceEnablePeerAccess(int peerDevice):
-    status = cudaDeviceEnablePeerAccess(peerDevice, 0)
+    with nogil:
+        status = cudaDeviceEnablePeerAccess(peerDevice, 0)
     check_status(status)
 
 
@@ -230,7 +242,8 @@ cpdef freeHost(size_t ptr):
 
 cpdef memGetInfo():
     cdef size_t free, total
-    status = cudaMemGetInfo(&free, &total)
+    with nogil:
+        status = cudaMemGetInfo(&free, &total)
     check_status(status)
     return free, total
 
@@ -281,7 +294,8 @@ cpdef memsetAsync(size_t ptr, int value, size_t size, size_t stream):
 
 cpdef PointerAttributes pointerGetAttributes(size_t ptr):
     cdef _PointerAttributes attrs
-    status = cudaPointerGetAttributes(&attrs, <void*>ptr)
+    with nogil:
+        status = cudaPointerGetAttributes(&attrs, <void*>ptr)
     check_status(status)
     return PointerAttributes(
         attrs.device, <size_t>attrs.devicePointer, <size_t>attrs.hostPointer,
@@ -294,20 +308,23 @@ cpdef PointerAttributes pointerGetAttributes(size_t ptr):
 
 cpdef size_t streamCreate() except *:
     cdef driver.Stream stream
-    status = cudaStreamCreate(&stream)
+    with nogil:
+        status = cudaStreamCreate(&stream)
     check_status(status)
     return <size_t>stream
 
 
 cpdef size_t streamCreateWithFlags(unsigned int flags) except *:
     cdef driver.Stream stream
-    status = cudaStreamCreateWithFlags(&stream, flags)
+    with nogil:
+        status = cudaStreamCreateWithFlags(&stream, flags)
     check_status(status)
     return <size_t>stream
 
 
 cpdef streamDestroy(size_t stream):
-    status = cudaStreamDestroy(<driver.Stream>stream)
+    with nogil:
+        status = cudaStreamDestroy(<driver.Stream>stream)
     check_status(status)
 
 
@@ -337,7 +354,9 @@ cpdef streamAddCallback(size_t stream, callback, size_t arg,
 
 
 cpdef streamQuery(size_t stream):
-    return cudaStreamQuery(<driver.Stream>stream)
+    with nogil:
+        status = cudaStreamQuery(<driver.Stream>stream)
+    return status
 
 
 cpdef streamWaitEvent(size_t stream, size_t event, unsigned int flags=0):
@@ -349,35 +368,43 @@ cpdef streamWaitEvent(size_t stream, size_t event, unsigned int flags=0):
 
 cpdef size_t eventCreate() except *:
     cdef driver.Event event
-    status = cudaEventCreate(&event)
+    with nogil:
+        status = cudaEventCreate(&event)
     check_status(status)
     return <size_t>event
 
 cpdef size_t eventCreateWithFlags(unsigned int flags) except *:
     cdef driver.Event event
-    status = cudaEventCreateWithFlags(&event, flags)
+    with nogil:
+        status = cudaEventCreateWithFlags(&event, flags)
     check_status(status)
     return <size_t>event
 
 
 cpdef eventDestroy(size_t event):
-    status = cudaEventDestroy(<driver.Event>event)
+    with nogil:
+        status = cudaEventDestroy(<driver.Event>event)
     check_status(status)
 
 
 cpdef float eventElapsedTime(size_t start, size_t end) except *:
     cdef float ms
-    status = cudaEventElapsedTime(&ms, <driver.Event>start, <driver.Event>end)
+    with nogil:
+        status = cudaEventElapsedTime(
+            &ms, <driver.Event>start, <driver.Event>end)
     check_status(status)
     return ms
 
 
 cpdef eventQuery(size_t event):
-    return cudaEventQuery(<driver.Event>event)
+    with nogil:
+        status = cudaEventQuery(<driver.Event>event)
+    return status
 
 
 cpdef eventRecord(size_t event, size_t stream):
-    status = cudaEventRecord(<driver.Event>event, <driver.Stream>stream)
+    with nogil:
+        status = cudaEventRecord(<driver.Event>event, <driver.Stream>stream)
     check_status(status)
 
 


### PR DESCRIPTION
This PR add "with notil" to all CUDA API call to fix deadlock issue on multi-threaded application.

A deadlock issue I found before was fixed at #2084. I found another deadlock issue. Calling CUDA API without "nogil" has a possibility of deadlock. We added "with nogil" to all CUDA API call to eliminate the deadlock possibility. My application needs this fix to make it work.