### PR TITLE
Fix a bug dependent on glibc version

### DIFF
--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -76,8 +76,8 @@ class AdamRule(optimizer.UpdateRule):
 
     @property
     def lr(self):
-        fix1 = 1. - self.hyperparam.beta1 ** self.t
-        fix2 = 1. - self.hyperparam.beta2 ** self.t
+        fix1 = 1. - math.pow(self.hyperparam.beta1, self.t)
+        fix2 = 1. - math.pow(self.hyperparam.beta2, self.t)
         return self.hyperparam.alpha * math.sqrt(fix2) / fix1
 
 
@@ -116,6 +116,6 @@ class Adam(optimizer.GradientMethod):
 
     @property
     def lr(self):
-        fix1 = 1. - self.hyperparam.beta1 ** self.t
-        fix2 = 1. - self.hyperparam.beta2 ** self.t
+        fix1 = 1. - math.pow(self.hyperparam.beta1, self.t)
+        fix2 = 1. - math.pow(self.hyperparam.beta2, self.t)
         return self.hyperparam.alpha * math.sqrt(fix2) / fix1


### PR DESCRIPTION
I eliminated a bug that depend on the version of glibc from adam.py.

If you use glibc-2.11 or earlier, the pow() function (and also '**' operator) in python gives the following error when its result is a denormalized number. (This bug does not depend on python version but glibc version.)

The result tried in my environment is as follows.

* use glibc-2.11 or earlier
```
$ rpm -q glibc
glibc-2.11.3-17.109.1
$ python
Python 2.7.11 (default, Feb 28 2017, 20:05:35)
[GCC 4.8.5] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> 0.1 ** 307
1.0000000000000171e-307
>>> 0.1 ** 308
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: (34, 'Numerical result out of range')
>>> 0.1 ** 323
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: (34, 'Numerical result out of range')
>>> 0.1 ** 324
0.0
```
* use glibc-2.12 or later
```
$ rpm -q glibc
glibc-2.12-1.132.el6_5.4.x86_64
$ python
Python 2.7.11 (default, May 24 2016, 18:27:46)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-11)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> 0.1 ** 307
1.0000000000000171e-307
>>> 0.1 ** 308
1.000000000000017e-308
>>> 0.1 ** 323
1e-323
>>> 0.1 ** 324
0.0
```

This effect can make calculations in adam.py fail.

If you use math.pow() function, the error like this does not occur.
Therefore, I suggest replacing '**' operator with math.pow() function in adam.py.