### PR TITLE
Add path option for load_npz method

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -124,7 +124,7 @@ class HDF5Deserializer(serializer.Deserializer):
         return value
 
 
-def load_hdf5(filename, obj, path=''):
+def load_hdf5(filename, obj):
     """Loads an object from the file in HDF5 format.
 
     This is a short-cut function to load from an HDF5 file that contains only
@@ -139,5 +139,5 @@ def load_hdf5(filename, obj, path=''):
     """
     _check_available()
     with h5py.File(filename, 'r') as f:
-        d = HDF5Deserializer(f, path=path)
+        d = HDF5Deserializer(f)
         d.load(obj)

--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -124,7 +124,7 @@ class HDF5Deserializer(serializer.Deserializer):
         return value
 
 
-def load_hdf5(filename, obj):
+def load_hdf5(filename, obj, path=''):
     """Loads an object from the file in HDF5 format.
 
     This is a short-cut function to load from an HDF5 file that contains only
@@ -139,5 +139,5 @@ def load_hdf5(filename, obj):
     """
     _check_available()
     with h5py.File(filename, 'r') as f:
-        d = HDF5Deserializer(f)
+        d = HDF5Deserializer(f, path=path)
         d.load(obj)

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -115,7 +115,7 @@ class NpzDeserializer(serializer.Deserializer):
         return value
 
 
-def load_npz(filename, obj):
+def load_npz(filename, obj, path=''):
     """Loads an object from the file in NPZ format.
 
     This is a short-cut function to load from an `.npz` file that contains only
@@ -127,5 +127,5 @@ def load_npz(filename, obj):
 
     """
     with numpy.load(filename) as f:
-        d = NpzDeserializer(f)
+        d = NpzDeserializer(f, path=path)
         d.load(obj)

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -125,8 +125,8 @@ def load_npz(filename, obj, path=''):
         filename (str): Name of the file to be loaded.
         obj: Object to be deserialized. It must support serialization protocol.
         path: The path in the hierarchy of the serialized data under which the
-            data is to be loaded. The default behavior (blank) will load all data
-            under the root path.
+            data is to be loaded. The default behavior (blank) will load all
+            data under the root path.
 
     """
     with numpy.load(filename) as f:

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -124,6 +124,9 @@ def load_npz(filename, obj, path=''):
     Args:
         filename (str): Name of the file to be loaded.
         obj: Object to be deserialized. It must support serialization protocol.
+        path: The path in the hierarchy of the serialized data under which the
+            data is to be loaded. The default behavior (blank) will load all data
+            under the root path.
 
     """
     with numpy.load(filename) as f:

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -236,9 +236,13 @@ class TestLoadNpz(unittest.TestCase):
         fd, path = tempfile.mkstemp()
         os.close(fd)
         self.temp_file_path = path
-        with open(path, 'wb') as f:
-            savez = numpy.savez_compressed if self.compress else numpy.savez
-            savez(f, None)
+        child = link.Chain(child_linear=links.Linear(2, 3))
+        parent = link.Chain(
+            parent_linear=links.Linear(3, 2), child=child)
+        npz.save_npz(path, parent, self.compress)
+
+        self.source_child = child
+        self.source_parent = parent
 
     def tearDown(self):
         if hasattr(self, 'temp_file_path'):
@@ -251,6 +255,19 @@ class TestLoadNpz(unittest.TestCase):
         self.assertEqual(obj.serialize.call_count, 1)
         (serializer,), _ = obj.serialize.call_args
         self.assertIsInstance(serializer, npz.NpzDeserializer)
+
+    def test_load_with_path(self):
+        target = link.Chain(child_linear=links.Linear(2, 3))
+        npz.load_npz(self.temp_file_path, target, 'child/')
+        numpy.testing.assert_array_equal(
+            self.source_child.child_linear.W.data, target.child_linear.W.data)
+
+    def test_load_without_path(self):
+        target = link.Chain(parent_linear=links.Linear(3, 2))
+        npz.load_npz(self.temp_file_path, target, path='')
+        numpy.testing.assert_array_equal(
+            self.source_parent.parent_linear.W.data,
+            target.parent_linear.W.data)
 
 
 @testing.parameterize(*testing.product({'compress': [False, True]}))


### PR DESCRIPTION
I came across a situation where I want to load the serialized parameters under a _certain path_.
If my understanding is correct, the only way to achieve the behavior is to write something like the following:

```py
serializers.NpzDeserializer(np.load('saved_model'))['path_of_interest'].load(obj)
```

which would produce quite a lot of the same code written in the `load_npz` method.
By applying the change I propose here, the user can obtain the same result by:

```py
serializers.load_npz('saved_model', obj, path='path_of_interest')
```

which I think is more straightforward.
