### PR TITLE
[EXPERIMENTAL] Add Cupy memory profiler

### DIFF
--- a/chainer/function_hooks/__init__.py
+++ b/chainer/function_hooks/__init__.py
@@ -1,9 +1,11 @@
 from chainer.function_hooks import cuda_profile  # NOQA
+from chainer.function_hooks import cupy_memory_profile  # NOQA
 from chainer.function_hooks import debug_print  # NOQA
 from chainer.function_hooks import timer  # NOQA
 
 
 # import class and function
 from chainer.function_hooks.cuda_profile import CUDAProfileHook  # NOQA
+from chainer.function_hooks.cupy_memory_profile import CupyMemoryProfileHook  # NOQA
 from chainer.function_hooks.debug_print import PrintHook  # NOQA
 from chainer.function_hooks.timer import TimerHook  # NOQA

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -1,0 +1,111 @@
+import sys
+
+import six
+
+from chainer.cuda import memory_pool
+from chainer import function
+
+
+class CupyMemoryProfileHook(function.FunctionHook):
+    """Function hook for measuring memory usage of functions in cupy memory pool.
+
+    Example:
+        Code example::
+
+            from chainer.function_hooks import CupyMemoryProfileHook
+            hook = CupyMemoryProfileHook()
+            with hook:
+                trainer.run()
+            hook.print_report()
+
+        Output example::
+
+            FunctionName        UsedBytes AcquiredBytes Occurrence
+            LinearFunction      5.16GB    179.98MB      3900
+            ReLU                992.77MB  458.97MB      2600
+            SoftmaxCrossEntropy 5.76MB    5.08MB        1300
+            Accuracy            350.00KB  351.00KB      700
+
+        where *FunctionName* is the name of function that calls the hook, and
+        *UsedBytes* is the memory bytes the function used from cupy memory
+        pool, and *AcquiredBytes* is the actual memory bytes the cupy memory
+        pool acquired from GPU device on the function call, and *Occurrence*
+        is the number of calls.
+    Attributes:
+        call_history: List of measurement results. It consists of the function
+            that calls this hook,  the memory bytes the function used from cupy
+            memory pool, and the memory bytes the cupy memory pool acquired
+            from GPU device on the function call.
+    """
+
+    name = 'CupyMemoryProfileHook'
+
+    def __init__(self):
+        self.call_history = []
+
+    def _preprocess(self):
+        self.start_used_bytes = memory_pool.used_bytes()
+        self.start_total_bytes = memory_pool.total_bytes()
+
+    def forward_preprocess(self, function, in_data):
+        self._preprocess()
+
+    def backward_preprocess(self, function, in_data, out_grad):
+        self._preprocess()
+
+    def _postprocess(self, function):
+        used_bytes = memory_pool.used_bytes() - self.start_used_bytes
+        acquired_bytes = memory_pool.total_bytes() - self.start_total_bytes
+        self.call_history.append((function, used_bytes, acquired_bytes))
+
+    def forward_postprocess(self, function, in_data):
+        self._postprocess(function)
+
+    def backward_postprocess(self, function, in_data, out_grad):
+        self._postprocess(function)
+
+    def summary(self):
+        """Returns a summary of memory profiling in functions.
+
+        Returns:
+            A summarized dictionary whose keys are function names and
+            values are dictionaries of ``used_bytes``, ``acquired_bytes``,
+            and ``occurrrence``.
+        """
+        summary = {}
+        for func, used_bytes, acquired_bytes in self.call_history:
+            function_name = func.__class__.__name__
+            if function_name not in summary:
+                summary[function_name] = {'used_bytes': 0,
+                                          'acquired_bytes': 0, 'occurrence': 0}
+            record = summary[function_name]
+            record['used_bytes'] += used_bytes
+            record['acquired_bytes'] += acquired_bytes
+            record['occurrence'] += 1
+        return summary
+
+    def _humanized_size(self, size):
+        """Returns a human redable bytes string."""
+        for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E']:
+            if size < 1024.0:
+                return '%3.2f%sB' % (size, unit)
+            size /= 1024.0
+        return '%.2f%sB' % (size, 'Z')
+
+    def print_report(self, end='\n', file=sys.stdout):
+        """Prints a summary report of memory profiling in functions."""
+        entries = [['FunctionName', 'UsedBytes', 'AcquiredBytes', 'Occurrence']]
+        for function_name, record in self.summary().items():
+            used_bytes = self._humanized_size(record['used_bytes'])
+            acquired_bytes = self._humanized_size(record['acquired_bytes'])
+            occurrence = str(record['occurrence'])
+            entries.append([function_name, used_bytes, acquired_bytes, occurrence])
+        entry_widths = []
+        entry_widths.append(max(len(f) for f, _, _, _ in entries))
+        entry_widths.append(max(len(u) for _, u, _, _ in entries))
+        entry_widths.append(max(len(a) for _, _, a, _ in entries))
+        entry_widths.append(max(len(o) for _, _, _, o in entries))
+        template = '  '.join('{:>%d}' % w for w in entry_widths)
+        for function_name, used_bytes, acquired_bytes, occurrence in entries:
+            line = template.format(function_name, used_bytes, acquired_bytes, occurrence)
+            six.print_(line, end=end, file=file)

