### PR TITLE
Cupy memory profiler with cupy memory hook

### DIFF
--- a/chainer/function_hook.py
+++ b/chainer/function_hook.py
@@ -99,10 +99,30 @@ class FunctionHook(object):
             raise KeyError('hook %s already exists' % self.name)
 
         function_hooks[self.name] = self
+        self.added()
         return self
 
     def __exit__(self, *_):
+        chainer.get_function_hooks()[self.name].deleted()
         del chainer.get_function_hooks()[self.name]
+
+    def added(self, function=None):
+        """Callback function invoked when a function hook is added
+
+        Args:
+            function(~chainer.Function): Function object to which
+                the function hook is added.
+        """
+        pass
+
+    def deleted(self, function=None):
+        """Callback function invoked when a function hook is deleted
+
+        Args:
+            function(~chainer.Function): Function object to which
+                the function hook is deleted.
+        """
+        pass
 
     # forward
     def forward_preprocess(self, function, in_data):

--- a/chainer/function_hooks/__init__.py
+++ b/chainer/function_hooks/__init__.py
@@ -1,9 +1,11 @@
 from chainer.function_hooks import cuda_profile  # NOQA
+from chainer.function_hooks import cupy_memory_profile  # NOQA
 from chainer.function_hooks import debug_print  # NOQA
 from chainer.function_hooks import timer  # NOQA
 
 
 # import class and function
 from chainer.function_hooks.cuda_profile import CUDAProfileHook  # NOQA
+from chainer.function_hooks.cupy_memory_profile import CupyMemoryProfileHook  # NOQA
 from chainer.function_hooks.debug_print import PrintHook  # NOQA
 from chainer.function_hooks.timer import TimerHook  # NOQA

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -1,0 +1,111 @@
+import sys
+
+import six
+
+from chainer.cuda import memory_pool
+from chainer import function
+
+
+class CupyMemoryProfileHook(function.FunctionHook):
+    """Function hook for measuring memory usage of functions in cupy memory pool.
+
+    Example:
+        Code example::
+
+            from chainer.function_hooks import CupyMemoryProfileHook
+            hook = CupyMemoryProfileHook()
+            with hook:
+                trainer.run()
+            hook.print_report()
+
+        Output example::
+
+            FunctionName        UsedBytes AcquiredBytes Occurrence
+            LinearFunction      5.16GB    179.98MB      3900
+            ReLU                992.77MB  458.97MB      2600
+            SoftmaxCrossEntropy 5.76MB    5.08MB        1300
+            Accuracy            350.00KB  351.00KB      700
+
+        where *FunctionName* is the name of function that calls the hook, and
+        *UsedBytes* is the memory bytes the function used from cupy memory
+        pool, and *AcquiredBytes* is the actual memory bytes the cupy memory
+        pool acquired from GPU device on the function call, and *Occurrence*
+        is the number of calls.
+    Attributes:
+        call_history: List of measurement results. It consists of the function
+            that calls this hook,  the memory bytes the function used from cupy
+            memory pool, and the memory bytes the cupy memory pool acquired
+            from GPU device on the function call.
+    """
+
+    name = 'CupyMemoryProfileHook'
+
+    def __init__(self):
+        self.call_history = []
+
+    def _preprocess(self):
+        self.start_used_bytes = memory_pool.used_bytes()
+        self.start_total_bytes = memory_pool.total_bytes()
+
+    def forward_preprocess(self, function, in_data):
+        self._preprocess()
+
+    def backward_preprocess(self, function, in_data, out_grad):
+        self._preprocess()
+
+    def _postprocess(self, function):
+        used_bytes = memory_pool.used_bytes() - self.start_used_bytes
+        acquired_bytes = memory_pool.total_bytes() - self.start_total_bytes
+        self.call_history.append((function, used_bytes, acquired_bytes))
+
+    def forward_postprocess(self, function, in_data):
+        self._postprocess(function)
+
+    def backward_postprocess(self, function, in_data, out_grad):
+        self._postprocess(function)
+
+    def summary(self):
+        """Returns a summary of memory profiling in functions.
+
+        Returns:
+            A summarized dictionary whose keys are function names and
+            values are dictionaries of ``used_bytes``, ``acquired_bytes``,
+            and ``occurrrence``.
+        """
+        summary = {}
+        for func, used_bytes, acquired_bytes in self.call_history:
+            function_name = func.__class__.__name__
+            if function_name not in summary:
+                summary[function_name] = {'used_bytes': 0,
+                                          'acquired_bytes': 0, 'occurrence': 0}
+            record = summary[function_name]
+            record['used_bytes'] += used_bytes
+            record['acquired_bytes'] += acquired_bytes
+            record['occurrence'] += 1
+        return summary
+
+    def _humanized_size(self, size):
+        """Returns a human redable bytes string."""
+        for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E']:
+            if size < 1024.0:
+                return '%3.2f%sB' % (size, unit)
+            size /= 1024.0
+        return '%.2f%sB' % (size, 'Z')
+
+    def print_report(self, end='\n', file=sys.stdout):
+        """Prints a summary report of memory profiling in functions."""
+        entries = [['FunctionName', 'UsedBytes', 'AcquiredBytes', 'Occurrence']]
+        for function_name, record in self.summary().items():
+            used_bytes = self._humanized_size(record['used_bytes'])
+            acquired_bytes = self._humanized_size(record['acquired_bytes'])
+            occurrence = str(record['occurrence'])
+            entries.append([function_name, used_bytes, acquired_bytes, occurrence])
+        entry_widths = []
+        entry_widths.append(max(len(f) for f, _, _, _ in entries))
+        entry_widths.append(max(len(u) for _, u, _, _ in entries))
+        entry_widths.append(max(len(a) for _, _, a, _ in entries))
+        entry_widths.append(max(len(o) for _, _, _, o in entries))
+        template = '  '.join('{:>%d}' % w for w in entry_widths)
+        for function_name, used_bytes, acquired_bytes, occurrence in entries:
+            line = template.format(function_name, used_bytes, acquired_bytes, occurrence)
+            six.print_(line, end=end, file=file)

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -112,7 +112,7 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
         # TODO(sonots): PROBLEM: takes count of nested functions duplicately
         summary = {}
         for func, used_bytes, acquired_bytes, depth in self.call_history:
