### PR TITLE
Support batch-common-mask dropconnect

### DIFF
--- a/chainer/functions/noise/simplified_dropconnect.py
+++ b/chainer/functions/noise/simplified_dropconnect.py
@@ -53,13 +53,13 @@ class SimplifiedDropconnect(function.Function):
     def forward(self, inputs):
         scale = inputs[1].dtype.type(1. / (1 - self.ratio))
         xp = cuda.get_array_module(*inputs)
-        if self.batchwise_mask:
-            mask_shape = (inputs[0].shape[0], inputs[1].shape[0],
-                          inputs[1].shape[1])
-        else:
-            mask_shape = (inputs[1].shape[0], inputs[1].shape[1])
 
         if self.mask is None:
+            if self.batchwise_mask:
+                mask_shape = (inputs[0].shape[0], inputs[1].shape[0],
+                              inputs[1].shape[1])
+            else:
+                mask_shape = (inputs[1].shape[0], inputs[1].shape[1])
             if xp == numpy:
                 self.mask = xp.random.rand(*mask_shape) >= self.ratio
             else:

--- a/chainer/functions/noise/simplified_dropconnect.py
+++ b/chainer/functions/noise/simplified_dropconnect.py
@@ -25,7 +25,7 @@ class SimplifiedDropconnect(function.Function):
 
     """Linear unit regularized by simplified dropconnect."""
 
-    def __init__(self, ratio: object, mask: object = None, batchwise_mask: object = True) -> object:
+    def __init__(self, ratio, mask=None, batchwise_mask=True):
         self.ratio = ratio
         self.mask = mask
         self.batchwise_mask = batchwise_mask

--- a/chainer/functions/noise/simplified_dropconnect.py
+++ b/chainer/functions/noise/simplified_dropconnect.py
@@ -134,7 +134,8 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, batchwise_mask=True,
         ratio (float):
             Dropconnect ratio.
         batchwise_mask (bool):
-            If ``True``, dropped value depends on each sample in mini-batch.
+            If ``True``, dropped connections depend on each sample in
+            mini-batch.
         train (bool):
             If ``True``, executes simplified dropconnect.
             Otherwise, simplified dropconnect function works as a linear

--- a/chainer/functions/noise/simplified_dropconnect.py
+++ b/chainer/functions/noise/simplified_dropconnect.py
@@ -25,9 +25,10 @@ class SimplifiedDropconnect(function.Function):
 
     """Linear unit regularized by simplified dropconnect."""
 
-    def __init__(self, ratio, mask=None):
+    def __init__(self, ratio, batchwise_mask, mask=None):
         self.ratio = ratio
         self.mask = mask
+        self.batchwise_mask = batchwise_mask
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -52,8 +53,12 @@ class SimplifiedDropconnect(function.Function):
     def forward(self, inputs):
         scale = inputs[1].dtype.type(1. / (1 - self.ratio))
         xp = cuda.get_array_module(*inputs)
-        mask_shape = (inputs[0].shape[0], inputs[1].shape[0],
-                      inputs[1].shape[1])
+        if self.batchwise_mask:
+            mask_shape = (inputs[0].shape[0], inputs[1].shape[0],
+                          inputs[1].shape[1])
+        else:
+            mask_shape = (inputs[1].shape[0], inputs[1].shape[1])
+
         if self.mask is None:
             if xp == numpy:
                 self.mask = xp.random.rand(*mask_shape) >= self.ratio
@@ -66,8 +71,12 @@ class SimplifiedDropconnect(function.Function):
         x = _as_mat(inputs[0])
         W = inputs[1] * scale * self.mask
 
-        # ijk,ik->ij
-        y = _matmul(W, x[:, :, None], xp)
+        if self.batchwise_mask:
+            # ijk,ik->ij
+            y = _matmul(W, x[:, :, None], xp)
+        else:
+            y = x.dot(W.T)
+
         y = y.reshape(y.shape[0], y.shape[1]).astype(x.dtype, copy=False)
 
         if len(inputs) == 3:
@@ -82,12 +91,18 @@ class SimplifiedDropconnect(function.Function):
         gy = grad_outputs[0]
         xp = cuda.get_array_module(*inputs)
 
