### PR TITLE
Implement the core part of the new-style differentiable function

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -10,6 +10,7 @@ from chainer import cuda  # NOQA
 from chainer import dataset  # NOQA
 from chainer import datasets  # NOQA
 from chainer import function  # NOQA
+from chainer import function_node  # NOQA
 from chainer import functions  # NOQA
 from chainer import initializer  # NOQA
 from chainer import initializers  # NOQA
@@ -32,6 +33,7 @@ from chainer.configuration import using_config  # NOQA
 from chainer.function import force_backprop_mode  # NOQA
 from chainer.function import Function  # NOQA
 from chainer.function import no_backprop_mode  # NOQA
+from chainer.function_node import FunctionNode  # NOQA
 from chainer.functions import array  # NOQA
 from chainer.functions.math import basic_math  # NOQA
 from chainer.initializer import Initializer  # NOQA

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -120,7 +120,8 @@ class FunctionAdapter(function_node.FunctionNode):
         grad_out_data = tuple([None if grad is None else grad.data
                                for grad in grad_outputs])
 
-        gxs = self._function.backward(in_data, grad_out_data)
+        with cuda.get_device_from_array(*(in_data + grad_out_data)):
+            gxs = self._function.backward(in_data, grad_out_data)
         for x, gx in six.moves.zip(self.inputs, gxs):
             variable._check_grad_type(self, x, gx)
 

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -1,13 +1,13 @@
-import collections
-import traceback
+import warnings
 import weakref
 
 import six
 
-import chainer
 from chainer import configuration
 from chainer import cuda
-from chainer.utils import type_check
+# for backward compatibility
+from chainer.function_hook import FunctionHook  # NOQA
+from chainer import function_node
 from chainer import variable
 
 
@@ -55,111 +55,129 @@ def force_backprop_mode():
     return configuration.using_config('enable_backprop', True)
 
 
-class Function(object):
+class FunctionAdapter(function_node.FunctionNode):
 
-    """Function on variables with backpropagation ability.
+    """Adapter class to wrap Function with FunctionNode.
 
-    All function implementations defined in :mod:`chainer.functions` inherit
-    this class.
-
-    The main feature of this class is keeping track of function applications as
-    a backward graph. When a function is applied to :class:`Variable` objects,
-    its :meth:`forward` method is called on :data:`~Variable.data` fields of
-    input variables, and at the same time it chains references from output
-    variable nodes to the function and from the function to its input nodes.
+    While :class:`FunctionNode` provides the interface of new-style
+    differentiable functions, the old-style :class:`Function` can still be
+    used for the backward compatibility. This class provides an adapter of
+    there interface; it adds :class:`FunctionNode` interface to any
+    :class:`Function` object by delegation.
 
     .. note::
-       As of v2.0, the input/output variables and their corresponding variable
-       nodes in the graph are distinguished. Function acts like a function on
-       :class:`Variable` objects that returns :class:`Variable` objects as
-       outputs, whereas these objects do not appear directly in the graph.
-       Instead, their corresponding :class:`VariableNode` objects are inserted
-       to the graph.
 
-    .. note::
-       As of v1.5, a function instance cannot be used twice in any
-       computational graphs. In order to reuse a function object multiple
-       times, use :func:`copy.copy` before the function applications to make a
-       copy of the instance.
+       The ownership of ``FunctionAdapter`` and :class:`Function` is a bit
+       tricky. At the initialization, :class:`FunctionAdapter` is owned by the
+       :class:`Function` object. Once the function is applied to variables,
+       the ownership is reversed; the adapter becomes the owner of the
+       :class:`Function` object and the :class:`Function` object changes the
+       reference to a weak one.
 
-       This restriction also means that we cannot make a *stateful function*
-       anymore. For example, it is now not allowed to let a function hold
-       parameters. Define a function as a pure (stateless) procedure, and use
-       :class:`~chainer.Link` to combine it with parameter variables.
+    Args:
+        function (Function): The function object to wrap.
 
-    .. admonition:: Example
-
-       Let ``x`` an instance of :class:`Variable` and ``f`` an instance of
-       :class:`Function` taking only one argument. Then a line
-
-       >>> import numpy, chainer, chainer.functions as F
-       >>> x = chainer.Variable(numpy.zeros(10))
-       >>> f = F.Identity()
-       >>> y = f(x)
-
-       computes a new variable ``y`` and creates backward references. Actually,
-       backward references are set as per the following diagram::
-
-           x.node <--- f <--- y.node
-
-       If an application of another function ``g`` occurs as
-
-       >>> g = F.Identity()
-       >>> z = g(x)
-
-       then the graph grows with a branch::
-
-                    |--- f <--- y.node
-           x.node <-+
-                    |--- g <--- z.node
-
-       Note that the branching is correctly managed on backward computation,
-       i.e. the gradients from ``f`` and ``g`` are accumulated to the gradient
-       of ``x``.
-
-    Every function implementation should provide :meth:`forward_cpu`,
-    :meth:`forward_gpu`, :meth:`backward_cpu` and :meth:`backward_gpu`.
-    Alternatively, one can provide :meth:`forward` and :meth:`backward` instead
-    of separate methods. Backward methods have default implementations that
-    just return ``None``, which indicates that the function is non-
-    differentiable.
-
-    For functions that do not need a part of inputs in backward computation,
-    there is a way to possibly reduce the memory consumption by quickly
-    releasing the input arrays after the forward propagation. This is done by
-    calling :meth:`retain_inputs` from inside of :meth:`forward` (including
-    :meth:`forward_cpu` and :meth:`forward_gpu`). See the documentation of
-    :meth:`retain_inputs` for details.
-
-    For functions that need a part of outputs in backward computation, it is
-    **strongly recommended** to call :meth:`retain_outputs` from inside of
-    :meth:`forward` (including :meth:`forward_cpu` and :meth:`forward_gpu`).
-    It marks the specified output variable nodes to retain the data. The
-    retained data can be accessed by :attr:`output_arrays` property.
-
-    Attributes:
-        inputs: A tuple or list of input variables.
-        outputs: A tuple or list of output variables.
-        output_data: A tuple of retained output arrays. It has the same length
-            as :attr:`outputs`. The data of variables that are not retained are
-            set to ``None``. See :meth:`retain_outputs` for details.
+    .. versionadded:: 3.0.0
 
     """
 
-    rank = 0  # default value of the rank
+    _function = None
+    _weak_function = None
+
+    def __init__(self, function):
+        super(FunctionAdapter, self).__init__()
+        self._weak_function = weakref.ref(function)
+        function._owned_node = self
+
+    @property
+    def function(self):
+        """The :class:`Function` object that this adapter is wrapping."""
+        func = self._function
+        if func is not None:
+            return func
+
+        weak_func = self._weak_function
+        return weak_func and weak_func()
+
+    @property
+    def label(self):
+        return self._function.label
+
+    @property
+    def _impl_name(self):
+        return self._function.__class__.__name__
+
+    def check_type_forward(self, in_types):
+        self._function.check_type_forward(in_types)
+
+    def forward(self, inputs):
+        # Retain all inputs by default in old-style functions.
+        self.retain_inputs(six.moves.range(len(inputs)))
+        return self._function.forward(inputs)
+
+    def backward(self, target_input_indexes, grad_outputs):
+        in_data = tuple([input.data for input in self.inputs])
+        grad_out_data = tuple([None if grad is None else grad.data
+                               for grad in grad_outputs])
+
+        gxs = self._function.backward(in_data, grad_out_data)
+        for x, gx in six.moves.zip(self.inputs, gxs):
+            variable._check_grad_type(self, x, gx)
+
+        return tuple([
+            None if gxs[i] is None else variable.Variable(
+                gxs[i], requires_grad=False)
+            for i in target_input_indexes
+        ])
+
+
+class Function(object):
+
+    """Old-style interface of a differentiable function.
+
+    This class provides an interface to implement an old-style differentiable
+    function (i.e., the function application is recorded to the computational
+    graph). The subclass of :class:`Function` that implement :meth:`forward`
+    and :meth:`backward` can be used to run the forward computation and
+    automatically induce the backpropagation procedure.
+
+    There is another way to implement such a function: subclassing
+    :class:`FunctionNode`. There are mainly two differences between them.
+
+    1. The *differentiable backprop* is available for :class:`FunctionNode`,
+       while it is not for :class:`Function` because the :meth:`backward`
+       of the latter directly operates on the arrays instead of
+       :class:`Variable` objects so that it cannot record the history of
+       the computation.
+    2. The information passed to :meth:`backward` is different. In
+       :class:`FunctionNode`, which inputs the function node has to compute
+       the gradients w.r.t. is passed so that it can omit unnecessary
+       computations, while :class:`Function` always has to compute gradients
+       w.r.t. all the input nodes. The :class:`FunctionNode` also accepts the
+       current gradient values of the input nodes so that the accumulation
+       work can be merged with the gradient computation if an efficient kernel
+       is available.
+
+    This class uses :class:`FunctionAdapter` to convert the interface to that
+    of :class:`FunctionNode` and adds the :class:`FunctionNode` object to the
+    computational graph.
+
+    See :class:`FunctionNode` for the details of building the computational
+    graph in Chainer.
+
+    """
+
+    _node = None
+    _owned_node = None
 
     def __call__(self, *inputs):
         """Applies forward propagation with chaining backward references.
 
-        Basic behavior is expressed in documentation of :class:`Function`
-        class.
+        This method creates a new :class:`FunctionAdapter` object and runs
+        the forward propagation using it.
 
-        .. note::
-
-           If the :data:`~Variable.data` attribute of input variables exist on
-           GPU device, then, before it calls :meth:`forward` method, the
-           appropriate device is selected, so in most cases implementers do
-           not need to take care of device selection.
+        See :class:`FunctionNode` for the detailed behavior of building the
+        computational graph.
 
         Args:
             inputs: Tuple of input :class:`Variable`, :class:`numpy.ndarray` or
@@ -173,69 +191,15 @@ class Function(object):
             :class:`Variable` objects.
 
         """
+        node = self.node
 
-        inputs = [x if isinstance(x, variable.Variable)
-                  else variable.Variable(x, requires_grad=False)
-                  for x in inputs]
-        in_data = tuple([x.data for x in inputs])
-        requires_grad = any([x.requires_grad for x in inputs])
+        # Swap the ownership
+        node._function = self
+        node._weak_function = None
+        self._node = weakref.ref(node)
+        self._owned_node = None
 
-        if chainer.is_debug():
-            self._stack = traceback.extract_stack()
-
-        if configuration.config.type_check:
-            self._check_data_type_forward(in_data)
-
-        hooks = chainer.get_function_hooks()
-        if self._n_local_function_hooks != 0:
-            hooks = collections.OrderedDict(hooks)
-            hooks.update(self.local_function_hooks)
-        hooks = hooks.values()  # avoid six for performance
-        for hook in hooks:
-            hook.forward_preprocess(self, in_data)
-
-        # Forward prop
-        with cuda.get_device_from_array(*in_data):
-            self._input_indexes_to_retain = None
-            self._output_indexes_to_retain = None
-            outputs = self.forward(in_data)
-            assert type(outputs) == tuple
-        for hook in hooks:
-            hook.forward_postprocess(self, in_data)
-
-        if chainer.is_debug():
-            if any(out.dtype.kind == 'f' and
-                   cuda.get_array_module(out).isnan(out).any()
-                   for out in outputs):
-                msg = 'NaN is detected on forward computation'
-                raise RuntimeError(msg)
-
-        ret = [variable.Variable(y, requires_grad=requires_grad)
-               for y in outputs]
-
-        if configuration.config.enable_backprop:
-            # Topological ordering
-            self.rank = max([x.rank for x in inputs]) if inputs else 0
-            # Backward edges
-            for y in ret:
-                y.set_creator(self)
-            self.inputs = tuple([x.node for x in inputs])
-            # Forward edges (must be weak references)
-            self.outputs = tuple([weakref.ref(y.node) for y in ret])
-
-            input_indexes_to_retain = self._input_indexes_to_retain
-            if input_indexes_to_retain is None:
-                # input arrays are retained by default
-                input_indexes_to_retain = six.moves.range(len(inputs))
-            for index in input_indexes_to_retain:
-                inputs[index].retain_data()
-            del self._input_indexes_to_retain
-
-            output_indexes_to_retain = self._output_indexes_to_retain
-            if output_indexes_to_retain is not None:
-                for index in output_indexes_to_retain:
-                    ret[index].retain_data()
-            del self._output_indexes_to_retain
+        ret = node.apply(inputs)
 
         if len(ret) == 1:
             return ret[0]
@@ -243,22 +207,40 @@ class Function(object):
             return tuple(ret)
 
     @property
+    def inputs(self):
+        """The input nodes of the function."""
+        return self.node.inputs
+
+    @property
+    def outputs(self):
+        """Weak references to the output nodes of the function."""
+        return self.node.outputs
+
+    @property
+    def node(self):
+        """The :class:`FunctionAdapter` object that wraps this Function.
+
+        If the Function does not have a node object, this property
+        automatically creates a new one.
+
+        """
+        noderef = self._node
+        nd = (noderef and noderef()) or self._owned_node
+        if nd is not None:
+            return nd
+
+        nd = FunctionAdapter(self)
+        self._owned_node = nd
+        return nd
+
+    @property
     def local_function_hooks(self):
         """Ordered Dictionary of registered function hooks.
 
