### PR TITLE
add write_trigger argument for LogRecord extension

### DIFF
--- a/chainer/training/extensions/log_report.py
+++ b/chainer/training/extensions/log_report.py
@@ -19,14 +19,14 @@ class LogReport(extension.Extension):
     :class:`~chainer.DictSummary` at a regular interval specified by a supplied
     trigger, and writes them into a log file in JSON format.
 
-    There are two triggers to handle this extension. One is the trigger to
+    There are three triggers to handle this extension. One is the trigger to
     invoke this extension, which is used to handle the timing of accumulating
-    the results. It is set to ``1, 'iteration'`` by default. The other is the
+    the results. It is set to ``1, 'iteration'`` by default. The second is the
     trigger to determine when to emit the result. When this trigger returns
     True, this extension appends the summary of accumulated values to the list
-    of past summaries, and writes the list to the log file. Then, this
-    extension makes a new fresh summary object which is used until the next
-    time that the trigger fires.
+    of past summaries. Then, this extension makes a new fresh summary object
+    which is used until the next time that the trigger fires. Last is the
+    trigger to determine when to write the list to the log file.
 
     It also adds some entries to each result dictionary.
 
@@ -38,10 +38,13 @@ class LogReport(extension.Extension):
     Args:
         keys (iterable of strs): Keys of values to accumulate. If this is None,
             all the values are accumulated and output to the log file.
-        trigger: Trigger that decides when to aggregate the result and output
-            the values. This is distinct from the trigger of this extension
+        trigger: Trigger that decides when to aggregate the result values.
+            This is distinct from the trigger of this extension
             itself. If it is a tuple in the form ``<int>, 'epoch'`` or
             ``<int>, 'iteration'``, it is passed to :class:`IntervalTrigger`.
+        write_trigger: Trigger that decides when to write the results the list
+            to the log file. if `None` is given, default for this argument,
+            use ``triger`` arguments, invoked after each aggregations.
         postprocess: Callback to postprocess the result dictionaries. Each
             result dictionary is passed to this callback on the output. This
             callback can modify the result dictionaries, which are used to
