### PR TITLE
fix evaluator target without 'main'

### DIFF
--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -151,8 +151,7 @@ class Evaluator(extension.Extension):
 
         """
         iterator = self._iterators['main']
-        target = self._targets['main']
-        eval_func = self.eval_func or target
+        eval_func = self.eval_func or self._targets['main']
 
         if self.eval_hook:
             self.eval_hook(self)


### PR DESCRIPTION
When using `extensions.Evaluator` without the target of 'main', it occurs`KeyError`.