-        Contrary to ``chainer.thread_local.function_hooks``,
-        which registers its elements to all functions,
-        Function hooks in this property is specific to this function.
-        """
-        if not hasattr(self, '_local_function_hooks'):
-            self._local_function_hooks = collections.OrderedDict()
-        return self._local_function_hooks
+        See :attr:`FunctionNode.local_function_hooks` for the detail.
 
-    @property
-    def _n_local_function_hooks(self):
-        if hasattr(self, '_local_function_hooks'):
-            return len(self._local_function_hooks)
-        return 0
+        """
+        return self.node.local_function_hooks
 
     @property
     def label(self):
@@ -266,29 +248,28 @@ class Function(object):
 
         The default implementation returns its type name.
         Each function should override it to give more information.
+
         """
         return self.__class__.__name__
 
     @property
+    def output_data(self):
+        """A tuple of the retained output arrays.
+
+        It has the same length as the :attr:`outputs`. Elements that are not
+        retained are set to ``None``.
+
+        """
+        return self.node.output_data
+
+    @property
+    def rank(self):
+        """The topological ordinal of the corresponding function node."""
+        return self.node.rank
+
+    @property
     def stack(self):
-        if hasattr(self, '_stack'):
-            return self._stack
-        else:
-            return None
-
-    def _check_data_type_forward(self, in_data):
-        in_type = type_check.get_light_types(in_data)
-        try:
-            with type_check.light_mode:
-                self.check_type_forward(in_type)
-            return
-        except type_check.InvalidType:
-            # Ignore errors on first run
-            pass
-
-        in_type = type_check.get_types(in_data, 'in_types', False)
-        with type_check.get_function_check_context(self):
-            self.check_type_forward(in_type)
+        return self.node.stack
 
     def check_type_forward(self, in_types):
         """Checks types of input data before forward propagation.
@@ -438,17 +419,15 @@ class Function(object):
     def unchain(self):
         """Purges in/out nodes and this function itself from the graph.
 
-        This method is called from :meth:`Variable.unchain_backward` method.
+        See :meth:`FunctionNode.unchain` for the detail.
 
         """
-        for y in self.outputs:
-            y_ref = y()
-            if y_ref is not None:
-                y_ref.unchain()
-        self.inputs = None
+        self.node.unchain()
 
     def add_hook(self, hook, name=None):
-        """Registers the function hook.
+        """Registers a function hook.
+
+        See :meth:`FunctionNode.add_hook` for the detail.
 
         Args:
             hook(~chainer.function.FunctionHook):
@@ -457,23 +436,19 @@ class Function(object):
                 name must be unique among function hooks
                 registered to the function. If ``None``,
                 default name of the function hook is used.
+
         """
-        if not isinstance(hook, FunctionHook):
-            raise TypeError('Hook must be a FunctionHook')
-        if name is None:
-            name = hook.name
-        if name in self.local_function_hooks:
-            raise KeyError('Hook %s already exists' % name)
-        self.local_function_hooks[name] = hook
+        self.node.add_hook(hook, name)
 
     def delete_hook(self, name):
-        """Unregisters the function hook.
+        """Unregisters the specified function hook.
 
         Args:
             name(str): the name of the function hook
                 to be unregistered.
+
         """
-        del self.local_function_hooks[name]
+        self.node.delete_hook(name)
 
     def retain_inputs(self, indexes):
         """Lets specified input variable nodes keep data arrays.
@@ -483,7 +458,8 @@ class Function(object):
 
         If this method is not called, the function keeps all input arrays. If
         you want to release all input arrays, call this method by passing an
-        empty sequence.
+        empty sequence. *Note that this behavior is different from that of*
+        :meth:`FunctionNode.retain_inputs`.
 
         Note that **this method must not be called from the outside of
         forward method.**
@@ -493,7 +469,7 @@ class Function(object):
                 function does not require for backprop.
 
         """
-        self._input_indexes_to_retain = indexes
+        self.node.retain_inputs(indexes)
 
     def retain_outputs(self, indexes, retain_after_backward=False):
         """Lets specified output variable nodes keep data arrays.
@@ -518,161 +494,11 @@ class Function(object):
             indexes (iterable of int): Indexes of input variables that the
                 function does not require for backprop.
 
-            retain_after_backward (bool): If ``True``, a reference to the
-                outputs will remain after the backprop of the function is over.
-                If ``False``, the reference will be deleted.
+            retain_after_backward (bool): This option has no effect. It is
+                left only for the backward compatibility.
 
         """
-        self._output_indexes_to_retain = indexes
         if retain_after_backward:
-            self._retain_after_backward = retain_after_backward
-
-
-class FunctionHook(object):
-    """Base class of hooks for Functions.
-
-    :class:`~chainer.function.FunctionHook` is an callback object
-    that is registered to :class:`~chainer.Function`.
-    Registered function hooks are invoked before and after
-    forward and backward operations of each function.
-
-    Function hooks that derive :class:`FunctionHook` are required
-    to implement four methods:
-    :meth:`~chainer.function.FunctionHook.forward_preprocess`,
-    :meth:`~chainer.function.FunctionHook.forward_postprocess`,
-    :meth:`~chainer.function.FunctionHook.backward_preprocess`, and
-    :meth:`~chainer.function.FunctionHook.backward_postprocess`.
-    By default, these methods do nothing.
-
-    Specifically, when :meth:`~chainer.Function.__call__`
-    method of some function is invoked,
-    :meth:`~chainer.function.FunctionHook.forward_preprocess`
-    (resp. :meth:`~chainer.function.FunctionHook.forward_postprocess`)
-    of all function hooks registered to this function are called before
-    (resp. after) forward propagation.
-
-    Likewise, when :meth:`~chainer.Variable.backward` of some
-    :class:`~chainer.Variable` is invoked,
-    :meth:`~chainer.function.FunctionHook.backward_preprocess`
-    (resp. :meth:`~chainer.function.FunctionHook.backward_postprocess`)
-    of all function hooks registered to the function which holds this variable
-    as a gradient are called before (resp. after) backward propagation.
-
-    There are two ways to register :class:`~chainer.function.FunctionHook`
-    objects to :class:`~chainer.Function` objects.
-
-    First one is to use ``with`` statement. Function hooks hooked
-    in this way are registered to all functions within ``with`` statement
-    and are unregistered at the end of ``with`` statement.
-
-    .. admonition:: Example
-
-        The following code is a simple example in which
-        we measure the elapsed time of a part of forward propagation procedure
-        with :class:`~chainer.function_hooks.TimerHook`, which is a subclass of
-        :class:`~chainer.function.FunctionHook`.
-
-        >>> from chainer import function_hooks
-        >>> class Model(chainer.Chain):
-        ...     def __call__(self, x1):
-        ...         return F.exp(self.l(x1))
-        >>> model1 = Model(l=L.Linear(10, 10))
-        >>> model2 = Model(l=L.Linear(10, 10))
-        >>> x = chainer.Variable(np.zeros((1, 10), 'f'))
-        >>> with chainer.function_hooks.TimerHook() as m:
-        ...     _ = model1(x)
-        ...     y = model2(x)
-        ...     print("Total time : " + str(m.total_time()))
-        ...     model3 = Model(l=L.Linear(10, 10))
-        ...     z = model3(y) # doctest:+ELLIPSIS
-        Total time : ...
-
-        In this example, we measure the elapsed times for each forward
-        propagation of all functions in ``model1`` and ``model2``
-        (specifically, :class:`~chainer.functions.LinearFunction` and
-        :class:`~chainer.functions.Exp` of ``model1`` and ``model2``).
-        Note that ``model3`` is not a target of measurement
-        as :class:`~chainer.function_hooks.TimerHook` is unregistered
-        before forward propagation of ``model3``.
-
-    .. note::
-
-       Chainer stores the dictionary of registered function hooks
-       as a thread local object. So, function hooks registered
-       are different depending on threads.
-
-    The other one is to register directly to
-    :class:`~chainer.Function` object with
-    :meth:`~chainer.Function.add_hook` method.
-    Function hooks registered in this way can be removed by
-    :meth:`~chainer.Function.delete_hook` method.
-    Contrary to former registration method, function hooks are registered
-    only to the function which :meth:`~chainer.Function.add_hook`
-    is called.
-
-    Args:
-        name(str): Name of this function hook.
-    """
-
-    name = 'FunctionHook'
-
-    def __enter__(self):
-        function_hooks = chainer.get_function_hooks()
-        if self.name in function_hooks:
-            raise KeyError('hook %s already exists' % self.name)
-
-        function_hooks[self.name] = self
-        return self
-
-    def __exit__(self, *_):
-        del chainer.get_function_hooks()[self.name]
-
-    # forward
-    def forward_preprocess(self, function, in_data):
-        """Callback function invoked before forward propagation.
-
-        Args:
-            function(~chainer.Function): Function object to which
-                the function hook is registered.
-            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Input data of forward propagation.
-        """
-        pass
-
-    def forward_postprocess(self, function, in_data):
-        """Callback function invoked after forward propagation.
-
-        Args:
-            function(~chainer.Function): Function object to which
-                the function hook is registered.
-            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Input data of forward propagation.
-        """
-        pass
-
-    # backward
-    def backward_preprocess(self, function, in_data, out_grad):
-        """Callback function invoked before backward propagation.
-
-        Args:
-            function(~chainer.Function): Function object to which
-                the function hook is registered.
-            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Input data of forward propagation.
-            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Gradient data of backward propagation.
-        """
-        pass
-
-    def backward_postprocess(self, function, in_data, out_grad):
-        """Callback function invoked after backward propagation.
-
-        Args:
-            function(~chainer.Function): Function object to which
-                the function hook is registered.
-            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Input of forward propagation.
-            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray):
-                Gradient data of backward propagation.
-        """
-        pass
+            warnings.warn('retain_after_backward option has no effect',
+                          DeprecationWarning)
+        self.node.retain_outputs(indexes)

