### PR TITLE
Fix F.pad_sequence error on 64bit Windows GPU

### DIFF
--- a/chainer/functions/array/pad_sequence.py
+++ b/chainer/functions/array/pad_sequence.py
@@ -49,7 +49,7 @@ class PadSequence(function.Function):
         else:
             # This code assumes that all arrays are c_contiguous
             ptr_shape = (Ellipsis,) + (None,) * xs[0].ndim
-            ptrs = cuda.cupy.array([x.data for x in xs], 'L')[ptr_shape]
+            ptrs = cuda.cupy.array([x.data for x in xs], 'P')[ptr_shape]
             lengths = cuda.cupy.array([len(x) for x in xs], 'i')[ptr_shape]
             base = numpy.prod(xs[0].shape[1:], dtype='i')
             cuda.elementwise(


### PR DESCRIPTION
`F.pad_sequence` causes an error on 64bit Windows when the input arrays are `cupy.ndarray`.

The cause of the error is that the function internally creates an array of pointers, but `dtype='L'` is `np.uint32` in 64bit Windows. 
To fix it I replaced 'L' with 'P' which is [dtype for pointer type](https://docs.scipy.org/doc/numpy-1.12.0/reference/arrays.scalars.html).
> uint 	compatible: Python int 	'L'
> uintp 	large enough to fit a pointer 	'P'

The following code reproduces the error (Chainer 2.0.0, Python 3.6.1, 64bit Windows 10).

code:
```python
import chainer.functions as F
import cupy

x = [cupy.arange(5), cupy.arange(3)]
F.pad_sequence(x)
```

output:
```python
Traceback (most recent call last):

  File "<ipython-input-13-f23231849e76>", line 5, in <module>
    F.pad_sequence(x)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\functions\array\pad_sequence.py", line 97, in pad_sequence
    return PadSequence(length, padding)(*xs)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\function.py", line 200, in __call__
    outputs = self.forward(in_data)

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\chainer\functions\array\pad_sequence.py", line 52, in forward
    ptrs = cuda.cupy.array([x.data for x in xs], 'L')[ptr_shape]

  File "C:\Users\sakurai\Anaconda3\lib\site-packages\cupy\creation\from_data.py", line 26, in array
    return core.array(obj, dtype, copy, ndmin)

  File "cupy/core/core.pyx", line 1795, in cupy.core.core.array (cupy\core\core.cpp:58633)

  File "cupy/core/core.pyx", line 1812, in cupy.core.core.array (cupy\core\core.cpp:58244)

OverflowError: Python int too large to convert to C long
```

The following are results of `nosetests` before and after the fix.

before fix:
```
>nosetests tests\chainer_tests\functions_tests\array_tests\test_pad_sequence.py

...

======================================================================
384) ERROR: test_forward_gpu (test_pad_sequence.transplant_class.<locals>.C)  parameter: {'dtype': <class 'numpy.int8'>, 'length': 6, 'lengths': [2, 1, 5, 3], 'pad': -1, 'shape': ()}
----------------------------------------------------------------------
   Traceback (most recent call last):
    tests\chainer_tests\functions_tests\array_tests\test_pad_sequence.py line 58 in test_forward_gpu
      self.check_forward([cuda.to_gpu(x) for x in self.xs])
    tests\chainer_tests\functions_tests\array_tests\test_pad_sequence.py line 45 in check_forward
      y = functions.pad_sequence(xs, length=self.length, padding=self.pad)
    chainer\functions\array\pad_sequence.py line 97 in pad_sequence
      return PadSequence(length, padding)(*xs)
    chainer\function.py line 200 in __call__
      outputs = self.forward(in_data)
    chainer\functions\array\pad_sequence.py line 52 in forward
      ptrs = cuda.cupy.array([x.data for x in xs], 'L')[ptr_shape]
    C:\Users\sakurai\Anaconda3\lib\site-packages\cupy\creation\from_data.py line 26 in array
      return core.array(obj, dtype, copy, ndmin)
    cupy\core\core.pyx line 1795 in cupy.core.core.array (cupy\core\core.cpp:58633)

    cupy\core\core.pyx line 1812 in cupy.core.core.array (cupy\core\core.cpp:58244)

   OverflowError: Python int too large to convert to C long

-----------------------------------------------------------------------------
2880 tests run in 7.289 seconds.
384 errors (2496 tests passed)
```

after fix:
```
>nosetests tests\chainer_tests\functions_tests\array_tests\test_pad_sequence.py

...

2880 tests run in 11.188 seconds (2880 tests passed)
```