-            function_name = func.__class__.__name__
+            function_name = func._impl_name
             if function_name not in summary:
                 summary[function_name] = {'used_bytes': 0,
                                           'acquired_bytes': 0, 'occurrence': 0}

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -1,3 +1,4 @@
+import collections
 import sys
 
 from chainer import cuda
@@ -110,7 +111,7 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
             ``used_bytes``, ``acquired_bytes``, and ``occurrrence``.
         """
         # TODO(sonots): PROBLEM: takes count of nested functions duplicately
-        summary = {}
+        summary = collections.OrderedDict()
         for func, used_bytes, acquired_bytes, depth in self.call_history:
             function_name = func._impl_name
             if function_name not in summary:

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -158,8 +158,8 @@ class CupyMemoryCumulativeHook(memory_hook.MemoryHook):
         self.used_bytes = 0
         self.acquired_bytes = 0
 
-    def alloc_preprocess(self, device_id, rounded_size):
-        self.acquired_bytes += rounded_size
+    def alloc_preprocess(self, **kwargs):
+        self.acquired_bytes += kwargs['mem_size']
 
-    def malloc_preprocess(self, device_id, size, rounded_size):
-        self.used_bytes += rounded_size
+    def malloc_preprocess(self, **kwargs):
+        self.used_bytes += kwargs['mem_size']

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -579,6 +579,7 @@ class FunctionNode(object):
         if name in hooks:
             raise KeyError('Hook %s already exists' % name)
         hooks[name] = hook
+        hook.added(function=self)
 
     def delete_hook(self, name):
         """Unregisters the function hook.