--- a/chainer/function_hook.py
+++ b/chainer/function_hook.py
@@ -1,0 +1,151 @@
+import chainer
+
+
+class FunctionHook(object):
+    """Base class of hooks for Functions.
+
+    :class:`~chainer.function.FunctionHook` is an callback object
+    that is registered to :class:`~chainer.Function`.
+    Registered function hooks are invoked before and after
+    forward and backward operations of each function.
+
+    Function hooks that derive :class:`FunctionHook` are required
+    to implement four methods:
+    :meth:`~chainer.function.FunctionHook.forward_preprocess`,
+    :meth:`~chainer.function.FunctionHook.forward_postprocess`,
+    :meth:`~chainer.function.FunctionHook.backward_preprocess`, and
+    :meth:`~chainer.function.FunctionHook.backward_postprocess`.
+    By default, these methods do nothing.
+
+    Specifically, when :meth:`~chainer.Function.__call__`
+    method of some function is invoked,
+    :meth:`~chainer.function.FunctionHook.forward_preprocess`
+    (resp. :meth:`~chainer.function.FunctionHook.forward_postprocess`)
+    of all function hooks registered to this function are called before
+    (resp. after) forward propagation.
+
+    Likewise, when :meth:`~chainer.Variable.backward` of some
+    :class:`~chainer.Variable` is invoked,
+    :meth:`~chainer.function.FunctionHook.backward_preprocess`
+    (resp. :meth:`~chainer.function.FunctionHook.backward_postprocess`)
+    of all function hooks registered to the function which holds this variable
+    as a gradient are called before (resp. after) backward propagation.
+
+    There are two ways to register :class:`~chainer.function.FunctionHook`
+    objects to :class:`~chainer.Function` objects.
+
+    First one is to use ``with`` statement. Function hooks hooked
+    in this way are registered to all functions within ``with`` statement
+    and are unregistered at the end of ``with`` statement.
+
+    .. admonition:: Example
+
+        The following code is a simple example in which
+        we measure the elapsed time of a part of forward propagation procedure
+        with :class:`~chainer.function_hooks.TimerHook`, which is a subclass of
+        :class:`~chainer.function.FunctionHook`.
+
+        >>> from chainer import function_hooks
+        >>> class Model(chainer.Chain):
+        ...     def __call__(self, x1):
+        ...         return F.exp(self.l(x1))
+        >>> model1 = Model(l=L.Linear(10, 10))
+        >>> model2 = Model(l=L.Linear(10, 10))
+        >>> x = chainer.Variable(np.zeros((1, 10), 'f'))
+        >>> with chainer.function_hooks.TimerHook() as m:
+        ...     _ = model1(x)
+        ...     y = model2(x)
+        ...     print("Total time : " + str(m.total_time()))
+        ...     model3 = Model(l=L.Linear(10, 10))
+        ...     z = model3(y) # doctest:+ELLIPSIS
+        Total time : ...
+
+        In this example, we measure the elapsed times for each forward
+        propagation of all functions in ``model1`` and ``model2``
+        (specifically, :class:`~chainer.functions.LinearFunction` and
+        :class:`~chainer.functions.Exp` of ``model1`` and ``model2``).
+        Note that ``model3`` is not a target of measurement
+        as :class:`~chainer.function_hooks.TimerHook` is unregistered
+        before forward propagation of ``model3``.
+
+    .. note::
+
+       Chainer stores the dictionary of registered function hooks
+       as a thread local object. So, function hooks registered
+       are different depending on threads.
+
+    The other one is to register directly to
+    :class:`~chainer.Function` object with
+    :meth:`~chainer.Function.add_hook` method.
+    Function hooks registered in this way can be removed by
+    :meth:`~chainer.Function.delete_hook` method.
+    Contrary to former registration method, function hooks are registered
+    only to the function which :meth:`~chainer.Function.add_hook`
+    is called.
+
+    Args:
+        name(str): Name of this function hook.
+    """
+
+    name = 'FunctionHook'
+
+    def __enter__(self):
+        function_hooks = chainer.get_function_hooks()
+        if self.name in function_hooks:
+            raise KeyError('hook %s already exists' % self.name)
+
+        function_hooks[self.name] = self
+        return self
+
+    def __exit__(self, *_):
+        del chainer.get_function_hooks()[self.name]
+
+    # forward
+    def forward_preprocess(self, function, in_data):
+        """Callback function invoked before forward propagation.
+
+        Args:
+            function(~chainer.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+               Input data of forward propagation.
+        """
+        pass
+
+    def forward_postprocess(self, function, in_data):
+        """Callback function invoked after forward propagation.
+
+        Args:
+            function(~chainer.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Input data of forward propagation.
+        """
+        pass
+
+    # backward
+    def backward_preprocess(self, function, in_data, out_grad):
+        """Callback function invoked before backward propagation.
+
+        Args:
+            function(~chainer.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Input data of forward propagation.
+            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Gradient data of backward propagation.
+        """
+        pass
+
+    def backward_postprocess(self, function, in_data, out_grad):
+        """Callback function invoked after backward propagation.
+
+        Args:
+            function(~chainer.Function): Function object to which
+                the function hook is registered.
+            in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Input of forward propagation.
+            out_grad(tuple of numpy.ndarray or tuple of cupy.ndarray):
+                Gradient data of backward propagation.
+        """
+        pass

--- a/chainer/function_hooks/cuda_profile.py
+++ b/chainer/function_hooks/cuda_profile.py
@@ -1,8 +1,8 @@
 from chainer import cuda
-from chainer import function
+from chainer import function_hook
 
 
-class CUDAProfileHook(function.FunctionHook):
+class CUDAProfileHook(function_hook.FunctionHook):
 
     name = 'CUDAProfileHook'
 

--- a/chainer/function_hooks/debug_print.py
+++ b/chainer/function_hooks/debug_print.py
@@ -2,11 +2,11 @@ from __future__ import print_function
 import sys
 
 from chainer import cuda
-from chainer import function
+from chainer import function_hook
 from chainer import variable
 
 
-class PrintHook(function.FunctionHook):
+class PrintHook(function_hook.FunctionHook):
     """Function hook that prints debug information.
 
     This function hook outputs the debug information of input arguments of

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -4,10 +4,10 @@ import time
 import numpy
 
 from chainer import cuda
-from chainer import function
+from chainer import function_hook
 
 
-class TimerHook(function.FunctionHook):
+class TimerHook(function_hook.FunctionHook):
     """Function hook for measuring elapsed time of functions.
 
     Example:
@@ -105,7 +105,7 @@ class TimerHook(function.FunctionHook):
         """
         summary = {}
         for func, elapsed_time in self.call_history:
-            function_name = func.__class__.__name__
+            function_name = func._impl_name
             if function_name not in summary:
                 summary[function_name] = {'elapsed_time': 0, 'occurrence': 0}
             record = summary[function_name]

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -1,0 +1,591 @@
+import collections
+import traceback
+import weakref
+
+import six
+
+import chainer
+from chainer import configuration
+from chainer import cuda
+from chainer import function_hook
+from chainer.utils import type_check
+from chainer import variable
+
+
+class FunctionNode(object):
+
+    """Function node of the computational graph.
+
+    FunctionNode is a class representing a node in a computational graph. The
+    node corresponds to an application of a differentiable function to input
+    variables.
+
+    When a differentiable function is applied to :class:`Variable` objects,
+    it creates an instance of FunctionNode implementation and calls its
+    :meth:`apply` method. The :meth:`apply` method basically does the following
+    three things.
+
+    1. Adding an edge from the function node to the variable node corresponding
+       to each input. The node of each input is extracted by
+       :attr:`Variable.node`.
+    2. Computing the output arrays of the function.
+    3. Creating a :class:`Variable` object for each output array and adding an
+       edge from the node of the variable to the function node.
+
+    The output variables are then returned.
+
+    .. admonition:: Example
+
+       Let ``x`` be an instance of :class:`Variable` and ``f`` be an instance
+       of :class:`FunctionNode` taking only one argument. Then a line
+
+       >>> import numpy, chainer, chainer.functions as F
+       >>> x = chainer.Variable(numpy.zeros(10))
+       >>> f = F.Identity()
+       >>> y = f.apply((x,))[0]
+
+       computes a new variable ``y`` and creates backward references. Actually,
+       backward references are set as per the following diagram::
+
+           x.node <--- f <--- y.node
+
+       If an application of another function ``g`` occurs as
+
+       >>> g = F.Identity()
+       >>> z = g.apply((x,))[0]
+
+       then the graph grows with a branch::
+
+                    |--- f <--- y.node
+           x.node <-+
+                    |--- g <--- z.node
+
+       Note that the branching is correctly managed on backward computation,
+       i.e. the gradients from ``f`` and ``g`` are accumulated to the gradient
+       of ``x``.
+
+    Every function-node implementation should provide :meth:`forward` and
+    :meth:`backward`. Instead of overriding :meth:`forward`, one can also
+    implement :meth:`forward_cpu` and :meth:`forward_gpu` when the
+    implementations for CPU and GPU arrays are totally different.
+
+    Note that the input and output variables are inaccessible from
+    :meth:`backward` by default. If it needs accesses to these variables, the
+    :meth:`forward` method (or its CPU/GPU variants) has to call
+    :meth:`retain_inputs` and :meth:`retain_outputs` appropriately. The
+    retained input/output variables can be accessed from :meth:`backward` by
+    calling :meth:`get_retained_inputs` and :meth:`get_retained_outputs`.
+
+    .. note::
+
+       There are two types of differentiable functions in Chainer (since v3).
+       The first type is of a function using a subclass of :class:`Function`,
+       which is called *old-style differentiable function*. The second type is
+       of a function using a subclass of :class:`FunctionNode`, which is called
+       **new-style differentiable function**. There are several advantages on
+       using the new-style differentiable function.
+
+       - The new-style differentiable function supports *differentiable
+         backpropagation*. The backpropagated gradients computed through the
+         new-style differentiable functions themselves support further
+         backpropagations so that the automatic higher-order differentiation is
+         available.
+       - The backpropagation of the new-style differentiable function can be
+         more computationally saving because the interface allows an
+         implementation to omit the computation of unneeded input gradients.
+
+       Note that the new-style differentiable function is the standard way of
+       defining a function node of the computational graph in Chainer; old-
+       style differentiable functions are implemented as wrappers of the new-
+       style differentiable functions.
+
+    Attributes:
+        inputs: A tuple of the input :class:`VariableNode` objects.
+        outputs: A tuple of weak references to the output
+            :class:`VariableNode` objects.
+        rank (int): An ordinal following the topological order of the
+            computational graph.
+        stack: Stack trace retrieved at the forward computation. The stack
+            trace is available only in the debug mode.
+
+    .. versionadded:: 3.0.0
+
+    """
+
+    inputs = None
+    outputs = None
+    rank = 0
+    stack = None
+    _input_indexes_to_retain = None
+    _output_indexes_to_retain = None
+    _retained_output_data = None
+    _local_function_hooks = None
+
+    @property
+    def local_function_hooks(self):
+        """Ordered dictionary of registered function hooks.
+
+        Contrary to ``chainer.thread_local.function_hooks``,
+        which registers its elements to all functions,
+        Function hooks in this property is specific to this function.
+
+        """
+        if self._local_function_hooks is None:
+            self._local_function_hooks = collections.OrderedDict()
+        return self._local_function_hooks
+
+    @property
+    def _n_local_function_hooks(self):
+        return (0 if self._local_function_hooks is None
+                else len(self._local_function_hooks))
+
+    @property
+    def label(self):
+        """Short text that represents the function.
+
+        The default implementation returns its type name.
+        Each function should override it to give more information.
+
+        """
+        return self.__class__.__name__
+
+    @property
+    def output_data(self):
+        """A tuple of the retained output arrays.
+
+        This property is mainly used by :class:`Function`. Users basically do
+        not have to use this property; use :meth:`get_retained_outputs`
+        instead.
+
+        """
+        if self._retained_output_data is None:
+            raise RuntimeError('retained output data is gone')
+        out_data = [None] * len(self.outputs)
+        for index, data in six.moves.zip(self._output_indexes_to_retain,
+                                         self._retained_output_data):
+            out_data[index] = data
+        return tuple(out_data)
+
+    @property
+    def _impl_name(self):
+        return self.__class__.__name__
+
+    def apply(self, inputs):
+        """Computes output variables and grows the computational graph.
+
+        Basic behavior is expressed in the documentation of
+        :class:`FunctionNode`.
+
+        .. note::
+
+           If the :data:`~Variable.data` attribute of input variables exist on
+           a GPU device, that device is made current before calling
+           :meth:`forward`, so implementors do not need to take care of device
+           selection in most cases.
+
+        Args:
+            inputs: Tuple of input variables. Each element can be either
+                :class:`Variable`, :class:`numpy.ndarray`,
+                or :class:`cupy.ndarray`. If the element is an ndarray, it is
+                automatically wrapped with :class:`Variable`.
+
+        Returns:
+            A tuple of output :class:`Variable` objects.
+
+        """
+        input_vars = [x if isinstance(x, variable.Variable)
+                      else variable.Variable(x, requires_grad=False)
+                      for x in inputs]
+        in_data = tuple([x.data for x in input_vars])
+        requires_grad = any([x.requires_grad for x in input_vars])
+
+        if chainer.is_debug():
+            self.stack = traceback.extract_stack()
+
+        if configuration.config.type_check:
+            self._check_data_type_forward(in_data)
+
+        hooks = chainer.get_function_hooks()
+        if self._n_local_function_hooks > 0:
+            hooks = collections.OrderedDict(hooks)
+            hooks.update(self.local_function_hooks)
+        hooks = hooks.values()  # avoid six for performance
+
+        for hook in hooks:
+            hook.forward_preprocess(self, in_data)
+
+        # Forward propagation
+        with cuda.get_device_from_array(*in_data):
+            self._input_indexes_to_retain = None
+            self._output_indexes_to_retain = None
+            outputs = self.forward(in_data)
+            assert type(outputs) is tuple
+
+        for hook in hooks:
+            hook.forward_postprocess(self, in_data)
+
+        # NaN check of output values
+        if chainer.is_debug():
+            if any(out.dtype.kind == 'f' and
+                   cuda.get_array_module(out).isnan(out).any()
+                   for out in outputs):
+                msg = 'NaN is detected on forward computation'
+                raise RuntimeError(msg)
+
+        ret = tuple([variable.Variable(y, requires_grad=requires_grad)
+                     for y in outputs])
+
+        if configuration.config.enable_backprop:
+            # Topological ordering
+            self.rank = max([x.rank for x in input_vars]) if input_vars else 0
+            # Add backward edges
+            for i, y in enumerate(ret):
+                y.creator_node = self
+            self.inputs = tuple([x.node for x in input_vars])
+            # Add forward edges (must be weak references)
+            self.outputs = tuple([weakref.ref(y.node) for y in ret])
+
+            if self._input_indexes_to_retain is not None:
+                for index in self._input_indexes_to_retain:
+                    input_vars[index].retain_data()
+
+            if self._output_indexes_to_retain is not None:
+                retained_data = []
+                for index in self._output_indexes_to_retain:
+                    ret[index].retain_data()
+                    retained_data.append(outputs[index])
+                self._retained_output_data = tuple(retained_data)
+
+        return ret
+
+    def _check_data_type_forward(self, in_data):
+        in_type = type_check.get_light_types(in_data)
+        try:
+            with type_check.light_mode:
+                self.check_type_forward(in_type)
+            return
+        except type_check.InvalidType:
+            # Ignore errors on first run
+            pass
+
+        in_type = type_check.get_types(in_data, 'in_types', False)
+        with type_check.get_function_check_context(self):
+            self.check_type_forward(in_type)
+
+    def check_type_forward(self, in_types):
+        """Checks types of input data before forward propagation.
+
+        This method is called before :meth:`forward` and validates the types of
+        input variables using
+        :ref:`the type checking utilities <type-check-utils>`.
+
+        Args:
+            in_types (~chainer.utils.type_check.TypeInfoTuple): The type
+                information of input variables for :meth:`forward`.
+
+        """
+        pass
+
+    def forward(self, inputs):
+        """Computes the output arrays from the input arrays.
+
+        It delegates the procedure to :meth:`forward_cpu` or
+        :meth:`forward_gpu` by default. Which of them this method selects is
+        determined by the type of input arrays. Implementations of
+        :class:`FunctionNode` must implement either CPU/GPU methods or this
+        method.
+
+        Args:
+            inputs: Tuple of input array(s).
+
+        Returns:
+            Tuple of output array(s).
+
+        .. warning::
+
+            Implementations of :class:`FunctionNode` must take care that the
+            return value must be a tuple even if it returns only one array.
+
+        """
+        assert len(inputs) > 0
+        if isinstance(inputs[0], cuda.ndarray):
+            return self.forward_gpu(inputs)
+        return self.forward_cpu(inputs)
+
+    def forward_cpu(self, inputs):
+        """Computes the output arrays from the input NumPy arrays.
+
+        Args:
+            inputs: Tuple of input :class:`numpy.ndarray` objects.
+
+        Returns:
+            Tuple of output arrays. Each element can be NumPy or CuPy arrays.
+
+        .. warning::
+
+            Implementation of :class:`FunctionNode` must take care that the
+            return value must be a tuple even if it returns only one array.
+
+        """
+        raise NotImplementedError
+
+    def forward_gpu(self, inputs):
+        """Computes the output arrays from the input CuPy arrays.
+
+        Args:
+            inputs: Tuple of input :class:`cupy.ndarray` objects.
+
+        Returns:
+            Tuple of output arrays. Each element can be NumPy or CuPy arrays.
+
+        .. warning::
+
+            Implementation of :class:`FunctionNode` must take care that the
+            return value must be a tuple even if it returns only one array.
+
+        """
+        raise NotImplementedError
+
+    def retain_inputs(self, indexes):
+        """Lets specified input variable nodes keep data arrays.
+
+        By calling this method from :meth:`forward`, the function node can
+        specify which inputs are required for backprop. The input variables
+        with retained arrays can be obtained by :meth:`get_retained_inputs`
+        from :meth:`backward`.
+
+        Unlike :class:`Function`, the function node **DOES NOT** keep input
+        arrays by default. If you want to keep some or all input arrays, do not
+        forget to call this method.
+
+        Note that **this method must not be called from the outside of
+        forward method.**
+
+        Args:
+            indexes (iterable of int): Indexes of input variables that the
+                function does not require for backprop.
+
+        """
+        self._input_indexes_to_retain = indexes
+
+    def retain_outputs(self, indexes):
+        """Lets specified output variable nodes keep data arrays.
+
+        By calling this method from :meth:`forward`, the function node can
+        specify which outputs are required for backprop. If this method is not
+        called, any output variables are not marked to keep the data array at
+        the point of returning from :meth:`apply`. The output variables with
+        retained arrays can be obtained by :meth:`get_retained_outputs` from
+        :meth:`backward`.
+
+        .. note::
+
+           It is recommended to use this method if the function requires some
+           or all output arrays in backprop. The function can also use output
+           arrays just by keeping references to them directly, whereas it might
+           influence on the performance of later function applications to the
+           output variables.
+
+        Note that **this method must not be called from the outside of
+        forward method.**
+
+        Args:
+            indexes (iterable of int): Indexes of input variables that the
+                function does not require for backprop.
+
+        """
+        self._output_indexes_to_retain = indexes
+
+    def backward(self, target_input_indexes, grad_outputs):
+        """Computes gradients w.r.t. specified inputs given output gradients.
+
+        This method is used to compute one step of the backpropagation
+        corresponding to the forward computation of this function node.
+        Given the gradients w.r.t. output variables, this method computes the
+        gradients w.r.t. specified input variables. Note that this method does
+        not need to compute any input gradients not specified by
+        ``target_input_indices``.
+
+        Unlike :meth:`Function.backward`, gradients are given as
+        :class:`Variable` objects and this method itself has to return input
+        gradients as :class:`Variable` objects. It enables the function node to
+        return the input gradients with the full computational history, in
+        which case it supports *differentiable backpropagation* or
+        *higher-order differentiation*.
+
+        The default implementation returns ``None`` s, which means the
+        function is not differentiable.
+
+        Args:
+            target_input_indexes (tuple of int): Indices of the input variables
+                w.r.t. which the gradients are required. It is guaranteed that
+                this tuple contains at least one element.
+            grad_outputs (tuple of Variable): Gradients w.r.t. the output
+                variables. If the gradient w.r.t. an output variable is not
+                given, the corresponding element is ``None``.
+
+        Returns:
+            Tuple of variables that represent the gradients w.r.t. specified
+            input variables. The length of the tuple can be same as either
+            ``len(target_input_indexes)`` or the number of inputs. In the
+            latter case, the elements not specified by ``target_input_indexes``
+            will be discarded.
+
+        .. seealso::
+
+           :meth:`backward_accumulate` provides an alternative interface that
+           allows you to implement the backward computation fused with the
+           gradient accumulation.
+
+        """
+        return (None,) * len(target_input_indexes)
+
+    def backward_accumulate(self, target_input_indexes, grad_outputs,
+                            grad_inputs):
+        """Computes gradients w.r.t. specified inputs and accumulates them.
+
+        This method provides a way to fuse the backward computation and the
+        gradient accumulations in the case that the multiple functions are
+        applied to the same variable.
+
+        Users have to override either of this method or :meth:`backward`.
+        It is often simpler to implement :meth:`backward` and is recommended
+        if you do not need to provide efficient gradient accumulation.
+
+        Args:
+            target_input_indexes (tuple of int): Indices of the input variables
+                w.r.t. which the gradients are required. It is guaranteed that
+                this tuple contains at least one element.
+            grad_outputs (tuple of Variable): Gradients w.r.t. the output
+                variables. If the gradient w.r.t. an output variable is not
+                given, the corresponding element is ``None``.
+            grad_inputs (tuple of Variable): Gradients w.r.t. the input
+                variables specified by ``target_input_indexes``. These values
+                are computed by other computation paths. If there is no
+                gradient value existing for the variable, the corresponding
+                element is ``None``. See also the note below.
+
+        Returns:
+            Tuple of variables that represent the gradients w.r.t. specified
+            input variables. Unlike :meth:`backward`, the length of the tuple
+            **must** be same as that of ``target_input_indices``.
+
+        .. note::
+
+           When the same variable is passed to the multiple input arguments of
+           a function, only the first position of ``grad_inputs`` corresponding
+           to these input arguments may contain the gradient variable
+           corresponding to that input variable, and other entries are set to
+           ``None``. This is an implementation-detail convention to avoid the
+           complication of correctly accumulating gradients in such a case.
+           This behavior might be changed in a future version.
+
+        """
+        # The default implementation uses backward(). You can override this
+        # method without using backward().
+        gxs = self.backward(target_input_indexes, grad_outputs)
+
+        len_gxs = len(gxs)
+        if len_gxs == len(self.inputs):
+            gxs = tuple([gxs[i] for i in target_input_indexes])
+        elif len_gxs != len(target_input_indexes):
+            raise ValueError(
+                'number of gradients returned by %s (%s) is incorrect.'
+                % (self._impl_name, self.label))
+
+        return tuple([gx if g_input is None else
+                      g_input if gx is None else
+                      gx + g_input
+                      for gx, g_input in six.moves.zip(gxs, grad_inputs)])
+
+    def get_retained_inputs(self):
+        """Returns a tuple of retained input variables.
+
+        This method is used to retrieve the input variables retained in
+        :meth:`forward`.
+
+        Returns:
+            A tuple of retained input variables.
+
+        """
+        inputs = self.inputs
+        return tuple([inputs[index].get_variable()
+                      for index in self._input_indexes_to_retain])
+
+    def get_retained_outputs(self):
+        """Returns a tuple of retained output variables.
+
+        This method is used to retrieve the output variables retained in
+        :meth:`forward`.
+
+        Returns:
+            A tuple of retained output variables.
+
+        .. note::
+
+           This method does a tricky thing to support the case of an output
+           node garbage-collected before this method is called; in this case,
+           this method creates a fresh variable node that acts as an output
+           node of the function node.
+
+        """
+        ret = []
+        outputs = self.outputs
+
+        new_outputs = list(outputs)
+        outputs_modified = False
+        for index, data in six.moves.zip(self._output_indexes_to_retain,
+                                         self._retained_output_data):
+            output = outputs[index]()
+            if output is None:
+                # The output node is garbage collected, so create a fresh
+                # Variable object.
+                output_var = variable.Variable(data)
+                output_var.creator_node = self
+                new_outputs[index] = weakref.ref(output_var)
+                outputs_modified = True
+            else:
+                output_var = output.get_variable()
+            ret.append(output_var)
+
+        if outputs_modified:
+            self.outputs = tuple(new_outputs)
+
+        return ret
+
+    def unchain(self):
+        """Purges in/out nodes and this function node itself from the graph."""
+        for y in self.outputs:
+            y_ref = y()
+            if y_ref is not None:
+                y_ref.unchain()
+        self.inputs = None
+
+    def add_hook(self, hook, name=None):
+        """Registers a function hook.
+
+        Args:
+            hook (~chainer.function.FunctionHook): Function hook to be
+                registered.
+            name (str): Name of the function hook. The name must be unique
+                among function hooks registered to this function. If ``None``,
+                the default name of the function hook is used.
+
+        """
+        if not isinstance(hook, function_hook.FunctionHook):
+            raise TypeError('Hook must be of type FunctionHook')
+        if name is None:
+            name = hook.name
+        hooks = self.local_function_hooks
+        if name in hooks:
+            raise KeyError('Hook %s already exists' % name)
+        hooks[name] = hook
+
+    def delete_hook(self, name):
+        """Unregisters the function hook.
+
+        Args:
+            name (str): The name of the function hook to be unregistered.
+
+        """
+        del self.local_function_hooks[name]

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -2,6 +2,7 @@ import numpy
 
 from chainer import cuda
 from chainer import function
+from chainer import function_node
 from chainer.functions.math import matmul as _matmul
 from chainer import utils
 from chainer.utils import type_check
@@ -105,7 +106,7 @@ def absolute(self):
     return Absolute()(self)
 
 
-class Add(function.Function):
+class Add(function_node.FunctionNode):
 
     @property
     def label(self):
@@ -119,15 +120,14 @@ class Add(function.Function):
         )
 
     def forward(self, x):
-        self.retain_inputs(())
         y = utils.force_array(x[0] + x[1])
         return y,
 
-    def backward(self, x, gy):
+    def backward(self, indexes, gy):
         return gy[0], gy[0]
 
 
-class AddConstant(function.Function):
+class AddConstant(function_node.FunctionNode):
 
     def __init__(self, value):
         self.value = value
@@ -140,11 +140,10 @@ class AddConstant(function.Function):
         type_check.expect(in_types.size() == 1)
 
     def forward(self, x):
-        self.retain_inputs(())
         value = _preprocess_const(x[0], self.value)
         return utils.force_array(x[0] + value),
 
-    def backward(self, x, gy):
+    def backward(self, indexes, gy):
         return gy[0],
 
 
@@ -155,9 +154,9 @@ def add(self, rhs):  # lhs + rhs
         ~chainer.Variable: Output variable.
     """
     if isinstance(rhs, variable.Variable):
