### PR TITLE
Fix Variable repr and str failure when data is None

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -75,10 +75,13 @@ def variable_repr(var):
     else:
         prefix = 'variable'
 
-    if arr.size > 0 or arr.shape == (0,):
+    if arr is None:
+        lst = 'None'
+    elif arr.size > 0 or arr.shape == (0,):
         lst = numpy.array2string(arr, None, None, None, ', ', prefix + '(')
     else:  # show zero-length shape unless it is (0,)
         lst = '[], shape=%s' % (repr(arr.shape),)
+
     return '%s(%s)' % (prefix, lst)
 
 
@@ -94,12 +97,18 @@ def variable_str(var):
         arr = var.data
     else:
         arr = var.data.get()
+
     if var.name:
-        prefix = 'variable ' + var.name + '('
+        prefix = 'variable ' + var.name
     else:
-        prefix = 'variable('
-    return (prefix + numpy.array2string(arr, None, None, None, ' ', prefix) +
-            ')')
+        prefix = 'variable'
+
+    if arr is None:
+        lst = 'None'
+    else:
+        lst = numpy.array2string(arr, None, None, None, ' ', prefix + '(')
+
+    return '%s(%s)' % (prefix, lst)
 
 
 class VariableNode(object):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1137,6 +1137,8 @@ class TestTranspose(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'x_shape': None, 'dtype': None, 'repr': 'variable(None)',
+     'str': 'variable(None)'},
     {'x_shape': (2, 2,), 'dtype': np.float16,
      'repr': 'variable([[ 0.,  1.],\n          [ 2.,  3.]])',
      'str': 'variable([[ 0.  1.]\n          [ 2.  3.]])'},
@@ -1152,10 +1154,13 @@ class TestTranspose(unittest.TestCase):
 class TestUnnamedVariableToString(unittest.TestCase):
 
     def setUp(self):
-        x = np.empty(self.x_shape)
-        x = np.arange(x.size).reshape(self.x_shape)
-        x = x.astype(self.dtype)
-        self.x = chainer.Variable(x)
+        if self.x_shape is None:
+            self.x = chainer.Variable()
+        else:
+            x = np.empty(self.x_shape)
+            x = np.arange(x.size).reshape(self.x_shape)
+            x = x.astype(self.dtype)
+            self.x = chainer.Variable(x)
 
     def test_repr_cpu(self):
         self.assertEqual(repr(self.x), self.repr)
@@ -1205,6 +1210,8 @@ class TestUnnamedVariableDim2Size0ToString(unittest.TestCase):
 
 
 @testing.parameterize(
+    {'x_shape': None, 'dtype': None, 'repr': 'variable x(None)',
+     'str': 'variable x(None)'},
     {'x_shape': (2, 2,), 'dtype': np.float32,
      'repr': 'variable x([[ 0.,  1.],\n            [ 2.,  3.]])',
      'str': 'variable x([[ 0.  1.]\n            [ 2.  3.]])'},
@@ -1214,10 +1221,13 @@ class TestUnnamedVariableDim2Size0ToString(unittest.TestCase):
 class TestNamedVariableToString(unittest.TestCase):
 
     def setUp(self):
-        x = np.empty(self.x_shape)
-        x = np.arange(x.size).reshape(self.x_shape)
-        x = x.astype(self.dtype)
-        self.x = chainer.Variable(x, name='x')
+        if self.x_shape is None:
+            self.x = chainer.Variable(name='x')
+        else:
+            x = np.empty(self.x_shape)
+            x = np.arange(x.size).reshape(self.x_shape)
+            x = x.astype(self.dtype)
+            self.x = chainer.Variable(x, name='x')
 
     def test_named_repr(self):
         self.assertEqual(repr(self.x), self.repr)


### PR DESCRIPTION
Fixes #2787 

Slightly reorganized str() logic to align with repr() code.