### PR TITLE
Check for None in HyperparameterProxy descriptor

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -595,6 +595,8 @@ class HyperparameterProxy(object):
         self.__doc__ = 'Alias to ``self.hyperparam.{}``'.format(attr_name)
 
     def __get__(self, obj, type=None):
+        if obj is None:
+            return self
         return getattr(obj.hyperparam, self._attr_name)
 
     def __set__(self, obj, value):


### PR DESCRIPTION
Fixes #2851

See also: https://stackoverflow.com/questions/29436716/why-do-you-need-if-instance-is-none-in-get-of-a-descriptor-class