--- a/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
+++ b/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
@@ -1,0 +1,125 @@
+import unittest
+
+import numpy
+import re
+import six
+
+import chainer
+from chainer import cuda
+from chainer import function_hooks
+from chainer import functions
+from chainer.functions.connection import linear
+from chainer import links
+from chainer import testing
+from chainer.testing import attr
+
+
+def check_history(self, t, function_type, used_bytes_type, acquired_bytes_type):
+    self.assertIsInstance(t[0], function_type)
+    self.assertIsInstance(t[1], used_bytes_type)
+    self.assertIsInstance(t[2], acquired_bytes_type)
+
+
+class TestCupyMemoryProfileHookHookToLink(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.CupyMemoryProfileHook()
+        self.l = links.Linear(5, 5)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    def test_name(self):
+        self.assertEqual(self.h.name, 'CupyMemoryProfileHook')
+
+    def check_forward(self, x):
+        with self.h:
+            self.l(chainer.Variable(x))
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      linear.LinearFunction, int, int)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.l.to_gpu()
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x, gy):
+        x = chainer.Variable(x)
+        y = self.l(x)
+        y.grad = gy
+        with self.h:
+            y.backward()
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      linear.LinearFunction, int, int)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.l.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+
+class TestCupyMemoryProfileHookHookToFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.CupyMemoryProfileHook()
+        self.f = functions.Exp()
+        self.f.add_hook(self.h)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    def check_forward(self, x):
+        self.f(chainer.Variable(x))
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      functions.Exp, int, int)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x, gy):
+        x = chainer.Variable(x)
+        y = self.f(x)
+        y.grad = gy
+        y.backward()
+        self.assertEqual(2, len(self.h.call_history))
+        check_history(self, self.h.call_history[1],
+                      functions.Exp, int, int)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+
+class TestCupyMemoryProfileSummary(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.CupyMemoryProfileHook()
+        self.f = functions.Exp()
+        self.f.add_hook(self.h)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    @attr.gpu
+    def test_summary(self):
+        x = cuda.to_gpu(self.x)
+        self.f(chainer.Variable(x))
+        self.f(chainer.Variable(x))
+        self.assertEqual(2, len(self.h.call_history))
+        self.assertEqual(1, len(self.h.summary()))
+
+    @attr.gpu
+    def test_print_report(self):
+        x = cuda.to_gpu(self.x)
+        self.f(chainer.Variable(x))
+        self.f(chainer.Variable(x))
+        io = six.StringIO()
+        self.h.print_report(file=io)
+        expect = '''\AFunctionName  UsedBytes  AcquiredBytes  Occurrence
+ +Exp +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+$
+'''
+        actual = io.getvalue()
+        self.assertTrue(re.match(expect, actual), actual)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fix https://github.com/chainer/chainer/issues/918

This profiler uses function hook and relies on memory usage api of cupy which I added at https://github.com/cupy/cupy/pull/184 to profile behaviors of cupy memory pool.

An example code:

```python
from chainer.function_hooks import CupyMemoryProfileHook

hook = CupyMemoryProfileHook()
with hook:
    trainer.run()
hook.print_summary()
```

Outputs from mnist example become as followings:

```
FunctionName        UsedBytes AcquiredBytes Occurrence
LinearFunction      5.16GB    179.98MB      3900
ReLU                992.77MB  458.97MB      2600
SoftmaxCrossEntropy 5.76MB    5.08MB        1300
Accuracy            350.00KB  351.00KB      700
```

where `UsedBytes` is the memory bytes the function used from cupy memory pool, and `AcquiredBytes` is the actual memory bytes the cupy memory pool acquired from GPU device on the function call, and `Occurrence` is the number of calls.