-        # ij,ijk->ik
-        gx = _matmul(gy[:, None, :], W, xp).reshape(inputs[0].shape)
+        if self.batchwise_mask:
+            # ij,ijk->ik
+            gx = _matmul(gy[:, None, :], W, xp).reshape(inputs[0].shape)
+        else:
+            gx = gy.dot(W)
         gx = gx.astype(x.dtype, copy=False)
 
-        # ij,ik,ijk->jk
-        gW = (gy[:, :, None] * x[:, None, :] * self.mask).sum(0) * scale
+        if self.batchwise_mask:
+            # ij,ik,ijk->jk
+            gW = (gy[:, :, None] * x[:, None, :] * self.mask).sum(0) * scale
+        else:
+            gW = gy.T.dot(x) * scale
         gW = gW.astype(W.dtype, copy=False)
 
         if len(inputs) == 3:
@@ -97,12 +112,13 @@ class SimplifiedDropconnect(function.Function):
             return gx, gW
 
 
-def simplified_dropconnect(x, W, b=None, ratio=.5, train=True, mask=None):
+def simplified_dropconnect(x, W, b=None, ratio=.5, batchwise_mask=True,
+                           train=True, mask=None):
     """Linear unit regularized by simplified dropconnect.
 
     Simplified dropconnect drops weight matrix elements randomly with
     probability ``ratio`` and scales the remaining elements by factor
-    ``1 / (1 - ratio)``. Which element is dropped depends on each sample.
+    ``1 / (1 - ratio)``.
     It accepts two or three arguments: an input minibatch ``x``, a weight
     matrix ``W``, and optionally a bias vector ``b``. It computes
     :math:`Y = xW^\\top + b`.
@@ -127,6 +143,8 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, train=True, mask=None):
         b (~chainer.Variable): Bias variable (optional) of shape ``(M,)``.
         ratio (float):
             Dropconnect ratio.
+        batchwise_mask (bool):
+            If ``True``, dropped value depends on each sample in mini-batch.
         train (bool):
             If ``True``, executes simplified dropconnect.
             Otherwise, simplified dropconnect function works as a linear
@@ -151,6 +169,6 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, train=True, mask=None):
     if not train:
         ratio = 0
     if b is None:
-        return SimplifiedDropconnect(ratio, mask)(x, W)
+        return SimplifiedDropconnect(ratio, batchwise_mask, mask)(x, W)
     else:
-        return SimplifiedDropconnect(ratio, mask)(x, W, b)
+        return SimplifiedDropconnect(ratio, batchwise_mask, mask)(x, W, b)

--- a/chainer/functions/noise/simplified_dropconnect.py
+++ b/chainer/functions/noise/simplified_dropconnect.py
@@ -50,6 +50,15 @@ class SimplifiedDropconnect(function.Function):
                 b_type.shape[0] == w_type.shape[0],
             )
 
+        if self.mask is not None:
+            if self.use_batchwise_mask:
+                type_check.expect(
+                    self.mask.shape[0] == x_type.shape[0],
+                    self.mask.shape[1:] == w_type.shape,
+                )
+            else:
+                type_check.expect(self.mask.shape == w_type.shape)
+
     def forward(self, inputs):
         scale = inputs[1].dtype.type(1. / (1 - self.ratio))
         xp = cuda.get_array_module(*inputs)

--- a/chainer/functions/noise/simplified_dropconnect.py
+++ b/chainer/functions/noise/simplified_dropconnect.py
@@ -25,10 +25,10 @@ class SimplifiedDropconnect(function.Function):
 
     """Linear unit regularized by simplified dropconnect."""
 
-    def __init__(self, ratio, mask=None, batchwise_mask=True):
+    def __init__(self, ratio, mask=None, use_batchwise_mask=True):
         self.ratio = ratio
         self.mask = mask
-        self.batchwise_mask = batchwise_mask
+        self.use_batchwise_mask = use_batchwise_mask
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -55,7 +55,7 @@ class SimplifiedDropconnect(function.Function):
         xp = cuda.get_array_module(*inputs)
 
         if self.mask is None:
-            if self.batchwise_mask:
+            if self.use_batchwise_mask:
                 mask_shape = (inputs[0].shape[0], inputs[1].shape[0],
                               inputs[1].shape[1])
             else:
@@ -103,7 +103,7 @@ class SimplifiedDropconnect(function.Function):
 
 
 def simplified_dropconnect(x, W, b=None, ratio=.5, train=True, mask=None,
-                           batchwise_mask=True):
+                           use_batchwise_mask=True):
     """Linear unit regularized by simplified dropconnect.
 
     Simplified dropconnect drops weight matrix elements randomly with
