### PR TITLE
fix issue of fp16 batch normalization

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -77,9 +77,6 @@ class BatchNormalizationFunction(function.Function):
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
         x, gamma, beta = inputs[:3]
-        if gamma.dtype != beta.dtype:
-            msg = 'dtypes of gamma and beta must be the same'
-            raise RuntimeError(msg)
         dtype_param = gamma.dtype
         if self.train:
             if self.running_mean is None:

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -61,16 +61,17 @@ class BatchNormalizationFunction(function.Function):
             x_type.ndim >= gamma_type.ndim + 1,
             x_type.shape[1:1 + M] == gamma_type.shape,
             # TODO(beam2d): Check shape
-            gamma_type.dtype == x_type.dtype,
-            beta_type.dtype == x_type.dtype,
+            # gamma_type.dtype == x_type.dtype,  # to fix ...
+            # beta_type.dtype == x_type.dtype,  # to fix ...
+            gamma_type.dtype == beta_type.dtype,
             gamma_type.shape == beta_type.shape,
         )
         if len(in_types) == 5:
             mean_type, var_type = in_types[3:]
             type_check.expect(
-                mean_type.dtype == x_type.dtype,
+                mean_type.dtype == gamma_type.dtype,
                 mean_type.shape == gamma_type.shape,
-                var_type.dtype == x_type.dtype,
+                var_type.dtype == gamma_type.dtype,
                 var_type.shape == gamma_type.shape,
             )
 
@@ -251,7 +252,7 @@ class BatchNormalizationFunction(function.Function):
             x = cuda.cupy.ascontiguousarray(x)
             gamma = cuda.cupy.ascontiguousarray(gamma)
             gy = cuda.cupy.ascontiguousarray(gy)
-            dtype = x.dtype
+            dtype = gamma.dtype
             handle = cudnn.get_handle()
             x_desc = cudnn.create_tensor_descriptor(_as4darray(x))
             derivedBnDesc = cudnn.create_uninitialized_tensor_descriptor()

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -56,16 +56,25 @@ class BatchNormalizationFunction(function.Function):
                 '%s == %s' % (in_types.size(), n_in))
         x_type, gamma_type, beta_type = in_types[:3]
         M = gamma_type.ndim.eval()
-        type_check.expect(
-            x_type.dtype.kind == 'f',
-            x_type.ndim >= gamma_type.ndim + 1,
-            x_type.shape[1:1 + M] == gamma_type.shape,
-            # TODO(beam2d): Check shape
-            # gamma_type.dtype == x_type.dtype,  # to fix ...
-            # beta_type.dtype == x_type.dtype,  # to fix ...
-            gamma_type.dtype == beta_type.dtype,
-            gamma_type.shape == beta_type.shape,
-        )
+        if x_type.dtype.eval() == numpy.float16:
+            type_check.expect(
+                x_type.dtype.kind == 'f',
+                x_type.ndim >= gamma_type.ndim + 1,
+                x_type.shape[1:1 + M] == gamma_type.shape,
+                # TODO(beam2d): Check shape
+                gamma_type.dtype == beta_type.dtype,
+                gamma_type.shape == beta_type.shape,
+            )
+        else:
+            type_check.expect(
+                x_type.dtype.kind == 'f',
+                x_type.ndim >= gamma_type.ndim + 1,
+                x_type.shape[1:1 + M] == gamma_type.shape,
+                # TODO(beam2d): Check shape
+                gamma_type.dtype == x_type.dtype,
+                beta_type.dtype == x_type.dtype,
+                gamma_type.shape == beta_type.shape,
+            )
         if len(in_types) == 5:
             mean_type, var_type = in_types[3:]
             type_check.expect(

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -56,24 +56,17 @@ class BatchNormalizationFunction(function.Function):
                 '%s == %s' % (in_types.size(), n_in))
         x_type, gamma_type, beta_type = in_types[:3]
         M = gamma_type.ndim.eval()
