### PR TITLE
Allow initialization of vision models by zeros

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -64,6 +64,9 @@ class ResNetLayers(link.Chain):
             this costructor. Note that in this case the converted chainer
             model is stored on the same directory and automatically used from
             the next time.
+            If this argument is specified as ``zeros``, it initializes
+            weights by zeros. This option is useful when the model needs
+            to initialize quickly.
             If this argument is specified as ``None``, all the parameters
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
@@ -108,6 +111,8 @@ class ResNetLayers(link.Chain):
         if pretrained_model and pretrained_model.endswith('.caffemodel'):
             _retrieve(n_layers, 'ResNet-{}-model.npz'.format(n_layers),
                       pretrained_model, self)
+        elif pretrained_model == 'zeros':
+            pass
         elif pretrained_model:
             npz.load_npz(pretrained_model, self)
         self.functions = collections.OrderedDict([

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -64,15 +64,17 @@ class ResNetLayers(link.Chain):
             this costructor. Note that in this case the converted chainer
             model is stored on the same directory and automatically used from
             the next time.
-            If this argument is specified as ``zeros``, it initializes
-            weights by zeros. This option is useful when the model needs
-            to initialize quickly.
             If this argument is specified as ``None``, all the parameters
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.HeNormal(scale=1.0)``.
         n_layers (int): The number of layers of this model. It should be either
             50, 101, or 152.
+        initialW (callable): The initial weight value initializer for
+            convolution layers. This is a callable that takes
+            ``numpy.ndarray`` or ``cupy.ndarray``
+            and edits its value.
+            If ``None``, the default initializer is used.
 
     Attributes:
         available_layers (list of str): The list of available layer names
@@ -80,14 +82,16 @@ class ResNetLayers(link.Chain):
 
     """
 
-    def __init__(self, pretrained_model, n_layers):
-        if pretrained_model:
-            # As a sampling process is time-consuming,
-            # we employ a zero initializer for faster computation.
-            kwargs = {'initialW': constant.Zero()}
-        else:
-            # employ default initializers used in the original paper
-            kwargs = {'initialW': normal.HeNormal(scale=1.0)}
+    def __init__(self, pretrained_model, n_layers, initialW=None):
+        if initialW is None:
+            if pretrained_model:
+                # As a sampling process is time-consuming,
+                # we employ a zero initializer for faster computation.
+                initialW = constant.Zero()
+            else:
+                # employ default initializers used in the original paper
+                initialW = normal.HeNormal(scale=1.0)
+        kwargs = {'initialW': initialW}
 
         if n_layers == 50:
             block = [3, 4, 6, 3]
@@ -318,6 +322,10 @@ class ResNet50Layers(ResNetLayers):
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.HeNormal(scale=1.0)``.
+        initialW (callable): The initial weight value initializer. This is a
+            callable that takes ``numpy.ndarray`` or ``cupy.ndarray``
+            and edits its value.
+            If ``None``, the default initializer is used.
 
     Attributes:
         available_layers (list of str): The list of available layer names
@@ -325,10 +333,10 @@ class ResNet50Layers(ResNetLayers):
 
     """
 
-    def __init__(self, pretrained_model='auto'):
+    def __init__(self, pretrained_model='auto', initialW=None):
         if pretrained_model == 'auto':
             pretrained_model = 'ResNet-50-model.caffemodel'
-        super(ResNet50Layers, self).__init__(pretrained_model, 50)
+        super(ResNet50Layers, self).__init__(pretrained_model, 50, initialW)
 
 
 class ResNet101Layers(ResNetLayers):
@@ -371,6 +379,10 @@ class ResNet101Layers(ResNetLayers):
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.HeNormal(scale=1.0)``.
+        initialW (callable): The initial weight value initializer. This is a
+            callable that takes ``numpy.ndarray`` or ``cupy.ndarray``
+            and edits its value.
+            If ``None``, the default initializer is used.
 
     Attributes:
         available_layers (list of str): The list of available layer names
@@ -378,10 +390,10 @@ class ResNet101Layers(ResNetLayers):
 
     """
 
-    def __init__(self, pretrained_model='auto'):
+    def __init__(self, pretrained_model='auto', initialW=None):
         if pretrained_model == 'auto':
             pretrained_model = 'ResNet-101-model.caffemodel'
-        super(ResNet101Layers, self).__init__(pretrained_model, 101)
+        super(ResNet101Layers, self).__init__(pretrained_model, 101, initialW)
 
 
 class ResNet152Layers(ResNetLayers):
@@ -423,6 +435,10 @@ class ResNet152Layers(ResNetLayers):
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.HeNormal(scale=1.0)``.
+        initialW (callable): The initial weight value initializer. This is a
+            callable that takes ``numpy.ndarray`` or ``cupy.ndarray``
+            and edits its value.
+            If ``None``, the default initializer is used.
 
     Attributes:
         available_layers (list of str): The list of available layer names
@@ -430,10 +446,10 @@ class ResNet152Layers(ResNetLayers):
 
     """
 
-    def __init__(self, pretrained_model='auto'):
+    def __init__(self, pretrained_model='auto', initialW=None):
         if pretrained_model == 'auto':
             pretrained_model = 'ResNet-152-model.caffemodel'
-        super(ResNet152Layers, self).__init__(pretrained_model, 152)
+        super(ResNet152Layers, self).__init__(pretrained_model, 152, initialW)
 
 
 def prepare(image, size=(224, 224)):

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -61,13 +61,20 @@ class VGG16Layers(link.Chain):
             ``$HOME/.chainer/dataset`` unless you specify another value
             as a environment variable. The converted chainer model is
             automatically used from the second time.
-            If this argument is specified as ``zeros``, it initializes
-            weights by zeros. This option is useful when the model needs
-            to initialize quickly.
             If the argument is specified as ``None``, all the parameters
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.Normal(scale=0.01)``.
+        initialW (callable): The initial weight value initializer for
+            convolution layers and fully connected layers. This is a
+            callable that takes ``numpy.ndarray`` or ``cupy.ndarray``
+            and edits its value.
+            If ``None``, the default initializer is used.
+        initial_bias (callable): The initial bias value initializer for
+            convolution layers and fully connected layers. This is a
+            callable that takes ``numpy.ndarray`` or ``cupy.ndarray``
+            and edits its value.
+            If ``None``, the default initializer is used.
 
     Attributes:
         available_layers (list of str): The list of available layer names
@@ -75,18 +82,25 @@ class VGG16Layers(link.Chain):
 
     """
 
-    def __init__(self, pretrained_model='auto'):
+    def __init__(self, pretrained_model='auto',
+                 initialW=None, initial_bias=None):
         if pretrained_model:
             # As a sampling process is time-consuming,
             # we employ a zero initializer for faster computation.
             init = constant.Zero()
-            kwargs = {'initialW': init, 'initial_bias': init}
+            default_kwargs = {'initialW': init, 'initial_bias': init}
         else:
             # employ default initializers used in the original paper
-            kwargs = {
+            default_kwargs = {
                 'initialW': normal.Normal(0.01),
                 'initial_bias': constant.Zero(),
             }
+        if initialW is None:
+            initialW = default_kwargs['initialW']
+        if initial_bias is None:
+            initial_bias = default_kwargs['initial_bias']
+        kwargs = {'initialW': initialW, 'initial_bias': initial_bias}
+
         super(VGG16Layers, self).__init__(
             conv1_1=Convolution2D(3, 64, 3, 1, 1, **kwargs),
             conv1_2=Convolution2D(64, 64, 3, 1, 1, **kwargs),
@@ -111,8 +125,6 @@ class VGG16Layers(link.Chain):
                 'http://www.robots.ox.ac.uk/%7Evgg/software/very_deep/'
                 'caffe/VGG_ILSVRC_16_layers.caffemodel',
                 self)
-        elif pretrained_model == 'zeros':
-            pass
         elif pretrained_model:
             npz.load_npz(pretrained_model, self)
 

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -61,6 +61,9 @@ class VGG16Layers(link.Chain):
             ``$HOME/.chainer/dataset`` unless you specify another value
             as a environment variable. The converted chainer model is
             automatically used from the second time.
+            If this argument is specified as ``zeros``, it initializes
+            weights by zeros. This option is useful when the model needs
+            to initialize quickly.
             If the argument is specified as ``None``, all the parameters
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
@@ -108,6 +111,8 @@ class VGG16Layers(link.Chain):
                 'http://www.robots.ox.ac.uk/%7Evgg/software/very_deep/'
                 'caffe/VGG_ILSVRC_16_layers.caffemodel',
                 self)
+        elif pretrained_model == 'zeros':
+            pass
         elif pretrained_model:
             npz.load_npz(pretrained_model, self)
 

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -12,6 +12,7 @@ from chainer.variable import Variable
 
 @testing.parameterize(*testing.product({
     'n_layers': [50, 101, 152],
+    'pretrained_model': [None, 'zeros'],
 }))
 @unittest.skipUnless(resnet.available, 'Pillow is required')
 @attr.slow
@@ -19,11 +20,14 @@ class TestResNetLayers(unittest.TestCase):
 
     def setUp(self):
         if self.n_layers == 50:
-            self.link = resnet.ResNet50Layers(pretrained_model=None)
+            self.link = resnet.ResNet50Layers(
+                pretrained_model=self.pretrained_model)
         elif self.n_layers == 101:
-            self.link = resnet.ResNet101Layers(pretrained_model=None)
+            self.link = resnet.ResNet101Layers(
+                pretrained_model=self.pretrained_model)
         elif self.n_layers == 152:
-            self.link = resnet.ResNet152Layers(pretrained_model=None)
+            self.link = resnet.ResNet152Layers(
+                pretrained_model=self.pretrained_model)
 
     def test_available_layers(self):
         result = self.link.available_layers
@@ -128,12 +132,16 @@ class TestResNetLayers(unittest.TestCase):
         self.check_predict()
 
 
+@testing.parameterize(*testing.product({
+    'pretrained_model': [None, 'zeros'],
+}))
 @unittest.skipUnless(resnet.available, 'Pillow is required')
 @attr.slow
 class TestVGG16Layers(unittest.TestCase):
 
     def setUp(self):
-        self.link = vgg.VGG16Layers(pretrained_model=None)
+        self.link = vgg.VGG16Layers(
+            pretrained_model=self.pretrained_model)
 
     def test_available_layers(self):
         result = self.link.available_layers


### PR DESCRIPTION
Currently, initializing vision models take long amount of time due to random.uniform of weights or copying of weights.
I added an option to the initialization functions to instantiate objects quickly by setting zeros to weights.
In my local environment, VGG speeded up from 5.6s to 0.1s.


This is a line by line profiling when initialized by random tensors.
```
Timer unit: 1e-06 s                                                                                                                                                        
                                                                                                                                                                           
Total time: 5.7949 s                                                                                                                                                       
File: /home/leus/install/chainer/chainer/links/model/vision/vgg.py                                                                                                         
Function: __init__ at line 80                                                                                                                                              
                                                                                                                                                                           
Line #      Hits         Time  Per Hit   % Time  Line Contents                                                                                                             
==============================================================                                                                                                             
    80                                               @do_line_profile()                                                                                                    
    81                                               def __init__(self, pretrained_model='auto'):                                                                         
    82         1            5      5.0      0.0          if pretrained_model:                                                                                              
    83                                                       # As a sampling process is time-consuming,                                                                    
    84                                                       # we employ a zero initializer for faster computation.                                                        
    85                                                       init = constant.Zero()                                                                                        
    86                                                       kwargs = {'initialW': init, 'initial_bias': init}                                                             
    87                                                   else:                                                                                                             
    88                                                       # employ default initializers used in the original paper                                                      
    89         1            5      5.0      0.0              kwargs = {                                                                                                    
    90         1           20     20.0      0.0                  'initialW': normal.Normal(0.01),                                                                          
    91         1           24     24.0      0.0                  'initial_bias': constant.Zero(),                                                                          
    92                                                       }                                                                                                             
    93         1            6      6.0      0.0          super(VGG16Layers, self).__init__(                                                                                
    94         1          920    920.0      0.0              conv1_1=Convolution2D(3, 64, 3, 1, 1, **kwargs),                                                              
    95         1         8095   8095.0      0.1              conv1_2=Convolution2D(64, 64, 3, 1, 1, **kwargs),                                                             
    96         1        14675  14675.0      0.3              conv2_1=Convolution2D(64, 128, 3, 1, 1, **kwargs),                                                            
    97         1        14356  14356.0      0.2              conv2_2=Convolution2D(128, 128, 3, 1, 1, **kwargs),                                                           
    98         1        16880  16880.0      0.3              conv3_1=Convolution2D(128, 256, 3, 1, 1, **kwargs),                                                           
    99         1        25879  25879.0      0.4              conv3_2=Convolution2D(256, 256, 3, 1, 1, **kwargs),                                                           
   100         1        25675  25675.0      0.4              conv3_3=Convolution2D(256, 256, 3, 1, 1, **kwargs),                                                           
   101         1        49397  49397.0      0.9              conv4_1=Convolution2D(256, 512, 3, 1, 1, **kwargs),                                                           
   102         1        97553  97553.0      1.7              conv4_2=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                           
   103         1        96978  96978.0      1.7              conv4_3=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                           
   104         1        96858  96858.0      1.7              conv5_1=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                           
   105         1        96835  96835.0      1.7              conv5_2=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                           
   106         1        97021  97021.0      1.7              conv5_3=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                           
   107         1      4222659 4222659.0     72.9              fc6=Linear(512 * 7 * 7, 4096, **kwargs),                                                                     
   108         1       740794 740794.0     12.8              fc7=Linear(4096, 4096, **kwargs),                                                                             
   109         1       190124 190124.0      3.3              fc8=Linear(4096, 1000, **kwargs),                                                                             
   110                                                   )                                                                                                                 
   111         1            2      2.0      0.0          if pretrained_model == 'auto':                                                                                    
   112                                                       _retrieve(                                                                                                    
   113                                                           'VGG_ILSVRC_16_layers.npz',                                                                               
   114                                                           'http://www.robots.ox.ac.uk/%7Evgg/software/very_deep/'                                                   
   115                                                           'caffe/VGG_ILSVRC_16_layers.caffemodel',                                                                  
   116                                                           self)                                                                                                     
   117         1            1      1.0      0.0          elif pretrained_model == 'zeros':                                                                                 
   118                                                       pass                                                                                                          
   119         1            1      1.0      0.0          elif pretrained_model:                                                                                            
   120                                                       npz.load_npz(pretrained_model, self)                                                                          
   121                                                                                                                                                                     
   122         1            2      2.0      0.0          self.functions = collections.OrderedDict([                                                                        
   123         1            2      2.0      0.0              ('conv1_1', [self.conv1_1, relu]),                                                                            
   124         1            2      2.0      0.0              ('conv1_2', [self.conv1_2, relu]),                                                                            
   125         1            1      1.0      0.0              ('pool1', [_max_pooling_2d]),                                                                                 
   126         1            2      2.0      0.0              ('conv2_1', [self.conv2_1, relu]),                                                                            
   127         1            2      2.0      0.0              ('conv2_2', [self.conv2_2, relu]),                                                                            
   128         1            1      1.0      0.0              ('pool2', [_max_pooling_2d]),                                                                                 
   129         1            1      1.0      0.0              ('conv3_1', [self.conv3_1, relu]),                                                                            
   130         1            1      1.0      0.0              ('conv3_2', [self.conv3_2, relu]),                                                                            
   131         1            1      1.0      0.0              ('conv3_3', [self.conv3_3, relu]),                                                                            
   132         1            2      2.0      0.0              ('pool3', [_max_pooling_2d]),                                                                                 
   133         1            1      1.0      0.0              ('conv4_1', [self.conv4_1, relu]),                                                                            
   134         1            2      2.0      0.0              ('conv4_2', [self.conv4_2, relu]),                                                                            
   135         1            1      1.0      0.0              ('conv4_3', [self.conv4_3, relu]),                                                                            
   136         1            1      1.0      0.0              ('pool4', [_max_pooling_2d]),                                                                                 
   137         1            1      1.0      0.0              ('conv5_1', [self.conv5_1, relu]),                                                                            
   138         1            1      1.0      0.0              ('conv5_2', [self.conv5_2, relu]),                                                                            
   139         1            1      1.0      0.0              ('conv5_3', [self.conv5_3, relu]),                                                                            
   140         1            1      1.0      0.0              ('pool5', [_max_pooling_2d]),                                                                                 
   141         1            2      2.0      0.0              ('fc6', [self.fc6, relu, dropout]),                                                                           
   142         1            1      1.0      0.0              ('fc7', [self.fc7, relu, dropout]),                                                                           
   143         1            2      2.0      0.0              ('fc8', [self.fc8]),                                                                                          
   144         1          105    105.0      0.0              ('prob', [softmax]),                                                                                          
   145                                                   ])                                                                                                                

```



This is a line by line profile when initialized by zeros.
```
Timer unit: 1e-06 s                                                                                                                                                                
                                                                                                                                                                                   
Total time: 0.102063 s                                                                                                                                                             
File: /home/leus/install/chainer/chainer/links/model/vision/vgg.py                                                                                                                 
Function: __init__ at line 80                                                                                                                                                      
                                                                                                                                                                                   
Line #      Hits         Time  Per Hit   % Time  Line Contents                                                                                                                     
==============================================================                                                                                                                     
    80                                               @do_line_profile()                                                                                                            
    81                                               def __init__(self, pretrained_model='auto'):                                                                                 
    82         1            2      2.0      0.0          if pretrained_model:                                                                                                      
    83                                                       # As a sampling process is time-consuming,                                                                            
    84                                                       # we employ a zero initializer for faster computation.                                                                
    85         1           10     10.0      0.0              init = constant.Zero()                                                                                                
    86         1            2      2.0      0.0              kwargs = {'initialW': init, 'initial_bias': init}                                                                     
    87                                                   else:                                                                                                                     
    88                                                       # employ default initializers used in the original paper                                                              
    89                                                       kwargs = {                                                                                                            
    90                                                           'initialW': normal.Normal(0.01),                                                                                  
    91                                                           'initial_bias': constant.Zero(),                                                                                  
    92                                                       }                                                                                                                     
    93         1            2      2.0      0.0          super(VGG16Layers, self).__init__(                                                                                        
    94         1          187    187.0      0.2              conv1_1=Convolution2D(3, 64, 3, 1, 1, **kwargs),                                                                      
    95         1          295    295.0      0.3              conv1_2=Convolution2D(64, 64, 3, 1, 1, **kwargs),                                                                     
    96         1          320    320.0      0.3              conv2_1=Convolution2D(64, 128, 3, 1, 1, **kwargs),                                                                    
    97         1          529    529.0      0.5              conv2_2=Convolution2D(128, 128, 3, 1, 1, **kwargs),                                                                   
    98         1          826    826.0      0.8              conv3_1=Convolution2D(128, 256, 3, 1, 1, **kwargs),                                                                   
    99         1         1531   1531.0      1.5              conv3_2=Convolution2D(256, 256, 3, 1, 1, **kwargs),                                                                   
   100         1         1566   1566.0      1.5              conv3_3=Convolution2D(256, 256, 3, 1, 1, **kwargs),                                                                   
   101         1         1616   1616.0      1.6              conv4_1=Convolution2D(256, 512, 3, 1, 1, **kwargs),                                                                   
   102         1         2730   2730.0      2.7              conv4_2=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                                   
   103         1         2823   2823.0      2.8              conv4_3=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                                   
   104         1         2664   2664.0      2.6              conv5_1=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                                   
   105         1         2641   2641.0      2.6              conv5_2=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                                   
   106         1         2650   2650.0      2.6              conv5_3=Convolution2D(512, 512, 3, 1, 1, **kwargs),                                                                   
   107         1        68176  68176.0     66.8              fc6=Linear(512 * 7 * 7, 4096, **kwargs),                                                                              
   108         1        10157  10157.0     10.0              fc7=Linear(4096, 4096, **kwargs),                                                                                     
   109         1         3224   3224.0      3.2              fc8=Linear(4096, 1000, **kwargs),                                                                                     
   110                                                   )                                                                                                                         
   111         1            1      1.0      0.0          if pretrained_model == 'auto':                                                                                            
   112                                                       _retrieve(                                                                                                            
   113                                                           'VGG_ILSVRC_16_layers.npz',                                                                                       
   114                                                           'http://www.robots.ox.ac.uk/%7Evgg/software/very_deep/'                                                           
   115                                                           'caffe/VGG_ILSVRC_16_layers.caffemodel',                                                                          
   116                                                           self)                                                                                                             
   117         1            1      1.0      0.0          elif pretrained_model == 'zeros':                                                                                         
   118         1            1      1.0      0.0              pass                                                                                                                  
   119                                                   elif pretrained_model:                                                                                                    
   120                                                       npz.load_npz(pretrained_model, self)                                                                                  
   121                                                                                                                                                                             
   122         1            2      2.0      0.0          self.functions = collections.OrderedDict([                                                                                
   123         1            2      2.0      0.0              ('conv1_1', [self.conv1_1, relu]),                                                                                    
   124         1            1      1.0      0.0              ('conv1_2', [self.conv1_2, relu]),                                                                                    
   125         1            1      1.0      0.0              ('pool1', [_max_pooling_2d]),                                                                                         
   126         1            1      1.0      0.0              ('conv2_1', [self.conv2_1, relu]),                                                                                    
   127         1            1      1.0      0.0              ('conv2_2', [self.conv2_2, relu]),                                                                                    
   128         1            1      1.0      0.0              ('pool2', [_max_pooling_2d]),                                                                                         
   129         1            1      1.0      0.0              ('conv3_1', [self.conv3_1, relu]),                                                                                    
   130         1            1      1.0      0.0              ('conv3_2', [self.conv3_2, relu]),                                                                                    
   131         1            1      1.0      0.0              ('conv3_3', [self.conv3_3, relu]),                                                                                    
   132         1            1      1.0      0.0              ('pool3', [_max_pooling_2d]),                                                                                         
   133         1            1      1.0      0.0              ('conv4_1', [self.conv4_1, relu]),                                                                                    
   134         1            1      1.0      0.0              ('conv4_2', [self.conv4_2, relu]),                                                                                    
   135         1            1      1.0      0.0              ('conv4_3', [self.conv4_3, relu]),                                                                                    
   136         1            1      1.0      0.0              ('pool4', [_max_pooling_2d]),                                                                                         
   137         1            1      1.0      0.0              ('conv5_1', [self.conv5_1, relu]),                                                                                    
   138         1            1      1.0      0.0              ('conv5_2', [self.conv5_2, relu]),                                                                                    
   139         1            1      1.0      0.0              ('conv5_3', [self.conv5_3, relu]),                                                                                    
   140         1            1      1.0      0.0              ('pool5', [_max_pooling_2d]),                                                                                         
   141         1            1      1.0      0.0              ('fc6', [self.fc6, relu, dropout]),                                                                                   
   142         1            1      1.0      0.0              ('fc7', [self.fc7, relu, dropout]),                                                                                   
   143         1            1      1.0      0.0              ('fc8', [self.fc8]),                                                                                                  
   144         1           85     85.0      0.1              ('prob', [softmax]),                                                                                                  
   145                                                   ])                                                                                                                        
                                                                                                                                                                                   

```