### PR TITLE
Add F.pad_sequence to the reference

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -69,6 +69,7 @@ Array manipulations
    chainer.functions.hstack
    chainer.functions.im2col
    chainer.functions.pad
+   chainer.functions.pad_sequence
    chainer.functions.permutate
    chainer.functions.reshape
    chainer.functions.resize_images


### PR DESCRIPTION
This PR adds `pad_sequence` function to reference, which seems to be missing after it was implemented.