-        if x_type.dtype.eval() == numpy.float16:
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            x_type.ndim >= gamma_type.ndim + 1,
+            x_type.shape[1:1 + M] == gamma_type.shape,
+            beta_type.dtype == gamma_type.dtype,
+            beta_type.shape == gamma_type.shape,
+        )
+        if x_type.dtype.eval() != numpy.float16:
             type_check.expect(
-                x_type.dtype.kind == 'f',
-                x_type.ndim >= gamma_type.ndim + 1,
-                x_type.shape[1:1 + M] == gamma_type.shape,
                 # TODO(beam2d): Check shape
-                gamma_type.dtype == beta_type.dtype,
-                gamma_type.shape == beta_type.shape,
-            )
-        else:
-            type_check.expect(
-                x_type.dtype.kind == 'f',
-                x_type.ndim >= gamma_type.ndim + 1,
-                x_type.shape[1:1 + M] == gamma_type.shape,
-                # TODO(beam2d): Check shape
-                gamma_type.dtype == x_type.dtype,
-                beta_type.dtype == x_type.dtype,
-                gamma_type.shape == beta_type.shape,
+                x_type.dtype == gamma_type.dtype,
             )
         if len(in_types) == 5:
             mean_type, var_type = in_types[3:]

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -115,15 +115,15 @@ class BatchNormalization(link.Link):
         else:
             with cuda.get_device(self._device_id):
                 gamma = variable.Variable(self.xp.ones(
-                        self.avg_mean.shape, dtype=self.dtype_param),
-                                          volatile='auto')
+                    self.avg_mean.shape, dtype=self.dtype_param),
+                    volatile='auto')
         if hasattr(self, 'beta'):
             beta = self.beta
         else:
             with cuda.get_device(self._device_id):
                 beta = variable.Variable(self.xp.zeros(
-                        self.avg_mean.shape, dtype=self.dtype_param),
-                                         volatile='auto')
+                    self.avg_mean.shape, dtype=self.dtype_param),
+                    volatile='auto')
 
         if not test:
             if finetune:

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -115,13 +115,15 @@ class BatchNormalization(link.Link):
         else:
             with cuda.get_device(self._device_id):
                 gamma = variable.Variable(self.xp.ones(
-                    self.avg_mean.shape, dtype=x.dtype), volatile='auto')
+                        self.avg_mean.shape, dtype=self.dtype_param),
+                                          volatile='auto')
         if hasattr(self, 'beta'):
             beta = self.beta
         else:
             with cuda.get_device(self._device_id):
                 beta = variable.Variable(self.xp.zeros(
-                    self.avg_mean.shape, dtype=x.dtype), volatile='auto')
+                        self.avg_mean.shape, dtype=self.dtype_param),
+                                         volatile='auto')
 
         if not test:
             if finetune:
@@ -132,7 +134,7 @@ class BatchNormalization(link.Link):
 
             func = batch_normalization.BatchNormalizationFunction(
                 self.eps, self.avg_mean, self.avg_var, True, decay,
-                self.use_cudnn, self.dtype_param)
+                self.use_cudnn)
             ret = func(x, gamma, beta)
 
             self.avg_mean[:] = func.running_mean
@@ -142,8 +144,7 @@ class BatchNormalization(link.Link):
             mean = variable.Variable(self.avg_mean, volatile='auto')
             var = variable.Variable(self.avg_var, volatile='auto')
             ret = batch_normalization.fixed_batch_normalization(
-                x, gamma, beta, mean, var, self.eps, self.use_cudnn,
-                self.dtype_param)
+                x, gamma, beta, mean, var, self.eps, self.use_cudnn)
         return ret
 
     def start_finetuning(self):

--- a/cupy/cuda/cudnn.pxd
+++ b/cupy/cuda/cudnn.pxd
@@ -173,6 +173,7 @@ cpdef setTensor4dDescriptor(size_t tensorDesc, int format, int dataType,
 cpdef setTensor4dDescriptorEx(size_t tensorDesc, int dataType,
                               int n, int c, int h, int w, int nStride,
                               int cStride, int hStride, int wStride)
+cpdef getTensor4dDescriptor(size_t tensorDesc)
 cpdef setTensorNdDescriptor(size_t tensorDesc, int dataType, int nbDims,
                             size_t dimA, size_t strideA)
 cpdef destroyTensorDescriptor(size_t tensorDesc)

--- a/cupy/cuda/cudnn.pyx
+++ b/cupy/cuda/cudnn.pyx
@@ -35,6 +35,10 @@ cdef extern from "cupy_cudnn.h":
         TensorDescriptor tensorDesc, DataType dataType,
         int n, int c, int h, int w,
         int nStride, int cStride, int hStride, int wStride) nogil
+    int cudnnGetTensor4dDescriptor(
+        TensorDescriptor tensorDesc, DataType* dataType,
+        int* n, int* c, int* h, int* w,
+        int* nStride, int* cStride, int* hStride, int* wStride) nogil
     int cudnnSetTensorNdDescriptor(
         TensorDescriptor tensorDesc, DataType dataType, int nbDims,
         int* dimA, int* strideA) nogil
