### PR TITLE
Use v2 api for spatial_transformer_*

### DIFF
--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -1,5 +1,6 @@
 import numpy
 
+import chainer
 from chainer import cuda
 from chainer import function
 from chainer.utils import type_check
@@ -14,9 +15,8 @@ if cuda.cudnn_enabled:
 
 class SpatialTransformerGrid(function.Function):
 
-    def __init__(self, output_shape, use_cudnn=True):
+    def __init__(self, output_shape):
         self.output_shape = output_shape
-        self.use_cudnn = use_cudnn
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -34,8 +34,7 @@ class SpatialTransformerGrid(function.Function):
         return self._forward(inputs)
 
     def forward_gpu(self, inputs):
-        if not (cuda.cudnn_enabled and self.use_cudnn and
-                _cudnn_version >= 5000):
+        if not chainer.should_use_cudnn('>=auto', 5000):
             return self._forward(inputs)
         theta, = inputs
         B, _, _ = theta.shape
@@ -79,8 +78,7 @@ class SpatialTransformerGrid(function.Function):
         return self._backward(inputs, grad_outputs)
 
     def backward_gpu(self, inputs, grad_outputs):
-        if not (cuda.cudnn_enabled and self.use_cudnn and
-                _cudnn_version >= 5000):
+        if not chainer.should_use_cudnn('>=auto', 5000):
             return self._backward(inputs, grad_outputs)
         theta, = inputs
         ggrid, = grad_outputs
@@ -115,7 +113,7 @@ class SpatialTransformerGrid(function.Function):
         return gtheta,
 
 
-def spatial_transformer_grid(theta, output_shape, use_cudnn=True):
+def spatial_transformer_grid(theta, output_shape):
     """2D Spatial Transformer grid.
 
     This function generates coordinates of the points sampled from an image
@@ -148,9 +146,6 @@ def spatial_transformer_grid(theta, output_shape, use_cudnn=True):
             This is a batch of :math:`2 \\times 3` matrix used for
             the warping described above.
         output_shape (tuple): A tuple of 2 elements: :math:`h_O, w_O`.
-        use_cudnn (bool): If ``True``, then this function uses cuDNN if
-            available. Note that, cuDNN supports SpatialTransformerGrid
-            from version 5.0.0.
 
     Returns:
         ~chainer.Variable:  A variable of shape :math:`(n, 2, h_O, w_O)`.
@@ -162,4 +157,4 @@ def spatial_transformer_grid(theta, output_shape, use_cudnn=True):
         the upper-left corner of the input image.
 
     """
-    return SpatialTransformerGrid(output_shape, use_cudnn)(theta)
+    return SpatialTransformerGrid(output_shape)(theta)

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_sampler.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_sampler.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import chainer
 from chainer import cuda
 from chainer import functions
 from chainer import gradient_check
@@ -41,7 +42,7 @@ def _rotate_BCHW(x):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'never'],
 }))
 class TestSpatialTransformerSampler(unittest.TestCase):
 
@@ -57,8 +58,8 @@ class TestSpatialTransformerSampler(unittest.TestCase):
         self.grads = numpy.random.uniform(
             size=self.out_shape).astype(numpy.float32)
 
-    def check_forward(self, x, grid, use_cudnn=True):
-        y = functions.spatial_transformer_sampler(x, grid, use_cudnn)
+    def check_forward(self, x, grid, use_cudnn='always'):
+        y = functions.spatial_transformer_sampler(x, grid)
         self.assertEqual(y.shape, self.out_shape)
 
     @condition.retry(3)
@@ -71,9 +72,9 @@ class TestSpatialTransformerSampler(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.grid),
                            self.use_cudnn)
 
-    def check_backward(self, x, grid, grads, use_cudnn=True):
+    def check_backward(self, x, grid, grads, use_cudnn='always'):
         gradient_check.check_backward(
-            functions.SpatialTransformerSampler(use_cudnn),
+            functions.SpatialTransformerSampler(),
             (x, grid), (grads,), atol=1e-2, rtol=1e-2, eps=1e-5)
 
     @condition.retry(3)
@@ -106,22 +107,22 @@ class TestSpatialTransformerSamplerConsistencyWithCuDNN(unittest.TestCase):
     def _apply_backward(self, x, grid, grads, use_cudnn):
         x = Variable(x)
         grid = Variable(grid)
