### PR TITLE
Make vision models copyable

### DIFF
--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -127,7 +127,10 @@ class GoogLeNet(link.Chain):
                 self)
         elif pretrained_model:
             npz.load_npz(pretrained_model, self)
-        self.functions = collections.OrderedDict([
+
+    @property
+    def functions(self):
+        return collections.OrderedDict([
             ('conv1', [self.conv1, relu]),
             ('pool1', [_max_pooling_2d, _local_response_normalization]),
             ('conv2_reduce', [self.conv2_reduce, relu]),

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -112,7 +112,10 @@ class ResNetLayers(link.Chain):
                       pretrained_model, self)
         elif pretrained_model:
             npz.load_npz(pretrained_model, self)
-        self.functions = collections.OrderedDict([
+
+    @property
+    def functions(self):
+        return collections.OrderedDict([
             ('conv1', [self.conv1, self.bn1, relu]),
             ('pool1', [lambda x: max_pooling_2d(x, ksize=3, stride=2)]),
             ('res2', [self.res2]),

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -504,17 +504,22 @@ class BuildingBlock(link.Chain):
         with self.init_scope():
             self.a = BottleneckA(
                 in_channels, mid_channels, out_channels, stride, initialW)
-            self.forward = [self.a]
+            self._forward = ["a"]
             for i in range(n_layer - 1):
                 name = 'b{}'.format(i + 1)
                 bottleneck = BottleneckB(out_channels, mid_channels, initialW)
                 setattr(self, name, bottleneck)
-                self.forward.append(bottleneck)
+                self._forward.append(name)
 
     def __call__(self, x):
-        for l in self.forward:
+        for name in self._forward:
+            l = getattr(self, name)
             x = l(x)
         return x
+
+    @property
+    def forward(self):
+        return [getattr(self, name) for name in self._forward]
 
 
 class BottleneckA(link.Chain):

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -113,7 +113,9 @@ class VGG16Layers(link.Chain):
         elif pretrained_model:
             npz.load_npz(pretrained_model, self)
 
-        self.functions = collections.OrderedDict([
+    @property
+    def functions(self):
+        return collections.OrderedDict([
             ('conv1_1', [self.conv1_1, relu]),
             ('conv1_2', [self.conv1_2, relu]),
             ('pool1', [_max_pooling_2d]),

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -131,8 +131,8 @@ class TestResNetLayers(unittest.TestCase):
     def check_copy(self):
         copied = self.link.copy()
 
-        self.assertTrue(copied.conv1 is copied.functions['conv1'][0])
-        self.assertTrue(copied.res2.a is copied.res2.forward[0])
+        self.assertIs(copied.conv1, copied.functions['conv1'][0])
+        self.assertIs(copied.res2.a, copied.res2.forward[0])
 
     def test_copy_cpu(self):
         self.check_copy()
@@ -244,7 +244,7 @@ class TestVGG16Layers(unittest.TestCase):
     def check_copy(self):
         copied = self.link.copy()
 
-        self.assertTrue(copied.conv1_1 is copied.functions['conv1_1'][0])
+        self.assertIs(copied.conv1_1, copied.functions['conv1_1'][0])
 
     def test_copy_cpu(self):
         self.check_copy()
@@ -378,7 +378,7 @@ class TestGoogLeNet(unittest.TestCase):
     def check_copy(self):
         copied = self.link.copy()
 
-        self.assertTrue(copied.conv1 is copied.functions['conv1'][0])
+        self.assertIs(copied.conv1, copied.functions['conv1'][0])
 
     def test_copy_cpu(self):
         self.check_copy()

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -128,6 +128,19 @@ class TestResNetLayers(unittest.TestCase):
         self.link.to_gpu()
         self.check_predict()
 
+    def check_copy(self):
+        copied = self.link.copy()
+
+        self.assertTrue(copied.conv1 is copied.functions['conv1'][0])
+
+    def test_copy_cpu(self):
+        self.check_copy()
+
+    @attr.gpu
+    def test_copy_gpu(self):
+        self.link.to_gpu()
+        self.check_copy()
+
 
 @unittest.skipUnless(resnet.available, 'Pillow is required')
 @attr.slow
@@ -226,6 +239,19 @@ class TestVGG16Layers(unittest.TestCase):
     def test_predict_gpu(self):
         self.link.to_gpu()
         self.check_predict()
+
+    def check_copy(self):
+        copied = self.link.copy()
+
+        self.assertTrue(copied.conv1_1 is copied.functions['conv1_1'][0])
+
+    def test_copy_cpu(self):
+        self.check_copy()
+
+    @attr.gpu
+    def test_copy_gpu(self):
+        self.link.to_gpu()
+        self.check_copy()
 
 
 @unittest.skipUnless(googlenet.available, 'Pillow is required')
@@ -347,6 +373,19 @@ class TestGoogLeNet(unittest.TestCase):
     def test_predict_gpu(self):
         self.link.to_gpu()
         self.check_predict()
+
+    def check_copy(self):
+        copied = self.link.copy()
+
+        self.assertTrue(copied.conv1 is copied.functions['conv1'][0])
+
+    def test_copy_cpu(self):
+        self.check_copy()
+
+    @attr.gpu
+    def test_copy_gpu(self):
+        self.link.to_gpu()
+        self.check_copy()
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -132,6 +132,7 @@ class TestResNetLayers(unittest.TestCase):
         copied = self.link.copy()
 
         self.assertTrue(copied.conv1 is copied.functions['conv1'][0])
+        self.assertTrue(copied.res2.a is copied.res2.forward[0])
 
     def test_copy_cpu(self):
         self.check_copy()


### PR DESCRIPTION
When one copies a vision model, `self.functions` is not correctly copied. This PR fixes the problem by making `functions` a property.