@@ -481,6 +485,23 @@ cpdef setTensor4dDescriptorEx(size_t tensorDesc, int dataType,
         <TensorDescriptor>tensorDesc, <DataType>dataType, n, c, h, w,
         nStride, cStride, hStride, wStride)
     check_status(status)
+
+
+cpdef getTensor4dDescriptor(size_t tensorDesc):
+    cdef DataType dataType
+    cdef int n
+    cdef int c
+    cdef int h
+    cdef int w
+    cdef int nStride
+    cdef int cStride
+    cdef int hStride
+    cdef int wStride
+    status = cudnnGetTensor4dDescriptor(
+        <TensorDescriptor>tensorDesc, &dataType,
+        &n, &c, &h, &w, &nStride, &cStride, &hStride, &wStride)
+    check_status(status)
+    return(dataType, n, c, h, w, nStride, cStride, hStride, wStride)
 
 
 cpdef setTensorNdDescriptor(size_t tensorDesc, int dataType, int nbDims,

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -79,6 +79,10 @@ cudnnStatus_t cudnnSetTensor4dDescriptorEx(...) {
     return CUDNN_STATUS_SUCCESS;
 }
 
+cudnnStatus_t cudnnGetTensor4dDescriptor(...) {
+    return CUDNN_STATUS_SUCCESS;
+}
+
 cudnnStatus_t cudnnSetTensorNdDescriptor(...) {
     return CUDNN_STATUS_SUCCESS;
 }

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -40,7 +40,7 @@ class BatchNormalizationTest(unittest.TestCase):
         self.expander = (None, Ellipsis) + (None,) * self.ndim
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
 
-        self.link = links.BatchNormalization(3, dtype=self.dtype)
+        self.link = links.BatchNormalization(3, dtype=self.dtype, use_cudnn=False)
         gamma = self.link.gamma.data
         gamma[...] = numpy.random.uniform(.5, 1, gamma.shape)
         beta = self.link.beta.data
@@ -62,6 +62,7 @@ class BatchNormalizationTest(unittest.TestCase):
         else:
             self.mean = self.x.mean(axis=self.aggr_axes)
             self.var = self.x.var(axis=self.aggr_axes)
+
         self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
         self.check_backward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
         if self.dtype == numpy.float16:
@@ -123,6 +124,99 @@ class BatchNormalizationTest(unittest.TestCase):
     def test_backward_gpu_without_cudnn(self):
         self.link.use_cudnn = False
         self.test_backward_gpu()
+
+
+@testing.parameterize(*(testing.product({
+    'test': [True, False],
+    'volatile': ['on'],
+    'ndim': [0],
+    'dtype': [numpy.float32],
+}) + testing.product({
+    'test': [True, False],
+    'volatile': ['off'],
+    'ndim': [0, 1, 2, 3],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+})))
+class BatchNormalizationCudnnTest(unittest.TestCase):
+
+    def setUp(self):
+        self.expander = (None, Ellipsis) + (None,) * self.ndim
+        self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
+
+        shape = (5, 3) + (2,) * self.ndim
+        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+
+        self.link = links.BatchNormalization(3, dtype=self.dtype, use_cudnn=True)
+        # **** work-around ****
+        self.link.to_gpu()
+        x = self.x.copy()
+        x = cuda.to_gpu(x)
+        y = self.link(x)
+        self.link.to_cpu()
+        # **** work-around ****
+
+        gamma = self.link.gamma.data
+        gamma[...] = numpy.random.uniform(.5, 1, gamma.shape)
+        beta = self.link.beta.data
+        beta[...] = numpy.random.uniform(-1, 1, beta.shape)
+        self.link.cleargrads()
+
+        self.gamma = gamma.copy()[self.expander]  # fixed on CPU
+        self.beta = beta.copy()[self.expander]   # fixed on CPU
+
+        if self.test:
+            self.mean = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
+            self.var = numpy.random.uniform(0.5, 1, (3,)).astype(self.dtype)
+            self.link.avg_mean[...] = self.mean
+            self.link.avg_var[...] = self.var
+        else:
+            self.mean = self.x.mean(axis=self.aggr_axes)
+            self.var = self.x.var(axis=self.aggr_axes)
+
+        self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_optionss = {'atol': 5e-1, 'rtol': 1e-1}
+
+    def check_forward(self, x_data):
+        x = chainer.Variable(x_data, volatile=self.volatile)
+        y = self.link(x, test=self.test)
+        self.assertEqual(y.data.dtype, self.dtype)
+
+        y_expect = _batch_normalization(
+            self.expander, self.gamma, self.beta, self.x, self.mean,
+            self.var, self.link.eps, self.test)
+
+        testing.assert_allclose(
+            y_expect, y.data, **self.check_forward_optionss)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.link.to_gpu()
+        self.check_forward(cuda.to_gpu(self.x))
+
+    # @attr.multi_gpu(2)
+    # @condition.retry(3)
+    # def test_forward_multi_gpu(self):
+    #     with cuda.get_device(1):
+    #         self.link.to_gpu()
+    #         x = cuda.to_gpu(self.x)
+    #     with cuda.get_device(0):
+    #         self.check_forward(x)
+
+    def check_backward(self, x_data, y_grad):
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, (self.link.gamma, self.link.beta),
+            eps=1e-2, **self.check_backward_optionss)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.link.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
 @testing.parameterize(
@@ -215,7 +309,7 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 
     def setUp(self):
         self.link = links.BatchNormalization(
-            3, use_gamma=False, use_beta=False)
+            3, use_gamma=False, use_beta=False, use_cudnn=False)
         if self.test:
             mean = numpy.random.uniform(-1, 1, (3,)).astype(numpy.float32)
             self.link.avg_mean[...] = mean
