### PR TITLE
fp16 compute

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -33,6 +33,8 @@ from chainer.flag import ON  # NOQA
 from chainer.function import force_backprop_mode  # NOQA
 from chainer.function import Function  # NOQA
 from chainer.function import no_backprop_mode  # NOQA
+from chainer.function import no_fp16_compute  # NOQA
+from chainer.function import use_fp16_compute  # NOQA
 from chainer.function_set import FunctionSet  # NOQA
 from chainer.functions import array  # NOQA
 from chainer.functions import basic_math  # NOQA

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -78,6 +78,24 @@ def force_backprop_mode():
     _thread_local.default_backprop = default
 
 
+@contextlib.contextmanager
+def use_fp16_compute():
+    """Enable fp16 compute for convolution related functions."""
+    default = getattr(_thread_local, 'fp16_compute_mode', False)
+    _thread_local.fp16_compute_mode = True
+    yield
+    _thread_local.fp16_compute_mode = default
+
+
+@contextlib.contextmanager
+def no_fp16_compute():
+    """Disable fp16 compute for convolution related functions."""
+    default = getattr(_thread_local, 'fp16_compute_mode', False)
+    _thread_local.fp16_compute_mode = False
+    yield
+    _thread_local.fp16_compute_mode = default
+
+
 class Function(object):
 
     """Function on variables with backpropagation ability.

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -94,8 +94,10 @@ def no_fp16_compute():
     """Disable fp16 compute for convolution related functions."""
     default = getattr(_thread_local, 'fp16_compute_mode', False)
     _thread_local.fp16_compute_mode = False
-    yield
-    _thread_local.fp16_compute_mode = default
+    try:
+        yield
+    finally:
+        _thread_local.fp16_compute_mode = default
 
 
 class Function(object):

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -83,8 +83,10 @@ def use_fp16_compute():
     """Enable fp16 compute for convolution related functions."""
     default = getattr(_thread_local, 'fp16_compute_mode', False)
     _thread_local.fp16_compute_mode = True
-    yield
-    _thread_local.fp16_compute_mode = default
+    try:
+        yield
+    finally:
+        _thread_local.fp16_compute_mode = default
 
 
 @contextlib.contextmanager

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -46,8 +46,8 @@ class Convolution2DFunction(function.Function):
         if self.fp16_compute_mode:
             # fp16 compute is available on GPUs with compute capability 6.0.
             if not _cc == '60':
-                msg = "fp16 compute is not supported by the GPU " + \
-                      "with compute capability {}".format(_cc)
+                msg = 'fp16 compute is not supported by the GPU ' + \
+                      'with compute capability {}'.format(_cc)
                 raise RuntimeError(msg)
 
     def check_type_forward(self, in_types):

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -1,5 +1,8 @@
 import numpy
 
+import chainer
+import warnings
+
 from chainer import cuda
 from chainer import function
 from chainer.utils import conv
@@ -278,7 +281,8 @@ class Convolution2DFunction(function.Function):
                             conv_desc_bd.value, x_desc.value, _bwd_data_pref,
                             workspace_size)
                     except RuntimeError:
-                        # print("No algorithm found for fp16 compute (kh:{}, kw:{}, n:{}, c:{}, h:{}, w:{}, out_c:{}, out_h:{}, out_w:{})".format(kh, kw, n, c, h, w, out_c, out_h, out_w))  # NOQA
+                        if chainer.is_debug():
+                            warnings.warn('No algorithm found for fp16 compute (kh:{}, kw:{}, n:{}, c:{}, h:{}, w:{}, out_c:{}, out_h:{}, out_w:{})'.format(kh, kw, n, c, h, w, out_c, out_h, out_w))  # NOQA
                         # use fp32 compute instead
                         conv_desc_bd = self.conv_desc_fp32
                         algo = libcudnn.getConvolutionBackwardDataAlgorithm(

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -16,6 +16,9 @@ if cuda.cudnn_enabled:
         _bwd_data_pref = \
             libcudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT
 
+    from cupy.cuda import device  # NOQA
+    _cc = device.Device().compute_capability  # compute capability
+
 
 def _check_cudnn_acceptable_type(x_dtype, W_dtype):
     return x_dtype == W_dtype and (
@@ -37,6 +40,15 @@ class Convolution2DFunction(function.Function):
         self.use_cudnn = use_cudnn
         self.cover_all = cover_all
         self.deterministic = deterministic
+
+        self.fp16_compute_mode = getattr(function._thread_local,
+                                         'fp16_compute_mode', False)
+        if self.fp16_compute_mode:
+            # fp16 compute is available on GPUs with compute capability 6.0.
+            if not _cc == '60':
+                msg = "fp16 compute is not supported by the GPU " + \
+                      "with compute capability {}".format(_cc)
+                raise RuntimeError(msg)
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -122,7 +134,14 @@ class Convolution2DFunction(function.Function):
 
             self.filter_desc = cudnn.create_filter_descriptor(W)
             self.conv_desc = cudnn.create_convolution_descriptor(
-                (self.ph, self.pw), (self.sy, self.sx), x.dtype)
+                (self.ph, self.pw), (self.sy, self.sx), x.dtype,
+                fp16_compute_mode=self.fp16_compute_mode)
+            if x.dtype == numpy.float16 and self.fp16_compute_mode:
+                # fp16 compute may not be available in some case.
+                # make descriptor for convolution at fp32 precision.
+                self.conv_desc_fp32 = cudnn.create_convolution_descriptor(
+                    (self.ph, self.pw), (self.sy, self.sx), x.dtype,
+                    fp16_compute_mode=False)
             if b is not None:
                 self.bias_desc = cudnn.create_tensor_descriptor(
                     b[None, :, None, None])
@@ -244,17 +263,43 @@ class Convolution2DFunction(function.Function):
                     algo, workspace.data.ptr, workspace_size,
                     zero.data, self.filter_desc.value, gW.data.ptr)
 
-                if not self.deterministic:
-                    algo = libcudnn.getConvolutionBackwardDataAlgorithm(
-                        handle, self.filter_desc.value, gy_desc.value,
-                        self.conv_desc.value, x_desc.value, _bwd_data_pref,
-                        workspace_size)
+                conv_desc_bd = self.conv_desc
+                if hasattr(self, 'conv_desc_fp32'):
+                    # WA for cuDNN 6.0 or below.
+                    # When stride > 1, fp16 is slower than fp32.
+                    # Try to remove the WA, when new cuDNN is released.
+                    if self.sx != 1 or self.sy != 1:
+                        conv_desc_bd = self.conv_desc_fp32
+
+                    try:
+                        # try to find algo for fp16 compute
+                        algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                            handle, self.filter_desc.value, gy_desc.value,
+                            conv_desc_bd.value, x_desc.value, _bwd_data_pref,
+                            workspace_size)
+                    except RuntimeError:
+                        # print("No algorithm found for fp16 compute (kh:{}, kw:{}, n:{}, c:{}, h:{}, w:{}, out_c:{}, out_h:{}, out_w:{})".format(kh, kw, n, c, h, w, out_c, out_h, out_w))  # NOQA
+                        # use fp32 compute instead
+                        conv_desc_bd = self.conv_desc_fp32
+                        algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                            handle, self.filter_desc.value, gy_desc.value,
+                            conv_desc_bd.value, x_desc.value, _bwd_data_pref,
+                            workspace_size)
+
+                    if self.deterministic:
+                        algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1  # NOQA
                 else:
-                    algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1  # NOQA
+                    if not self.deterministic:
+                        algo = libcudnn.getConvolutionBackwardDataAlgorithm(
+                            handle, self.filter_desc.value, gy_desc.value,
+                            conv_desc_bd.value, x_desc.value, _bwd_data_pref,
+                            workspace_size)
+                    else:
+                        algo = cuda.cupy.cuda.cudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1  # NOQA
 
                 libcudnn.convolutionBackwardData_v3(
                     handle, one.data, self.filter_desc.value, W.data.ptr,
-                    gy_desc.value, gy.data.ptr, self.conv_desc.value,
+                    gy_desc.value, gy.data.ptr, conv_desc_bd.value,
                     algo, workspace.data.ptr, workspace_size,
                     zero.data, x_desc.value, gx.data.ptr)
             else:

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -469,15 +469,6 @@ cudnnStatus_t cudnnFindConvolutionBackwardDataAlgorithmEx(...) {
 #endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 5000)
 
 
-#if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 6000)
-// ***_v4 functions are not declared in cuDNN v2, v3, v4 and v5.
-// Following definitions are for compatibility with cuDNN v6.
-
-#define cudnnSetConvolution2dDescriptor_v4 cudnnSetConvolution2dDescriptor
-
-#endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 6000)
-
-
 #if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 5000)
 // Some functions are renamed in cuDNN v5.
 // Following definitions are for compatibility with cuDNN v5 and higher.

--- a/cupy/cuda/cupy_cudnn.h
+++ b/cupy/cuda/cupy_cudnn.h
@@ -469,6 +469,15 @@ cudnnStatus_t cudnnFindConvolutionBackwardDataAlgorithmEx(...) {
 #endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 5000)
 
 
+#if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 6000)
+// ***_v4 functions are not declared in cuDNN v2, v3, v4 and v5.
+// Following definitions are for compatibility with cuDNN v6.
+
+#define cudnnSetConvolution2dDescriptor_v4 cudnnSetConvolution2dDescriptor
+
+#endif // #if defined(CUPY_NO_CUDA) || (CUDNN_VERSION < 6000)
+
+
 #if !defined(CUPY_NO_CUDA) && (CUDNN_VERSION >= 5000)
 // Some functions are renamed in cuDNN v5.
 // Following definitions are for compatibility with cuDNN v5 and higher.

--- a/cupy/cudnn.py
+++ b/cupy/cudnn.py
@@ -145,7 +145,8 @@ def create_filter_descriptor(arr, format=cudnn.CUDNN_TENSOR_NCHW):
 
 
 def create_convolution_descriptor(pad, stride, dtype,
-                                  mode=cudnn.CUDNN_CROSS_CORRELATION):
+                                  mode=cudnn.CUDNN_CROSS_CORRELATION,
+                                  fp16_compute_mode=False):
     desc = Descriptor(cudnn.createConvolutionDescriptor(),
                       cudnn.destroyConvolutionDescriptor)
     ndim = len(pad)
@@ -155,9 +156,7 @@ def create_convolution_descriptor(pad, stride, dtype,
     if ndim == 2:
         if _cudnn_version >= 5000:
             data_type = get_data_type(dtype)
-            # TODO(takagi) Temporarily use computing precision of FP32 for
-            #     storing precision of FP16.
-            if dtype == numpy.float16:
+            if dtype == numpy.float16 and fp16_compute_mode is False:
                 data_type = cudnn.CUDNN_DATA_FLOAT
             cudnn.setConvolution2dDescriptor_v5(
                 desc.value, pad[0], pad[1], stride[0], stride[1], 1, 1, mode,

--- a/examples/imagenet/alex.py
+++ b/examples/imagenet/alex.py
@@ -68,3 +68,14 @@ class AlexFp16(Alex):
 
     def __call__(self, x, t):
         return Alex.__call__(self, F.cast(x, self.dtype), t)
+
+
+class AlexFp16c(AlexFp16):
+
+    """Single-GPU AlexNet without partition toward the channel axis."""
+
+    insize = 227
+
+    def __call__(self, x, t):
+        with chainer.use_fp16_compute():
+            return AlexFp16.__call__(self, x, t)

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -79,6 +79,7 @@ def main():
     archs = {
         'alex': alex.Alex,
         'alex_fp16': alex.AlexFp16,
+        'alex_fp16c': alex.AlexFp16c,
         'googlenet': googlenet.GoogLeNet,
         'googlenetbn': googlenetbn.GoogLeNetBN,
         'googlenetbn_fp16': googlenetbn.GoogLeNetBNFp16,


### PR DESCRIPTION
This PR is related to fp16 compute with cuDNN 5 or above.

Current chainer supports fp16 I/O, meaning tensor data is kept as fp16 precision and compute is done at fp32 precision. This branch allows the compute at fp16 precision. If you already have models for fp16 I/O, usage of fp16 compute is very simple, just using **chainer.use_fp16_compute()** as below.

    with chainer.use_fp16_compute():
        loss = model(x, t)

Please also see the file [example/imagenet/alex.py](https://github.com/anaruse/chainer/blob/fp16_compute/examples/imagenet/alex.py) for an example of the usage.

Note 1: Computation of convolution gets done at fp16 precision using **chainer.user_fp16_compute()**, but computation of others such as activation and normalization stays at fp32 precision.

Note 2: You should use GPUs with compute capability 6.0 like Tesla P100 to test this branch, because fp16 compute is not fully supported by GPUs with compute capability other than 6.0.
