### PR TITLE
Use zeros instead of empty for ROIPooling2D CPU mode

### DIFF
--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -73,9 +73,9 @@ class ROIPooling2D(function.Function):
         bottom_data, bottom_rois = inputs
         channels, height, width = bottom_data.shape[1:]
         n_rois = bottom_rois.shape[0]
-        top_data = numpy.empty((n_rois, channels, self.outh, self.outw),
+        top_data = numpy.zeros((n_rois, channels, self.outh, self.outw),
                                dtype=numpy.float32)
-        self.argmax_data = numpy.empty(top_data.shape, numpy.int32)
+        self.argmax_data = numpy.zeros(top_data.shape, numpy.int32)
 
         for i_roi in six.moves.range(n_rois):
             idx, xmin, ymin, xmax, ymax = bottom_rois[i_roi]

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -73,6 +73,8 @@ class ROIPooling2D(function.Function):
         bottom_data, bottom_rois = inputs
         channels, height, width = bottom_data.shape[1:]
         n_rois = bottom_rois.shape[0]
+        # `numpy.zeros` needs to be used because the arrays can be
+        # returned without having some of its values updated.
         top_data = numpy.zeros((n_rois, channels, self.outh, self.outw),
                                dtype=numpy.float32)
         self.argmax_data = numpy.zeros(top_data.shape, numpy.int32)


### PR DESCRIPTION
The value can get returned without initialization in some case.
Therefore, we should use `zeros` instead of `empty`.

For example, `sliceh.stop == `sliceh.start`, when height and ymin are very close. 

https://github.com/yuyu2172/chainer/blob/bee0deb0dae30bf0db7a2f630860cb9a4a97116d/chainer/functions/pooling/roi_pooling_2d.py#L94