@@ -139,10 +139,11 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, train=True, mask=None,
             function.
         mask (None or chainer.Variable or numpy.ndarray or cupy.ndarray):
             If ``None``, randomized dropconnect mask is generated.
-            Otherwise, The mask must be ``(n, M, N)`` shaped array.
+            Otherwise, The mask must be ``(n, M, N)`` or ``(M, N)`` shaped
+            array, and `use_batchwise_mask` is ignored.
             Main purpose of this option is debugging.
             `mask` array will be used as a dropconnect mask.
-        batchwise_mask (bool):
+        use_batchwise_mask (bool):
             If ``True``, dropped connections depend on each sample in
             mini-batch.
 
@@ -160,6 +161,6 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, train=True, mask=None,
     if not train:
         ratio = 0
     if b is None:
-        return SimplifiedDropconnect(ratio, mask, batchwise_mask)(x, W)
+        return SimplifiedDropconnect(ratio, mask, use_batchwise_mask)(x, W)
     else:
-        return SimplifiedDropconnect(ratio, mask, batchwise_mask)(x, W, b)
+        return SimplifiedDropconnect(ratio, mask, use_batchwise_mask)(x, W, b)

--- a/chainer/functions/noise/simplified_dropconnect.py
+++ b/chainer/functions/noise/simplified_dropconnect.py
@@ -25,7 +25,7 @@ class SimplifiedDropconnect(function.Function):
 
     """Linear unit regularized by simplified dropconnect."""
 
-    def __init__(self, ratio, batchwise_mask, mask=None):
+    def __init__(self, ratio: object, mask: object = None, batchwise_mask: object = True) -> object:
         self.ratio = ratio
         self.mask = mask
         self.batchwise_mask = batchwise_mask
@@ -102,8 +102,8 @@ class SimplifiedDropconnect(function.Function):
             return gx, gW
 
 
-def simplified_dropconnect(x, W, b=None, ratio=.5, batchwise_mask=True,
-                           train=True, mask=None):
+def simplified_dropconnect(x, W, b=None, ratio=.5, train=True, mask=None,
+                           batchwise_mask=True):
     """Linear unit regularized by simplified dropconnect.
 
     Simplified dropconnect drops weight matrix elements randomly with
@@ -133,9 +133,6 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, batchwise_mask=True,
         b (~chainer.Variable): Bias variable (optional) of shape ``(M,)``.
         ratio (float):
             Dropconnect ratio.
-        batchwise_mask (bool):
-            If ``True``, dropped connections depend on each sample in
-            mini-batch.
         train (bool):
             If ``True``, executes simplified dropconnect.
             Otherwise, simplified dropconnect function works as a linear
@@ -145,6 +142,9 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, batchwise_mask=True,
             Otherwise, The mask must be ``(n, M, N)`` shaped array.
             Main purpose of this option is debugging.
             `mask` array will be used as a dropconnect mask.
+        batchwise_mask (bool):
+            If ``True``, dropped connections depend on each sample in
+            mini-batch.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -160,6 +160,6 @@ def simplified_dropconnect(x, W, b=None, ratio=.5, batchwise_mask=True,
     if not train:
         ratio = 0
     if b is None:
-        return SimplifiedDropconnect(ratio, batchwise_mask, mask)(x, W)
+        return SimplifiedDropconnect(ratio, mask, batchwise_mask)(x, W)
     else:
-        return SimplifiedDropconnect(ratio, batchwise_mask, mask)(x, W, b)
+        return SimplifiedDropconnect(ratio, mask, batchwise_mask)(x, W, b)

--- a/chainer/links/activation/simplified_dropconnect.py
+++ b/chainer/links/activation/simplified_dropconnect.py
@@ -71,7 +71,7 @@ class SimplifiedDropconnect(link.Link):
     def _initialize_params(self, in_size):
         self.W.initialize((self.out_size, in_size))
 
-    def __call__(self, x, train=True, mask=None, batchwise_mask=True):
+    def __call__(self, x, train=True, mask=None, use_batchwise_mask=True):
         """Applies the simplified dropconnect layer.
 
         Args:
