### PR TITLE
Support all float types in upsampling_2d

### DIFF
--- a/chainer/functions/pooling/upsampling_2d.py
+++ b/chainer/functions/pooling/upsampling_2d.py
@@ -49,7 +49,7 @@ class Upsampling2D(pooling_2d.Pooling2D):
             self.outw = conv.get_deconv_outsize(
                 w, self.kw, self.sx, self.pw, cover_all=self.cover_all)
 
-        up_y = numpy.zeros((n, c, self.outh, self.outw), dtype=numpy.float32)
+        up_y = numpy.zeros((n, c, self.outh, self.outw), dtype=self._in_dtype)
         up_y = conv.im2col_cpu(
             up_y, self.kh, self.kw, self.sy, self.sx, self.ph, self.pw,
             cover_all=self.cover_all)
@@ -76,7 +76,7 @@ class Upsampling2D(pooling_2d.Pooling2D):
         if self.outw is None:
             self.outw = conv.get_deconv_outsize(
                 w, self.kw, self.sx, self.pw, cover_all=self.cover_all)
-        up_y = xp.zeros((n, c, self.outh, self.outw), dtype=numpy.float32)
+        up_y = xp.zeros((n, c, self.outh, self.outw), dtype=self._in_dtype)
         up_y = conv.im2col_gpu(
             up_y, self.kh, self.kw, self.sy, self.sx, self.ph, self.pw,
             cover_all=self.cover_all)
@@ -84,8 +84,8 @@ class Upsampling2D(pooling_2d.Pooling2D):
         n, c, oy, ox, ky, kx = up_y.shape
         indexes = xp.asarray(self.indexes, dtype=numpy.int32)
         xp.ElementwiseKernel(
-            'int32 index, float32 x, int32 n, int32 c, int32 oy, int32 ox,'
-            'int32 ky, int32 kx', 'raw float32 up_y',
+            'int32 index, T x, int32 n, int32 c, int32 oy, int32 ox,'
+            'int32 ky, int32 kx', 'raw T up_y',
             '''
             int yn = i / c / oy / ox;
             int yc = (i / oy / ox) % c;
@@ -132,9 +132,9 @@ class Upsampling2D(pooling_2d.Pooling2D):
         indexes = xp.asarray(self.indexes, dtype=numpy.int32)
         gx = xp.empty((n, c, oy, ox), dtype=self._in_dtype)
         xp.ElementwiseKernel(
-            'int32 indexes, raw float32 gcol, int32 n, int32 c, int32 oy,'
+            'int32 indexes, raw T gcol, int32 n, int32 c, int32 oy,'
             'int32 ox, int32 ky, int32 kx',
-            'raw float32 gx',
+            'raw T gx',
             '''
             int ind_n = i / c / oy / ox;
             int ind_c = (i / oy / ox) % c;

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
@@ -61,7 +61,7 @@ class TestUpsampling2D(unittest.TestCase):
             self.p.indexes, ksize=(self.p.kh, self.p.kw),
             stride=(self.p.sy, self.p.sx), pad=(self.p.ph, self.p.pw),
             outsize=self.in_shape[2:], cover_all=self.p.cover_all)
-        gradient_check.check_backward(func, x_data, y_grad)
+        gradient_check.check_backward(func, x_data, y_grad, dtype='d')
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
@@ -11,19 +11,19 @@ import numpy
 import unittest
 
 
-@testing.parameterize(
-    {'in_shape': (4, 3, 6, 8)},
-    {'in_shape': (4, 3, 5, 7)},
-)
+@testing.parameterize(*testing.product({
+    'in_shape': [(4, 3, 6, 8), (4, 3, 5, 7)],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestUpsampling2D(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.in_shape).astype('f')
+        self.x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
         self.p = F.MaxPooling2D(2, 2)
         with chainer.using_config('use_cudnn', 'never'):
             self.pooled_y = self.p(self.x)
         self.gy = numpy.random.uniform(
-            -1, 1, self.in_shape).astype(numpy.float32)
+            -1, 1, self.in_shape).astype(self.dtype)
 
     def check_forward(self, y):
         y = F.upsampling_2d(


### PR DESCRIPTION
Type check of upsampling_2d only checks if an input variable is float, but actually it does not support float types except float32. I fixed it to support all float types.