-        y = functions.spatial_transformer_sampler(
-            x, grid, use_cudnn=use_cudnn)
-        x.zerograd()
-        grid.zerograd()
-        y.grad = grads
-        y.backward()
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.spatial_transformer_sampler(x, grid)
+            x.zerograd()
+            grid.zerograd()
+            y.grad = grads
+            y.backward()
         return x, grid, y
 
     @attr.gpu
     @attr.cudnn
     def test_consistency_with_cudnn_cpu(self):
         x_cpu, grid_cpu, y_cpu = self._apply_backward(
-            self.x, self.grid, self.grads, use_cudnn=False)
+            self.x, self.grid, self.grads, use_cudnn='never')
         x_cudnn, grid_cudnn, y_cudnn = self._apply_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.grid),
-            cuda.to_gpu(self.grads), use_cudnn=True)
+            cuda.to_gpu(self.grads), use_cudnn='always')
 
         testing.assert_allclose(y_cpu.data, y_cudnn.data)
         testing.assert_allclose(x_cpu.grad, x_cudnn.grad)
@@ -132,10 +133,10 @@ class TestSpatialTransformerSamplerConsistencyWithCuDNN(unittest.TestCase):
     def test_consistency_with_cudnn_gpu(self):
         x_gpu, grid_gpu, y_gpu = self._apply_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.grid),
-            cuda.to_gpu(self.grads), use_cudnn=False)
+            cuda.to_gpu(self.grads), use_cudnn='never')
         x_cudnn, grid_cudnn, y_cudnn = self._apply_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.grid),
-            cuda.to_gpu(self.grads), use_cudnn=True)
+            cuda.to_gpu(self.grads), use_cudnn='always')
 
         testing.assert_allclose(y_gpu.data, y_cudnn.data)
         testing.assert_allclose(x_gpu.grad, x_cudnn.grad)
@@ -144,13 +145,13 @@ class TestSpatialTransformerSamplerConsistencyWithCuDNN(unittest.TestCase):
 
 @testing.parameterize(
     {'grid_creator': _identiy_grid, 'operator': lambda x: x,
-     'use_cudnn': True},
+     'use_cudnn': 'always'},
     {'grid_creator': _identiy_grid, 'operator': lambda x: x,
-     'use_cudnn': False},
+     'use_cudnn': 'never'},
     {'grid_creator': _rotate_grid, 'operator': _rotate_BCHW,
-     'use_cudnn': True},
+     'use_cudnn': 'always'},
     {'grid_creator': _rotate_grid, 'operator': _rotate_BCHW,
-     'use_cudnn': False},
+     'use_cudnn': 'never'},
 )
 class TestSpatialTransformerSamplerForwardToyCases(unittest.TestCase):
 
@@ -162,8 +163,9 @@ class TestSpatialTransformerSamplerForwardToyCases(unittest.TestCase):
             size=self.in_shape).astype(numpy.float32)
         self.grid = self.grid_creator(self.in_shape)
 
-    def check_forward(self, x, grid, use_cudnn=True):
-        y = functions.spatial_transformer_sampler(x, grid, use_cudnn)
+    def check_forward(self, x, grid, use_cudnn='always'):
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.spatial_transformer_sampler(x, grid)
         testing.assert_allclose(y.data, self.operator(self.x))
 
     @condition.retry(3)
@@ -178,7 +180,7 @@ class TestSpatialTransformerSamplerForwardToyCases(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': [True, False],
+    'use_cudnn': ['always', 'never'],
 }))
 class TestSpatialTransformerSamplerForwardPaddedImage(unittest.TestCase):
 
@@ -212,8 +214,9 @@ class TestSpatialTransformerSamplerForwardPaddedImage(unittest.TestCase):
              exp_p4[:, None]), axis=1)
         self.expected = self.expected.reshape(1, 2, 4, 1).astype(numpy.float32)
 
-    def check_forward(self, x, grid, expected, use_cudnn=True):
-        y = functions.spatial_transformer_sampler(x, grid, use_cudnn)
+    def check_forward(self, x, grid, expected, use_cudnn='always'):
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.spatial_transformer_sampler(x, grid)
         testing.assert_allclose(y.data, expected)
 
     @condition.retry(3)


### PR DESCRIPTION
The functions `spatial_transformer_grid` and `spatial_transformer_sampler` do not follow `v2` API with respect to cuDNN use settings.