### PR TITLE
Only use one direction of numerical grad

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -269,7 +269,8 @@ def check_backward(func, x_data, y_grad, params=(),
             assert x.grad is None
             continue
 
-    one = variable.Variable(numpy.array(1., dtype))
+    xp = cuda.get_array_module(*xs)
+    one = variable.Variable(xp.array(1., dtype))
 
     def g():
         for skip, cx, data in zip(no_grads, casted_xs, casted_data):

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -110,7 +110,7 @@ def check_backward(func, x_data, y_grad, params=(),
                    eps=1e-3, atol=1e-5, rtol=1e-4, no_grads=None, dtype=None):
     """Test backward procedure of a given function.
 
-    This function automatically check backward-process of a given function.
+    This function automatically checks backward-process of a given function.
     For example, when you have a :class:`~chainer.Function` class ``MyFunc``,
     that gets two arguments and returns one value, you can make its test like
     this::
@@ -131,7 +131,7 @@ def check_backward(func, x_data, y_grad, params=(),
     :func:`numerical_grad` to calculate numerically the gradients and compares
     the types of gradients with :func:`chainer.testing.assert_allclose`.
 
-    To reduce computational time, the method uses a function
+    To reduce computational time, it uses a function
     :math:`g: \\mathbb{R} \\rightarrow \\mathbb{R}^n` defined as 
     :math:`g(\\alpha) = f(\\alpha x)`, where :math:`\\alpha \in \\mathbb{R}`
     and :math:`f` is a function which actually
@@ -142,8 +142,8 @@ def check_backward(func, x_data, y_grad, params=(),
        g'(\\alpha) = f'(\\alpha x) \\cdot x.
 
     When :math:`\\alpha = 1`, :math:`g'(1) = f'(x) \\cdot x`.
-    So the method caclculates :math:`g'(1)` with :func:`numerical_grad` and
-    compares its result with dot product of the gradient :math:`f` and
+    So :math:`g'(1)` is calculated with :func:`numerical_grad` and
+    compared with dot product of the gradient :math:`f` and
     :math:`x`.
 
     If input objects (``x1_data`` or/and ``x2_data`` in this example) represent

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -289,7 +289,7 @@ def check_backward(func, x_data, y_grad, params=(),
         for skip, cx, data in six.moves.zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue
-            data = (one * data).astype(cx.data.dtype)
+            data = one * data.astype(cx.data.dtype)
             if numpy.isscalar(data):
                 data = xp.array(data)
             cx.data = data
@@ -298,7 +298,7 @@ def check_backward(func, x_data, y_grad, params=(),
                 param_dtype = dtype
             else:
                 param_dtype = param.dtype
-            param.data = (one * data).astype(param_dtype)
+            param.data = one * data.astype(param_dtype)
         ys = func(*casted_xs)
         ys = _as_tuple(ys)
         ys_data = tuple(y.data for y in ys)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -289,6 +289,9 @@ def check_backward(func, x_data, y_grad, params=(),
         for skip, cx, data in six.moves.zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue
+            # Inner astype is required to execute __mul__ with the given
+            # type, and outer astype is require to store data with the given
+            # type
             data = (one * data.astype(cx.data.dtype)).astype(cx.data.dtype)
             if numpy.isscalar(data):
                 data = xp.array(data)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -289,10 +289,8 @@ def check_backward(func, x_data, y_grad, params=(),
         for skip, cx, data in six.moves.zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue
-            # Inner astype is required to execute __mul__ with the given
-            # type, and outer astype is require to store data with the given
-            # type
-            data = (one * data.astype(cx.data.dtype)).astype(cx.data.dtype)
+            # astype is require to store data with the given type
+            data = (one * data).astype(data.dtype)
             if numpy.isscalar(data):
                 data = xp.array(data)
             cx.data = data
@@ -301,7 +299,7 @@ def check_backward(func, x_data, y_grad, params=(),
                 param_dtype = dtype
             else:
                 param_dtype = param.dtype
-            param.data = (one * data.astype(param_dtype)).astype(param_dtype)
+            param.data = (one * data).astype(param_dtype)
         ys = func(*casted_xs)
         ys = _as_tuple(ys)
         ys_data = tuple(y.data for y in ys)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -282,7 +282,7 @@ def check_backward(func, x_data, y_grad, params=(),
                 param_dtype = dtype
             else:
                 param_dtype = param.dtype
-            param.data = (one * data.astype(dtype)).astype(dtype)
+            param.data = (one * data.astype(param_dtype)).astype(param_dtype)
         ys = func(*casted_xs)
         ys = _as_tuple(ys)
         ys_data = tuple(y.data for y in ys)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -283,7 +283,7 @@ def check_backward(func, x_data, y_grad, params=(),
         ys = func(*casted_xs)
         ys = _as_tuple(ys)
         ys_data = tuple(y.data for y in ys)
-        for cx, data in six.moves.zip(casted_xs, casted_data):
+        for skip, cx, data in six.moves.zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue
             cx.data = data

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -270,7 +270,7 @@ def check_backward(func, x_data, y_grad, params=(),
     one = xp.array(1., dtype)
 
     def g():
-        for skip, cx, data in zip(no_grads, casted_xs, casted_data):
+        for skip, cx, data in six.moves.zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue
             data = (one * data).astype(cx.data.dtype)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -110,7 +110,7 @@ def check_backward(func, x_data, y_grad, params=(),
                    eps=1e-3, atol=1e-5, rtol=1e-4, no_grads=None, dtype=None):
     """Test backward procedure of a given function.
 
-    This function automatically check backward-process of given function.
+    This function automatically check backward-process of a given function.
     For example, when you have a :class:`~chainer.Function` class ``MyFunc``,
     that gets two arguments and returns one value, you can make its test like
     this::
@@ -130,6 +130,22 @@ def check_backward(func, x_data, y_grad, params=(),
     To check correctness of the gradients, the function calls
     :func:`numerical_grad` to calculate numerically the gradients and compares
     the types of gradients with :func:`chainer.testing.assert_allclose`.
+
+    To reduce computational time, the method uses a function
+    :math:`g: \\mathbb{R} \\rightarrow \\mathbb{R}^n` defined as 
+    :math:`g(\\alpha) = f(\\alpha x)`, where :math:`\\alpha \in \\mathbb{R}`
+    and :math:`f` is a function which actually
+    you want to test.
+    Its gradient is
+
+    .. math::
+       g'(\\alpha) = f'(\\alpha x) \\cdot x.
+
+    When :math:`\\alpha = 1`, :math:`g'(1) = f'(x) \\cdot x`.
+    So the method caclculates :math:`g'(1)` with :func:`numerical_grad` and
+    compares its result with dot product of the gradient :math:`f` and
+    :math:`x`.
+
     If input objects (``x1_data`` or/and ``x2_data`` in this example) represent
     integer variables, their gradients are ignored.
 

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -265,13 +265,13 @@ def check_backward(func, x_data, y_grad, params=(),
             continue
 
     xp = cuda.get_array_module(*xs)
-    one = variable.Variable(xp.array(1., dtype))
+    one = xp.array(1., dtype)
 
     def g():
         for skip, cx, data in zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue
-            data = (one.data * data).astype(cx.data.dtype)
+            data = (one * data).astype(cx.data.dtype)
             if numpy.isscalar(data):
                 data = xp.array(data)
             cx.data = data
@@ -284,7 +284,7 @@ def check_backward(func, x_data, y_grad, params=(),
             cx.data = data
         return ys_data
 
-    gx, = numerical_grad(g, (one.data,), y_grad, eps=eps)
+    gx, = numerical_grad(g, (one,), y_grad, eps=eps)
     gx_accum = 0
     for skip, x, cx in six.moves.zip(no_grads, xs, casted_xs):
         if skip:

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -299,7 +299,10 @@ def check_backward(func, x_data, y_grad, params=(),
                 param_dtype = dtype
             else:
                 param_dtype = param.dtype
-            param.data = (one * data).astype(param_dtype)
+            # The inner astype is required to calculates __mul__ in
+            # `param_type` when data is low accuracy float.
+            # The outer one is require to store data with the given type.
+            param.data = (one * data.astype(param_dtype)).astype(param_dtype)
         ys = func(*casted_xs)
         ys = _as_tuple(ys)
         ys_data = tuple(y.data for y in ys)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -282,7 +282,7 @@ def check_backward(func, x_data, y_grad, params=(),
                 param_dtype = dtype
             else:
                 param_dtype = param.dtype
-            param.data = (one * data.astype(param_dtype)).astype(param_dtype)
+            param.data = (one * data).astype(param_dtype)
         ys = func(*casted_xs)
         ys = _as_tuple(ys)
         ys_data = tuple(y.data for y in ys)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -286,6 +286,9 @@ def check_backward(func, x_data, y_grad, params=(),
     one = xp.array(1., dtype)
 
     def g():
+        # This functions is called twice in `numerical_grad`.
+        # `one` is `1 + epsilon` or `1 - epsilon` in these calls.
+        # See the document of `numerical_grad`.
         for skip, cx, data in six.moves.zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -132,7 +132,7 @@ def check_backward(func, x_data, y_grad, params=(),
     the types of gradients with :func:`chainer.testing.assert_allclose`.
 
     To reduce computational time, it uses a function
-    :math:`g: \\mathbb{R} \\rightarrow \\mathbb{R}^n` defined as 
+    :math:`g: \\mathbb{R} \\rightarrow \\mathbb{R}^n` defined as
     :math:`g(\\alpha) = f(\\alpha x)`, where :math:`\\alpha \in \\mathbb{R}`
     and :math:`f` is a function which actually
     you want to test.

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -289,7 +289,7 @@ def check_backward(func, x_data, y_grad, params=(),
         for skip, cx, data in six.moves.zip(no_grads, casted_xs, casted_data):
             if skip:
                 continue
-            data = one * data.astype(cx.data.dtype)
+            data = (one * data.astype(cx.data.dtype)).astype(cx.data.dtype)
             if numpy.isscalar(data):
                 data = xp.array(data)
             cx.data = data
@@ -298,7 +298,7 @@ def check_backward(func, x_data, y_grad, params=(),
                 param_dtype = dtype
             else:
                 param_dtype = param.dtype
-            param.data = one * data.astype(param_dtype)
+            param.data = (one * data.astype(param_dtype)).astype(param_dtype)
         ys = func(*casted_xs)
         ys = _as_tuple(ys)
         ys_data = tuple(y.data for y in ys)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -258,10 +258,13 @@ def check_backward(func, x_data, y_grad, params=(),
             raise ValueError(
                 'Length of no_grads param and xs should be same.')
     casted_data = [x.data.copy() for x in casted_xs]
-    for skip, x, cx in six.moves.zip(no_grads, xs, casted_xs):
+    for skip, x in six.moves.zip(no_grads, xs):
         if skip:
             assert x.grad is None
-            continue
+        else:
+            if x.grad is None:
+                raise TypeError(
+                    'gradients of some arguments are not calculated')
 
     xp = cuda.get_array_module(*xs)
     one = xp.array(1., dtype)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -263,7 +263,7 @@ def check_backward(func, x_data, y_grad, params=(),
             assert x.grad is None
         else:
             if x.grad is None:
-                raise TypeError(
+                raise RuntimeError(
                     'gradients of some arguments are not calculated')
 
     xp = cuda.get_array_module(*xs)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -288,7 +288,12 @@ def check_backward(func, x_data, y_grad, params=(),
     for skip, x, cx in six.moves.zip(no_grads, xs, casted_xs):
         if skip:
             continue
-        gx_accum += x.grad.ravel().dot(cx.data.ravel())
+        gxi = x.grad.ravel()
+        cxi = cx.data.ravel()
+        if dtype is not None:
+            gxi = gxi.astype(dtype)
+            cxi = cxi.astype(dtype)
+        gx_accum += gxi.dot(cxi)
     testing.assert_allclose(gx, gx_accum, atol=atol, rtol=rtol)
 
     for p in params:

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -66,7 +66,7 @@ class TestNonparameterizedMaxout(unittest.TestCase):
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             lambda x: functions.maxout(x, self.pool_size, self.axis),
-            x_data, y_grad, eps=0.125)
+            x_data, y_grad, eps=0.125, dtype='d')
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_cast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_cast.py
@@ -48,7 +48,8 @@ class TestCast(unittest.TestCase):
     def check_backward(self, x_data, g_data):
         func = functions.Cast(self.out_type)
         gradient_check.check_backward(
-            func, x_data, g_data, eps=2.0 ** -2, atol=1e-3, rtol=1e-3)
+            func, x_data, g_data, dtype='d',
+            eps=2.0 ** -2, atol=1e-3, rtol=1e-3)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_cast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_cast.py
@@ -49,7 +49,7 @@ class TestCast(unittest.TestCase):
         func = functions.Cast(self.out_type)
         gradient_check.check_backward(
             func, x_data, g_data, dtype='d',
-            eps=2.0 ** -2, atol=1e-3, rtol=1e-3)
+            eps=2.0 ** -2, atol=1e-2, rtol=1e-3)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_dstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_dstack.py
@@ -55,8 +55,7 @@ class TestDstack(unittest.TestCase):
         def func(*xs):
             return functions.dstack(xs)
 
-        gradient_check.check_backward(
-            func, xs_data, g_data, eps=2.0 ** -2, atol=1e-3, rtol=1e-3)
+        gradient_check.check_backward(func, xs_data, g_data, dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.xs, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -64,8 +64,8 @@ class TestGetItem(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x_data))
 
     def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(functions.GetItem(self.slices),
-                                      (x_data,), y_grad)
+        gradient_check.check_backward(
+            functions.GetItem(self.slices), (x_data,), y_grad, dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.x_data, self.gy_data)
@@ -136,8 +136,8 @@ class TestGetItemAdvanced(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x_data))
 
     def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(functions.GetItem(self.slices),
-                                      (x_data,), y_grad)
+        gradient_check.check_backward(
+            functions.GetItem(self.slices), (x_data,), y_grad, dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.x_data, self.gy_data)
@@ -192,8 +192,8 @@ class TestCupyIndicesGetItem(unittest.TestCase):
                 s = chainer.cuda.cupy.array(s, dtype=numpy.int32)
             slices.append(s)
         slices = tuple(slices)
-        gradient_check.check_backward(functions.GetItem(slices),
-                                      (x_data,), y_grad)
+        gradient_check.check_backward(
+            functions.GetItem(slices), (x_data,), y_grad, dtype='d')
 
     @attr.gpu
     def test_backward_gpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
@@ -56,7 +56,7 @@ class TestHstack(unittest.TestCase):
             return functions.hstack(xs)
 
         gradient_check.check_backward(
-            func, xs_data, g_data, eps=2.0 ** -2, atol=1e-3, rtol=1e-3)
+            func, xs_data, g_data, dtype='d', atol=1e-3, rtol=1e-3)
 
     def test_backward_cpu(self):
         self.check_backward(self.xs, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_pad.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_pad.py
@@ -33,7 +33,7 @@ class TestPadDefault(unittest.TestCase):
         self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
             self.check_backward_options.update({
-                'atol': 2 ** -6, 'rtol': 2 ** -6})
+                'atol': 2 ** -5, 'rtol': 2 ** -5})
 
     def check_forward(self, x_data):
         y = functions.pad(x_data, self.pad_width, self.mode)
@@ -91,8 +91,8 @@ class TestPad(unittest.TestCase):
         self.g = numpy.random.uniform(-1, 1, out_shape).astype(self.dtype)
         self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
-            self.check_backward_options = {
-                'atol': 2 ** -6, 'rtol': 2 ** -6}
+            self.check_backward_options.update({
+                'atol': 2 ** -5, 'rtol': 2 ** -5})
 
     def check_forward(self, x_data):
         y = functions.pad(x_data, self.pad_width, mode=self.mode,

--- a/tests/chainer_tests/functions_tests/array_tests/test_permutate.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_permutate.py
@@ -48,7 +48,7 @@ class TestPermutate(unittest.TestCase):
     def check_backward(self, x_data, ind_data, g_data):
         fun = functions.Permutate(axis=self.axis, inv=self.inv)
         gradient_check.check_backward(
-            fun, (x_data, ind_data), g_data)
+            fun, (x_data, ind_data), g_data, dtype='d', atol=0.001, rtol=0.001)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.indices, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -110,7 +110,7 @@ class TestResizeImagesBackward(unittest.TestCase):
     def check_backward(self, x, output_shape, grads):
         gradient_check.check_backward(
             functions.ResizeImages(output_shape),
-            (x,), (grads,), atol=1e-2, rtol=1e-3, eps=1e-5)
+            (x,), (grads,), dtype='d', atol=1e-2, rtol=1e-3, eps=1e-5)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
@@ -45,7 +45,8 @@ class TestRollaxis(unittest.TestCase):
 
     def check_backward(self, x_data, g_data):
         gradient_check.check_backward(
-            functions.Rollaxis(self.axis, self.start), x_data, g_data)
+            functions.Rollaxis(self.axis, self.start), x_data, g_data,
+            dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -33,9 +33,9 @@ class TestSelectItem(unittest.TestCase):
             0, 2, self.out_shape).astype(numpy.int32)
         self.gy_data = numpy.random.uniform(
             -1, 1, self.out_shape).astype(self.dtype)
-        self.check_backward_options = {}
+        self.check_backward_options = {'atol': 0.01, 'rtol': 0.01}
         if self.dtype == numpy.float16:
-            self.check_backward_options = {'atol': 0.05, 'rtol': 0.05}
+            self.check_backward_options = {'atol': 0.1, 'rtol': 0.1}
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
@@ -57,7 +57,8 @@ class TestSelectItem(unittest.TestCase):
     def check_backward(self, x_data, t_data, gy_data):
         gradient_check.check_backward(
             functions.SelectItem(),
-            (x_data, t_data), gy_data, eps=0.01, **self.check_backward_options)
+            (x_data, t_data), gy_data, eps=0.01, dtype='d',
+            **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x_data, self.t_data, self.gy_data)

--- a/tests/chainer_tests/functions_tests/array_tests/test_separate.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_separate.py
@@ -33,10 +33,6 @@ class TestSeparate(unittest.TestCase):
         del yshape[self.axis]
         self.gys = [numpy.random.uniform(-1, 1, yshape).astype(self.dtype)
                     for _ in range(self.shape[self.axis])]
-        self.check_backward_options = {}
-        if self.dtype == numpy.float16:
-            self.check_backward_options = {
-                'eps': 2 ** -5, 'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
@@ -59,8 +55,7 @@ class TestSeparate(unittest.TestCase):
         def f(x):
             return separate.separate(x, self.axis)
 
-        gradient_check.check_backward(
-            f, x_data, gys_data, **self.check_backward_options)
+        gradient_check.check_backward(f, x_data, gys_data, dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gys)

--- a/tests/chainer_tests/functions_tests/array_tests/test_stack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_stack.py
@@ -64,7 +64,7 @@ class TestStack(unittest.TestCase):
             return functions.stack(xs, self.axis)
 
         gradient_check.check_backward(
-            func, xs_data, g_data, eps=2.0 ** -2, atol=1e-3, rtol=1e-3)
+            func, xs_data, g_data, eps=2.0 ** -2, dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.xs, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_vstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_vstack.py
@@ -56,7 +56,7 @@ class TestVstack(unittest.TestCase):
             return functions.vstack(xs)
 
         gradient_check.check_backward(
-            func, xs_data, g_data, eps=2.0 ** -2, atol=1e-3, rtol=1e-3)
+            func, xs_data, g_data, eps=2.0 ** -2, dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.xs, self.g)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_black_out.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_black_out.py
@@ -87,7 +87,7 @@ class TestBlackOut(unittest.TestCase):
 
         gradient_check.check_backward(
             _black_out, (x_data, t_data, w_data, samples_data),
-            gy_data, atol=1.e-3)
+            gy_data, dtype='d', atol=1e-2)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -80,7 +80,8 @@ class TestContrastive(unittest.TestCase):
     def check_backward(self, x0_data, x1_data, t_data, gy_data):
         gradient_check.check_backward(
             functions.Contrastive(self.margin, self.reduce),
-            (x0_data, x1_data, t_data), gy_data, rtol=1e-4, atol=1e-4)
+            (x0_data, x1_data, t_data), gy_data, dtype='d',
+            rtol=1e-3, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -67,7 +67,7 @@ class TestHinge(unittest.TestCase):
     def check_backward(self, x_data, t_data):
         gradient_check.check_backward(
             functions.Hinge(self.norm), (x_data, t_data), None,
-            eps=0.01, atol=1e-4)
+            dtype='d', rtol=1e-3, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -127,7 +127,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         gradient_check.check_backward(
             functions.SigmoidCrossEntropy(),
-            (x_data, t_data), None, eps=1e-2)
+            (x_data, t_data), None, atol=1e-4, rtol=1e-3)
 
     def check_backward_no_reduction(
             self, x_data, t_data, y_grad):
@@ -137,7 +137,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         gradient_check.check_backward(
             functions.SigmoidCrossEntropy(reduce='no'),
-            (x_data, t_data), y_grad, eps=1e-2)
+            (x_data, t_data), y_grad, atol=1e-4, rtol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -45,12 +45,9 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             if (self.ignore_index is not None and
                     len(self.ignore_index) <= self.t.ndim):
                 self.t[self.ignore_index] = -1
-        self.check_forward_options = {}
-        self.check_backward_options = {'dtype': numpy.float64}
-        if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+        self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
+        self.check_backward_options = {
+            'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
         if self.weight_apply:
             self.class_weight = numpy.random.uniform(
                 0, 10, (self.x.shape[1],)).astype(self.dtype)
@@ -120,7 +117,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             func = functions.SoftmaxCrossEntropy(
                 cache_score=self.cache_score, class_weight=class_weight)
             gradient_check.check_backward(
-                func, (x_data, t_data), None, eps=0.02,
+                func, (x_data, t_data), None,
                 **self.check_backward_options)
 
     @condition.retry(3)
@@ -270,12 +267,9 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
                     len(self.ignore_index) <= self.t.ndim):
                 self.t[self.ignore_index] = -1
         self.g = numpy.random.uniform(-1, 1, self.t.shape).astype(self.dtype)
-        self.check_forward_options = {}
-        self.check_backward_options = {'dtype': numpy.float64}
-        if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
+        self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
+        self.check_backward_options = {
+            'dtype': numpy.float64, 'atol': 5e-4, 'rtol': 5e-3}
         if self.weight_apply:
             self.class_weight = numpy.random.uniform(
                 0, 10, (self.x.shape[1],)).astype(self.dtype)
@@ -331,7 +325,7 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
             cache_score=self.cache_score,
             class_weight=class_weight, reduce='no')
         gradient_check.check_backward(
-            func, (x_data, t_data), g_data, eps=0.02,
+            func, (x_data, t_data), g_data,
             **self.check_backward_options)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
@@ -79,7 +79,7 @@ class TestMax(unittest.TestCase):
     def check_backward(self, x_data, y_grad, axis=None, keepdims=False):
         gradient_check.check_backward(
             functions.Max(axis, keepdims),
-            x_data, y_grad, eps=1e-5, rtol=1e-3, atol=1e-3)
+            x_data, y_grad, dtype='d', eps=1e-5, rtol=1e-3, atol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -60,7 +60,7 @@ class TestL2Normalization(unittest.TestCase):
     def check_backward(self, x_data, axis, y_grad):
         gradient_check.check_backward(
             functions.NormalizeL2(eps=1e-6, axis=axis), x_data, y_grad,
-            rtol=1e-3, atol=1e-4)
+            dtype='d', rtol=1e-3, atol=1e-4)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -31,7 +31,6 @@ class TestMaxPooling2D(unittest.TestCase):
         else:
             self.gy = numpy.random.uniform(
                 -1, 1, (2, 3, 2, 2)).astype(self.dtype)