@@ -83,10 +83,11 @@ class SimplifiedDropconnect(link.Link):
                 Otherwise, simplified dropconnect link works as a linear unit.
             mask (None or chainer.Variable or numpy.ndarray or cupy.ndarray):
                 If ``None``, randomized simplified dropconnect mask is
-                generated. Otherwise, The mask must be ``(n, M, N)``
-                shaped array. Main purpose of this option is debugging.
+                generated. Otherwise, The mask must be ``(n, M, N)`` or
+                ``(M, N)`` shaped array, and `use_batchwise_mask` is ignored.
+                Main purpose of this option is debugging.
                 `mask` array will be used as a dropconnect mask.
-            batchwise_mask (bool):
+            use_batchwise_mask (bool):
                 If ``True``, dropped connections depend on each sample in
                 mini-batch.
 
@@ -101,4 +102,4 @@ class SimplifiedDropconnect(link.Link):
         return simplified_dropconnect.simplified_dropconnect(x, self.W, self.b,
                                                              self.ratio,
                                                              train, mask,
-                                                             batchwise_mask)
+                                                             use_batchwise_mask)

--- a/chainer/links/activation/simplified_dropconnect.py
+++ b/chainer/links/activation/simplified_dropconnect.py
@@ -79,7 +79,7 @@ class SimplifiedDropconnect(link.Link):
                 Batch of input vectors. Its first dimension ``n`` is assumed
                 to be the *minibatch dimension*.
             batchwise_mask (bool):
-                If ``True``, dropped value depends on each sample in
+                If ``True``, dropped connections depend on each sample in
                 mini-batch.
             train (bool):
                 If ``True``, executes simplified dropconnect.

--- a/chainer/links/activation/simplified_dropconnect.py
+++ b/chainer/links/activation/simplified_dropconnect.py
@@ -99,7 +99,5 @@ class SimplifiedDropconnect(link.Link):
             self._initialize_params(x.size // len(x.data))
         if mask is not None and 'mask' not in self.__dict__:
             self.add_persistent('mask', mask)
-        return simplified_dropconnect.simplified_dropconnect(x, self.W, self.b,
-                                                             self.ratio,
-                                                             train, mask,
-                                                             use_batchwise_mask)
+        return simplified_dropconnect.simplified_dropconnect(
+            x, self.W, self.b, self.ratio, train, mask, use_batchwise_mask)

--- a/chainer/links/activation/simplified_dropconnect.py
+++ b/chainer/links/activation/simplified_dropconnect.py
@@ -71,16 +71,13 @@ class SimplifiedDropconnect(link.Link):
     def _initialize_params(self, in_size):
         self.W.initialize((self.out_size, in_size))
 
-    def __call__(self, x, batchwise_mask=True, train=True, mask=None):
+    def __call__(self, x, train=True, mask=None, batchwise_mask=True):
         """Applies the simplified dropconnect layer.
 
         Args:
             x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
                 Batch of input vectors. Its first dimension ``n`` is assumed
                 to be the *minibatch dimension*.
-            batchwise_mask (bool):
-                If ``True``, dropped connections depend on each sample in
-                mini-batch.
             train (bool):
                 If ``True``, executes simplified dropconnect.
                 Otherwise, simplified dropconnect link works as a linear unit.
@@ -89,6 +86,9 @@ class SimplifiedDropconnect(link.Link):
                 generated. Otherwise, The mask must be ``(n, M, N)``
                 shaped array. Main purpose of this option is debugging.
                 `mask` array will be used as a dropconnect mask.
+            batchwise_mask (bool):
+                If ``True``, dropped connections depend on each sample in
+                mini-batch.
 
         Returns:
             ~chainer.Variable: Output of the simplified dropconnect layer.
@@ -100,5 +100,5 @@ class SimplifiedDropconnect(link.Link):
             self.add_persistent('mask', mask)
         return simplified_dropconnect.simplified_dropconnect(x, self.W, self.b,
                                                              self.ratio,
-                                                             batchwise_mask,
-                                                             train, mask)
+                                                             train, mask,
+                                                             batchwise_mask)

--- a/chainer/links/activation/simplified_dropconnect.py
+++ b/chainer/links/activation/simplified_dropconnect.py
@@ -71,13 +71,16 @@ class SimplifiedDropconnect(link.Link):
     def _initialize_params(self, in_size):
         self.W.initialize((self.out_size, in_size))
 
-    def __call__(self, x, train=True, mask=None):
+    def __call__(self, x, batchwise_mask=True, train=True, mask=None):
         """Applies the simplified dropconnect layer.
 
         Args:
             x (chainer.Variable or :class:`numpy.ndarray` or cupy.ndarray):
                 Batch of input vectors. Its first dimension ``n`` is assumed
                 to be the *minibatch dimension*.
+            batchwise_mask (bool):
+                If ``True``, dropped value depends on each sample in
+                mini-batch.
             train (bool):
                 If ``True``, executes simplified dropconnect.
                 Otherwise, simplified dropconnect link works as a linear unit.
@@ -96,5 +99,6 @@ class SimplifiedDropconnect(link.Link):
         if mask is not None and 'mask' not in self.__dict__:
             self.add_persistent('mask', mask)
         return simplified_dropconnect.simplified_dropconnect(x, self.W, self.b,
-                                                             self.ratio, train,
-                                                             mask)
+                                                             self.ratio,
+                                                             batchwise_mask,
+                                                             train, mask)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -44,12 +44,16 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         x = chainer.Variable(x_data)
         W = chainer.Variable(W_data)
         if b_data is None:
-            y = functions.simplified_dropconnect(x, W, None, self.ratio, True,
-                                                 self.train)
+            y = functions.simplified_dropconnect(x, W, None,
+                                                 ratio=self.ratio,
+                                                 train=self.train,
+                                                 batchwise_mask=True)
         else:
             b = chainer.Variable(b_data)
-            y = functions.simplified_dropconnect(x, W, b, self.ratio, True,
-                                                 self.train)
+            y = functions.simplified_dropconnect(x, W, b,
+                                                 ratio=self.ratio,
+                                                 train=self.train,
+                                                 batchwise_mask=True)
         self.assertEqual(y.data.dtype, self.x_dtype)
 
     def test_forward_cpu(self):
@@ -71,10 +75,11 @@ class TestSimplifiedDropconnect(unittest.TestCase):
     def check_backward(self, x_data, W_data, b_data, y_grad):
         args = x_data, W_data
         if b_data is not None:
-            args = args + (b_data,)
+            args += (b_data,)
 
         gradient_check.check_backward(
-            simplified_dropconnect.SimplifiedDropconnect(self.ratio, True),
+            simplified_dropconnect.SimplifiedDropconnect(self.ratio, None,
+                                                         True),
             args, y_grad, eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)
@@ -117,7 +122,7 @@ class TestSimplifiedDropconnectBatchwiseMask(unittest.TestCase):
         x = chainer.Variable(x_data)
         W = chainer.Variable(W_data)
         b = chainer.Variable(b_data)
-        func = simplified_dropconnect.SimplifiedDropconnect(0.5, True)
+        func = simplified_dropconnect.SimplifiedDropconnect(0.5, None, True)
         y = func(x, W, b)
         self.assertEqual(y.data.dtype, numpy.float32)
         self.assertEqual(func.mask.shape, (x.shape[0],) + W.shape)
@@ -150,7 +155,7 @@ class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
         x = chainer.Variable(x_data)
         W = chainer.Variable(W_data)
         b = chainer.Variable(b_data)
-        func = simplified_dropconnect.SimplifiedDropconnect(0.5, False)
+        func = simplified_dropconnect.SimplifiedDropconnect(0.5, None, False)
         y = func(x, W, b)
         self.assertEqual(y.data.dtype, numpy.float32)
         self.assertEqual(func.mask.shape, W.shape)
@@ -168,7 +173,7 @@ class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
         args = args + (b_data,)
 
         gradient_check.check_backward(
-            simplified_dropconnect.SimplifiedDropconnect(0.5, True),
+            simplified_dropconnect.SimplifiedDropconnect(0.5, None, True),
             args, y_grad, eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -148,4 +148,5 @@ class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             cuda.to_gpu(self.b), cuda.to_gpu(self.gy))
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -98,6 +98,39 @@ class TestSimplifiedDropconnect(unittest.TestCase):
                             None, cuda.to_gpu(self.gy))
 
 
