### PR TITLE
Register squared error to docs

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -149,6 +149,7 @@ Loss functions
    chainer.functions.negative_sampling
    chainer.functions.sigmoid_cross_entropy
    chainer.functions.softmax_cross_entropy
+   chainer.functions.squared_error
    chainer.functions.triplet
 
 Mathematical functions


### PR DESCRIPTION
This PR adds `F.squared_error` to the document.