-        self.check_backward_options = {'eps': 2.0 ** -8}
 
     def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
@@ -133,7 +132,7 @@ class TestMaxPooling2D(unittest.TestCase):
             gradient_check.check_backward(
                 functions.MaxPooling2D(
                     3, stride=2, pad=1, cover_all=self.cover_all),
-                x_data, y_grad, **self.check_backward_options)
+                x_data, y_grad, dtype='d', atol=1e-4, rtol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -44,10 +44,10 @@ class TestMaxPoolingND(unittest.TestCase):
         gy_shape = (2, 3) + outs
         self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
 
-        self.check_backward_options = {'eps': 2.0 ** -8}
+        self.check_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
-                'eps': 2.0 ** -8, 'atol': 1e-03, 'rtol': 1e-03}
+                'atol': 1e-03, 'rtol': 1e-03}
 
     def check_forward(self, x_data, use_cudnn='always'):
         dims = self.dims
@@ -135,7 +135,7 @@ class TestMaxPoolingND(unittest.TestCase):
                 functions.MaxPoolingND(
                     self.ndim, self.ksize, stride=self.stride, pad=self.pad,
                     cover_all=self.cover_all),
-                x_data, y_grad, **self.check_backward_options)
+                x_data, y_grad, dtype='d', **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
@@ -65,7 +65,7 @@ class TestSimplifiedDropconnect(unittest.TestCase):
                                          W, x[:, :, None]).reshape(4, -1) + b
 
         self.check_forward_options = {}