-        return Add()(self, rhs)
+        return Add().apply((self, rhs))[0]
     _check_constant_type(rhs)
-    return AddConstant(rhs)(self)
+    return AddConstant(rhs).apply((self,))[0]
 
 
 class Sub(function.Function):
@@ -191,7 +190,7 @@ def sub(self, rhs):  # lhs - rhs
     if isinstance(rhs, variable.Variable):
         return Sub()(self, rhs)
     _check_constant_type(rhs)
-    return AddConstant(-rhs)(self)
+    return AddConstant(-rhs).apply((self,))[0]
 
 
 class SubFromConstant(function.Function):
@@ -227,7 +226,7 @@ def rsub(self, rhs):  # rhs - lhs
     return SubFromConstant(rhs)(self)
 
 
-class Mul(function.Function):
+class Mul(function_node.FunctionNode):
 
     @property
     def label(self):
@@ -242,13 +241,15 @@ class Mul(function.Function):
         )
 
     def forward(self, x):
+        self.retain_inputs((0, 1))
         return utils.force_array(x[0] * x[1]),
 
-    def backward(self, x, gy):
-        return utils.force_array(gy[0] * x[1]), utils.force_array(gy[0] * x[0])
+    def backward(self, indexes, gy):
+        xs = self.get_retained_inputs()
+        return tuple(gy[0] * xs[1 - i] for i in indexes)
 
 
-class MulConstant(function.Function):
+class MulConstant(function_node.FunctionNode):
 
     def __init__(self, value):
         self.value = value
@@ -264,10 +265,8 @@ class MulConstant(function.Function):
         value = _preprocess_const(x[0], self.value)
         return utils.force_array(value * x[0]),
 
-    def backward(self, x, gy):
-        # TODO(beam2d): Make it not use the input
-        value = _preprocess_const(x[0], self.value)
-        return utils.force_array(value * gy[0]),
+    def backward(self, indexes, gy):
+        return self.value * gy[0],
 
 
 def mul(self, rhs):  # lhs * rhs
@@ -278,9 +277,9 @@ def mul(self, rhs):  # lhs * rhs
     """
 
     if isinstance(rhs, variable.Variable):
-        return Mul()(self, rhs)
+        return Mul().apply((self, rhs))[0]
     _check_constant_type(rhs)
-    return MulConstant(rhs)(self)
+    return MulConstant(rhs).apply((self,))[0]
 
 
 class Div(function.Function):
@@ -324,7 +323,7 @@ def div(self, rhs):  # lhs / rhs
     if isinstance(rhs, variable.Variable):
         return Div()(self, rhs)
     _check_constant_type(rhs)
-    return MulConstant(1. / rhs)(self)
+    return MulConstant(1. / rhs).apply((self,))[0]
 
 
 class DivFromConstant(function.Function):

--- a/chainer/functions/math/identity.py
+++ b/chainer/functions/math/identity.py
@@ -1,21 +1,19 @@
-from chainer import function
+from chainer import function_node
 
 
-class Identity(function.Function):
+class Identity(function_node.FunctionNode):
 
     """Identity function."""
-
-    def check_type_forward(self, in_types):
-        pass
 
     def forward(self, xs):
         self.retain_inputs(())
         return xs
 
-    def backward(self, xs, gys):
+    def backward(self, indexes, gys):
         return gys
 
 
 def identity(*inputs):
     """Just returns input variables."""
-    return Identity()(*inputs)
+    ret = Identity().apply(inputs)
+    return ret[0] if len(ret) == 1 else ret

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -47,12 +47,11 @@ class SpatialPyramidPooling2D(pooling_2d.Pooling2D):
     def forward(self, x):
         self.ys = []
         for pooler in self.poolers:
-            y = pooler.forward(x)[0]
-            pooler.output_data = y  # work around
-            n, c, h, w = pooler.out_shape = y.shape
-            self.ys.append(y.reshape((n, c * h * w, 1, 1)))
+            y_var = pooler(*x)
+            n, c, h, w = pooler.out_shape = y_var.shape
+            self.ys.append(y_var.reshape((n, c * h * w, 1, 1)))
 
-        return concat.Concat(axis=1).forward(self.ys)
+        return concat.Concat(axis=1).forward([y.data for y in self.ys])
 
     def backward(self, x, gy):
         xp = cuda.get_array_module(*x)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -221,8 +221,7 @@ def check_backward(func, x_data, y_grad, params=(),
     # To do so we need to insert a dummy function `Ident` to the
     # computational graph.
     # Note that `func` may not be a `Function` object.
-    y = identity.Identity()(*y)
-    y = _as_tuple(y)
+    y = identity.Identity().apply(y)
 
     if y_grad is not None:
         if len(y) != len(y_grad):

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -11,7 +11,6 @@ import chainer
 from chainer import cuda
 from chainer import initializers
 from chainer.initializers import constant
-from chainer import utils
 from chainer.utils import argument
 
 
@@ -37,11 +36,11 @@ def _check_grad_type(func, x, gx):
     detail = ''
     if func:
         detail = 'Function `{0}` ({1}) has a bug.\n'.format(
-            type(func).__name__, func.label)
+            type(func)._impl_name, func.label)
         stack = func.stack
         if stack:
             detail += 'Stacktrace of the function is below:\n'
-            for line in traceback.format_list(func._stack):
+            for line in traceback.format_list(func.stack):
                 detail += line
         detail += '''
 Please report this error to the issue tracker with the stack trace,
@@ -145,9 +144,14 @@ class VariableNode(object):
 
     """
 
-    def __init__(self, variable, name, grad=None):
+    def __init__(self, variable, name, **kwargs):
+        argument.check_unexpected_kwargs(
+            kwargs,
+            grad='unexpected keyword argument "grad": '
+                 'pass the gradient to Variable instead'
+        )
         self._variable = weakref.ref(variable)
-        self._creator = None
+        self._creator_node = None
         self._data = None
         self._rank = 0
         self.name = name
@@ -156,16 +160,76 @@ class VariableNode(object):
         vdata = variable.data
         self._set_data_type(vdata)
 
-        self.grad = grad
-
     @property
     def creator(self):
-        """Function node that created this variable node."""
-        return self._creator
+        """Function object that created this variable node.
+
+        When the function is implemented with the old-style API (i.e., it uses
+        :class:`Function` class), this property returns the :class:`Function`
+        object. The object is extracted from the :class:`FunctionAdapter`
+        object, so the returned object is not the function node, but instead
+        the actual implementation of forward and backward procedures.
+
+        When the function is implemented with the new-style API (i.e., it uses
+        :class:`FunctionNode` class), this property returns the function node
+        object. In this case, the returned object is same as
+        :attr:`creator_node`.
+
+        .. warning::
+
+           As of v3.0.0, when the creator is an old-style function, the
+           following code is invalid:
+
+           .. code-block:: python
+
+              creator = v.creator
+              v.creator = None
+              ...
+              v.creator = creator
+
+           The point is that :class:`FunctionNode` objects are used as nodes
+           in the computational graph instead of :class:`Function`, and each
+           :class:`Function` object only holds a *weak reference* to the
+           corresponding :class:`FunctionNode`. Since ``creator`` returns the
+           :class:`Function` object, the :class:`FunctionNode` object is not
+           kept by preserving ``creator``.
+
+           The above code should be fixed as follows.
+
+           .. code-block:: python
+
+              creator_node = v.creator_node
+              v.creator_node = None
+              ...
+              v.creator_node = creator_node
+
+        """
+        node = self._creator_node
+        if node is None:
+            return None
+
+        if isinstance(node, chainer.function.FunctionAdapter):
+            return node.function
+        return node
 
     @creator.setter
     def creator(self, func):