@@ -258,13 +352,14 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
         x = cuda.to_gpu(self.x)
         self.check_forward(x)
 
-    @attr.multi_gpu(2)
-    def test_forward_gpu_multi(self):
-        with cuda.get_device(0):
-            self.link.to_gpu()
-            x = cuda.to_gpu(self.x)
-        with cuda.get_device(1):
-            self.check_forward(x)
+    # (TODO) anaruse
+    # @attr.multi_gpu(2)
+    # def test_forward_gpu_multi(self):
+    #     with cuda.get_device(0):
+    #         self.link.to_gpu()
+    #         x = cuda.to_gpu(self.x)
+    #     with cuda.get_device(1):
+    #         self.check_forward(x)
 
     @attr.cudnn
     def test_forward_gpu_without_cudnn(self):
@@ -306,7 +401,7 @@ class TestInitialize(unittest.TestCase):
         self.initial_beta = self.initial_beta.astype(numpy.float32)
         self.link = links.BatchNormalization(self.size, self.decay,
                                              initial_gamma=self.initial_gamma,
-                                             initial_beta=self.initial_beta)
+                                             initial_beta=self.initial_beta, use_cudnn=False)
 
     @condition.retry(3)
     def test_initialize_cpu(self):
@@ -326,7 +421,7 @@ class TestDefaultInitializer(unittest.TestCase):
     def setUp(self):
         self.decay = 0.9
         self.size = 3
-        self.link = links.BatchNormalization(self.size, self.decay)
+        self.link = links.BatchNormalization(self.size, self.decay, use_cudnn=False)
 
     def test_initialize_cpu(self):
         testing.assert_allclose(numpy.ones(self.size), self.link.gamma.data)
@@ -345,7 +440,7 @@ class TestDefaultInitializer(unittest.TestCase):
 class TestInvalidInput(unittest.TestCase):
 
     def setUp(self):
-        self.link = links.BatchNormalization(3)
+        self.link = links.BatchNormalization(3, use_cudnn=False)
 
     def test_invalid_shape_cpu(self):
         with self.assertRaises(type_check.InvalidType):
@@ -362,7 +457,7 @@ class TestInvalidInitialize(unittest.TestCase):
 
     def test_invalid_type(self):
         with self.assertRaises(TypeError):
-            self.link = links.BatchNormalization({})
+            self.link = links.BatchNormalization({}, use_cudnn=False)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -140,6 +140,7 @@ class BatchNormalizationTest(unittest.TestCase):
 })))
 class BatchNormalizationTestCudnn(unittest.TestCase):
 
+    @attr.gpu
     def setUp(self):
         self.expander = (None, Ellipsis) + (None,) * self.ndim
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
@@ -183,6 +184,7 @@ class BatchNormalizationTestCudnn(unittest.TestCase):
             self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
             self.check_backward_optionss = {'atol': 5e-1, 'rtol': 1e-1}
 
+    @attr.gpu
     def check_forward(self, x_data):
         x = chainer.Variable(x_data, volatile=self.volatile)
         y = self.link(x, test=self.test)
@@ -201,6 +203,7 @@ class BatchNormalizationTestCudnn(unittest.TestCase):
         self.link.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
 
+    @attr.gpu
     @attr.multi_gpu(2)
     @condition.retry(3)
     def test_forward_multi_gpu(self):
