### PR TITLE
Skip uninitialized param

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -489,6 +489,8 @@ class Link(object):
             # Note: There should only be uninitialized parameters
             # during deserialization.
             initialized_value = serializer(name, None)
+            if initialized_value is None:
+                continue
             self.add_param(name, initialized_value.shape)
             uninitialized_value = d[name].data
             if isinstance(uninitialized_value, numpy.ndarray):


### PR DESCRIPTION
This PR is related to #2601.

Despite that `load_npz` can treat unsaved key, `Link` fails to deserialize if the shape of param is not defined.
Here is an example.
```
import numpy as np

import chainer
import chainer.links as L
from chainer.serializers import save_npz
from chainer.serializers import NpzDeserializer


def load_npz(filename, obj):
    with np.load(filename) as f:
        d = NpzDeserializer(f, strict=False)
        d.load(obj)


chain1 = chainer.Chain(
    fc1=L.Linear(None, 4),
    fc2=L.Linear(None, 5),
)
# forward to initialize weights
h = chain1.fc1(np.empty((1, 3), dtype=np.float32))
h = chain1.fc2(h)
save_npz('tmp', chain1)

chain2 = chainer.Chain(
    fc1=L.Linear(None, 4),
    fc2=L.Linear(None, 5),
    fc3=L.Linear(None, 6),
)
# AttributeError: 'NoneType' object has no attribute 'shape'
load_npz('tmp', chain2)
```

If we specify the shape of params, for example `L.Linear(3, 4)`, this code works well.