### PR TITLE
link deepcopy test

### DIFF
--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -144,12 +144,12 @@ class TestLink(unittest.TestCase):
         self.assertTrue(hasattr(link, 'p'))
         self.assertIsNot(link.x, self.link.x)
         self.assertIsNot(link.x.data, self.link.x.data)
-        numpy.testing.assert_array_equal(cuda.cupy.asnumpy(link.x.data),
-                                         cuda.cupy.asnumpy(self.link.x.data))
+        numpy.testing.assert_array_equal(cuda.to_cpu(link.x.data),
+                                         cuda.to_cpu(self.link.x.data))
         self.assertIsNot(link.y, self.link.y)
         self.assertIsNot(link.y.data, self.link.y.data)
-        numpy.testing.assert_array_equal(cuda.cupy.asnumpy(link.y.data),
-                                         cuda.cupy.asnumpy(self.link.y.data))
+        numpy.testing.assert_array_equal(cuda.to_cpu(link.y.data),
+                                         cuda.to_cpu(self.link.y.data))
         self.assertIsNone(link.u.data)
         self.assertIsNot(link.p, self.link.p)
         self.assertEqual(link.name, self.link.name)


### PR DESCRIPTION
Adds test cases for link deepcopy (reported in #2972).
This depends on CuPy `ndarray` deepcopy fix (https://github.com/cupy/cupy/pull/254), so please merge it first.