### PR TITLE
fixed typo in upgrade doc example for volatile mode changes

### DIFF
--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -174,7 +174,7 @@ If you are using the ``Variable.volatile`` flag, you have to stop setting this f
 
       # Chainer v2
       x_data = ...   # ndarray
-      x = chainer.Variable(x)
+      x = chainer.Variable(x_data)
       with chainer.no_backprop_mode():
           y = model(x)
 


### PR DESCRIPTION
Fixed typo between v1 and v2 code examples in documentation (chainer.Variable(x) -> chainer.Variable(x_data))