### PR TITLE
Add links to slack archive to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 | [**Install Guide**](https://docs.chainer.org/en/stable/install.html)
 | [**Tutorial**](https://docs.chainer.org/en/stable/tutorial/)
 | **Examples** ([Official](https://github.com/chainer/chainer/blob/master/examples), [External](https://github.com/chainer/chainer/wiki/External-examples))
-| **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
-| **Slack (Invitation)** ([en](https://bit.ly/chainer-slack), [ja](https://bit.ly/chainer-jp-slack))
-| **Slack (Archive)** ([en](https://chainer.slackarchive.io), [ja](https://chainer-jp.slackarchive.io))
+
+**Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
+| **Slack Invitation** ([en](https://bit.ly/chainer-slack), [ja](https://bit.ly/chainer-jp-slack))
+| **Slack Archive** ([en](https://chainer.slackarchive.io), [ja](https://chainer-jp.slackarchive.io))
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
 | **Slack (en)** [Invitation](https://bit.ly/chainer-slack), [Archive](https://chainer.slackarchive.io)
-| **Slack (ja)** [Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io))
+| **Slack (ja)** [Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io)
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 | [**Tutorial**](https://docs.chainer.org/en/stable/tutorial/)
 | **Examples** ([Official](https://github.com/chainer/chainer/blob/master/examples), [External](https://github.com/chainer/chainer/wiki/External-examples))
 | **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
-| **Slack** ([en](https://bit.ly/chainer-slack), [ja](https://bit.ly/chainer-jp-slack))
+| **Slack (Invitation)** ([en](https://bit.ly/chainer-slack), [ja](https://bit.ly/chainer-jp-slack))
+| **Slack (Archive)** ([en](https://chainer.slackarchive.io), [ja](https://chainer-jp.slackarchive.io))
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 | **Examples** ([Official](https://github.com/chainer/chainer/blob/master/examples), [External](https://github.com/chainer/chainer/wiki/External-examples))
 
 **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
-| **Slack(en) [Invitation](https://bit.ly/chainer-slack), [Archive](https://chainer.slackarchive.io)
-| **Slack(ja) [Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io))
+| **Slack (en)** [Invitation](https://bit.ly/chainer-slack), [Archive](https://chainer.slackarchive.io)
+| **Slack (ja)** [Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io))
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 | **Examples** ([Official](https://github.com/chainer/chainer/blob/master/examples), [External](https://github.com/chainer/chainer/wiki/External-examples))
 
 **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
-| **Slack Invitation** ([en](https://bit.ly/chainer-slack), [ja](https://bit.ly/chainer-jp-slack))
-| **Slack Archive** ([en](https://chainer.slackarchive.io), [ja](https://chainer-jp.slackarchive.io))
+| **Slack(en) [Invitation](https://bit.ly/chainer-slack), [Archive](https://chainer.slackarchive.io)
+| **Slack(ja) [Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io))
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 | **Examples** ([Official](https://github.com/chainer/chainer/blob/master/examples), [External](https://github.com/chainer/chainer/wiki/External-examples))
 
 **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
-| **Slack (en)** ([Invitation](https://bit.ly/chainer-slack), [Archive](https://chainer.slackarchive.io))
-| **Slack (ja)** ([Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io))
+| **Slack invitation** ([en](https://bit.ly/chainer-slack), [ja](https://bit.ly/chainer-jp-slack))
+| **Slack archive** ([en](https://chainer.slackarchive.io), [ja](https://chainer-jp.slackarchive.io))
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 | **Examples** ([Official](https://github.com/chainer/chainer/blob/master/examples), [External](https://github.com/chainer/chainer/wiki/External-examples))
 
 **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
-| **Slack (en)** [Invitation](https://bit.ly/chainer-slack), [Archive](https://chainer.slackarchive.io)
-| **Slack (ja)** [Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io)
+| **Slack (en)** ([Invitation](https://bit.ly/chainer-slack), [Archive](https://chainer.slackarchive.io))
+| **Slack (ja)** ([Invitation](https://bit.ly/chainer-jp-slack), [Archive](https://chainer-jp.slackarchive.io))
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.


### PR DESCRIPTION
This PR adds links to public slack archives (both English and Japanese) to `README.md`.

Fixes #2980 