### PR TITLE
Remove use_cudnn argument from SpetialTransformerGrid/Sampler

### DIFF
--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -9,7 +9,6 @@ from chainer.utils import type_check
 if cuda.cudnn_enabled:
     cudnn = cuda.cudnn
     libcudnn = cudnn.cudnn
-    _cudnn_version = libcudnn.getVersion()
     _sampler_type = libcudnn.CUDNN_SAMPLER_BILINEAR
 
 
@@ -34,8 +33,7 @@ class SpatialTransformerGrid(function.Function):
         return self._forward(inputs)
 
     def forward_gpu(self, inputs):
-        if not (cuda.cudnn_enabled and chainer.should_use_cudnn('>=auto') and
-                _cudnn_version >= 5000):
+        if not chainer.should_use_cudnn('>=auto', 5000):
             return self._forward(inputs)
         theta, = inputs
         B, _, _ = theta.shape
@@ -79,8 +77,7 @@ class SpatialTransformerGrid(function.Function):
         return self._backward(inputs, grad_outputs)
 
     def backward_gpu(self, inputs, grad_outputs):
-        if not (cuda.cudnn_enabled and chainer.should_use_cudnn('>=auto') and
-                _cudnn_version >= 5000):
+        if not chainer.should_use_cudnn('>=auto', 5000):
             return self._backward(inputs, grad_outputs)
         theta, = inputs
         ggrid, = grad_outputs

--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -1,5 +1,6 @@
 import numpy
 
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check

--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -14,9 +14,8 @@ if cuda.cudnn_enabled:
 
 class SpatialTransformerGrid(function.Function):
 
-    def __init__(self, output_shape, use_cudnn=True):
+    def __init__(self, output_shape):
         self.output_shape = output_shape
-        self.use_cudnn = use_cudnn
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -34,7 +33,7 @@ class SpatialTransformerGrid(function.Function):
         return self._forward(inputs)
 
     def forward_gpu(self, inputs):
-        if not (cuda.cudnn_enabled and self.use_cudnn and
+        if not (cuda.cudnn_enabled and chainer.should_use_cudnn('>=auto') and
                 _cudnn_version >= 5000):
             return self._forward(inputs)
         theta, = inputs
@@ -79,7 +78,7 @@ class SpatialTransformerGrid(function.Function):
         return self._backward(inputs, grad_outputs)
 
     def backward_gpu(self, inputs, grad_outputs):
-        if not (cuda.cudnn_enabled and self.use_cudnn and
+        if not (cuda.cudnn_enabled and chainer.should_use_cudnn('>=auto') and
                 _cudnn_version >= 5000):
             return self._backward(inputs, grad_outputs)
         theta, = inputs
@@ -115,7 +114,7 @@ class SpatialTransformerGrid(function.Function):
         return gtheta,
 
 
-def spatial_transformer_grid(theta, output_shape, use_cudnn=True):
+def spatial_transformer_grid(theta, output_shape):
     """2D Spatial Transformer grid.
 
     This function generates coordinates of the points sampled from an image
@@ -125,6 +124,10 @@ def spatial_transformer_grid(theta, output_shape, use_cudnn=True):
     Given a coordinate in the warped image :math:`(x_i^t, y_i^t)`, the point
     sampled from the source image :math:`(x_i^s, y_i^s)` are calculated
     by the following equation.
+
+    .. note::
+
+        cuDNN supports SpatialTransformerGrid from version 5.0.0.
 
     .. math::
 
@@ -148,9 +151,6 @@ def spatial_transformer_grid(theta, output_shape, use_cudnn=True):
             This is a batch of :math:`2 \\times 3` matrix used for
             the warping described above.
         output_shape (tuple): A tuple of 2 elements: :math:`h_O, w_O`.
-        use_cudnn (bool): If ``True``, then this function uses cuDNN if
-            available. Note that, cuDNN supports SpatialTransformerGrid
-            from version 5.0.0.
 
     Returns:
         ~chainer.Variable:  A variable of shape :math:`(n, 2, h_O, w_O)`.
@@ -162,4 +162,4 @@ def spatial_transformer_grid(theta, output_shape, use_cudnn=True):
         the upper-left corner of the input image.
 
     """
-    return SpatialTransformerGrid(output_shape, use_cudnn)(theta)
+    return SpatialTransformerGrid(output_shape)(theta)

--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -3,8 +3,8 @@ import numpy
 import chainer
 from chainer import cuda
 from chainer import function
+from chainer.utils import argument
 from chainer.utils import type_check
-
 
 if cuda.cudnn_enabled:
     cudnn = cuda.cudnn
@@ -112,7 +112,7 @@ class SpatialTransformerGrid(function.Function):
         return gtheta,
 
 
-def spatial_transformer_grid(theta, output_shape):
+def spatial_transformer_grid(theta, output_shape, **kwargs):
     """2D Spatial Transformer grid.
 
     This function generates coordinates of the points sampled from an image
@@ -160,4 +160,10 @@ def spatial_transformer_grid(theta, output_shape):
         the upper-left corner of the input image.
 
     """
+    argument.check_unexpected_kwargs(
+        kwargs, use_cudnn="The argument \"use_cudnn\" is not "
+        "supported anymore. "
+        "Use chainer.using_config('use_cudnn', value) "
+        "context where value can be `always`, `never`, or `auto`.")
+    argument.assert_kwargs_empty(kwargs)
     return SpatialTransformerGrid(output_shape)(theta)

--- a/chainer/functions/array/spatial_transformer_sampler.py
+++ b/chainer/functions/array/spatial_transformer_sampler.py
@@ -1,5 +1,6 @@
 import numpy
 
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check

--- a/chainer/functions/array/spatial_transformer_sampler.py
+++ b/chainer/functions/array/spatial_transformer_sampler.py
@@ -9,7 +9,6 @@ from chainer.utils import type_check
 if cuda.cudnn_enabled:
     cudnn = cuda.cudnn
     libcudnn = cudnn.cudnn
-    _cudnn_version = libcudnn.getVersion()
     _sampler_type = libcudnn.CUDNN_SAMPLER_BILINEAR
 
 
@@ -34,8 +33,7 @@ class SpatialTransformerSampler(function.Function):
         return self._forward(inputs)
 
     def forward_gpu(self, inputs):
-        if not (cuda.cudnn_enabled and chainer.should_use_cudnn('>=auto') and
-                _cudnn_version >= 5000):
+        if not chainer.should_use_cudnn('>=auto', 5000):
             return self._forward(inputs)
         x, grid = inputs
         out_shape = x.shape[:2] + grid.shape[2:]
@@ -122,8 +120,7 @@ class SpatialTransformerSampler(function.Function):
         return self._backward(inputs, grad_outputs)
 
     def backward_gpu(self, inputs, grad_outputs):
-        if not (cuda.cudnn_enabled and chainer.should_use_cudnn('>=auto') and
-                _cudnn_version >= 5000):
+        if not chainer.should_use_cudnn('>=auto', 5000):
             return self._backward(inputs, grad_outputs)
         x, grid = inputs
         gy, = grad_outputs

--- a/chainer/functions/array/spatial_transformer_sampler.py
+++ b/chainer/functions/array/spatial_transformer_sampler.py
@@ -3,6 +3,7 @@ import numpy
 import chainer
 from chainer import cuda
 from chainer import function
+from chainer.utils import argument
 from chainer.utils import type_check
 
 
@@ -248,7 +249,7 @@ class SpatialTransformerSampler(function.Function):
         return gx, ggrid
 
 
-def spatial_transformer_sampler(x, grid):
+def spatial_transformer_sampler(x, grid, **kwargs):
     """2D Spatial Transformer sampler.
 
     This is a differentiable image sampler. With a set of sampling points
@@ -299,4 +300,10 @@ def spatial_transformer_sampler(x, grid):
             :math:`(n, c_I, h_O, w_O)`.
 
     """
+    argument.check_unexpected_kwargs(
+        kwargs, use_cudnn="The argument \"use_cudnn\" is not "
+        "supported anymore. "
+        "Use chainer.using_config('use_cudnn', value) "
+        "context where value can be `always`, `never`, or `auto`.")
+    argument.assert_kwargs_empty(kwargs)
     return SpatialTransformerSampler()(x, grid)

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import chainer
 from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
@@ -11,7 +12,7 @@ from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'never'],
 }))
 class TestSpatialTransformerGrid(unittest.TestCase):
 
