### PR TITLE
Fix resuming issue of *Shift extensions

### DIFF
--- a/chainer/training/extensions/exponential_shift.py
+++ b/chainer/training/extensions/exponential_shift.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+import numpy as np
+
 from chainer.training import extension
 
 
@@ -70,6 +72,8 @@ class ExponentialShift(extension.Extension):
     def serialize(self, serializer):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
+        if isinstance(self._last_value, np.ndarray):
+            self._last_value = np.asscalar(self._last_value)
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/chainer/training/extensions/linear_shift.py
+++ b/chainer/training/extensions/linear_shift.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+import numpy as np
+
 from chainer.training import extension
 
 
@@ -55,6 +57,8 @@ class LinearShift(extension.Extension):
     def serialize(self, serializer):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
+        if isinstance(self._last_value, np.ndarray):
+            self._last_value = np.asscalar(self._last_value)
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/tests/chainer_tests/training_tests/extensions_tests/test_exponential_shift.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_exponential_shift.py
@@ -77,6 +77,7 @@ class TestExponentialShift(unittest.TestCase):
 
         new_extension.initialize(new_trainer)
         self.assertEqual(new_optimizer.x, self.optimizer.x)
+        self.assertIsInstance(new_optimizer.x, float)
 
 
 class TestExponentialShiftInvalidArgument(unittest.TestCase):

--- a/tests/chainer_tests/training_tests/extensions_tests/test_linear_shift.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_linear_shift.py
@@ -65,6 +65,7 @@ class TestLinearShift(unittest.TestCase):
 
         new_extension.initialize(new_trainer)
         self.assertEqual(new_optimizer.x, self.optimizer.x)
+        self.assertIsInstance(new_optimizer.x, float)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
`ExponentialShift` and `LinearShift` cause an error when they are used in GPU training. Updating weights in optimizer is failed because they set `optimizer.lr` as `numpy.ndarray`.

Here is an example code.
```
import argparse
import numpy as np

import chainer
import chainer.links as L
from chainer import training
from chainer.training import extensions


def get_trainer(dataset, model, gpu):
    iterator = chainer.iterators.SerialIterator(dataset, 1)

    optimizer = chainer.optimizers.MomentumSGD()
    optimizer.setup(model)

    updater = training.StandardUpdater(iterator, optimizer, device=gpu)
    trainer = training.Trainer(updater, (10, 'iteration'))
    trainer.extend(
        extensions.ExponentialShift('lr', 0.1, init=0.01),
        trigger=(3, 'iteration'))
    trainer.extend(extensions.snapshot(), trigger=(5, 'iteration'))
    return trainer


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--gpu', type=int, default=-1)
    args = parser.parse_args()

    model = L.Linear(None, 1)
    if args.gpu >= 0:
        chainer.cuda.get_device(args.gpu).use()
        model.to_gpu()

    dataset = np.random.uniform(size=(1, 16)).astype(np.float32)

    trainer = get_trainer(dataset, model, args.gpu)
    trainer.run()

    trainer = get_trainer(dataset, model, args.gpu)
    chainer.serializers.load_npz('result/snapshot_iter_5', trainer)
    trainer.run()


if __name__ == '__main__':
    main()
```
```
Traceback (most recent call last):
  File "***.py", line 49, in <module>
    main()
  File "***.py", line 45, in main
    trainer.run()
  File "***/lib/python3.5/site-packages/chainer/training/trainer.py", line 296, in run
    update()
  File "***/lib/python3.5/site-packages/chainer/training/updater.py", line 177, in update
    self.update_core()
  File "***/lib/python3.5/site-packages/chainer/training/updater.py", line 192, in update_core
    optimizer.update(loss_func, in_arrays)
  File "***/lib/python3.5/site-packages/chainer/optimizer.py", line 541, in update
    param.update()
  File "***/lib/python3.5/site-packages/chainer/variable.py", line 1003, in update
    self.update_rule.update(self)
  File "***/lib/python3.5/site-packages/chainer/optimizer.py", line 191, in update
    self.update_core(param)
  File "***/lib/python3.5/site-packages/chainer/optimizer.py", line 207, in update_core
    self.update_core_gpu(param)
  File "***/lib/python3.5/site-packages/chainer/optimizers/momentum_sgd.py", line 58, in update_core_gpu
    param.data, self.state['v'])
  File "cupy/core/elementwise.pxi", line 511, in cupy.core.core.ElementwiseKernel.__call__ (cupy/core/core.cpp:42721)
  File "cupy/core/elementwise.pxi", line 110, in cupy.core.core._preprocess_args (cupy/core/core.cpp:35427)
TypeError: Unsupported type <class 'numpy.ndarray'>
```