### PR TITLE
Avoid itervalues for performance

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -190,7 +190,8 @@ class Function(object):
         if self._n_local_function_hooks != 0:
             hooks = collections.OrderedDict(hooks)
             hooks.update(self.local_function_hooks)
-        for hook in six.itervalues(hooks):
+        hooks = hooks.values()  # avoid six for performance
+        for hook in hooks:
             hook.forward_preprocess(self, in_data)
 
         # Forward prop
@@ -199,7 +200,7 @@ class Function(object):
             self._output_indexes_to_retain = None
             outputs = self.forward(in_data)
             assert type(outputs) == tuple
-        for hook in six.itervalues(hooks):
+        for hook in hooks:
             hook.forward_postprocess(self, in_data)
 
         if chainer.is_debug():
@@ -209,8 +210,8 @@ class Function(object):
                 msg = 'NaN is detected on forward computation'
                 raise RuntimeError(msg)
 
-        ret = tuple([variable.Variable(y, requires_grad=requires_grad)
-                     for y in outputs])
+        ret = [variable.Variable(y, requires_grad=requires_grad)
+               for y in outputs]
 
         if configuration.config.enable_backprop:
             # Topological ordering
@@ -239,7 +240,7 @@ class Function(object):
         if len(ret) == 1:
             return ret[0]
         else:
-            return ret
+            return tuple(ret)
 
     @property
     def local_function_hooks(self):

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -6,7 +6,6 @@ import warnings
 import weakref
 
 import numpy
-import six
 
 import chainer
 from chainer import cuda
@@ -700,9 +699,10 @@ Actual: {0}'''.format(type(data))
             if func._n_local_function_hooks != 0:
                 hooks = collections.OrderedDict(hooks)
                 hooks.update(func.local_function_hooks)
+            hooks = hooks.values()  # avoid six for performance
 
             cuda.get_device_from_array(*(in_data + out_grad)).use()
-            for hook in six.itervalues(hooks):
+            for hook in hooks:
                 hook.backward_preprocess(func, in_data, out_grad)
             func.output_data = tuple(
                 [None if y is None else y.data for y in outputs])
@@ -710,7 +710,7 @@ Actual: {0}'''.format(type(data))
             assert len(gxs) == len(in_data)
             if not getattr(func, '_retain_after_backward', False):
                 func.output_data = None
-            for hook in six.itervalues(hooks):
+            for hook in hooks:
                 hook.backward_postprocess(func, in_data, out_grad)
 
             if is_debug:


### PR DESCRIPTION
Avoid `itervalues` in `forward` and `backward` for performance