### PR TITLE
Update target url for ptb dataset

### DIFF
--- a/chainer/datasets/ptb.py
+++ b/chainer/datasets/ptb.py
@@ -11,7 +11,7 @@ def get_ptb_words():
     `Penn Tree Bank <https://www.cis.upenn.edu/~treebank/>`_ is originally a
     corpus of English sentences with linguistic structure annotations. This
     function uses a variant distributed at
-    `https://github.com/tomsercu/lstm <https://github.com/tomsercu/lstm>`_,
+    `https://github.com/wojzaremba/lstm <https://github.com/wojzaremba/lstm>`_,
     which omits the annotation and splits the dataset into three parts:
     training, validation, and test.
 
@@ -48,9 +48,9 @@ def get_ptb_words_vocabulary():
     return _retrieve_word_vocabulary()
 
 
-_train_url = 'https://raw.githubusercontent.com/tomsercu/lstm/master/data/ptb.train.txt'  # NOQA
-_valid_url = 'https://raw.githubusercontent.com/tomsercu/lstm/master/data/ptb.valid.txt'  # NOQA
-_test_url = 'https://raw.githubusercontent.com/tomsercu/lstm/master/data/ptb.test.txt'  # NOQA
+_train_url = 'https://raw.githubusercontent.com/wojzaremba/lstm/master/data/ptb.train.txt'  # NOQA
+_valid_url = 'https://raw.githubusercontent.com/wojzaremba/lstm/master/data/ptb.valid.txt'  # NOQA
+_test_url = 'https://raw.githubusercontent.com/wojzaremba/lstm/master/data/ptb.test.txt'  # NOQA
 
 
 def _retrieve_ptb_words(name, url):


### PR DESCRIPTION
Currently, chainer.datasets.ptb downloads the dataset from forked repository.
The contents of original repository seems to be exactly the same.
So I think it would be better chainer downloads dataset from original repository.

I checked the difference between original data and forked one in the way below.
```
$ git clone git@github.com:wojzaremba/lstm.git lstm_original
Cloning into 'lstm_original'...
remote: Counting objects: 53, done.
remote: Total 53 (delta 0), reused 0 (delta 0), pack-reused 53
Receiving objects: 100% (53/53), 1.91 MiB | 391.00 KiB/s, done.
Resolving deltas: 100% (26/26), done.

$ git clone git@github.com:tomsercu/lstm.git lstm_forked
Cloning into 'lstm_forked'...
remote: Counting objects: 72, done.
remote: Total 72 (delta 0), reused 0 (delta 0), pack-reused 72
Receiving objects: 100% (72/72), 4.10 MiB | 669.00 KiB/s, done.
Resolving deltas: 100% (30/30), done.

$ diff lstm_original/data/ptb.train.txt lstm_forked/data/ptb.train.txt
$ diff lstm_original/data/ptb.test.txt lstm_forked/data/ptb.test.txt
$ diff lstm_original/data/ptb.valid.txt lstm_forked/data/ptb.valid.txt
```