@@ -54,10 +57,14 @@ class LogReport(extension.Extension):
 
     """
 
-    def __init__(self, keys=None, trigger=(1, 'epoch'), postprocess=None,
-                 log_name='log'):
+    def __init__(self, keys=None, trigger=(1, 'epoch'), write_trigger=None,
+                 postprocess=None, log_name='log'):
         self._keys = keys
         self._trigger = trigger_module.get_trigger(trigger)
+        if write_trigger:
+            self._write_trigger = trigger_module.get_trigger(write_trigger)
+        else:
+            self._write_trigger = self._trigger
         self._postprocess = postprocess
         self._log_name = log_name
         self._log = []
@@ -75,7 +82,7 @@ class LogReport(extension.Extension):
         else:
             summary.add({k: observation[k] for k in keys if k in observation})
 
-        if self._trigger(trainer):
+        if self._trigger(trainer) or self._write_trigger(trainer):
             # output the result
             stats = self._summary.compute_mean()
             stats_cpu = {}
@@ -90,20 +97,24 @@ class LogReport(extension.Extension):
             if self._postprocess is not None:
                 self._postprocess(stats_cpu)
 
-            self._log.append(stats_cpu)
+            if self._trigger(trainer):
+                self._log.append(stats_cpu)
 
-            # write to the log file
-            if self._log_name is not None:
-                log_name = self._log_name.format(**stats_cpu)
-                fd, path = tempfile.mkstemp(prefix=log_name, dir=trainer.out)
-                with os.fdopen(fd, 'w') as f:
-                    json.dump(self._log, f, indent=4)
-
-                new_path = os.path.join(trainer.out, log_name)
-                shutil.move(path, new_path)
+            if self._write_trigger(trainer):
+                self._write(trainer)
 
             # reset the summary for the next output
             self._init_summary()
+
+    def _write(self, stats_cpu, out_dir):
+        # write to the log file
+        if self._log_name is not None:
+            log_name = self._log_name.format(**stats_cpu)
+            fd, path = tempfile.mkstemp(prefix=log_name, dir=out_dir)
+            with os.fdopen(fd, 'w') as f:
+                json.dump(self._log, f, indent=4)
+            new_path = os.path.join(out_dir, log_name)
+            shutil.move(path, new_path)
 
     @property
     def log(self):

--- a/chainer/training/extensions/log_report.py
+++ b/chainer/training/extensions/log_report.py
@@ -101,7 +101,7 @@ class LogReport(extension.Extension):
                 self._log.append(stats_cpu)
 
             if self._write_trigger(trainer):
-                self._write(trainer)
+                self._write(stats_cpu, trainer.out)
 
             # reset the summary for the next output
             self._init_summary()

--- a/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
@@ -1,6 +1,8 @@
 import shutil
 import tempfile
 import unittest
+import json
+import os.path
 
 import mock
 
@@ -22,6 +24,8 @@ class TestLogReport(unittest.TestCase):
         log_report = extensions.LogReport(trigger=(1, 'iteration'))
         trainer.extend(log_report)
         trainer.run()
+        with open(os.path.join(self.temp_dir, 'log')) as f:
+            self.assertEqual(log_report.log, json.load(f))
 
     def test_write_trigger(self):
         stops, aggregates, writes = 10, 2, 5

--- a/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
@@ -27,8 +27,10 @@ class TestLogReport(unittest.TestCase):
         stops, aggregates, writes = 10, 2, 5
         trainer = _get_mocked_trainer(self.temp_dir, (stops, 'iteration'))
         with mock.patch.object(extensions.LogReport, '_write') as mocked:
-            log_report = extensions.LogReport(trigger=(aggregates, 'iteration'),
-                                              write_trigger=(writes, 'iteration'))
+            log_report = extensions.LogReport(
+                trigger=(aggregates, 'iteration'),
+                write_trigger=(writes, 'iteration')
+            )
             trainer.extend(log_report)
             trainer.run()
             mocked.assert_called()

--- a/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
@@ -35,7 +35,7 @@ class TestLogReport(unittest.TestCase):
             trainer.run()
             mocked.assert_called_with(log_report.log[-1], self.temp_dir)
             self.assertEqual(mocked.call_count, stops // writes)
-            self.assertEqual(len(log_report._log), stops // aggregates)
+            self.assertEqual(len(log_report.log), stops // aggregates)
 
 
 def _get_mocked_trainer(stop_trigger=(10, 'iteration'), out='result'):

--- a/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
@@ -18,14 +18,14 @@ class TestLogReport(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def test_trigger(self):
-        trainer = _get_mocked_trainer(self.temp_dir, (10, 'iteration'))
+        trainer = _get_mocked_trainer((10, 'iteration'), self.temp_dir)
         log_report = extensions.LogReport(trigger=(1, 'iteration'))
         trainer.extend(log_report)
         trainer.run()
 
     def test_write_trigger(self):
         stops, aggregates, writes = 10, 2, 5
-        trainer = _get_mocked_trainer(self.temp_dir, (stops, 'iteration'))
+        trainer = _get_mocked_trainer((stops, 'iteration'), self.temp_dir)
         with mock.patch.object(extensions.LogReport, '_write') as mocked:
             log_report = extensions.LogReport(
                 trigger=(aggregates, 'iteration'),
@@ -33,12 +33,12 @@ class TestLogReport(unittest.TestCase):
             )
             trainer.extend(log_report)
             trainer.run()
-            mocked.assert_called()
+            mocked.assert_called_with(log_report.log[-1], self.temp_dir)
             self.assertEqual(mocked.call_count, stops // writes)
             self.assertEqual(len(log_report._log), stops // aggregates)
 
 
-def _get_mocked_trainer(out, stop_trigger=(10, 'iteration')):
+def _get_mocked_trainer(stop_trigger=(10, 'iteration'), out='result'):
     updater = mock.Mock()
     updater.get_all_optimizers.return_value = {}
     updater.iteration = 0

--- a/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
@@ -1,0 +1,53 @@
+import unittest
+
+import mock
+
+from chainer import testing
+from chainer import training
+from chainer.training import extensions
+
+
+class TestLogReport(unittest.TestCase):
+
+    def test_trigger(self):
+        trainer = _get_mocked_trainer((10, 'iteration'))
+        with mock.patch.object(extensions.LogReport, '_write') as mocked:
+            log_report = extensions.LogReport(trigger=(1, 'iteration'))
+            trainer.extend(log_report)
+            trainer.run()
+            mocked.assert_called()
+            self.assertEqual(mocked.call_count, 10)
+            self.assertEqual(len(log_report._log), 10)
+
+    def test_write_trigger(self):
+        trainer = _get_mocked_trainer((10, 'iteration'))
+        with mock.patch.object(extensions.LogReport, '_write') as mocked:
+            log_report = extensions.LogReport(trigger=(1, 'iteration'),
+                                              write_trigger=(10, 'iteration'))
+            trainer.extend(log_report)
+            trainer.run()
+            mocked.assert_called()
+            self.assertEqual(mocked.call_count, 1)
+            self.assertEqual(len(log_report._log), 10)
+
+
+def _get_mocked_trainer(stop_trigger=(10, 'iteration')):
+    updater = mock.Mock()
+    updater.get_all_optimizers.return_value = {}
+    updater.iteration = 0
+    updater.epoch = 0
+    updater.epoch_detail = 0
+    updater.is_new_epoch = True
+    iter_per_epoch = 10
+
+    def update():
+        updater.iteration += 1
+        updater.epoch = updater.iteration // iter_per_epoch
+        updater.epoch_detail = updater.iteration / iter_per_epoch
+        updater.is_new_epoch = updater.epoch == updater.epoch_detail
+
+    updater.update = update
+    return training.Trainer(updater, stop_trigger)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_logreport.py
@@ -1,8 +1,8 @@
+import json
+import os.path
 import shutil
 import tempfile
 import unittest
-import json
-import os.path
 
 import mock
 


### PR DESCRIPTION
In the current `LogRecord` extension implementation, it aggregate and write at *the same time*.
This cause performance penalty in long time training, because log getting bigger and bigger.
One can save writings with following code:

```python
log_report = extensions.LogReport(log_name=None) # to disable log write
trainer.extend(log_report)
trainer.run()
with open(os.path.join(trainer.out, "log"), "w") as f:
    json.dump(log_report.log, f, indent=4)
```

but this seems less flexible, so we use a `LogRecord` implementation in this pull request.