### PR TITLE
fix stream option not working with to_gpu

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -266,7 +266,7 @@ def to_gpu(array, device=None, stream=None):
                         mem, array.dtype, array.size).reshape(array.shape)
                     src[...] = array
                     ret.set(src, stream)
-                    cupy.cuda.pinned_memory._add_to_watch_lsit(
+                    cupy.cuda.pinned_memory._add_to_watch_list(
                         stream.record(), mem)
                 else:
                     # gpu to gpu


### PR DESCRIPTION
CPU-to-GPU transfer with CUDA stream is not working.
It seems that this error was introduced in #2238.