@@ -22,9 +23,8 @@ class TestSpatialTransformerGrid(unittest.TestCase):
         self.grads = numpy.random.uniform(
             size=(B, 2) + self.output_shape).astype(self.theta.dtype)
 
-    def check_forward(self, theta, output_shape, use_cudnn=True):
-        grid = functions.spatial_transformer_grid(
-            theta, output_shape, use_cudnn).data
+    def check_forward(self, theta, output_shape):
+        grid = functions.spatial_transformer_grid(theta, output_shape).data
 
         theta = cuda.to_cpu(theta)
         B = theta.shape[0]
@@ -46,13 +46,13 @@ class TestSpatialTransformerGrid(unittest.TestCase):
 
     @attr.gpu
     def test_forward_gpu(self):
-        self.check_forward(
-            cuda.to_gpu(self.theta), self.output_shape, self.use_cudnn)
+        self.check_forward(cuda.to_gpu(self.theta), self.output_shape)
 
-    def check_backward(self, theta, output_shape, grads, use_cudnn=True):
-        gradient_check.check_backward(
-            functions.SpatialTransformerGrid(output_shape, use_cudnn),
-            (theta,), (grads,), atol=1e-4, rtol=1e-3)
+    def check_backward(self, theta, output_shape, grads):
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            gradient_check.check_backward(
+                functions.SpatialTransformerGrid(output_shape),
+                (theta,), (grads,), atol=1e-4, rtol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -61,10 +61,9 @@ class TestSpatialTransformerGrid(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.theta),
-                            self.output_shape,
-                            cuda.to_gpu(self.grads),
-                            self.use_cudnn)
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.check_backward(cuda.to_gpu(self.theta), self.output_shape,
+                                cuda.to_gpu(self.grads))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_sampler.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_sampler.py
@@ -109,7 +109,7 @@ class TestSpatialTransformerSamplerConsistencyWithCuDNN(unittest.TestCase):
         grid = Variable(grid)
         y = functions.spatial_transformer_sampler(x, grid)
         x.cleargrad()
-        grid.claergrad()
+        grid.cleargrad()
         y.grad = grads
         y.backward()
         return x, grid, y


### PR DESCRIPTION
SpetialTransformerGrid and SpatialTransofrmerSampler are using `use_cudnn` flags to switch cudnn and non-cudnn implementation, so it ignores global/local configuration. Those `use_cudnn` should be replaced with `chainer.should_use_cudnn('>=auto')`.