+class TestSimplifiedDropconnectBatchwiseMask(unittest.TestCase):
+
+    def setUp(self):
+        self.W = numpy.random.uniform(
+            -1, 1, (2, 3)).astype(numpy.float32)
+        self.b = numpy.random.uniform(
+            -1, 1, 2).astype(numpy.float32)
+
+        self.x = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (4, 2)).astype(numpy.float32)
+        self.y = self.x.dot(self.W.T) + self.b
+        self.check_forward_options = {}
+        self.check_backward_options = {}
+
+    def check_forward(self, x_data, W_data, b_data):
+        # Check only data type, y is tested by SimplifiedDropconnect link test.
+        x = chainer.Variable(x_data)
+        W = chainer.Variable(W_data)
+        b = chainer.Variable(b_data)
+        func = simplified_dropconnect.SimplifiedDropconnect(0.5, True)
+        y = func(x, W, b)
+        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(func.mask.shape, (x.shape[0],) + W.shape)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, self.W, self.b)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b))
+
+
 class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -44,11 +44,11 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         x = chainer.Variable(x_data)
         W = chainer.Variable(W_data)
         if b_data is None:
-            y = functions.simplified_dropconnect(x, W, None, self.ratio,
+            y = functions.simplified_dropconnect(x, W, None, self.ratio, True,
                                                  self.train)
         else:
             b = chainer.Variable(b_data)
-            y = functions.simplified_dropconnect(x, W, b, self.ratio,
+            y = functions.simplified_dropconnect(x, W, b, self.ratio, True,
                                                  self.train)
         self.assertEqual(y.data.dtype, self.x_dtype)
 
@@ -74,8 +74,8 @@ class TestSimplifiedDropconnect(unittest.TestCase):
             args = args + (b_data,)
 
         gradient_check.check_backward(
-            simplified_dropconnect.SimplifiedDropconnect(self.ratio), args,
-            y_grad, eps=1e-2, **self.check_backward_options)
+            simplified_dropconnect.SimplifiedDropconnect(self.ratio, True),
+            args, y_grad, eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -97,5 +97,55 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             None, cuda.to_gpu(self.gy))
 
+
+class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
+
+    def setUp(self):
+        self.W = numpy.random.uniform(
+            -1, 1, (2, 3)).astype(numpy.float32)
+        self.b = numpy.random.uniform(
+            -1, 1, 2).astype(numpy.float32)
+
+        self.x = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, (4, 2)).astype(numpy.float32)
+        self.y = self.x.dot(self.W.T) + self.b
+        self.check_forward_options = {}
+        self.check_backward_options = {}
+
+    def check_forward(self, x_data, W_data, b_data):
+        # Check only data type, y is tested by SimplifiedDropconnect link test.
+        x = chainer.Variable(x_data)
+        W = chainer.Variable(W_data)
+        b = chainer.Variable(b_data)
+        func = simplified_dropconnect.SimplifiedDropconnect(0.5, False)
+        y = func(x, W, b)
+        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(func.mask.shape, W.shape)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, self.W, self.b)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b))
+
+    def check_backward(self, x_data, W_data, b_data, y_grad):
+        args = x_data, W_data
+        args = args + (b_data,)
+
+        gradient_check.check_backward(
+            simplified_dropconnect.SimplifiedDropconnect(0.5, True),
+            args, y_grad, eps=1e-2, **self.check_backward_options)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.W, self.b, self.gy)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
+                            cuda.to_gpu(self.b), cuda.to_gpu(self.gy))
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -103,7 +103,7 @@ class TestSimplifiedDropconnect(unittest.TestCase):
                             None, cuda.to_gpu(self.gy))
 
 
-class TestSimplifiedDropconnectBatchwiseMask(unittest.TestCase):
+class TestSimplifiedDropconnectBatchwiseMaskShape(unittest.TestCase):
 
     def setUp(self):
         self.W = numpy.random.uniform(

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -46,16 +46,12 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         W = chainer.Variable(W_data)
         if b_data is None:
             y = functions.simplified_dropconnect(x, W, None,
-                                                 ratio=self.ratio,
-                                                 train=self.train,
-                                                 use_batchwise_mask=
+                                                 self.ratio, self.train, None,
                                                  self.use_batchwise_mask)
         else:
             b = chainer.Variable(b_data)
             y = functions.simplified_dropconnect(x, W, b,
-                                                 ratio=self.ratio,
-                                                 train=self.train,
-                                                 use_batchwise_mask=
+                                                 self.ratio, self.train, None,
                                                  self.use_batchwise_mask)
         self.assertEqual(y.data.dtype, self.x_dtype)
         mask = y.creator.mask

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -17,6 +17,7 @@ from chainer.testing import condition
     'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'ratio': [0.0, 0.9],
     'train': [True, False],
+    'use_batchwise_mask': [True, False],
 }))
 class TestSimplifiedDropconnect(unittest.TestCase):
 
