### PR TITLE
Add print_report() method to Timer hook

### DIFF
--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -1,6 +1,8 @@
+import sys
 import time
 
 import numpy
+import six
 
 from chainer import cuda
 from chainer import function
@@ -9,6 +11,26 @@ from chainer import function
 class TimerHook(function.FunctionHook):
     """Function hook for measuring elapsed time of functions.
 
+    Example:
+        Code example::
+
+            from chainer.function_hooks import TimerHook
+            hook = TimerHook()
+            with hook:
+                trainer.run()
+            hook.print_report()
+
+        Output example::
+
+                   FunctionName  ElapsedTime  Occurrence
+                 LinearFunction      1.24sec        3900
+                           ReLU     593.05ms        2600
+            SoftmaxCrossEntropy     824.11ms        1300
+                       Accuracy     176.54ms         700
+
+        where *FunctionName* is the name of function that calls the hook,
+        and *ElapsedTime* is the elapsed time the function consumed,
+        and *Occurrence* is the number of calls.
     Attributes:
         call_history: List of measurement results. It consists of pairs of
             the function that calls this hook and the elapsed time
@@ -61,3 +83,44 @@ class TimerHook(function.FunctionHook):
     def total_time(self):
         """Returns total elapsed time in seconds."""
         return sum(t for (_, t) in self.call_history)
+
+    def summary(self):
+        """Returns a summary of time profiling in functions.
+
+        Returns:
+            A summarized dictionary whose keys are function names and
+            values are dictionaries of `elapsed_time` and `occurrrence`.
+        """
+        summary = {}
+        for func, elapsed_time in self.call_history:
+            function_name = func.__class__.__name__
+            if function_name not in summary:
+                summary[function_name] = {'elapsed_time': 0, 'occurrence': 0}
+            record = summary[function_name]
+            record['elapsed_time'] += elapsed_time
+            record['occurrence'] += 1
+        return summary
+
+    def _humanized_time(self, second):
+        """Returns a human readable time."""
+        for unit in ['sec', 'ms', 'us']:
+            if second >= 1:
+                return '%3.2f%s' % (second, unit)
+            second *= 1000.0
+        return '%.2f%s' % (second, 'ns')
+
+    def print_report(self, end='\n', file=sys.stdout):
+        """Prints a summary report of time profiling in functions."""
+        entries = [['FunctionName', 'ElapsedTime', 'Occurrence']]
+        for function_name, record in self.summary().items():
+            elapsed_time = self._humanized_time(record['elapsed_time'])
+            occurrence = str(record['occurrence'])
+            entries.append([function_name, elapsed_time, occurrence])
+        entry_widths = []
+        entry_widths.append(max(len(f) for f, _, _ in entries))
+        entry_widths.append(max(len(e) for _, e, _ in entries))
+        entry_widths.append(max(len(o) for _, _, o in entries))
+        template = '  '.join('{:>%d}' % w for w in entry_widths)
+        for function_name, elapsed_time, occurrence in entries:
+            line = template.format(function_name, elapsed_time, occurrence)
+            six.print_(line, end=end, file=file)

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -2,7 +2,6 @@ import sys
 import time
 
 import numpy
-import six
 
 from chainer import cuda
 from chainer import function
@@ -109,7 +108,7 @@ class TimerHook(function.FunctionHook):
             second *= 1000.0
         return '%.2f%s' % (second, 'ns')
 
-    def print_report(self, end='\n', file=sys.stdout):
+    def print_report(self, file=sys.stdout):
         """Prints a summary report of time profiling in functions."""
         entries = [['FunctionName', 'ElapsedTime', 'Occurrence']]
         for function_name, record in self.summary().items():
@@ -123,4 +122,6 @@ class TimerHook(function.FunctionHook):
         template = '  '.join('{:>%d}' % w for w in entry_widths)
         for function_name, elapsed_time, occurrence in entries:
             line = template.format(function_name, elapsed_time, occurrence)
-            six.print_(line, end=end, file=file)
+            file.write(line)
+            file.write('\n')
+        file.flush()


### PR DESCRIPTION
Added `print_summary()` method to Timer hook so that we can do time profile similarly with the memory profiler of https://github.com/chainer/chainer/pull/2925

An example code:

```python
from chainer.function_hooks import TimerHook

hook = TimerHook()
with hook:
    trainer.run()
hook.print_report()
```

Outputs from mnist example become as followings:

```
FunctionName    ElapsedTime     Occurrence
LinearFunction  1.17sec 3900
ReLU    547.88ms        2600
SoftmaxCrossEntropy     968.39ms        1300
Accuracy        155.53ms        700
``` #