### PR TITLE
Implement cupy.lexsort.

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -383,6 +383,7 @@ from cupy.sorting.search import argmin  # NOQA
 from cupy.sorting.search import where  # NOQA
 
 from cupy.sorting.sort import argsort  # NOQA
+from cupy.sorting.sort import lexsort  # NOQA
 from cupy.sorting.sort import sort  # NOQA
 
 # -----------------------------------------------------------------------------

--- a/cupy/core/__init__.py
+++ b/cupy/core/__init__.py
@@ -33,6 +33,7 @@ from cupy.core.core import invert  # NOQA
 from cupy.core.core import left_shift  # NOQA
 from cupy.core.core import less  # NOQA
 from cupy.core.core import less_equal  # NOQA
+from cupy.core.core import lexsort  # NOQA
 from cupy.core.core import matmul  # NOQA
 from cupy.core.core import multiply  # NOQA
 from cupy.core.core import nanmax  # NOQA

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3581,6 +3581,71 @@ cdef _clip = create_ufunc(
 
 
 # -----------------------------------------------------------------------------
+# Sorting, searching, and counting
+# -----------------------------------------------------------------------------
+
+cpdef lexsort(keys):
+    """
+    """
+
+    # TODO(takagi): Support axis argument.
+    cdef Py_ssize_t *idx_ptr
+    cdef void *keys_ptr
+    cdef Py_ssize_t k
+    cdef Py_ssize_t n
+
+    if keys.shape == ():
+        msg = 'Keys with the rank of zero is not supported in lexsort'
+        raise TypeError(msg)
+
+    if len(keys.shape) == 1:
+        return 0
+
+    # TODO(takagi): Support ranks of three or more.
+    if len(keys.shape) > 2:
+        msg = ('Keys with the rank of three or more is '
+               'not supported in lexsort')
+        raise ValueError(msg)
+
+    # Assuming that Py_ssize_t can be represented with numpy.int64.
+    assert cython.sizeof(Py_ssize_t) == 8
+
+    idx_array = ndarray(keys.shape[1:], dtype=numpy.int64)
+    idx_ptr = <Py_ssize_t *>idx_array.data.ptr
+    keys_ptr = <void *>keys.data.ptr
+    k = <Py_ssize_t>keys.shape[0]
+    n = <Py_ssize_t>keys.shape[1]
+
+    # TODO(takagi): Support float16 and bool
+    dtype = keys.dtype
+    if dtype == numpy.int8:
+        thrust.lexsort[common.cpy_byte](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.uint8:
+        thrust.lexsort[common.cpy_ubyte](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.int16:
+        thrust.lexsort[common.cpy_short](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.uint16:
+        thrust.lexsort[common.cpy_ushort](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.int32:
+        thrust.lexsort[common.cpy_int](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.uint32:
+        thrust.lexsort[common.cpy_uint](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.int64:
+        thrust.lexsort[common.cpy_long](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.uint64:
+        thrust.lexsort[common.cpy_ulong](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.float32:
+        thrust.lexsort[common.cpy_float](idx_ptr, keys_ptr, k, n)
+    elif dtype == numpy.float64:
+        thrust.lexsort[common.cpy_double](idx_ptr, keys_ptr, k, n)
+    else:
+        msg = "Lexsort with keys dtype '{}' is not supported"
+        raise TypeError(msg.format(dtype))
+
+    return idx_array
+
+
+# -----------------------------------------------------------------------------
 # Statistics
 # -----------------------------------------------------------------------------
 

--- a/cupy/core/core.pyx
+++ b/cupy/core/core.pyx
@@ -3585,8 +3585,12 @@ cdef _clip = create_ufunc(
 # -----------------------------------------------------------------------------
 
 cpdef lexsort(keys):
-    """
-    """
+    """Return an array of indices that sort the supplied keys.
+
+    .. seealso::
+        :func:`cupy.lexsort` for full documentation, :func:`numpy.lexsort`
+
+   """
 
     # TODO(takagi): Support axis argument.
     cdef Py_ssize_t *idx_ptr

--- a/cupy/cuda/cupy_thrust.h
+++ b/cupy/cuda/cupy_thrust.h
@@ -9,6 +9,8 @@ namespace thrust {
 
 template <typename T> void sort(void *, ssize_t);
 
+template <typename T> void lexsort(ssize_t *, void *, ssize_t, ssize_t);
+
 template <typename T> void argsort(ssize_t *, void *, ssize_t);
 
 } // namespace thrust
@@ -24,6 +26,8 @@ namespace cupy {
 namespace thrust {
 
 template <typename T> void sort(void *, ssize_t) { return; }
+
+template <typename T> void lexsort(ssize_t *, void *, ssize_t, ssize_t) { return; }
 
 template <typename T> void argsort(ssize_t *, void *, ssize_t) { return; }
 

--- a/cupy/cuda/thrust.pxd
+++ b/cupy/cuda/thrust.pxd
@@ -2,4 +2,5 @@
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
     void sort[T](void *start, ssize_t num)
+    void lexsort[T](ssize_t *idx_start, void *keys_start, ssize_t k, ssize_t n)
     void argsort[T](ssize_t *idx_start, void *data_start, ssize_t num)

--- a/cupy/cuda/thrust.pyx
+++ b/cupy/cuda/thrust.pyx
@@ -8,4 +8,5 @@
 
 cdef extern from "../cuda/cupy_thrust.h" namespace "cupy::thrust":
     void sort[T](void *start, ssize_t num)
+    void lexsort[T](ssize_t *idx_start, void *keys_start, ssize_t k, ssize_t n)
     void argsort[T](ssize_t *idx_start, void *data_start, ssize_t num)

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -1,3 +1,6 @@
+from cupy import core
+
+
 def sort(a):
     """Returns a sorted copy of an array with a stable sorting algorithm.
 
@@ -20,7 +23,10 @@ def sort(a):
     return ret
 
 
-# TODO(okuta): Implement lexsort
+def lexsort(keys):
+    """
+    """
+    return core.lexsort(keys)
 
 
 def argsort(a):

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -24,7 +24,23 @@ def sort(a):
 
 
 def lexsort(keys):
-    """
+    """Perform an indirect sort using an array of keys.
+
+    Args:
+        keys (cupy.ndarray): ``(k, N)`` array containing ``k`` ``(N,)``-shaped
+            arrays. The ``k`` different "rows" to be sorted. The last row is
+            the primary sort key.
+
+    Returns:
+        cupy.ndarray: Array of indices that sort the keys.
+
+    .. note::
+        For its implementation reason, ``cupy.lexsort`` currently supports only
+        keys with their rank of one or two and does not support ``axis``
+        parameter that ``numpy.lexsort`` supports.
+
+    .. seealso:: :func:`numpy.lexsort`
+
     """
     return core.lexsort(keys)
 

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -87,10 +87,10 @@ class TestLexsort(unittest.TestCase):
         a = testing.shaped_random((), xp)
         return xp.lexsort(a)
 
-    @testing.numpy_cupy_allclose()
     def test_lexsort_one_dim(self, xp):
-        a = testing.shaped_random((2,), xp)
-        return xp.lexsort(a)
+        a = testing.shaped_random((2,), numpy)
+        b = testing.shaped_random((2,), cupy)
+        self.assertEqual(numpy.lexsort(a), cupy.lexsort(b))
 
     def test_lexsort_three_or_more_dim(self):
         a = testing.shaped_random((2, 10, 10), cupy)

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -76,6 +76,44 @@ class TestSort(unittest.TestCase):
 
 
 @testing.gpu
+class TestLexsort(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    # Test rank
+
+    @testing.numpy_cupy_raises()
+    def test_lexsort_zero_dim(self, xp):
+        a = testing.shaped_random((), xp)
+        return xp.lexsort(a)
+
+    @testing.numpy_cupy_allclose()
+    def test_lexsort_one_dim(self, xp):
+        a = testing.shaped_random((2,), xp)
+        return xp.lexsort(a)
+
+    def test_lexsort_three_or_more_dim(self):
+        a = testing.shaped_random((2, 10, 10), cupy)
+        with self.assertRaises(ValueError):
+            return cupy.lexsort(a)
+
+    # Test dtypes
+
+    @testing.for_dtypes(['b', 'h', 'i', 'l', 'q', 'B', 'H', 'I', 'L', 'Q',
+                         numpy.float32, numpy.float64])
+    @testing.numpy_cupy_allclose()
+    def test_lexsort_dtype(self, xp, dtype):
+        a = testing.shaped_random((2, 10), xp, dtype)
+        return xp.lexsort(a)
+
+    @testing.for_dtypes([numpy.float16, numpy.bool_])
+    def test_lexsort_unsupported_dtype(self, dtype):
+        a = testing.shaped_random((2, 10), cupy, dtype)
+        with self.assertRaises(TypeError):
+            return cupy.lexsort(a)
+
+
+@testing.gpu
 class TestArgsort(unittest.TestCase):
 
     _multiprocess_can_split_ = True


### PR DESCRIPTION
This PR implements `cupy.lexsort` following the implementations of `cupy.sort` in #1817 and `cupy.argsort` in #2057 .