@@ -47,17 +48,22 @@ class TestSimplifiedDropconnect(unittest.TestCase):
             y = functions.simplified_dropconnect(x, W, None,
                                                  ratio=self.ratio,
                                                  train=self.train,
-                                                 batchwise_mask=True)
+                                                 use_batchwise_mask=
+                                                 self.use_batchwise_mask)
         else:
             b = chainer.Variable(b_data)
             y = functions.simplified_dropconnect(x, W, b,
                                                  ratio=self.ratio,
                                                  train=self.train,
-                                                 batchwise_mask=True)
+                                                 use_batchwise_mask=
+                                                 self.use_batchwise_mask)
         self.assertEqual(y.data.dtype, self.x_dtype)
         mask = y.creator.mask
         mask = cuda.to_cpu(mask)
-        self.assertEqual(mask.shape, (x.shape[0],) + W.shape)
+        if self.use_batchwise_mask:
+            self.assertEqual(mask.shape, (x.shape[0],) + W.shape)
+        else:
+            self.assertEqual(mask.shape, W.shape)
 
     def test_forward_cpu(self):
         self.check_forward(self.x, self.W, self.b)
@@ -78,7 +84,7 @@ class TestSimplifiedDropconnect(unittest.TestCase):
     def check_backward(self, x_data, W_data, b_data, y_grad):
         args = x_data, W_data
         if b_data is not None:
-            args += (b_data,)
+            args += b_data,
 
         gradient_check.check_backward(
             simplified_dropconnect.SimplifiedDropconnect(self.ratio, None,
@@ -104,57 +110,6 @@ class TestSimplifiedDropconnect(unittest.TestCase):
     def test_backward_gpu_nobias(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
                             None, cuda.to_gpu(self.gy))
-
-
-class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
-
-    def setUp(self):
-        self.W = numpy.random.uniform(
-            -1, 1, (2, 3)).astype(numpy.float32)
-        self.b = numpy.random.uniform(
-            -1, 1, 2).astype(numpy.float32)
-
-        self.x = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, (4, 2)).astype(numpy.float32)
-        self.y = self.x.dot(self.W.T) + self.b
-        self.check_forward_options = {}
-        self.check_backward_options = {}
-
-    def check_forward(self, x_data, W_data, b_data):
-        # Check only data type, y is tested by SimplifiedDropconnect link test.
-        x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
-        b = chainer.Variable(b_data)
-        func = simplified_dropconnect.SimplifiedDropconnect(0.5, None, False)
-        y = func(x, W, b)
-        self.assertEqual(y.data.dtype, numpy.float32)
-        self.assertEqual(func.mask.shape, W.shape)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x, self.W, self.b)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b))
-
-    def check_backward(self, x_data, W_data, b_data, y_grad):
-        args = x_data, W_data
-        args = args + (b_data,)
-
-        gradient_check.check_backward(
-            simplified_dropconnect.SimplifiedDropconnect(0.5, None, True),
-            args, y_grad, eps=1e-2, **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.W, self.b, self.gy)
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
-                            cuda.to_gpu(self.b), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
@@ -212,7 +212,6 @@ class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
         testing.assert_allclose(y.data[0], y.data[2])
         testing.assert_allclose(y.data[0], y.data[3])
 
-        xp = cuda.get_array_module(x)
         mask = y.creator.mask
         mask = cuda.to_cpu(mask)
 

--- a/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
@@ -66,7 +66,7 @@ class TestSimplifiedDropconnect(unittest.TestCase):
 
     def check_forward(self, x_data, mask):
         x = chainer.Variable(x_data)
