### PR TITLE
Add opt-out exception display to trainer loop before finally clause

### DIFF
--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -305,8 +305,8 @@ class Trainer(object):
                 print("Exception in main training loop: {}".format(e))
                 print("Traceback (most recent call last):")
                 traceback.print_tb(sys.exc_info()[2])
-                print("Will finalize trainer extensions and updater before")
-                print("reraising the exception.")
+                print("Will finalize trainer extensions and updater before "
+                      "reraising the exception.")
             six.reraise(*sys.exc_info())
         finally:
             for _, entry in extensions:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -1,6 +1,8 @@
 import collections
 import os
+import sys
 import time
+import traceback
 
 import six
 
@@ -297,11 +299,9 @@ class Trainer(object):
                         if entry.trigger(self):
                             entry.extension(self)
         except Exception as e:
-            import sys
             if show_loop_exception_msg:
                 # Show the exception here, as it will appear as if chainer
                 # hanged in case any finalize method below deadlocks.
-                import traceback
                 print("Exception in main training loop: {}".format(e))
                 print("Traceback (most recent call last):")
                 traceback.print_tb(sys.exc_info()[2])

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -297,10 +297,10 @@ class Trainer(object):
                         if entry.trigger(self):
                             entry.extension(self)
         except Exception as e:
+            import sys
             if show_loop_exception_msg:
                 # Show the exception here, as it will appear as if chainer hanged
                 # in case any finalize method below deadlocks.
-                import sys
                 import traceback
                 print("Exception in main training loop: {}".format(e))
                 print("Traceback (most recent call last):")

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -299,13 +299,14 @@ class Trainer(object):
         except Exception as e:
             import sys
             if show_loop_exception_msg:
-                # Show the exception here, as it will appear as if chainer hanged
-                # in case any finalize method below deadlocks.
+                # Show the exception here, as it will appear as if chainer
+                # hanged in case any finalize method below deadlocks.
                 import traceback
                 print("Exception in main training loop: {}".format(e))
                 print("Traceback (most recent call last):")
                 traceback.print_tb(sys.exc_info()[2])
-                print("Will finalize trainer extensions and updater before reraising the exception.")
+                print("Will finalize trainer extensions and updater before")
+                print("reraising the exception.")
             six.reraise(*sys.exc_info())
         finally:
             for _, entry in extensions:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import collections
 import os
 import sys
@@ -302,11 +304,12 @@ class Trainer(object):
             if show_loop_exception_msg:
                 # Show the exception here, as it will appear as if chainer
                 # hanged in case any finalize method below deadlocks.
-                print('Exception in main training loop: {}'.format(e))
-                print('Traceback (most recent call last):')
+                print('Exception in main training loop: {}'.format(e),
+                      file=sys.stderr)
+                print('Traceback (most recent call last):', file=sys.stderr)
                 traceback.print_tb(sys.exc_info()[2])
                 print('Will finalize trainer extensions and updater before '
-                      'reraising the exception.')
+                      'reraising the exception.', file=sys.stderr)
             six.reraise(*sys.exc_info())
         finally:
             for _, entry in extensions:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -302,11 +302,11 @@ class Trainer(object):
             if show_loop_exception_msg:
                 # Show the exception here, as it will appear as if chainer
                 # hanged in case any finalize method below deadlocks.
-                print("Exception in main training loop: {}".format(e))
-                print("Traceback (most recent call last):")
+                print('Exception in main training loop: {}'.format(e))
+                print('Traceback (most recent call last):')
                 traceback.print_tb(sys.exc_info()[2])
-                print("Will finalize trainer extensions and updater before "
-                      "reraising the exception.")
+                print('Will finalize trainer extensions and updater before '
+                      'reraising the exception.')
             six.reraise(*sys.exc_info())
         finally:
             for _, entry in extensions:


### PR DESCRIPTION
This PR makes sure that any exception raised during the training process is shown to the user before the finally clause is reached in the training loop.
This is needed because if any trainer extension or updater hangs or deadlocks (this has happened to me repeatedly when using `MultiprocessIterator`), it will appear as if Chainer has hanged, while the actual cause is the user's own code raising an exception.
Since exceptions often happen when developing new models, this fix will reduce user frustration.
By showing the exception, the user will immediately know that his/her model has a bug, and not wonder why Chainer is not responding.
This verbose behavior can be disabled with a parameter to `run()`.

I have tested this with Python 2.7.6 and 3.4.5.

Example output when adding the line `a = 1 / 0` inside the MLP in `train_mnist.py`:
```
GPU: 0
# unit: 1000
# Minibatch-size: 100
# epoch: 20

Exception in main training loop: division by zero
Traceback (most recent call last):
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/training/trainer.py", line 295, in run
    update()
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/training/updater.py", line 174, in update
    self.update_core()
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/training/updater.py", line 186, in update_core
    optimizer.update(loss_func, *in_vars)
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/optimizer.py", line 390, in update
    loss = lossfun(*args, **kwds)
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/links/model/classifier.py", line 67, in __call__
    self.y = self.predictor(*x)
  File "train_mnist.py", line 27, in __call__
    a = 1 / 0 # Raise an exeption here
Will finalize trainer extensions and updater before reraising the exception.
Traceback (most recent call last):
  File "train_mnist.py", line 118, in <module>
    main()
  File "train_mnist.py", line 115, in main
    trainer.run()
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/training/trainer.py", line 309, in run
    six.reraise(*sys.exc_info())
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/six-1.10.0-py3.4.egg/six.py", line 686, in reraise
    raise value
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/training/trainer.py", line 295, in run
    update()
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/training/updater.py", line 174, in update
    self.update_core()
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/training/updater.py", line 186, in update_core
    optimizer.update(loss_func, *in_vars)
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/optimizer.py", line 390, in update
    loss = lossfun(*args, **kwds)
  File "/home/tommi/.pyenv/versions/temp3.4/lib/python3.4/site-packages/chainer-1.20.0-py3.4-linux-x86_64.egg/chainer/links/model/classifier.py", line 67, in __call__
    self.y = self.predictor(*x)
  File "train_mnist.py", line 27, in __call__
    a = 1 / 0 # Raise an exeption here
ZeroDivisionError: division by zero
```