-        self.check_backward_options = {}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
         if self.x_dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
             self.check_backward_options = {'atol': 1e-2, 'rtol': 5e-2}
@@ -95,8 +95,8 @@ class TestSimplifiedDropconnect(unittest.TestCase):
     def check_backward(self, x_data, y_grad, mask):
         gradient_check.check_backward(
             self.link_wrapper, (x_data, mask), y_grad,
-            (self.link.W, self.link.b), eps=2 ** -3,
-            no_grads=(False, True), **self.check_backward_options)
+            (self.link.W, self.link.b),
+            no_grads=(False, True), dtype='d', **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -164,7 +164,8 @@ class TestSimplifiedDropconnectParameterShapePlaceholder(unittest.TestCase):
     def check_backward(self, x_data, y_grad, mask):
         gradient_check.check_backward(
             self.link_wrapper, (x_data, mask), y_grad,
-            (self.link.W, self.link.b), eps=1e-2, no_grads=(False, True))
+            (self.link.W, self.link.b), dtype='d', no_grads=(False, True),
+            atol=1e-4, rtol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/loss_tests/test_hierarchical_softmax.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_hierarchical_softmax.py
@@ -82,7 +82,7 @@ class TestBinaryHierarchicalSoftmax(unittest.TestCase):
     def check_backward(self, x_data, t_data, y_grad):
         gradient_check.check_backward(
             self.link, (x_data, t_data), y_grad, self.link.W,
-            eps=1e-2, atol=1e-4)
+            atol=1e-4, rtol=1e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -362,7 +362,7 @@ class TestCheckBackward(unittest.TestCase):
             s = Ident()(x)
             return s,
 
-        self.assertRaises(TypeError, gradient_check.check_backward,
+        self.assertRaises(RuntimeError, gradient_check.check_backward,
                           f, (x1, x2), g1, no_grads=[False, False])
         gradient_check.check_backward(f, (x1, x2), g1, no_grads=[False, True])
 


### PR DESCRIPTION
Gradient check requires too long time. I replaced a test for `f(x, y, z)` with a test for `g(a) = f(ax, ay, az)`. Here `g'(a) = f'(ax, ay, az) \dot (x, y, z)`. We can test the implementation of gradient to compare numerical gradient of `g` and dot product of `f'` and `(x, y, z)`.