### PR TITLE
Improve asynchronous host to device copy

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -254,28 +254,33 @@ def to_gpu(array, device=None, stream=None):
             return array
 
         if stream is not None:
-            ret = cupy.empty_like(array)
-            mem = None
-            if array_dev.id == -1:
-                # cpu to gpu
-                mem = cupy.cuda.alloc_pinned_memory(array.nbytes)
-                src = numpy.frombuffer(
-                    mem, array.dtype, array.size).reshape(array.shape)
-                src[...] = array
-                ret.set(src, stream)
-            else:
-                # gpu to gpu
-                with array_dev:
-                    src = array.copy()
-                    event = cupy.cuda.Event()
-                    event.record()
-                stream.wait_event(event)
-                ret.data.copy_from_device_async(src.data, src.nbytes, stream)
+            warnings.warn(
+                'The stream option is deprecated in chainer.cuda.to_gpu. '
+                'Please remove it.', DeprecationWarning)
+            if stream.ptr != 0:
+                ret = cupy.empty_like(array)
+                if array_dev.id == -1:
+                    # cpu to gpu
+                    mem = cupy.cuda.alloc_pinned_memory(array.nbytes)
+                    src = numpy.frombuffer(
+                        mem, array.dtype, array.size).reshape(array.shape)
+                    src[...] = array
+                    ret.set(src, stream)
+                    cupy.cuda.pinned_memory._add_to_watch_lsit(
+                        stream.record(), mem)
+                else:
+                    # gpu to gpu
+                    with array_dev:
+                        src = array.copy()
+                        event = Stream.null.record()
+                    stream.wait_event(event)
+                    ret.data.copy_from_device_async(
+                        src.data, src.nbytes, stream)
 
-            # to hold a reference until the end of the asynchronous memcpy
-            stream.add_callback(lambda *x: None, (src, mem, ret))
-
-            return ret
+                    # to hold a reference until the end of the asynchronous
+                    # memcpy
+                    stream.add_callback(lambda *x: None, (src, ret))
+                return ret
 
         if array_dev.id == -1:
             return cupy.asarray(array)

--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -32,7 +32,7 @@ def to_device(device, x):
     elif device < 0:
         return cuda.to_cpu(x)
     else:
-        return cuda.to_gpu(x, device, cuda.Stream.null)
+        return cuda.to_gpu(x, device)
 
 
 def concat_examples(batch, device=None, padding=None):


### PR DESCRIPTION
This PR implement asynchronous copy to `cupy.array`.
The stream option in `cuda.to_gpu` is deprecated, because stream option is difficult.
