### PR TITLE
Expose VariableNode as a documented API

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -51,6 +51,7 @@ from chainer.serializer import AbstractSerializer  # NOQA
 from chainer.serializer import Deserializer  # NOQA
 from chainer.serializer import Serializer  # NOQA
 from chainer.variable import Variable  # NOQA
+from chainer.variable import VariableNode  # NOQA
 
 
 if sys.version_info[:3] == (3, 5, 0):

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -51,7 +51,6 @@ from chainer.serializer import AbstractSerializer  # NOQA
 from chainer.serializer import Deserializer  # NOQA
 from chainer.serializer import Serializer  # NOQA
 from chainer.variable import Variable  # NOQA
-from chainer.variable import VariableNode  # NOQA
 
 
 if sys.version_info[:3] == (3, 5, 0):

--- a/docs/source/reference/core/variable.rst
+++ b/docs/source/reference/core/variable.rst
@@ -4,3 +4,7 @@ Variable
 .. currentmodule:: chainer
 .. autoclass:: Variable
    :members:
+
+
+.. autoclass:: VariableNode
+   :members:

--- a/docs/source/reference/core/variable.rst
+++ b/docs/source/reference/core/variable.rst
@@ -5,6 +5,6 @@ Variable
 .. autoclass:: Variable
    :members:
 
-
+.. currentmodule:: chainer.variable
 .. autoclass:: VariableNode
    :members:


### PR DESCRIPTION
This PR makes `chainer.variable.VariableNode`, which was introduced from v2 documented.

`VariableNode` corresponds to a part of documented API of `Variable` in v1.  Also, the upgrade guide we are working on in #2741 mentioned this object. Therefore, it is natural that we expose `VariableNode` to users in v2 as well.

But I do not create an alias `chainer.VariableNode` as I think we do not expect users  use this object through `Variable` and do not touch it directly. 