### PR TITLE
Fix issue of retain_outputs

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -235,25 +235,6 @@ class Function(object):
             if output_indexes_to_retain is not None:
                 for index in output_indexes_to_retain:
                     ret[index].retain_data()
-
-            # Work-around to prevent variable nodes in a computational graph
-            # from being released unexpectedly
-            self._outputs = [None for y in ret]
-            if output_indexes_to_retain is not None:
-                for index in output_indexes_to_retain:
-                    # Make a temporary reference to the variable node
-                    # of the retained output
-                    self._outputs[index] = ret[index].node
-
-            for x in self.inputs:
-                if x.creator is None:
-                    continue
-                for index in range(0, len(x.creator._outputs)):
-                    if (x.creator._outputs[index] is x):
-                        # Remove a temporary reference to my inputs
-                        # from the correspondig creator functions
-                        x.creator._outputs[index] = None
-
             del self._output_indexes_to_retain
 
         if len(ret) == 1:

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -232,9 +232,11 @@ class Function(object):
             del self._input_indexes_to_retain
 
             output_indexes_to_retain = self._output_indexes_to_retain
+            self.output_data = [None for y in ret]
             if output_indexes_to_retain is not None:
                 for index in output_indexes_to_retain:
                     ret[index].retain_data()
+                    self.output_data[index] = ret[index].node.data
             del self._output_indexes_to_retain
 
         if len(ret) == 1:
@@ -495,7 +497,7 @@ class Function(object):
         """
         self._input_indexes_to_retain = indexes
 
-    def retain_outputs(self, indexes, retain_after_backward=False):
+    def retain_outputs(self, indexes, retain_after_backward=True):
         """Lets specified output variable nodes keep data arrays.
 
         By calling this method from :meth:`forward`, the function can specify

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -713,12 +713,14 @@ Actual: {0}'''.format(type(data))
             cuda.get_device_from_array(*(in_data + out_grad)).use()
             for hook in hooks:
                 hook.backward_preprocess(func, in_data, out_grad)
-            func.output_data = tuple(
-                [None if y is None else y.data for y in outputs])
+            for index, y in enumerate(outputs):
+                if y is None or y.data is None:
+                    continue
+                func.output_data[index] = y.data
             gxs = func.backward(in_data, out_grad)
             assert len(gxs) == len(in_data)
             if not getattr(func, '_retain_after_backward', False):
-                func.output_data = None
+                func.output_data = [None for y in outputs]
             for hook in hooks:
                 hook.backward_postprocess(func, in_data, out_grad)
 

--- a/tests/chainer_tests/test_function.py
+++ b/tests/chainer_tests/test_function.py
@@ -475,13 +475,14 @@ class TestFunctionRetaining(unittest.TestCase):
     def test_retain_outputs_f1(self):
         self.assertEqual([y.data for y in self.f1_output_nodes],
                          [None, self.f1_output_data[1]])
-        self.assertEqual(tuple(y.data for y in self.f1_output_nodes),
+        self.assertEqual([y.data for y in self.f1_output_nodes],
                          self.f1.output_data)
 
     def test_retain_outputs_f2(self):
         self.assertEqual([y.data for y in self.f2_output_nodes],
                          [None, self.f2_output_data[1]])
-        self.assertEqual(None, self.f2.output_data)
+        nones = [None for y in self.f2_output_nodes]
+        self.assertEqual(nones, self.f2.output_data)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR is to fix an issue of retain_outputs (that is discussed in #2586).

The issue is that an output array might get inaccessible during backward even when it is declared to be retained by `retain_outputs()`. As far as I understand correctly, this issue may happen only when the `variable node` of the output array is a leaf node in a computational graph. So, my proposal to fix/work-around the issue is:
  1. to make a temporary reference from the function to the variable node when an output array is specified to be retained by `retain_outputs()`
  2. to remove the temporary reference when the variable node is used as an input by another function.

I've confirmed that the work-around above actually solve the case mentioned in #2586 while keeping GPU memory usage small.