### PR TITLE
Make LSTM serialization format compatible with NStepLSTM's one

### DIFF
--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -60,7 +60,9 @@ class LSTMBase(link.Chain):
             ws = [serializer('w%d' % weight_index[i], None)
                   for i in six.moves.range(4)]
             if all(w is not None for w in ws):
-                w = numpy.stack(ws, axis=1).reshape((-1, ws[0].shape[1]))
+                w = numpy.concatenate(
+                    [w[:, None, :] for w in ws], axis=1).reshape(
+                        (-1, ws[0].shape[1]))
 
                 param = self.upward.W
                 param.initialize(w.shape)

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -14,6 +14,8 @@ from chainer import variable
 
 class LSTMBase(link.Chain):
 
+    v1_serialize_format = False
+
     def __init__(self, in_size, out_size,
                  lateral_init=None, upward_init=None,
                  bias_init=0, forget_bias_init=1):
@@ -47,6 +49,9 @@ class LSTMBase(link.Chain):
         initializers.init_weight(o, self.bias_init)
 
     def serialize(self, serializer):
+        if self.v1_serialize_format:
+            return super(LSTMBase, self).serialize(serializer)
+
         # Order of parameters are diffrent in LSTM and NStepLSTM.
         # See chainer.functions.n_step_lstm
         weight_index = [2, 0, 1, 3]

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -46,6 +46,43 @@ class LSTMBase(link.Chain):
         initializers.init_weight(f, self.forget_bias_init)
         initializers.init_weight(o, self.bias_init)
 
+    def serialize(self, serializer):
+        # Order of parameters are diffrent in LSTM and NStepLSTM.
+        # See chainer.functions.n_step_lstm
+        weight_index = [2, 0, 1, 3]
+
+        # Only update.W may not be initialized.
+        if self.upward.W.data is not None:
+            for i in six.moves.range(4):
+                w = self.upward.W.data[i::4, :]
+                serializer('w%d' % weight_index[i], w)
+        else:
+            ws = [serializer('w%d' % weight_index[i], None)
+                  for i in six.moves.range(4)]
+            if all(w is not None for w in ws):
+                w = numpy.stack(ws, axis=1).reshape((-1, ws[0].shape[1]))
+
+                param = self.upward.W
+                param.initialize(w.shape)
+                if isinstance(param.data, numpy.ndarray):
+                    numpy.copyto(param.data, w)
+                else:
+                    param.data.set(numpy.asarray(w))
+
+        for i in six.moves.range(4):
+            b = self.upward.b.data[i::4]
+            serializer('b%d' % weight_index[i], b)
+
+            w = self.lateral.W.data[i::4, :]
+            serializer('w%d' % (weight_index[i] + 4), w)
+            # lateral of LSTM link does not have bias parameter.
+            # It is needed for compatibility with NStepLSTM link.
+            b = numpy.zeros(
+                self.state_size, self.upward.b.data.dtype)
+            serializer('b%d' % (weight_index[i] + 4), b)
+            if isinstance(serializer, chainer.Deserializer):
+                self.upward.b.data[i::4] += b
+
 
 class StatelessLSTM(LSTMBase):
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -366,5 +366,46 @@ class TestLSTMSerializationCompatibility(unittest.TestCase):
 
         self.check_call(n_step, lstm)
 
