### PR TITLE
Remove get_device

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -301,7 +301,7 @@ def copy(array, out=None, out_device=None, stream=None):
     if out is None:
         if out_device is None:
             out_device = array
-        with get_device_from_id(out_device):
+        with _get_device(out_device):
             out = cupy.empty_like(array)
 
     with get_device_from_array(array):

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -176,41 +176,6 @@ def get_device_from_array(*arrays):
     return DummyDevice
 
 
-def get_device(*args):
-    """Gets the device from a device object, an ID integer or an array object.
-
-    .. note::
-
-        This API is deprecated. Please use
-        :func:`~chainer.cuda.get_device_from_id`
-        or :func:`~chainer.cuda.get_device_from_array` instead.
-
-    This is a convenient utility to select a correct device if the type of
-    ``arg`` is unknown (i.e., one can use this function on arrays that may be
-    on CPU or GPU). The returned device object supports the context management
-    protocol of Python for the *with* statement.
-
-    Args:
-        args: Values to specify a GPU device. The first device object, integer
-            or :class:`cupy.ndarray` object is used to select a device.
-            If it is a device object, it is returned. If it is an integer,
-            the corresponding device is returned. If it is a CuPy array,
-            the device on which this array reside is returned. If any
-            arguments are neither integers nor CuPy arrays, a dummy device
-            object representing CPU is returned.
-
-    Returns:
-        Device object specified by given ``args``.
-
-    .. seealso::
-       See :class:`cupy.cuda.Device` for the device selection not by arrays.
-
-    """
-    warnings.warn('get_device is deprecated. Please use get_device_from_id or'
-                  ' get_device_from_array instead.', DeprecationWarning)
-    return _get_device(*args)
-
-
 def _get_device(*args):
     for arg in args:
         if type(arg) in _integer_types:
@@ -229,7 +194,6 @@ def _get_device(*args):
 # ------------------------------------------------------------------------------
 # cupy.ndarray allocation and copy
 # ------------------------------------------------------------------------------
-
 def to_gpu(array, device=None, stream=None):
     """Copies the given CPU array to specified device.
 

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -284,8 +284,7 @@ def copy(array, out=None, out_device=None, stream=None):
         array (cupy.ndarray): Array to be copied.
         out (cupy.ndarray): Destination array.
             If it is not ``None``, then ``out_device`` argument is ignored.
-        out_device: Destination device specifier. Actual device object is
-            obtained by passing this value to :func:`get_device`.
+        out_device: Destination device specifier.
         stream (cupy.cuda.Stream): CUDA stream.
 
     Returns:

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -264,7 +264,7 @@ def to_cpu(array, stream=None):
     """
     if isinstance(array, ndarray):
         check_cuda_available()
-        with get_device(array):
+        with get_device_from_array(array):
             return array.get(stream)
     elif isinstance(array, numpy.ndarray):
         return array
@@ -301,10 +301,10 @@ def copy(array, out=None, out_device=None, stream=None):
     if out is None:
         if out_device is None:
             out_device = array
-        with get_device(out_device):
+        with get_device_from_id(out_device):
             out = cupy.empty_like(array)
 
-    with get_device(array):
+    with get_device_from_array(array):
         cupy.copyto(out, array)
 
     return out

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -277,7 +277,7 @@ class UpdateRule(object):
             for name, value in six.iteritems(state):
                 if not isinstance(value, (numpy.ndarray, cuda.ndarray)):
                     continue
-                value_device = cuda.get_device(value)
+                value_device = cuda.get_device_from_array(value)
                 if value_device.id != device.id:
                     if device.id >= 0:
                         state[name] = cuda.to_gpu(value)
@@ -623,7 +623,7 @@ class WeightDecay(object):
 
     def __call__(self, rule, param):
         p, g = param.data, param.grad
-        with cuda.get_device(p) as dev:
+        with cuda.get_device_from_array(p) as dev:
             if int(dev) == -1:
                 g += self.rate * p
             else:

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -268,7 +268,7 @@ class UpdateRule(object):
                 self._state[key] = serializer(key, self._state[key])
 
     def _prepare(self, param):
-        with cuda.get_device(param.data) as device:
+        with cuda.get_device_from_array(param.data) as device:
             state = self.state
             if state is None:
                 state = self._state = {}


### PR DESCRIPTION
get_device has been marked as deprecated, so we can remove it in v2. It takes over this PR: #2243 