-        self._creator = func
+        self.creator_node = func
+
+    @property
+    def creator_node(self):
+        """Function node that has this variable as an output.
+
+        See :class:`FunctionNode` for the definition of a function node.
+
+        """
+        return self._creator_node
+
+    @creator_node.setter
+    def creator_node(self, func):
+        if isinstance(func, chainer.Function):
+            func = func.node
+        self._creator_node = func
         if func is not None:
             self._rank = func.rank + 1
 
@@ -185,13 +249,23 @@ class VariableNode(object):
 
     @property
     def grad(self):
-        """Gradient array of the corresponding variable."""
-        return self._grad
+        """Gradient array of the corresponding variable.
 
-    @grad.setter
-    def grad(self, g):
-        _check_grad_type(None, self, g)
-        self._grad = g
+        If the variable is not available, it returns ``None``.
+
+        """
+        var = self.get_variable()
+        return None if var is None else var.grad
+
+    @property
+    def grad_var(self):
+        """Gradient variable of the corresponding variable.
+
+        If the corresponding variable is not available, it return ``None``.
+
+        """
+        var = self.get_variable()
+        return None if var is None else var._grad_var
 
     @property
     def label(self):
@@ -210,24 +284,61 @@ class VariableNode(object):
         """It indicates that ``grad`` will be set in backward calculation."""
         return self._requires_grad
 
+    def get_variable(self):
+        """Returns the corresponding :class:`Variable` object.
+
+        VariableNode object holds a weak reference of the variable object. If
+        the reference is alive, it is returned by this property. Otherwise,
+        this property creates a new :class:`Variable` object from this node
+        object and returns it.
+
+        Returns:
+            Variable: The variable object that refers this node.
+
+        """
+        var = self._variable()
+        if var is not None:
+            return var
+
+        var = Variable(self.data, name=self.name,
+                       requires_grad=self._requires_grad)
+        var._node = self
+        return var
+
     def set_creator(self, creator):
         """Sets a :class:`Function` object that created this node.
 
-        This method is equivalent to ``self.creator = creator``.
+        This method is equivalent to ``self.creator = creator``. A
+        :class:`FunctionNode` object can also be passed.
 
         Args:
-            creator (Function): Function object that created this node.
+            creator (Function or FunctionNode): Function that has created this
+                variable.
 
         """
         self.creator = creator
 
+    def set_creator_node(self, creator_node):
+        """Sets a :class:`FunctionNode` object that created this node.
+
+        This method is equivalent to ``self.creator_node = creator_node``. A
+        :class:`Function` object can also be passed, in which case the
+        :attr:`~Function.node` object is extracted.
+
+        Args:
+            creator_node (FunctionNode or Function): Function node that has
+                this variable as an output.
+
+        """
+        self.creator_node = creator_node
+
     def unchain(self):
         """Deletes the reference to the creator of this variable node.
 
-        This method is equivalent to ``self.creator = None``.
+        This method is equivalent to ``self.creator_node = None``.
 
         """
-        self.creator = None
+        self.creator_node = None
 
     def retain_data(self):
         """Lets the node hold a reference to the underlying data array.
@@ -252,10 +363,6 @@ class VariableNode(object):
             self.dtype = d.dtype
             self.shape = d.shape
 
-    def _set_grad_with_check(self, g, func, var):
-        _check_grad_type(func, var, g)
-        self._grad = g
-
 
 def _create_variable(data, name, grad, requires_grad):
     return Variable(
@@ -273,10 +380,10 @@ class Variable(object):
 
     A variable object holds a data array and a :class:`VariableNode` object of
     a computational graph. If the variable is constructed by the user, the node
-    is _root_ and does not hold any parent. If the variable is constructed by a
-    :class:`Function` object, the node holds a reference to its parent called
-    `creator`. This reference is used in backpropagation to backtrack the
-    graph.
+    is *root* and does not hold any parent. If the variable is constructed by a
+    :class:`FunctionNode` object, the node holds a reference to its parent
+    called :attr:`creator_node`. This reference is used in backpropagation to
+    backtrack the graph.
 
     Users can disable (resp. enable) this chaining behavior by calling
     :func:`~chainer.no_backprop_mode` (resp.
@@ -300,9 +407,7 @@ class Variable(object):
         data: Data array of type either :class:`numpy.ndarray` or
             :class:`cupy.ndarray`. If it is None, the variable is left in an
             uninitialized state.
-        grad: Gradient array.
-        creator: The function who creates this variable. It is ``None`` if the
-            variable is not created by any function.
+        grad_var (Variable): Gradient variable.
 
     """  # NOQA
 
@@ -325,7 +430,8 @@ Actual: {0}'''.format(type(data))
         # abstract its initialized/uninitialized state.
         self._data = [data]
         self._requires_grad = requires_grad
-        self._node = VariableNode(self, name, grad)
+        self._node = VariableNode(self, name)
+        self._grad_var = None if grad is None else Variable(grad)
 
     def __copy__(self):
         return self._copy_to(Variable())
@@ -336,7 +442,7 @@ Actual: {0}'''.format(type(data))
         return target
 
     def __reduce__(self):
-        return _create_variable, (self.data, self.name, self._node._grad,
+        return _create_variable, (self.data, self.name, self.grad,
                                   self._requires_grad)
 
     def __repr__(self):
@@ -416,27 +522,47 @@ Actual: {0}'''.format(type(data))
 
     @property
     def creator(self):
-        """:meth:`Function` object that created this variable.
+        """Function implementation that created this variable.
+
+        When this variable has been created by an old-style function (i.e., it
+        is implemented as a subclass of :class:`Function`), this property
+        returns that :class:`Function` object.
+
+        When this variable has been created by a new-style function (i.e., it
+        is implemented as a subclass of :class:`FunctionNode` class), this
+        property returns that node object.
+
+        """
+        return self._node.creator
+
+    @creator.setter
+    def creator(self, func):
+        self._node.creator = func
+
+    @property
+    def creator_node(self):
+        """:class:`FunctionNode` object that created this variable.
 
         This property has a setter to which ``None`` can be set. Setting
         ``None`` to this property is equivalent to call :meth:`unchain`;
         it purges the variable from the function that created this variable.
 
-        The setter also accepts the original :meth:`Function` object that
+        The setter also accepts the original :class:`FunctionNode` object that
         created this variable. For example, you can once set ``None`` to this
         property and then set the original value again.
 
         .. note::
-           Setting an irrelevant :meth:`Function` object does not emit any
+           Setting an irrelevant :meth:`FunctionNode` object does not emit any
            error immediately, whereas the behavior is undefined. Do not set
-           a :meth:`Function` object that did not create this variable object.
+           a :meth:`FunctionNode` object that did not create this variable
+           object.
 
         """
-        return self._node._creator
+        return self._node._creator_node
 
-    @creator.setter
-    def creator(self, func):
-        self._node.creator = func
+    @creator_node.setter
+    def creator_node(self, func):
+        self._node.creator_node = func
 
     @property
     def data(self):
@@ -449,11 +575,29 @@ Actual: {0}'''.format(type(data))
 
     @property
     def grad(self):
-        return self._node._grad
+        """Gradient array of this variable.
+
+        Not that this property returns the underlying array of the gradient
+        variable instead of the gradient variable itself; to get/set
+        gradient variable, use :attr:`grad_var` instead.
+
+        """
+        gv = self._grad_var
+        return None if gv is None else gv.data
 
     @grad.setter
     def grad(self, g):
-        self._node._set_grad_with_check(g, None, self)
+        self.grad_var = None if g is None else Variable(g)
+
+    @property
+    def grad_var(self):
+        return self._grad_var
+
+    @grad_var.setter
+    def grad_var(self, g):
+        if g is not None:
+            _check_grad_type(None, self, g.data)
+        self._grad_var = g
 
     @property
     def shape(self):
@@ -490,12 +634,12 @@ Actual: {0}'''.format(type(data))
             return
 
         self._data = [cuda.to_cpu(self.data)]
+        if self._grad_var is not None:
+            self._grad_var.to_cpu()
         # ensure that the node tracks the device migration
         node = self._node
         if node._data is not None:
             node.retain_data()
-        if node._grad is not None:
-            node._grad = cuda.to_cpu(node._grad)
 
     def to_gpu(self, device=None):
         """Copies the data and gradient arrays to specified GPU.
@@ -510,19 +654,23 @@ Actual: {0}'''.format(type(data))
                                     if device is None else device)
         else:
             self._data = [cuda.to_gpu(self.data, device)]
+            if self._grad_var is not None:
+                self._grad_var.to_gpu(device)
             # ensure that the node tracks the device migration
             node = self._node
             if node._data is not None:
                 node.retain_data()
-            if node._grad is not None:
-                node._grad = cuda.to_gpu(node._grad, device)
 
     def cleargrad(self):
         """Clears the gradient array."""
-        self._node._grad = None
+        self._grad_var = None
 
     def zerograd(self):
         """Initializes the gradient array by zeros.
+
+        Note that the gradient variable is unchained from the computational
+        graph by this method because this operation breaks the backprop
+        validity.
 
         .. deprecated:: v1.15
            Use :meth:`cleargrad` instead.
@@ -536,12 +684,13 @@ Actual: {0}'''.format(type(data))
             return
 
         with cuda.get_device_from_array(self.data) as dev:
-            node = self._node
-            if node._grad is None:
-                xp = numpy if int(dev) == -1 else cuda.cupy
-                node._grad = xp.zeros_like(self.data)
+            gv = self._grad_var
+            if gv is None:
+                xp = numpy if dev.id == -1 else cuda.cupy
+                self.grad = xp.zeros_like(self.data)
             else:
-                node._grad.fill(0)
+                gv.unchain()
+                gv.data.fill(0)
 
     def copydata(self, var):
         """Copies the data array from given source variable.
@@ -584,43 +733,27 @@ Actual: {0}'''.format(type(data))
         This method adds the gradient of a given variable to the gradient of
         this variable. The accumulation is even done across the host and
         different devices. If this variable has uninitialized data/grad arrays,
-        this method initializes it with the shape of the given varaible and
+        this method initializes it with the shape of the given variable and
         then accumulates the gradient.
 
         Args:
             var (Variable): Source variable.
 
         """
-        src = var._node._grad
+        src = var._grad_var
         if src is None:
             return
 
         if self.data is None:
             self.initialize(var.shape)
-        dst = self._node._grad
+        dst = self._grad_var
 
-        src_dev = cuda.get_device_from_array(src)
+        src_dev = cuda.get_device_from_array(src.data)
         dst_dev = cuda.get_device_from_array(self.data)
 
-        if src_dev.id == dst_dev.id:
-            with dst_dev:
-                if dst is None:
-                    xp = cuda.get_array_module(src)
-                    self._node.grad = xp.copy(src)
-                else:
-                    dst += src
-            return
-
-        if dst_dev.id < 0:
-            src_grad = cuda.to_cpu(src)
-        else:
-            src_grad = cuda.to_gpu(src, device=dst_dev)
-
-        if dst is None:
-            self._node.grad = src_grad
-        else:
-            with dst_dev:
-                dst += src_grad
+        if src_dev.id != dst_dev.id:
+            src = chainer.functions.copy(src, dst_dev.id)
+        self._grad_var = src if dst is None else src + dst
 
     def set_creator(self, gen_func):
         """Notifies the variable that the given function is its creator.
@@ -632,16 +765,26 @@ Actual: {0}'''.format(type(data))
         """
         self._node.set_creator(gen_func)
 
+    def set_creator_node(self, fnode):
+        """Notifies the variable that the given node is its creator.
+
+        Args:
+            fnode (FunctionNode): Function node that has this variable as an
+                output.
+
+        """
+        self._node.set_creator_node(fnode)
+
     def backward(self, retain_grad=False):
         """Runs error backpropagation (a.k.a. backprop) from this variable.
 