+    def test_load_v1_format(self):
+        path = os.path.join(self.path, 'lstm.npz')
+
+        # Make an old format file
+        model = chainer.Chain(
+            upward=chainer.links.Linear(3, 4 * 4),
+            lateral=chainer.links.Linear(4, 4 * 4, nobias=True))
+        chainer.serializers.save_npz(path, model)
+
+        lstm = links.LSTM(3, 4)
+        lstm.v1_serialize_format = True
+        chainer.serializers.load_npz(path, lstm)
+
+        testing.assert_allclose(
+            model.upward.W.data, lstm.upward.W.data)
+        testing.assert_allclose(
+            model.upward.b.data, lstm.upward.b.data)
+        testing.assert_allclose(
+            model.lateral.W.data, lstm.lateral.W.data)
+        self.assertIsNone(lstm.lateral.b)
+
+    def test_save_v1_format(self):
+        path = os.path.join(self.path, 'lstm.npz')
+
+        lstm = links.LSTM(3, 4)
+        lstm.v1_serialize_format = True
+        chainer.serializers.save_npz(path, lstm)
+
+        model = chainer.Chain(
+            upward=chainer.links.Linear(3, 4 * 4),
+            lateral=chainer.links.Linear(4, 4 * 4, nobias=True))
+        chainer.serializers.load_npz(path, model)
+
+        testing.assert_allclose(
+            model.upward.W.data, lstm.upward.W.data)
+        testing.assert_allclose(
+            model.upward.b.data, lstm.upward.b.data)
+        testing.assert_allclose(
+            model.lateral.W.data, lstm.lateral.W.data)
+        self.assertIsNone(model.lateral.b)
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+import tempfile
 import unittest
 
 import numpy
@@ -290,6 +293,78 @@ class TestStatelessLSTM(unittest.TestCase):
             x = cuda.to_gpu(self.x)
         with cuda.get_device(1):
             self.check_forward(x)
+
+
+class TestLSTMSerializationCompatibility(unittest.TestCase):
+
+    def setUp(self):
+        self.path = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if hasattr(self, 'path'):
+            shutil.rmtree(self.path)
+
+    def check_call(self, n_step, lstm):
+        x = numpy.random.uniform(-1, 1, (3, 2, 3)).astype('f')
+        hy1, cy1, ys1 = n_step(None, None, [x[0], x[1], x[2]])
+
+        ys2 = []
+        for i in range(x.shape[1]):
+            h1 = lstm[0](x[:, i, :])
+            h2 = lstm[1](h1)
+            ys2.append(h2)
+
+        testing.assert_allclose(
+            functions.stack(ys1, axis=0).data,
+            functions.stack(ys2, axis=1).data)
+        testing.assert_allclose(
+            hy1.data[0], lstm[0].h.data)
+        testing.assert_allclose(
+            hy1.data[1], lstm[1].h.data)
+        testing.assert_allclose(
+            cy1.data[0], lstm[0].c.data)
+        testing.assert_allclose(
+            cy1.data[1], lstm[1].c.data)
+
+    def test_n_step_to_lstm(self):
+        path = os.path.join(self.path, 'lstm.npz')
+
+        n_step = chainer.links.NStepLSTM(2, 3, 4, 0.0)
+        chainer.serializers.save_npz(path, n_step)
+
+        lstm = chainer.ChainList(
+            chainer.links.LSTM(3, 4),
+            chainer.links.LSTM(4, 4))
+        chainer.serializers.load_npz(path, lstm)
+
+        self.check_call(n_step, lstm)
+
+    def test_n_step_to_lstm_uninitiliazed(self):
+        path = os.path.join(self.path, 'lstm.npz')
+
+        n_step = chainer.links.NStepLSTM(2, 3, 4, 0.0)
+        chainer.serializers.save_npz(path, n_step)
+
+        lstm = chainer.ChainList(
+            chainer.links.LSTM(None, 4),
+            chainer.links.LSTM(4, 4))
+        chainer.serializers.load_npz(path, lstm)
+
+        self.check_call(n_step, lstm)
+
+    def test_lstom_to_n_step(self):
+        path = os.path.join(self.path, 'lstm.npz')
+
+        lstm = chainer.ChainList(
+            chainer.links.LSTM(3, 4),
+            chainer.links.LSTM(4, 4))
+        chainer.serializers.save_npz(path, lstm)
+
+        # Note NStepLSTM does not support uninitialized parameter.
+        n_step = chainer.links.NStepLSTM(2, 3, 4, 0.0)
+        chainer.serializers.load_npz(path, n_step)
+
+        self.check_call(n_step, lstm)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
I fixed LSTM to load serialized file of NStepLSTM. With this fix, a user can train with NStepLSTM link and use it from LSTM link.

We need to consider backward compatibility. 