### PR TITLE
Select the best-resolution timer function

### DIFF
--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -14,6 +14,16 @@ from chainer.training import extension as extension_module
 from chainer.training import trigger as trigger_module
 
 
+# Select the best-resolution timer function
+try:
+    _get_time = time.perf_counter
+except AttributeError:
+    if os.name == 'nt':
+        _get_time = time.clock
+    else:
+        _get_time = time.time
+
+
 class _ExtensionEntry(object):
 
     def __init__(self, extension, priority, trigger, invoke_before_training):
@@ -161,7 +171,7 @@ class Trainer(object):
             return self._final_elapsed_time
         if self._start_at is None:
             raise RuntimeError('training has not been started yet')
-        return time.time() - self._start_at + self._snapshot_elapsed_time
+        return _get_time() - self._start_at + self._snapshot_elapsed_time
 
     def extend(self, extension, name=None, trigger=None, priority=None,
                invoke_before_training=None):
@@ -280,7 +290,7 @@ class Trainer(object):
         extensions = [(name, self._extensions[name])
                       for name in extension_order]
 
-        self._start_at = time.time()
+        self._start_at = _get_time()
 
         # invoke initializer of each extension
         for _, entry in extensions:


### PR DESCRIPTION
AppVeyor is failing due to insufficient timer resolution (probly).

This PR selects the best-resolution timer in the current environment.

([Python 3 time module documentation](https://docs.python.org/3/library/time.html))

**For Python >=3.3**
* `time.perf_counter` has the highest resolution.

**For Python <3.3**
 * `time.clock`: On Windows, it uses `QueryPerformanceCounter` Win32 API function, which has a good resolution. On Unix, it returns the "processor time", whose definition depends on C `clock` function.
 * `time.time`: Returns the time since the epoch. Not monotonic.