-        On backprop, :meth:`Function.backward` is called on each
-        :class:`Function` object appearing in the backward graph starting from
-        this variable. The backward graph is represented by backward references
-        from variable nodes to their creators, and from functions to their
-        input variable nodes. The backprop stops at all root nodes. Some
-        functions set ``None`` as gradients of some inputs, where further
-        backprop does not take place at such inputs.
+        On backprop, :meth:`FunctionNode.backward` is called on each
+        :class:`FunctionNode` object appearing in the backward graph starting
+        from this variable. The backward graph is represented by backward
+        references from variable nodes to their creators, and from function
+        nodes to their input variable nodes. The backprop stops at all root
+        nodes. Some function nodes set ``None`` as gradients of some inputs,
+        where further backprop does not take place at such inputs.
 
         This method uses :data:`grad` as the initial error array. User can
         manually set a gradient array before calling this method. If
@@ -649,6 +792,9 @@ Actual: {0}'''.format(type(data))
         :data:`grad` is ``None``, then this method automatically complements
         1.0 as the initial error. This is useful on starting backprop from
         some scalar loss value.
+
+        Note that this method does not support *differentiable backprop*. Use
+        :func:`grad` to compute the gradient of gradients.
 
         Args:
             retain_grad (bool): If ``True``, the gradient arrays of all
@@ -661,7 +807,7 @@ Actual: {0}'''.format(type(data))
                 and therefore it is recommended to set this flag ``False``.
 
         """
-        if self.creator is None:
+        if self.creator_node is None:
             return
         initial_device = None
         if cuda.available and isinstance(self.data, cuda.cupy.ndarray):
@@ -675,16 +821,16 @@ Actual: {0}'''.format(type(data))
 
         cand_funcs = []
         seen_set = set()
-        seen_vars = set()
-        need_copy = set()
+        grads = {}
 
         # Initialize error by 1, if this is a loss variable
-        if self.data.size == 1 and self.grad is None:
+        if self.data.size == 1 and self._grad_var is None:
             with cuda.get_device_from_array(self.data) as device:
                 if device is cuda.DummyDevice:
                     self.grad = numpy.ones_like(self.data)
                 else:
                     self.grad = cuda.cupy.ones_like(self.data)
+        grads[self._node] = self._grad_var
 
         def add_cand(cand):
             if cand not in seen_set:
@@ -692,80 +838,118 @@ Actual: {0}'''.format(type(data))
                 heapq.heappush(cand_funcs, (-cand.rank, len(seen_set), cand))
                 seen_set.add(cand)
 
-        add_cand(self.creator)
+        add_cand(self.creator_node)
+
+        def get_grad(node):
+            if node is None:
+                return None
+            if node in grads:
+                return grads[node]
+            return node.grad_var
 
         while cand_funcs:
             _, _, func = heapq.heappop(cand_funcs)
+            inputs = func.inputs
             outputs = [y() for y in func.outputs]  # access via weak ref
 
-            in_data = tuple([x.data for x in func.inputs])
-            out_grad = tuple([None if y is None else y.grad for y in outputs])
+            in_data = tuple([x.data for x in inputs])
+            out_grad = tuple([get_grad(y) for y in outputs])
+            out_grad_data = tuple(
+                [None if g is None else g.data for g in out_grad])
             hooks = chainer.get_function_hooks()
             if func._n_local_function_hooks != 0:
                 hooks = collections.OrderedDict(hooks)
                 hooks.update(func.local_function_hooks)
             hooks = hooks.values()  # avoid six for performance
 
-            cuda.get_device_from_array(*(in_data + out_grad)).use()
+            cuda.get_device_from_array(*in_data).use()
             for hook in hooks:
-                hook.backward_preprocess(func, in_data, out_grad)
-            func.output_data = tuple(
-                [None if y is None else y.data for y in outputs])
-            gxs = func.backward(in_data, out_grad)
-            assert len(gxs) == len(in_data)
-            if not getattr(func, '_retain_after_backward', False):
-                func.output_data = None
+                hook.backward_preprocess(func, in_data, out_grad_data)
+
+            # Collect the current input gradients.
+            #
+            # Note (Tokui): When the same variable is passed to multiple input
+            # slots (e.g. an expression like ``f(x, x)``), it makes the
+            # gradient accumulation complicated since the back-propagated
+            # gradients w.r.t. the first and second argument should be
+            # accumulated to the current gradient w.r.t. the same variable.
+            # In this case, the current implementation passes the current
+            # gradient only to the first occurrence of the variable in the
+            # input tuple and passes ``None`` to the rest of the occurrences.
+            # For example, when the input variables are ``(x, x)``, the
+            # input gradient passed to the ``backward_accumulate`` method is
+            # ``(gx, None)`` where ``gx`` is the current gradient of ``x``.
+            # See also the docstring of ``FunctionNode.backward_accumulate``.
+            target_input_indexes = [
+                i for i, x in enumerate(inputs) if x.requires_grad
+            ]
+            target_inputs = [inputs[i] for i in target_input_indexes]
+            in_grad = []
+            for i, index_i in enumerate(target_input_indexes):
+                x = inputs[index_i]
+                if x in target_inputs[:i]:
+                    # Pass ``None`` for duplicated input variables except for
+                    # the first occurrence (see the comment above).
+                    gx = None
+                elif x in grads:
+                    gx = grads[x]
+                elif x.creator_node is None:
+                    # accumulate the gradient only if the node is a leaf
+                    gx = x.grad_var
+                else:
+                    gx = None
+                in_grad.append(gx)
+
+            gxs = func.backward_accumulate(
+                target_input_indexes, out_grad, in_grad)
+
+            assert len(gxs) == len(in_grad)
             for hook in hooks:
-                hook.backward_postprocess(func, in_data, out_grad)
+                hook.backward_postprocess(func, in_data, out_grad_data)
 
             if is_debug:
                 for gx in gxs:
                     if gx is None:
                         continue
-                    cuda.get_device_from_array(gx).use()
-                    if cuda.get_array_module(gx).isnan(gx).any():
+                    gx_data = gx.data
+                    cuda.get_device_from_array(gx_data).use()
+                    if cuda.get_array_module(gx_data).isnan(gx_data).any():
                         msg = 'NaN is detected on backward computation'
                         raise RuntimeError(msg)
 
             if not retain_grad:
                 for y in outputs:
                     if y is not None and y is not self.node:
-                        y.grad = None
-            for x, gx in zip(func.inputs, gxs):
+                        grads[y] = None
+                        y_var = y.get_variable()
+                        if y_var is not None:
+                            y_var._grad_var = None
+
+            for i, gx in enumerate(gxs):
                 if gx is None:
                     continue
+
+                x = target_inputs[i]
                 if not x.requires_grad:
                     continue
 
-                _check_grad_type(func, x, gx)
+                _check_grad_type(func, x, gx.data)
 
-                # Accumulate the gradient to x. It is a bit tricky to handle
-                # branches and parameter gradient accumulation correctly.
-                id_x = id(x)
-                if x.creator is None:  # leaf
-                    if x._grad is None:
-                        x.grad = gx
-                        need_copy.add(id_x)
-                    else:
-                        cuda.get_device_from_array(gx).use()
-                        if id_x in need_copy:
-                            x.grad = utils.force_array(x._grad + gx)  # copy
-                            need_copy.remove(id_x)
-                        else:
-                            x._grad += gx
-                else:  # not a leaf
-                    add_cand(x.creator)
-                    if id_x not in seen_vars:  # 1st visit
-                        x.grad = gx
-                        seen_vars.add(id_x)
-                        need_copy.add(id_x)
-                    else:
-                        cuda.get_device_from_array(gx).use()
-                        if id_x in need_copy:  # 2nd visit
-                            x.grad = utils.force_array(gx + x._grad)  # copied
-                            need_copy.remove(id_x)
-                        else:  # 3rd or later visit
-                            x._grad += gx
+                if x in target_inputs[:i]:
+                    # Accumulate the duplicated gradients here. See the comment
+                    # above the code that builds ``in_grad``.
+                    cur_gx = grads[x]
+                    grads[x] = gx if cur_gx is None else gx + cur_gx
+                else:
+                    grads[x] = gx
+
+                x_var = x.get_variable()
+                if x_var is not None:
+                    x_var._grad_var = grads[x]
+
+                if x.creator_node is not None:
+                    add_cand(x.creator_node)
+
             del gxs  # to reduce memory usage
             if initial_device is not None:
                 initial_device.use()
@@ -802,10 +986,10 @@ Actual: {0}'''.format(type(data))
         variable node. Unlike :meth:`unchain_backward`, it does not backtrack
         the graph.
 
-        This method is equivalent to ``self.creator = None``.
+        This method is equivalent to ``self.creator_node = None``.
 
         """
