### PR TITLE
[Backport] Add F.pad_sequence to the reference (#2863)

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -69,6 +69,7 @@ Array manipulations
    chainer.functions.hstack
    chainer.functions.im2col
    chainer.functions.pad
+   chainer.functions.pad_sequence
    chainer.functions.permutate
    chainer.functions.reshape
    chainer.functions.resize_images


### PR DESCRIPTION
This PR is the backport of #2863. As it is made on top of #2883, please review that PR first.