### PR TITLE
Fix to abort TestModeEvaluator and add resnet50.

### DIFF
--- a/examples/imagenet/train_imagenet_data_parallel.py
+++ b/examples/imagenet/train_imagenet_data_parallel.py
@@ -26,6 +26,7 @@ import alex
 import googlenet
 import googlenetbn
 import nin
+import resnet50
 import train_imagenet
 
 
@@ -36,7 +37,8 @@ def main():
         'googlenet': googlenet.GoogLeNet,
         'googlenetbn': googlenetbn.GoogLeNetBN,
         'googlenetbn_fp16': googlenetbn.GoogLeNetBNFp16,
-        'nin': nin.NIN
+        'nin': nin.NIN,
+        'resnet50': resnet50.ResNet50
     }
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
This PR will add ResNet50 for "train_imagenet_data_parallel.py". (related to #2644) 
This PR will also abort TestModeEvaluator to solve the following error. (related to #2186) 
```
$ python train_imagenet_data_parallel.py train.txt val.txt -a alex -g 0 1 2 3 -R imagenet
/home/ubuntu/.pyenv/versions/anaconda3-4.3.1/lib/python3.6/site-packages/chainer/training/updaters/multiprocess_parallel_updater.py:142: UserWarning: optimizer.lr is changed to 0.0025 by MultiprocessParallelUpdater for new batch size.
  format(optimizer.lr))
Traceback (most recent call last):
  File "train_imagenet_data_parallel.py", line 136, in <module>
    main()
  File "train_imagenet_data_parallel.py", line 112, in main
    trainer.extend(train_imagenet.TestModeEvaluator(val_iter, model,
AttributeError: module 'train_imagenet' has no attribute 'TestModeEvaluator'
```