### PR TITLE
Add iter_per_epoch to get_trainer_with_mock_updater

### DIFF
--- a/chainer/testing/training.py
+++ b/chainer/testing/training.py
@@ -34,7 +34,8 @@ def get_trainer_with_mock_updater(
         updater.iteration += 1
         updater.epoch = updater.iteration // iter_per_epoch
         updater.epoch_detail = updater.iteration / iter_per_epoch
-        updater.is_new_epoch = updater.epoch == updater.epoch_detail
+        updater.is_new_epoch = (updater.iteration - 1) // \
+            iter_per_epoch != updater.epoch
 
     updater.update = update
     trainer = training.Trainer(updater, stop_trigger)

--- a/chainer/testing/training.py
+++ b/chainer/testing/training.py
@@ -5,7 +5,8 @@ import mock
 from chainer import training
 
 
-def get_trainer_with_mock_updater(stop_trigger=(10, 'iteration')):
+def get_trainer_with_mock_updater(
+        stop_trigger=(10, 'iteration'), iter_per_epoch=10):
     """Returns a :class:`~chainer.training.Trainer` object with mock updater.
 
     The returned trainer can be used for testing the trainer itself and the
@@ -15,6 +16,7 @@ def get_trainer_with_mock_updater(stop_trigger=(10, 'iteration')):
 
     Args:
         stop_trigger: Stop trigger of the trainer.
+        iter_per_epoch: The number of iterations per epoch.
 
     Returns:
         Trainer object with a mock updater.
@@ -26,7 +28,6 @@ def get_trainer_with_mock_updater(stop_trigger=(10, 'iteration')):
     updater.epoch = 0
     updater.epoch_detail = 0
     updater.is_new_epoch = True
-    iter_per_epoch = 10
 
     def update():
         updater.update_core()

--- a/tests/chainer_tests/testing_tests/test_training.py
+++ b/tests/chainer_tests/testing_tests/test_training.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import math
 import unittest
 
 from chainer import testing
@@ -40,7 +41,7 @@ class TestGetTrainerWithMockUpdater(unittest.TestCase):
         elif self.stop_trigger[1] == 'epoch':
             self.assertEqual(
                 iteration[0],
-                self.stop_trigger[0] * self.iter_per_epoch)
+                math.ceil(self.stop_trigger[0] * self.iter_per_epoch))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/testing_tests/test_training.py
+++ b/tests/chainer_tests/testing_tests/test_training.py
@@ -1,23 +1,46 @@
+from __future__ import division
+
 import unittest
 
 from chainer import testing
 
 
+@testing.parameterize(*testing.product({
+    'stop_trigger': [(5, 'iteration'), (5, 'epoch')],
+    'iter_per_epoch': [0.5, 1, 1.5, 5],
+}))
 class TestGetTrainerWithMockUpdater(unittest.TestCase):
 
     def setUp(self):
-        self.trainer = testing.get_trainer_with_mock_updater((5, 'iteration'))
+        self.trainer = testing.get_trainer_with_mock_updater(
+            self.stop_trigger, self.iter_per_epoch)
 
-    def test_update_count(self):
-        count = [0]
+    def test_run(self):
+        iteration = [0]
 
-        def check_count(trainer):
-            count[0] += 1
-            self.assertEqual(trainer.updater.iteration, count[0])
+        def check(trainer):
+            iteration[0] += 1
 
-        self.trainer.extend(check_count)
+            self.assertEqual(trainer.updater.iteration, iteration[0])
+            self.assertEqual(
+                trainer.updater.epoch, iteration[0] // self.iter_per_epoch)
+            self.assertEqual(
+                trainer.updater.epoch_detail,
+                iteration[0] / self.iter_per_epoch)
+            self.assertEqual(
+                trainer.updater.is_new_epoch,
+                (iteration[0] - 1) // self.iter_per_epoch !=
+                iteration[0] // self.iter_per_epoch)
+
+        self.trainer.extend(check)
         self.trainer.run()
-        self.assertEqual(count[0], 5)
+
+        if self.stop_trigger[1] == 'iteration':
+            self.assertEqual(iteration[0], self.stop_trigger[0])
+        elif self.stop_trigger[1] == 'epoch':
+            self.assertEqual(
+                iteration[0],
+                self.stop_trigger[0] * self.iter_per_epoch)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR is related to #2484.

I added `iter_per_epoch` option to `get_trainer_with_mock_updater`. This PR also includes a bugfix  and improvement of tests.