### PR TITLE
Implement cupy.msort.

### DIFF
--- a/cupy/__init__.py
+++ b/cupy/__init__.py
@@ -383,6 +383,7 @@ from cupy.sorting.search import argmin  # NOQA
 from cupy.sorting.search import where  # NOQA
 
 from cupy.sorting.sort import argsort  # NOQA
+from cupy.sorting.sort import msort  # NOQA
 from cupy.sorting.sort import sort  # NOQA
 
 # -----------------------------------------------------------------------------

--- a/cupy/sorting/sort.py
+++ b/cupy/sorting/sort.py
@@ -43,7 +43,29 @@ def argsort(a):
     return a.argsort()
 
 
-# TODO(okuta): Implement msort
+def msort(a):
+    """Returns a copy of an array sorted along the first axis.
+
+    Args:
+        a (cupy.ndarray): Array to be sorted.
+
+    Returns:
+        cupy.ndarray: Array of the same type and shape as ``a``.
+
+    .. note:
+       ``numpy.msort(a)``, the numpy counterpart of ``cupy.msort(a)``, is
+       equivalent to ``numpy.sort(a, axis=0)``. For its implementation reason,
+       ``cupy.sort`` currently supports only sorting an array with its rank of
+       one, so ``cupy.msort(a)`` is actually the same as``cupy.sort(a)`` for
+       now.
+
+    .. seealso:: :func:`numpy.msort`
+
+    """
+    # TODO(takagi): Support axis argument.
+    # TODO(takagi): Support ranks of two or more.
+    # TODO(takagi): Support float16 and bool.
+    return sort(a)
 
 
 # TODO(okuta): Implement sort_complex

--- a/tests/cupy_tests/sorting_tests/test_sort.py
+++ b/tests/cupy_tests/sorting_tests/test_sort.py
@@ -129,3 +129,36 @@ class TestArgsort(unittest.TestCase):
         a = testing.shaped_random((10,), cupy, dtype)
         with self.assertRaises(TypeError):
             return cupy.argsort(a)
+
+
+@testing.gpu
+class TestMsort(unittest.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    # Test rank
+
+    @testing.numpy_cupy_raises()
+    def test_msort_zero_dim(self, xp):
+        a = testing.shaped_random((), xp)
+        return xp.msort(a)
+
+    def test_msort_two_or_more_dim(self):
+        a = testing.shaped_random((2, 3), cupy)
+        with self.assertRaises(ValueError):
+            return cupy.msort(a)
+
+    # Test dtypes
+
+    @testing.for_dtypes(['b', 'h', 'i', 'l', 'q', 'B', 'H', 'I', 'L', 'Q',
+                         numpy.float32, numpy.float64])
+    @testing.numpy_cupy_allclose()
+    def test_msort_dtype(self, xp, dtype):
+        a = testing.shaped_random((10,), xp, dtype)
+        return xp.msort(a)
+
+    @testing.for_dtypes([numpy.float16, numpy.bool_])
+    def test_msort_unsupported_dtype(self, dtype):
+        a = testing.shaped_random((10,), cupy, dtype)
+        with self.assertRaises(TypeError):
+            return cupy.msort(a)


### PR DESCRIPTION
This PR implements `cupy.msort`. Please merge #2057 first.

`numpy.msort(a)` is equivalent to `numpy.sort(a, axis=0)`. For implementation reasons, `cupy.sort` currently supports only sorting an array with its rank of one, so `cupy.msort(a)` would be actually equivalent to `cupy.sort(a)` for now.