### PR TITLE
Support keyword argument in classifier link

### DIFF
--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -15,6 +15,9 @@ class Classifier(link.Chain):
         predictor (~chainer.Link): Predictor network.
         lossfun (function): Loss function.
         accfun (function): Function that computes accuracy.
+        label_key (int or str): Key to specify label variable from arguments.
+            When it is ``int``, a variable in positional arguments is used.
+            And when it is ``str``, a variable in keyword arguments is used.
 
     Attributes:
         predictor (~chainer.Link): Predictor network.
@@ -56,9 +59,13 @@ class Classifier(link.Chain):
 
         Args:
             args (list of ~chainer.Variable): Input minibatch.
+            kwargs (dict of ~chainer.Variable): Input minibatch.
 
-        The all elements of ``args`` but last one are features and
-        the last element corresponds to ground truth labels.
+        When ``label_key`` is ``int``, the correpoding element in ``args``
+        is treated as ground truth labels. And when it is ``str``, the
+        element in ``kwargs`` is used.
+        The all elements of ``args`` and ``kwargs`` except the ground trush
+        labels are features.
         It feeds features to the predictor and compare the result
         with ground truth labels.
 

--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -82,7 +82,7 @@ class Classifier(link.Chain):
             if self.label_key == -1:
                 args = args[:-1]
             else:
-                args = args[:self.label_key] + args[self.label_key+1:]
+                args = args[:self.label_key] + args[self.label_key + 1:]
         elif isinstance(self.label_key, str):
             if self.label_key not in kwargs:
                 msg = 'Label key "%s" is not found' % self.label_key

--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -75,13 +75,14 @@ class Classifier(link.Chain):
         """
 
         if isinstance(self.label_key, int):
-            if (self.label_key >= 0 and len(args) <= self.label_key or
-                    self.label_key < 0 and len(args) < -self.label_key):
+            if not (-len(args) <= self.label_key < len(args)):
                 msg = 'Label key %d is out of bounds' % self.label_key
                 raise ValueError(msg)
             t = args[self.label_key]
-            args = list(args)
-            del args[self.label_key]
+            if self.label_key == -1:
+                args = args[:-1]
+            else:
+                args = args[:self.label_key] + args[self.label_key+1:]
         elif isinstance(self.label_key, str):
             if self.label_key not in kwargs:
                 msg = 'Label key "%s" is not found' % self.label_key

--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -81,9 +81,7 @@ class Classifier(link.Chain):
                 raise ValueError(msg)
             t = args[self.label_key]
             args = list(args)
-            print(len(args))
             del args[self.label_key]
-            print(args)
         elif isinstance(self.label_key, str):
             if self.label_key not in kwargs:
                 msg = 'Label key "%s" is not found' % self.label_key

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -129,7 +129,9 @@ class TestInvalidArgument(unittest.TestCase):
 
     def check_invalid_argument(self):
         x = chainer.Variable(self.link.xp.asarray(self.x))
-        with self.assertRaisesRegexp(TypeError, 'missing'):
+        with self.assertRaises(TypeError):
+            # link.__call__ raises TypeError as the number of arguments
+            # is illegal
             self.link(x)
 
     def test_invalid_argument_cpu(self):

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -132,11 +132,11 @@ class TestInvalidLabelKey(unittest.TestCase):
     def test_invalid_argument_gpu(self):
         self.check_invalid_key(True, 1)
 
-    def test_invalid_index_cpu(self):
+    def test_invalid_index_too_small_cpu(self):
         self.check_invalid_key(False, -2)
 
     @attr.gpu
-    def test_invalid_argument_gpu(self):
+    def test_invalid_index_too_small_gpu(self):
         self.check_invalid_key(True, -2)
 
     def test_invalid_str_key_cpu(self):

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -2,6 +2,7 @@ import unittest
 
 import mock
 import numpy
+import six
 
 import chainer
 from chainer import cuda
@@ -149,8 +150,8 @@ class TestInvalidLabelKey(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
 
     def test_invalid_label_key_type(self):
-        with self.assertRaisesRegex(
-                TypeError, 'label_key must be int or str'):
+        with six.assertRaisesRegex(
+                self, TypeError, 'label_key must be int or str'):
             links.Classifier(links.Linear(10, 3), label_key=None)
 
     def check_invalid_key(self, gpu, label_key):
@@ -158,7 +159,7 @@ class TestInvalidLabelKey(unittest.TestCase):
         if gpu:
             link.to_gpu()
         x = chainer.Variable(link.xp.asarray(self.x))
-        with self.assertRaisesRegex(ValueError, 'Label key'):
+        with six.assertRaisesRegex(self, ValueError, 'Label key'):
             link(x)
 
     def test_invalid_index_cpu(self):

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -95,8 +95,8 @@ class TestInvalidArgument(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
 
     def check_invalid_argument(self):
-        with self.assertRaises(TypeError):
-            x = chainer.Variable(self.link.xp.asarray(self.x))
+        x = chainer.Variable(self.link.xp.asarray(self.x))
+        with self.assertRaisesRegexp(TypeError, 'missing'):
             self.link(x)
 
     def test_invalid_argument_cpu(self):
@@ -114,15 +114,16 @@ class TestInvalidLabelKey(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
 
     def test_invalid_label_key_type(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegexp(
+                TypeError, 'label_key must be int or str'):
             links.Classifier(links.Linear(10, 3), label_key=None)
 
     def check_invalid_key(self, gpu, label_key):
         link = links.Classifier(links.Linear(10, 3), label_key=label_key)
         if gpu:
             link.to_gpu()
-        with self.assertRaises(ValueError):
-            x = chainer.Variable(link.xp.asarray(self.x))
+        x = chainer.Variable(link.xp.asarray(self.x))
+        with self.assertRaisesRegexp(ValueError, 'Label key'):
             link(x)
 
     def test_invalid_index_cpu(self):

--- a/tests/chainer_tests/links_tests/model_tests/test_classifier.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_classifier.py
@@ -149,7 +149,7 @@ class TestInvalidLabelKey(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, (5, 10)).astype(numpy.float32)
 
     def test_invalid_label_key_type(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 TypeError, 'label_key must be int or str'):
             links.Classifier(links.Linear(10, 3), label_key=None)
 
@@ -158,7 +158,7 @@ class TestInvalidLabelKey(unittest.TestCase):
         if gpu:
             link.to_gpu()
         x = chainer.Variable(link.xp.asarray(self.x))
-        with self.assertRaisesRegexp(ValueError, 'Label key'):
+        with self.assertRaisesRegex(ValueError, 'Label key'):
             link(x)
 
     def test_invalid_index_cpu(self):


### PR DESCRIPTION
To support keyword arguments in Classifier, I added `label_key` attribute to specify label variable. When a user specify `str` key, this class uses keyword argument as a label variable.