-        self.creator = None
+        self.creator_node = None
 
     def unchain_backward(self):
         """Deletes references between variable nodes and functions backward.
@@ -826,12 +1010,12 @@ Actual: {0}'''.format(type(data))
                 cand_funcs.append(cand)
                 seen_set.add(cand)
 
-        add_cand(self.creator)
+        add_cand(self.creator_node)
 
         while cand_funcs:
             func = cand_funcs.pop()
             for var in func.inputs:
-                add_cand(var.creator)
+                add_cand(var.creator_node)
             func.unchain()
 
     def retain_data(self):
@@ -993,7 +1177,7 @@ class Parameter(Variable):
                 ginit, shape, xp)
 
         self._data[0] = data
-        self._node._grad = grad
+        self.grad = grad
 
     def update(self):
         """Updates the data array using the gradient and the update rule.

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -144,6 +144,10 @@ class VariableNode(object):
 
     """
 
+    _creator_node = None
+    _data = None
+    _rank = 0
+
     def __init__(self, variable, name, **kwargs):
         argument.check_unexpected_kwargs(
             kwargs,
@@ -151,9 +155,6 @@ class VariableNode(object):
                  'pass the gradient to Variable instead'
         )
         self._variable = weakref.ref(variable)
-        self._creator_node = None
-        self._data = None
-        self._rank = 0
         self.name = name
         self._requires_grad = variable.requires_grad
 

--- a/tests/chainer_tests/test_computational_graph.py
+++ b/tests/chainer_tests/test_computational_graph.py
@@ -143,7 +143,7 @@ class TestGraphBuilder5(unittest.TestCase):
     def setUp(self):
         self.x = variable.Variable(np.zeros((1, 2)).astype(np.float32))
         self.y = 2 * self.x
-        self.f = self.y.creator
+        self.f = self.y.creator_node
         self.g = c.build_computational_graph((self.y,))
 
     def test_edges(self):
@@ -163,7 +163,7 @@ class TestGraphBuilder6(unittest.TestCase):
         self.x1 = variable.Variable(np.zeros((1, 2)).astype(np.float32))
         self.x2 = variable.Variable(np.zeros((1, 2)).astype(np.float32))
         self.y = self.x1 + self.x2
-        self.f = self.y.creator
+        self.f = self.y.creator_node
         self.g = c.build_computational_graph((self.y,))
 
     def test_edges(self):
@@ -197,7 +197,7 @@ class TestGraphBuilderStylization(unittest.TestCase):
         self.x1 = variable.Variable(np.zeros((1, 2)).astype(np.float32))
         self.x2 = variable.Variable(np.zeros((1, 2)).astype(np.float32))
         self.y = self.x1 + self.x2
-        self.f = self.y.creator
+        self.f = self.y.creator_node
         self.variable_style = {'label': 'variable_0', 'shape': 'octagon',
                                'style': 'filled', 'fillcolor': '#E0E0E0'}
         self.function_style = {'label': 'function_0', 'shape': 'record',
@@ -260,7 +260,7 @@ class TestGraphBuilderRemoveVariable(unittest.TestCase):
         self.x1 = variable.Variable(np.zeros((1, 2)).astype('f'))
         self.x2 = variable.Variable(np.zeros((1, 2)).astype('f'))
         self.y = self.x1 + self.x2
-        self.f = self.y.creator
+        self.f = self.y.creator_node
         self.g = c.build_computational_graph((self.y,), remove_variable=True)
 
     def test_remove_variable(self):

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -290,7 +290,8 @@ class TestLink(unittest.TestCase):
     def test_addgrads(self):
         l = chainer.Link()
         with l.init_scope():
-            l.x = chainer.Parameter(shape=(2, 3))
+            l.x = chainer.Parameter(shape=(2, 3),
+                                    initializer=initializers.NaN('d'))
             l.y = chainer.Parameter(shape=2)
             l.u = chainer.Parameter(shape=(2, 3))
             l.v = chainer.Parameter()

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -14,18 +14,19 @@ from chainer import cuda
 from chainer import initializers
 from chainer import testing
 from chainer.testing import attr
+from chainer import variable
 
 
 class Constant(chainer.Function):
 
     def __init__(self, outputs):
-        self.outputs = outputs
+        self.__outputs = outputs
 
     def forward_cpu(self, inputs):
-        return self.outputs
+        return self.__outputs
 
     def forward_gpu(self, inputs):
-        return tuple(map(cuda.to_gpu, self.outputs))
+        return tuple(map(cuda.to_gpu, self.__outputs))
 
     def backward_cpu(self, inputs, grad_outputs):
         return tuple(map(np.zeros_like, inputs))
@@ -36,6 +37,13 @@ class Constant(chainer.Function):
 
 def constant(xs, value):
     return Constant(value)(*xs)
+
+
+class TestVariableNode(unittest.TestCase):
+
+    def test_grad(self):
+        with self.assertRaises(ValueError):
+            variable.VariableNode(chainer.Variable(), '', grad=None)
 
 
 @testing.parameterize(
@@ -68,6 +76,15 @@ class TestVariable(unittest.TestCase):
     @attr.gpu
     def test_attributes_gpu(self):
         self.check_attributes(True)
+
+    def check_grad(self, x, xp):
+        g = xp.array(x)
+        v = chainer.Variable(x)
+        gv = chainer.Variable(g)
+        v.grad_var = gv
+
+        self.assertIs(v.grad, g)
+        self.assertIs(v.grad_var, gv)
 
     def check_len(self, gpu):
         x = self.x
@@ -120,23 +137,26 @@ class TestVariable(unittest.TestCase):
     def test_label_gpu(self):
         self.check_label(self.label, True)
 
+    def get_xp_and_variable(self, gpu):
+        if gpu:
+            return cuda.cupy, chainer.Variable(cuda.to_gpu(self.x))
+        return np, chainer.Variable(self.x)
+
     def check_backward(self, inputs, intermediates, outputs, retain_grad):
         for o in outputs:
             o.backward(retain_grad)
 
-        self.assertTrue(all([x.grad is not None for x in inputs]))
+        self.assertTrue(all([x.grad_var is not None for x in inputs]))
         if retain_grad:
-            self.assertTrue(all([x.grad is not None for x in intermediates]))
+            self.assertTrue(
+                all([x.grad_var is not None for x in intermediates]))
         else:
-            self.assertTrue(all([x.grad is None for x in intermediates]))
-        self.assertTrue(any([x.grad is not None for x in outputs]))
+            self.assertTrue(all([x.grad_var is None for x in intermediates]))
+        self.assertTrue(any([x.grad_var is not None for x in outputs]))
 
     # length is number of edges. So, # of Variables created is length+1
     def create_linear_chain(self, length, gpu):
-        if gpu:
-            x = chainer.Variable(cuda.to_gpu(self.x))
-        else:
-            x = chainer.Variable(self.x)
+        _, x = self.get_xp_and_variable(gpu)
         ret = [x]
         for i in six.moves.range(length):
             ret.append(constant((ret[i], ), (self.a, )))
@@ -156,16 +176,11 @@ class TestVariable(unittest.TestCase):
         self.check_backward((ret[0], ), (ret[1], ), (ret[2], ), False)
 
     def check_backward_accumulate(self, gpu):
-        if gpu:
-            x = chainer.Variable(cuda.to_gpu(self.x))
-            xp = cuda.cupy
-        else:
-            x = chainer.Variable(self.x)
-            xp = np
+        xp, x = self.get_xp_and_variable(gpu)
         y = constant((x, x, x), (self.a, ))
         y.grad = xp.zeros_like(y.data)
         y.backward()
-        self.assertEqual(x.grad.shape, self.x_shape)
+        self.assertEqual(x.grad_var.shape, self.x_shape)
 
     def test_backward_accumulate_cpu(self):
         self.check_backward_accumulate(False)
@@ -183,6 +198,28 @@ class TestVariable(unittest.TestCase):
         ret = self.create_linear_chain(2, True)
         self.check_backward((ret[0], ), (ret[1], ), (ret[2], ), True)
 
+    def check_double_backprop(self, gpu):
+        xp, x = self.get_xp_and_variable(gpu)
+        x.grad_var = None
+
+        y = x * x * x
+        y.grad = xp.ones_like(y.data)
+        y.backward()
+        gx = x.grad_var
+        x.grad_var = None  # clear grad
+        gx.grad = xp.ones_like(x.data)
+        gx.backward()
+
+        expect = 6 * x
+        testing.assert_allclose(x.grad_var.data, expect.data)
+
+    def test_double_backprop_cpu(self):
+        self.check_double_backprop(False)
+
+    @attr.gpu
+    def test_double_backprop_gpu(self):
+        self.check_double_backprop(True)
+
     def test_unchain(self):
         ret = self.create_linear_chain(3, False)
         old_rank = ret[1].rank
@@ -191,26 +228,36 @@ class TestVariable(unittest.TestCase):
         self.assertEqual(ret[1].rank, old_rank)
         self.check_backward((ret[1],), (ret[2],), (ret[3],), False)
 
-    def test_set_none_to_creator(self):
+    def check_set_none_to_creator(self, use_creator_node):
         ret = self.create_linear_chain(3, False)
         old_rank = ret[1].rank
-        ret[1].creator = None
+        if use_creator_node:
+            ret[1].creator_node = None
+        else:
+            ret[1].creator = None
         self.assertIsNone(ret[1].creator)
+        self.assertIsNone(ret[1].creator_node)
         self.assertEqual(ret[1].rank, old_rank)
         self.check_backward((ret[1],), (ret[2],), (ret[3],), False)
+
+    def test_set_none_to_creator(self):
+        self.check_set_none_to_creator(False)
+
+    def test_set_none_to_creator_node(self):
+        self.check_set_none_to_creator(True)
 
     def test_set_none_and_original_to_creator(self):
         ret = self.create_linear_chain(2, False)
         old_rank = ret[1].rank
-        creator = ret[1].creator
+        creator_node = ret[1].creator_node
         ret[1].creator = None
         self.assertIsNone(ret[1].creator)
         self.assertEqual(ret[1].rank, old_rank)
 
         ret[1].node._rank = -1
-        ret[1].creator = creator
-        self.assertIs(ret[1].creator, creator)
-        self.assertEqual(ret[1].rank, creator.rank + 1)
+        ret[1].creator_node = creator_node
+        self.assertIs(ret[1].creator_node, creator_node)
+        self.assertEqual(ret[1].rank, creator_node.rank + 1)
         self.check_backward((ret[0],), (ret[1],), (ret[2],), False)
 
     def test_set_fresh_creator(self):
@@ -218,6 +265,15 @@ class TestVariable(unittest.TestCase):
         f = chainer.Function()
         v.creator = f
         self.assertIs(v.creator, f)
+        self.assertIs(v.creator_node, f.node)
+        self.assertEqual(v.rank, 1)
+
+    def test_set_fresh_creator_node(self):
+        v = chainer.Variable()
+        f = chainer.FunctionNode()
+        v.creator_node = f
+        self.assertIs(v.creator, f)
+        self.assertIs(v.creator_node, f)
         self.assertEqual(v.rank, 1)
 
     def test_unchain_backward_cpu(self):
@@ -357,10 +413,13 @@ class TestVariable(unittest.TestCase):
         xp = cuda.get_array_module(a_data)
         a = chainer.Variable(a_data)
         if fill:
-            a.grad = xp.full_like(a_data, np.nan)
+            a.grad_var = chainer.Variable(xp.full_like(a_data, np.nan))
+            a.grad_var.creator_node = chainer.FunctionNode()
 
         a.zerograd()
         self.assertIsNot(a.grad, None)
+        if fill:
+            self.assertIsNone(a.grad_var.creator_node)
         g_expect = xp.zeros_like(a.data)
         xp.testing.assert_array_equal(a.grad, g_expect)
 
@@ -919,13 +978,14 @@ class TestDebugPrint(unittest.TestCase):
 
 class TestVariableSetCreator(unittest.TestCase):
 
-    class MockFunction(object):
+    class MockFunction(chainer.Function):
         pass
 
     def setUp(self):
         self.x = np.random.uniform(-1, 1, (2, 5)).astype(np.float32)
         self.f = self.MockFunction()
-        self.f.rank = 10
+        self.node = self.f.node
+        self.node.rank = 10
 
     def check_set_creator(self, x):
         x = chainer.Variable(x)
@@ -939,6 +999,19 @@ class TestVariableSetCreator(unittest.TestCase):
     @attr.gpu
     def test_set_creator_gpu(self):
         self.check_set_creator(cuda.to_gpu(self.x))
+
+    def check_set_creator_node(self, x):
+        x = chainer.Variable(x)
+        x.set_creator_node(self.node)
+        self.assertEqual(x.creator_node, self.node)
+        self.assertEqual(x.rank, 11)
+
+    def test_set_creator_node_cpu(self):
+        self.check_set_creator_node(self.x)
+
+    @attr.gpu
+    def test_set_creator_node_gpu(self):
+        self.check_set_creator_node(cuda.to_gpu(self.x))
 
 
 class TestVariableBackwardError(unittest.TestCase):


### PR DESCRIPTION
This PR is the first step of #2871. It implements `FunctionNode` that supports differentiable and economical backprop. The following points are changed.

- `FunctionNode` is added.
- The computational graph in Chainer now consists of `VariableNode` and `FunctionNode`.
- Each variable holds its gradient *variable* instead of gradient *array*. It is stored at `grad_var` attribute as @muupan suggested (the name is slightly simplified). `Variable.grad` is now a proxy to extract the data array of `grad_var`.
  - Note that the owner of the gradient is moved from `VariableNode` to `Variable` so that we can avoid circular references in the computational graph.
- It also adds `FunctionAdapter`, which is an adapter class to convert an old-style function to a new-style one. `Function` is automatically wrapped by `FunctionAdapter` at the forward computation.
- `Variable.backward` is rewritten to support the new-style function interface.
- This PR also supports the new-style function interface for a tiny set tof functions (namely, `+`, `*`, and `F.identity`) for the debugging purpose. It also includes a small test of differentiable backprop using them (now we can differentiate `x * x * x` two times to get `6 * x`). See [here](https://github.com/beam2d/chainer/blob/71e758aa7c874e2ca1aaf59164b6fc3c87274904/tests/chainer_tests/test_variable.py#L201) for the test code.
