### PR TITLE
Optimize layer normalization

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -256,6 +256,8 @@ from chainer.functions.normalization.batch_normalization import batch_normalizat
 from chainer.functions.normalization.batch_normalization import fixed_batch_normalization  # NOQA
 from chainer.functions.normalization.l2_normalization import normalize  # NOQA
 from chainer.functions.normalization.l2_normalization import NormalizeL2  # NOQA
+from chainer.functions.normalization.layer_normalization import layer_normalization  # NOQA
+from chainer.functions.normalization.layer_normalization import LayerNormalization  # NOQA
 from chainer.functions.normalization.local_response_normalization import local_response_normalization  # NOQA
 from chainer.functions.normalization.local_response_normalization import LocalResponseNormalization  # NOQA
 

--- a/chainer/functions/normalization/layer_normalization.py
+++ b/chainer/functions/normalization/layer_normalization.py
@@ -63,10 +63,7 @@ class LayerNormalization(function.Function):
         g_x_mu_1 = g_x_hat * self.inv_std
 
         g_std = g_inv_std * (- 1. / self.var)
-        # = g_inv_std * (- 1. / (self.std ** 2))
-
         g_var = g_std * 0.5 * self.inv_std
-        # = g_std * 0.5 * 1. / xp.sqrt(self.var + self.eps)
 
         n_units = x.shape[1]
         g_squ_x_mu = _broadcast_to(xp, g_var * 1. / n_units, x.shape)
@@ -74,7 +71,6 @@ class LayerNormalization(function.Function):
 
         g_x_1 = g_x_mu_1 + g_x_mu_2
         g_mu = xp.sum(g_x_1, axis=1, keepdims=True) * (- 1.)
-        # = xp.sum(g_x_mu_1 + g_x_mu_2, axis=1, keepdims=True) * (- 1.)
 
         g_x_2 = _broadcast_to(xp, g_mu * 1. / n_units, x.shape)
 

--- a/chainer/functions/normalization/layer_normalization.py
+++ b/chainer/functions/normalization/layer_normalization.py
@@ -1,0 +1,99 @@
+from chainer import cuda
+from chainer import function
+from chainer.utils import type_check
+
+
+class LayerNormalization(function.Function):
+
+    """Layer normalization"""
+
+    def __init__(self, eps=1e-5):
+        self.eps = eps
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 3)
+        x_type, gamma_type, beta_type = in_types
+
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            x_type.ndim == 2,
+            gamma_type.ndim == 1,
+            beta_type.ndim == 1,
+            gamma_type.dtype == x_type.dtype,
+            beta_type.dtype == x_type.dtype,
+            gamma_type.shape == beta_type.shape,
+        )
+
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
+        x, gamma, beta = inputs
+        mu = xp.mean(x, axis=1, keepdims=True)
+        self.x_mu = x - mu
+        self.squ_x_mu = xp.square(self.x_mu)
+        self.var = xp.mean(self.squ_x_mu, axis=1, keepdims=True)
+        std = xp.sqrt(self.var + self.eps)
+        self.inv_std = 1. / std
+        self.x_hat = self.x_mu * self.inv_std
+        scaled_x = self.x_hat * gamma[None, ]
+        shifted_x = scaled_x + beta[None, ]
+        return shifted_x,
+
+    def backward(self, inputs, gy):
+        xp = cuda.get_array_module(*inputs)
+        x, gamma, beta = inputs
+        gy = gy[0]
+
+        g_beta = gy.sum(axis=0)
+        g_scaled_x = gy
+
+        g_gamma = xp.sum(g_scaled_x * self.x_hat, axis=0)
+        g_x_hat = g_scaled_x * gamma[None, ]
+
+        g_inv_std = xp.sum(g_x_hat * self.x_mu, axis=1, keepdims=True)
+        g_x_mu_1 = g_x_hat * self.inv_std
+
+        g_std = g_inv_std * (- 1. / self.var)
+        # = g_inv_std * (- 1. / (self.std ** 2))
+
+        g_var = g_std * 0.5 * self.inv_std
+        # = g_std * 0.5 * 1. / xp.sqrt(self.var + self.eps)
+
+        n_units = x.shape[1]
+        g_squ_x_mu = xp.broadcast_to(g_var * 1. / n_units, x.shape)
+        g_x_mu_2 = g_squ_x_mu * 2 * self.x_mu
+
+        g_x_1 = g_x_mu_1 + g_x_mu_2
+        g_mu = xp.sum(g_x_1, axis=1, keepdims=True) * (- 1.)
+        # = xp.sum(g_x_mu_1 + g_x_mu_2, axis=1, keepdims=True) * (- 1.)
+
+        g_x_2 = xp.broadcast_to(g_mu * 1. / n_units, x.shape)
+
+        g_x = g_x_1 + g_x_2
+
+        return g_x, g_gamma, g_beta,
+
+
+def layer_normalization(x, gamma, beta, eps=1e-5):
+    """Layer normalization.
+
+    This function implements a "layer normalization"
+    which normalizes the input units by statistics
+    that are computed along the second axis,
+    scales and shifts them.
+
+
+    Args:
+        x (~chainer.Variable): Batch vectors.
+            Shape of this value must be `(batch_size, unit_size)`,
+            e.g., the output of :func:`~chainer.functions.linear`.
+        gamma (~chainer.Variable): Scaling vectors.
+        beta (~chainer.Variable): Shifting vectors.
+
+
+    Returns:
+        ~chainer.Variable: The output variable which has the same shape
+        as :math:`x`.
+
+    See: `Layer Normalization <https://arxiv.org/abs/1607.06450>`_
+    """
+    return LayerNormalization(eps)(x, gamma, beta)

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,9 +1,4 @@
-from chainer.functions.array import broadcast
-from chainer.functions.math import bias
-from chainer.functions.math import scale
-from chainer.functions.math import sqrt
-from chainer.functions.math import square
-from chainer.functions.math import sum
+from chainer.functions.normalization import layer_normalization
 from chainer import link
 from chainer import utils
 from chainer import variable
@@ -66,16 +61,6 @@ class LayerNormalization(link.Link):
         self.gamma.initialize(size)
         self.beta.initialize(size)
 
-    def _normalize(self, x):
-        size = x.shape[1]
-        mean = broadcast.broadcast_to(
-            (sum.sum(x, axis=1) / size)[:, None],
-            x.shape)
-        std = broadcast.broadcast_to(sqrt.sqrt(
-            sum.sum(square.square(x - mean), axis=1) / size)[:, None],
-            x.shape) + self.eps
-        return (x - mean) / std
-
     def __call__(self, x):
         """Apply layer normalization to given input.
 
@@ -91,5 +76,5 @@ class LayerNormalization(link.Link):
         if self.gamma.data is None:
             self._initialize_params(x.size // x.shape[0])
 
-        normalized = self._normalize(x)
-        return bias.bias(scale.scale(normalized, self.gamma), self.beta)
+        return layer_normalization.layer_normalization(
+            x, self.gamma, self.beta, self.eps)

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -218,6 +218,7 @@ Normalization functions
 
    chainer.functions.batch_normalization
    chainer.functions.fixed_batch_normalization
+   chainer.functions.layer_normalization
    chainer.functions.local_response_normalization
    chainer.functions.normalize
 


### PR DESCRIPTION
The current implementation of layer normalization is slow (as [this](https://github.com/chainer/chainer/pull/1950#issuecomment-265613756) mentioned). I implemented forward and backward computation explicitly as a new function.