### PR TITLE
Fix a bug of to_gpu in cuda.py

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -281,7 +281,7 @@ def to_gpu(array, device=None, stream=None):
             return cupy.asarray(array)
 
         # Need to make a copy when an array is copied to another device
-        return cupy.array(array, copy=True)
+        return array.copy()
 
 
 def to_cpu(array, stream=None):


### PR DESCRIPTION
Current to_gpu tries to copy an array on a device to another device by calling `cupy.array(array, copy=True)`, but it causes the error `ValueError: Array device must be same as the current device: array device = 0 while current = 1`. Just calling `array.copy()` inside the context of the device to which it tries to copy the array is fine.

This fixes the test failres of `test_cupy_array2`.