### PR TITLE
Add mock to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ set CHAINER_PYTHON_350_FORCE environment variable to 1."""
 setup_requires = []
 install_requires = [
     'filelock',
+    'mock',
     'nose',
     'numpy>=1.9.0',
     'protobuf>=2.6.0',


### PR DESCRIPTION
This PR adds the mock module to `install_requires` in `setup.py`. This PR fixes #2973. 