@@ -587,4 +588,8 @@ class FunctionNode(object):
             name (str): The name of the function hook to be unregistered.
 
         """
-        del self.local_function_hooks[name]
+        if name in self.local_function_hooks:
+            self.local_function_hooks[name].deleted(function=self)
+            del self.local_function_hooks[name]
+        else:
+            raise KeyError('Hook %s does not exist' % name)

--- a/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
+++ b/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
@@ -1,0 +1,125 @@
+import unittest
+
+import numpy
+import re
+import six
+
+import chainer
+from chainer import cuda
+from chainer import function_hooks
+from chainer import functions
+from chainer.functions.connection import linear
+from chainer import links
+from chainer import testing
+from chainer.testing import attr
+
+
+def check_history(self, t, function_type, used_bytes_type, acquired_bytes_type):
+    self.assertIsInstance(t[0], function_type)
+    self.assertIsInstance(t[1], used_bytes_type)
+    self.assertIsInstance(t[2], acquired_bytes_type)
+
+
+class TestCupyMemoryProfileHookHookToLink(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.CupyMemoryProfileHook()
+        self.l = links.Linear(5, 5)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    def test_name(self):
+        self.assertEqual(self.h.name, 'CupyMemoryProfileHook')
+
+    def check_forward(self, x):
+        with self.h:
+            self.l(chainer.Variable(x))
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      linear.LinearFunction, int, int)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.l.to_gpu()
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x, gy):
+        x = chainer.Variable(x)
+        y = self.l(x)
+        y.grad = gy
+        with self.h:
+            y.backward()
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      linear.LinearFunction, int, int)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.l.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+
+class TestCupyMemoryProfileHookHookToFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.CupyMemoryProfileHook()
+        self.f = functions.Exp()
+        self.f.add_hook(self.h)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    def check_forward(self, x):
+        self.f(chainer.Variable(x))
+        self.assertEqual(1, len(self.h.call_history))
+        check_history(self, self.h.call_history[0],
+                      functions.Exp, int, int)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x, gy):
+        x = chainer.Variable(x)
+        y = self.f(x)
+        y.grad = gy
+        y.backward()
+        self.assertEqual(2, len(self.h.call_history))
+        check_history(self, self.h.call_history[1],
+                      functions.Exp, int, int)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+
+class TestCupyMemoryProfileSummary(unittest.TestCase):
+
+    def setUp(self):
+        self.h = function_hooks.CupyMemoryProfileHook()
+        self.f = functions.Exp()
+        self.f.add_hook(self.h)
+        self.x = numpy.random.uniform(-0.1, 0.1, (3, 5)).astype(numpy.float32)
+
+    @attr.gpu
+    def test_summary(self):
+        x = cuda.to_gpu(self.x)
+        self.f(chainer.Variable(x))
+        self.f(chainer.Variable(x))
+        self.assertEqual(2, len(self.h.call_history))
+        self.assertEqual(1, len(self.h.summary()))
+
+    @attr.gpu
+    def test_print_report(self):
+        x = cuda.to_gpu(self.x)
+        self.f(chainer.Variable(x))
+        self.f(chainer.Variable(x))
+        io = six.StringIO()
+        self.h.print_report(file=io)
+        expect = '''\AFunctionName  UsedBytes  AcquiredBytes  Occurrence
+ +Exp +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+$
+'''
+        actual = io.getvalue()
+        self.assertTrue(re.match(expect, actual), actual)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fix https://github.com/chainer/chainer/issues/918

This requires cupy memory hook added at https://github.com/cupy/cupy/pull/264

Code example::

    from chainer.function_hooks import CupyMemoryProfileHook
    hook = CupyMemoryProfileHook()
    with hook:
        trainer.run()
    hook.print_report()

Output example::

           FunctionName  UsedBytes  AcquiredBytes  Occurrence
         LinearFunction     5.16GB       179.98MB        3900
                   ReLU   991.82MB       458.97MB        2600
    SoftmaxCrossEntropy     7.71MB         5.08MB        1300
               Accuracy   617.97KB       351.00KB         700

where *FunctionName* is the name of function that calls the hook, and
*UsedBytes* is the memory bytes the function used from cupy memory
pool, and *AcquiredBytes* is the actual memory bytes the cupy memory
pool acquired from GPU device on the function call, and *Occurrence*
is the number of calls.

https://github.com/chainer/chainer/pull/2925 was simpler than this version, but not accurate. Therefore, I prefer this version.