### PR TITLE
Fix contibution guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ nvidia-docker run -it chainer/chainer /bin/bash
 ## Contribution
 
 Any contributions to Chainer are welcome!
-If you want to file an issue or send a pull request, [please follow the contribution guide](https://docs.chainer.org/contribution.html).
+If you want to file an issue or send a pull request, [please follow the contribution guide](https://docs.chainer.org/en/stable/contribution.html).
 
 
 ## License


### PR DESCRIPTION
Currently, the link in README.md is broken.