### PR TITLE
Add workspace size option to imagenet example

### DIFF
--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -112,6 +112,8 @@ def main():
     parser.add_argument('--val_batchsize', '-b', type=int, default=250,
                         help='Validation minibatch size')
     parser.add_argument('--test', action='store_true')
+    parser.add_argument('--workspacesize', type=int, default=None,
+                        help='The workspace size for cuDNN')
     parser.set_defaults(test=False)
     args = parser.parse_args()
 
@@ -123,6 +125,8 @@ def main():
     if args.gpu >= 0:
         chainer.cuda.get_device(args.gpu).use()  # Make the GPU current
         model.to_gpu()
+        if args.workspacesize is not None:
+            chainer.cuda.set_max_workspace_size(args.workspacesize)
 
     # Load the datasets and mean file
     mean = np.load(args.mean)


### PR DESCRIPTION
Chainer's default cuDNN workspace size is small (8MB).
So I add option that users can easily change cuDNN workspace size.
