### PR TITLE
Dump more info on assert_allclose failure

### DIFF
--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -24,16 +24,18 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
         numpy.testing.assert_allclose(
             x, y, atol=atol, rtol=rtol, verbose=verbose)
     except AssertionError:
+        xx = x if x.ndim != 0 else x.reshape((1,))
+        yy = y if y.ndim != 0 else y.reshape((1,))
         err = numpy.abs(x - y)
         i = numpy.unravel_index(numpy.argmax(err), err.shape)
         f = sys.stdout
         f.write(
             'assert_allclose failed: \n' +
-            '  shape: {}\n'.format(x.shape) +
+            '  shape: {} {}\n'.format(x.shape, y.shape) +
             '  dtype: {} {}\n'.format(x.dtype, y.dtype) +
             '  i: {}\n'.format(i) +
-            '  x[i]: {}\n'.format(x[i]) +
-            '  y[i]: {}\n'.format(y[i]) +
+            '  x[i]: {}\n'.format(xx[i]) +
+            '  y[i]: {}\n'.format(yy[i]) +
             '  err[i]: {}\n'.format(err[i]))
         f.flush()
         opts = numpy.get_printoptions()

--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -38,7 +38,7 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
         f.flush()
         opts = numpy.get_printoptions()
         try:
-            numpy.set_printoptions(threshold=numpy.inf)
+            numpy.set_printoptions(threshold=10000)
             f.write('x: ' + numpy.array2string(x, prefix='x: ') + '\n')
             f.write('y: ' + numpy.array2string(y, prefix='y: ') + '\n')
             f.flush()

--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -26,7 +26,7 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
     except AssertionError:
         err = numpy.abs(x - y)
         i = numpy.unravel_index(numpy.argmax(err), err.shape)
-        f = sys.stderr
+        f = sys.stdout
         f.write(
             'assert_allclose failed: \n' +
             '  shape: {}\n'.format(x.shape) +

--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -1,4 +1,5 @@
 import numpy
+import sys
 
 from chainer import cuda
 from chainer import utils
@@ -22,6 +23,25 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
     try:
         numpy.testing.assert_allclose(
             x, y, atol=atol, rtol=rtol, verbose=verbose)
-    except Exception:
-        print('error:', numpy.abs(x - y).max())
+    except AssertionError:
+        err = numpy.abs(x - y)
+        i = numpy.unravel_index(numpy.argmax(err), err.shape)
+        f = sys.stderr
+        f.write(
+            'assert_allclose failed: \n' +
+            '  shape: {}\n'.format(x.shape) +
+            '  dtype: {} {}\n'.format(x.dtype, y.dtype) +
+            '  i: {}\n'.format(i) +
+            '  x[i]: {}\n'.format(x[i]) +
+            '  y[i]: {}\n'.format(y[i]) +
+            '  err[i]: {}\n'.format(err[i]))
+        f.flush()
+        opts = numpy.get_printoptions()
+        try:
+            numpy.set_printoptions(threshold=numpy.inf)
+            f.write('x: ' + numpy.array2string(x, prefix='x: ') + '\n')
+            f.write('y: ' + numpy.array2string(y, prefix='y: ') + '\n')
+            f.flush()
+        finally:
+            numpy.set_printoptions(**opts)
         raise

--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -24,19 +24,21 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
         numpy.testing.assert_allclose(
             x, y, atol=atol, rtol=rtol, verbose=verbose)
     except AssertionError:
-        xx = x if x.ndim != 0 else x.reshape((1,))
-        yy = y if y.ndim != 0 else y.reshape((1,))
-        err = numpy.abs(x - y)
-        i = numpy.unravel_index(numpy.argmax(err), err.shape)
         f = sys.stdout
         f.write(
             'assert_allclose failed: \n' +
             '  shape: {} {}\n'.format(x.shape, y.shape) +
-            '  dtype: {} {}\n'.format(x.dtype, y.dtype) +
-            '  i: {}\n'.format(i) +
-            '  x[i]: {}\n'.format(xx[i]) +
-            '  y[i]: {}\n'.format(yy[i]) +
-            '  err[i]: {}\n'.format(err[i]))
+            '  dtype: {} {}\n'.format(x.dtype, y.dtype))
+        if x.shape == y.shape:
+            xx = x if x.ndim != 0 else x.reshape((1,))
+            yy = y if y.ndim != 0 else y.reshape((1,))
+            err = numpy.abs(xx - yy)
+            i = numpy.unravel_index(numpy.argmax(err), err.shape)
+            f.write(
+                '  i: {}\n'.format(i) +
+                '  x[i]: {}\n'.format(xx[i]) +
+                '  y[i]: {}\n'.format(yy[i]) +
+                '  err[i]: {}\n'.format(err[i]))
         f.flush()
         opts = numpy.get_printoptions()
         try:


### PR DESCRIPTION
When `assert_allclose` fails, it would be helpful to dump more infomation on arrays.

Previous:
```
error: 1.95503e-05
```

This PR:
```
assert_allclose failed: 
  shape: (2, 3, 3, 2)
  dtype: float32 float32
  i: (0, 2, 0, 1)
  x[i]: -0.30263751745224
  y[i]: -0.3026570677757263
  err[i]: 1.9550323486328125e-05
x: [[[[ 0.43169084  0.16512142]
      [ 0.67146325  0.1099173 ]
      [ 1.23372531 -0.59125972]]

     [[-0.15755028  0.89751655]
      [-0.51562357 -0.32308728]
      [-0.00440456  0.6219334 ]]

     [[-0.20816886 -0.30263752]
      [ 0.99176192 -0.08260274]
      [ 0.75846857 -0.07695036]]]


    [[[-0.41587684  1.23625815]
      [ 0.05834302  0.59018832]
      [ 1.13860416  0.00345436]]

     [[-0.5978561   0.72182804]
      [ 0.19278584  0.35793984]
      [ 0.22906038 -0.9143526 ]]

     [[ 0.41658399  0.69880784]
      [-0.09936009 -0.45113131]
      [ 0.95919168 -0.27436191]]]]
y: [[[[ 0.43168852  0.16511276]
      [ 0.67145467  0.10992813]
      [ 1.23373473 -0.59125519]]

     [[-0.15756036  0.8975144 ]
      [-0.5156377  -0.32307607]
      [-0.00441585  0.62193727]]

     [[-0.2081653  -0.30265707]
      [ 0.99176639 -0.0826023 ]
      [ 0.75847894 -0.07695082]]]


    [[[-0.41587213  1.23625958]
      [ 0.05834167  0.59019184]
      [ 1.13860214  0.0034607 ]]

     [[-0.59785533  0.72182828]
      [ 0.1927876   0.3579444 ]
      [ 0.22905572 -0.91435075]]

     [[ 0.41658679  0.69880337]
      [-0.09935161 -0.4511331 ]
      [ 0.95918959 -0.2743583 ]]]]
```

(Note: Stack trace and this message from `AssertionError` is displayed anyway:)
```
AssertionError: 
Not equal to tolerance rtol=0.0001, atol=1e-05

(mismatch 2.7777777777777715%)
 x: array([[[[ 0.431691,  0.165121],
         [ 0.671463,  0.109917],
         [ 1.233725, -0.59126 ]],...
 y: array([[[[ 0.431689,  0.165113],
         [ 0.671455,  0.109928],
         [ 1.233735, -0.591255]],...
```