-        y = self.link(x, True, True, mask)
+        y = self.link(x, train=True, mask=mask, batchwise_mask=True)
         self.assertEqual(y.data.dtype, self.x_dtype)
         testing.assert_allclose(self.y_expect, y.data,
                                 **self.check_forward_options)
@@ -80,7 +80,8 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.mask))
 
     def link_wrapper(self, *data):
-        return self.link(data[0], True, True, data[1])
+        return self.link(x=data[0], train=True, mask=data[1],
+                         batchwise_mask=True)
 
     def check_backward(self, x_data, y_grad, mask):
         gradient_check.check_backward(
@@ -135,7 +136,7 @@ class TestSimplifiedDropconnectParameterShapePlaceholder(unittest.TestCase):
 
     def check_forward(self, x_data, mask):
         x = chainer.Variable(x_data)
-        y = self.link(x, True, True, mask)
+        y = self.link(x, train=True, mask=mask, batchwise_mask=True)
         self.assertEqual(y.data.dtype, numpy.float32)
         testing.assert_allclose(self.y_expect, y.data)
 
@@ -148,7 +149,8 @@ class TestSimplifiedDropconnectParameterShapePlaceholder(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.mask))
 
     def link_wrapper(self, *data):
-        return self.link(data[0], True, True, data[1])
+        return self.link(x=data[0], train=True, mask=data[1],
+                         batchwise_mask=True)
 
     def check_backward(self, x_data, y_grad, mask):
         gradient_check.check_backward(

--- a/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
@@ -204,9 +204,9 @@ class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
         y = self.link(x, False, True)
 
         # check mask equality here.
-        self.assertTrue((y.data[0] == y.data[1]).all())
-        self.assertTrue((y.data[0] == y.data[2]).all())
-        self.assertTrue((y.data[0] == y.data[3]).all())
+        testing.assert_allclose(y.data[0], y.data[1])
+        testing.assert_allclose(y.data[0], y.data[2])
+        testing.assert_allclose(y.data[0], y.data[3])
 
     def test_forward_cpu(self):
         self.check_forward(self.x)

--- a/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
@@ -66,7 +66,7 @@ class TestSimplifiedDropconnect(unittest.TestCase):
 
     def check_forward(self, x_data, mask):
         x = chainer.Variable(x_data)
-        y = self.link(x, True, mask)
+        y = self.link(x, True, True, mask)
         self.assertEqual(y.data.dtype, self.x_dtype)
         testing.assert_allclose(self.y_expect, y.data,
                                 **self.check_forward_options)
@@ -80,7 +80,7 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.mask))
 
     def link_wrapper(self, *data):
-        return self.link(data[0], True, data[1])
+        return self.link(data[0], True, True, data[1])
 
     def check_backward(self, x_data, y_grad, mask):
         gradient_check.check_backward(
@@ -135,7 +135,7 @@ class TestSimplifiedDropconnectParameterShapePlaceholder(unittest.TestCase):
 
     def check_forward(self, x_data, mask):
         x = chainer.Variable(x_data)
-        y = self.link(x, True, mask)
+        y = self.link(x, True, True, mask)
         self.assertEqual(y.data.dtype, numpy.float32)
         testing.assert_allclose(self.y_expect, y.data)
 
@@ -148,7 +148,7 @@ class TestSimplifiedDropconnectParameterShapePlaceholder(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.mask))
 
     def link_wrapper(self, *data):
-        return self.link(data[0], True, data[1])
+        return self.link(data[0], True, True, data[1])
 
     def check_backward(self, x_data, y_grad, mask):
         gradient_check.check_backward(

--- a/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
@@ -13,7 +13,6 @@ from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
 from chainer.utils import type_check
-import cupy
 
 
 def gen_mask(ratio, shape):
@@ -215,8 +214,7 @@ class TestSimplifiedDropconnectNotBatchwiseMask(unittest.TestCase):
 
         xp = cuda.get_array_module(x)
         mask = y.creator.mask
-        if xp is cupy:
-            mask = mask.get()
+        mask = cuda.to_cpu(mask)
 
         y_expect = self.x.dot(self.W.T * mask.T) * (1. / (1 - self.ratio))
         y_expect += self.b


### PR DESCRIPTION
Current dropconnect support only batchwise mask. (i.e. masked element is different with each sample in mini-batch).
This mask specification is same with the original implementation.

One of purpose of this option is memory conservation.