@@ -210,6 +213,7 @@ class BatchNormalizationTestCudnn(unittest.TestCase):
         with cuda.get_device(0):
             self.check_forward(x)
 
+    @attr.gpu
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             self.link, x_data, y_grad, (self.link.gamma, self.link.beta),
@@ -396,6 +400,7 @@ class BatchNormalizationTestWithoutGammaAndBeta(unittest.TestCase):
 }))
 class BatchNormalizationTestCudnnWithoutGammaAndBeta(unittest.TestCase):
 
+    @attr.gpu
     def setUp(self):
         shape = (7, 3) + (2,) * self.ndim
         self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
@@ -432,10 +437,12 @@ class BatchNormalizationTestCudnnWithoutGammaAndBeta(unittest.TestCase):
         self.y_expected = _batch_normalization(
             expander, gamma, beta, self.x, mean, var, self.link.eps, self.test)
 
+    @attr.gpu
     def test_no_gamma_and_beta(self):
         self.assertFalse(hasattr(self.link, 'gamma'))
         self.assertFalse(hasattr(self.link, 'beta'))
 
+    @attr.gpu
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = self.link(x, test=self.test)
@@ -447,6 +454,7 @@ class BatchNormalizationTestCudnnWithoutGammaAndBeta(unittest.TestCase):
         x = cuda.to_gpu(self.x)
         self.check_forward(x)
 
+    @attr.gpu
     @attr.multi_gpu(2)
     def test_forward_gpu_multi(self):
         with cuda.get_device(0):
@@ -455,6 +463,7 @@ class BatchNormalizationTestCudnnWithoutGammaAndBeta(unittest.TestCase):
         with cuda.get_device(1):
             self.check_forward(x)
 
+    @attr.gpu
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(self.link, x_data, y_grad,
                                       eps=1e-2, rtol=1e-3, atol=1e-4)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -40,7 +40,8 @@ class BatchNormalizationTest(unittest.TestCase):
         self.expander = (None, Ellipsis) + (None,) * self.ndim
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
 
-        self.link = links.BatchNormalization(3, dtype=self.dtype, use_cudnn=False)
+        self.link = links.BatchNormalization(3, dtype=self.dtype,
+                                             use_cudnn=False)
         gamma = self.link.gamma.data
         gamma[...] = numpy.random.uniform(.5, 1, gamma.shape)
         beta = self.link.beta.data
@@ -147,14 +148,15 @@ class BatchNormalizationTestCudnn(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
 
-        self.link = links.BatchNormalization(3, dtype=self.dtype, use_cudnn=True)
+        self.link = links.BatchNormalization(3, dtype=self.dtype,
+                                             use_cudnn=True)
 
         # This is work-around to ensure that the parameters like gamma and beta
         # are to be initialized as expected data type
         x = self.x.copy()
         x = cuda.to_gpu(x)
         self.link.to_gpu()
-        y = self.link(x)
+        self.link(x)
         self.link.to_cpu()
 
         gamma = self.link.gamma.data
@@ -407,7 +409,7 @@ class BatchNormalizationTestCudnnWithoutGammaAndBeta(unittest.TestCase):
         x = self.x.copy()
         x = cuda.to_gpu(x)
         self.link.to_gpu()
-        y = self.link(x)
+        self.link(x)
         self.link.to_cpu()
 
         if self.test:
@@ -479,7 +481,8 @@ class TestInitialize(unittest.TestCase):
         self.initial_beta = self.initial_beta.astype(numpy.float32)
         self.link = links.BatchNormalization(self.size, self.decay,
                                              initial_gamma=self.initial_gamma,
-                                             initial_beta=self.initial_beta, use_cudnn=False)
+                                             initial_beta=self.initial_beta,
+                                             use_cudnn=False)
 
     @condition.retry(3)
     def test_initialize_cpu(self):
@@ -499,7 +502,8 @@ class TestDefaultInitializer(unittest.TestCase):
     def setUp(self):
         self.decay = 0.9
         self.size = 3
-        self.link = links.BatchNormalization(self.size, self.decay, use_cudnn=False)
+        self.link = links.BatchNormalization(self.size, self.decay,
+                                             use_cudnn=False)
 
     def test_initialize_cpu(self):
         testing.assert_allclose(numpy.ones(self.size), self.link.gamma.data)


### PR DESCRIPTION
This PR is to allow you to use cuDNN for fp16 batch normalization.
Note, you should set **CHAINER_TYPE_CHECK=0**, when you test this branch.