### PR TITLE
grad function

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -38,6 +38,7 @@ from chainer.function import FunctionAdapter  # NOQA
 from chainer.function import no_backprop_mode  # NOQA
 from chainer.function_hook import FunctionHook  # NOQA
 from chainer.function_node import FunctionNode  # NOQA
+from chainer.function_node import grad  # NOQA
 from chainer.functions import array  # NOQA
 from chainer.functions.math import basic_math  # NOQA
 from chainer.initializer import Initializer  # NOQA

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -599,7 +599,7 @@ class FunctionNode(object):
 
 def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
          retain_grad=False, enable_double_backprop=False):
-    """Computes the gradient of output variables w.r.t. the input variables.
+    """Computes the gradient of output variables w.r.t.\\ the input variables.
 
     This function implements the backpropagation algorithm. While
     :meth:`Variable.backward` also implements backprop, this function selects

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -613,9 +613,9 @@ def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
     the original variable. It means users do not need to clear the gradient
     w.r.t. each variable before computing the gradient using this function.
     If ``set_grad`` option is set to ``True``, the computed gradient is also
-    stored in the :attr:`Variable.grad_var` attribute of each variable, whereas
-    the original value of :attr:`Variable.grad_var` is ignored even if it has
-    been set.
+    stored in the :attr:`Variable.grad_var` attribute of each variable, in
+    which case any original value of :attr:`Variable.grad_var` will be updated
+    even if it had already been set.
 
     Args:
         outputs: A sequence of output variables from which backprop starts.
@@ -632,12 +632,13 @@ def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
             If this argument itself is ``None``, it is treated as a sequence of
             ``None`` s.
         set_grad (bool): If it is ``True``, the :attr:`Variable.grad_var`
-            attribute of each input is set to the computed gradient arrays.
+            attribute of each input variable is set to the corresponding
+            computed gradient variable.
         retain_grad (bool): If it is ``True``, the gradients w.r.t. all the
             intermediate variables are stored in the :attr:`Variable.grad_var`
             attribute. In this case, the ``set_grad`` option is ignored.
         enable_double_backprop (bool): If it is ``True``, the computed
-            gradients can be further backpropagated. Enabling it would increase
+            gradients can be further backpropagated. Enabling it may increase
             the memory consumption (and possibly the computational time) to
             remember the intermediate gradient values for the second
             backpropagation.

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -1,7 +1,9 @@
 import collections
+import heapq
 import traceback
 import weakref
 
+import numpy
 import six
 
 import chainer
@@ -593,3 +595,225 @@ class FunctionNode(object):
             del self.local_function_hooks[name]
         else:
             raise KeyError('Hook %s does not exist' % name)
+
+
+def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
+         retain_grad=False):
+    """Computes the gradient of output variables w.r.t. the input variables.
+
+    This function implements the backpropagation algorithm. While
+    :meth:`Variable.backward` also implements backprop, this function selects
+    the smallest paths in the computational graph needed to compute the
+    gradients w.r.t. inputs. The error is backpropagated only through these
+    selected paths, which may reduce the overall computational cost.
+
+    This function also differs from :meth:`Variable.backward` in the way to
+    return the gradients; it directly returns the gradient variables as a list
+    instead of setting gradients to the :attr:`Variable.grad_var` attribute of
+    the original variable. It means users do not need to clear the gradient
+    w.r.t. each variable before computing the gradient using this function.
+    If ``set_grad`` option is set to ``True``, the computed gradient is also
+    stored in the :attr:`Variable.grad_var` attribute of each variable, whereas
+    the original value of :attr:`Variable.grad_var` is ignored even if it has
+    been set.
+
+    Args:
+        outputs: A sequence of output variables from which backprop starts.
+        inputs: A sequence of input variables each of which this function
+            computes the gradient w.r.t.
+        grad_outputs: A sequence of variables that gives the initial value of
+            each output gradient. If an element is set to ``None``, an array
+            filled with 1 is used. If this argument itself is ``None``, it is
+            treated as a sequence of ``None`` s.
+        grad_inputs: A sequence of variables that gives the initial value of
+            each input gradient. The gradients computed by the backprop
+            algorithm are accumulated to them (not in-place). If an element
+            is set to ``None``, the gradient is not accumulated to this value.
+            If this argument itself is ``None``, it is treated as a sequence of
+            ``None`` s.
+        set_grad (bool): If it is ``True``, the :attr:`Variable.grad_var`
+            attribute of each input is set to the computed gradient arrays.
+        retain_grad (bool): If it is ``True``, the gradients w.r.t. all the
+            intermediate variables are stored in the :attr:`Variable.grad_var`
+            attribute. In this case, the ``set_grad`` option is ignored.
+
+    Returns:
+        A list of gradient variables w.r.t. the inputs.
+
+    """
+    # The implementation consists of three steps.
+
+    # 1. Backward enumeration: all the nodes reachable backward from the output
+    #    nodes are enumerated. The forward direction links are collected in
+    #    this step. Note that the variable nodes whose requires_grad is false
+    #    are ignored and their creators are not searched.
+    candidate_funcs = [v.creator_node for v in outputs
+                       if v.creator_node is not None]
+    visited_funcs = set()
+    forward_graph = collections.defaultdict(list)
+    while candidate_funcs:
+        func = candidate_funcs.pop()
+        if func in visited_funcs:
+            continue
+        visited_funcs.add(func)
+        for x in func.inputs:
+            if not x.requires_grad:
+                continue
+            forward_graph[x].append(func)
+            creator = x.creator_node
+            if creator is not None and creator not in visited_funcs:
+                candidate_funcs.append(creator)
+
+    # 2. Forward enumeration: all the nodes in the subgraph reachable from the
+    #    input nodes are enumerated. The extracted (sub-)subgraph is the union
+    #    of all paths that backpropagation will visit.
+    candidate_vars = [x.node for x in inputs]
+    visited_funcs = set()
+    grad_required = set()
+    while candidate_vars:
+        x = candidate_vars.pop()
+        grad_required.add(x)
+        for func in forward_graph[x]:
+            if func in visited_funcs:
+                continue
+            visited_funcs.add(func)
+            for y_ref in func.outputs:
+                y = y_ref()
+                if y is not None and y in forward_graph:
+                    candidate_vars.append(y)
+
+    # 3. Backpropagation: the backpropagation is executed along the
+    #    (sub-)subgraph. It uses the topological order of the subgraph which is
+    #    induced by the reversed order of function applications ("rank").
+    grads = {}  # mapping from variable nodes to their gradients
+
+    # Initialize the gradient mapping.
+    if grad_outputs is not None:
+        for y, gy in zip(outputs, grad_outputs):
+            if gy is None:
+                with cuda.get_device_from_array(y.data) as device:
+                    if device is cuda.DummyDevice:
+                        gy_data = numpy.ones_like(y.data)
+                    else:
+                        gy_data = cuda.cupy.ones_like(y.data)
+                    gy = variable.Variable(gy_data, requires_grad=False)
+            grads[y.node] = gy
+
+    if grad_inputs is not None:
+        for x, gx in zip(inputs, grad_inputs):
+            if gx is not None:
+                grads[x.node] = gx
+
+    # Backprop implementation. It edits grads which will only contain the
+    # gradients w.r.t. the inputs.
+    _backprop(outputs, inputs, grad_required, retain_grad, grads)
+
+    # Extract the gradients w.r.t. the inputs and return them.
+    ret = [grads.get(x.node, None) for x in inputs]
+    if set_grad:
+        for x, gx in zip(inputs, ret):
+            x.grad_var = gx
+
+    return ret
+
+
+def _backprop(outputs, inputs, grad_required, retain_grad, grads):
+    candidate_funcs, push_candidate, pop_candidate = _get_ordered_func_heap()
+
+    for y in outputs:
+        creator = y.creator_node
+        if creator is not None:
+            push_candidate(creator)
+
+    input_nodes = set(x.node for x in inputs)
+
+    while candidate_funcs:
+        func = pop_candidate()
+
+        # Collect the gradients w.r.t. the outputs
+        gys = []
+        for y_ref in func.outputs:
+            y = y_ref()
+            if y is None:
+                # output is not a part of the selected subgraph and has already
+                # been released.
+                gys.append(None)
+                continue
+            gys.append(grads.get(y, None))
+
+        # Collect the gradients w.r.t. the inputs
+        #
+        # Note (Tokui): when the same variable is passed multiple times as
+        # inputs in the same function (e.g. an expression like f(x, x)), the
+        # current implementation passes None as the current gradient w.r.t.
+        # such an input except for the first one (i.e., it builds gxs like
+        # (gx, None) where gx is the current gradient w.r.t. x).
+        gxs = []
+        input_indexes = []
+        selected_inputs = set()
+        for i, x in enumerate(func.inputs):
+            if x not in grad_required:
+                continue
+            input_indexes.append(i)
+            if x in selected_inputs:
+                gxs.append(None)
+            else:
+                gxs.append(grads.get(x, None))
+                selected_inputs.add(x)
+
+        if not input_indexes:
+            continue
+
+        # Do backward
+        new_gxs = func.backward_accumulate(input_indexes, gys, gxs)
+
+        # Delete output gradients that are not required to return
+        for y_ref in func.outputs:
+            y = y_ref()
+            if y is not None and y in grads and y not in input_nodes:
+                del grads[y]
+
+        # Update grads
+        selected_inputs = set()
+        for i, g in zip(input_indexes, new_gxs):
+            if g is None:
+                continue
+
+            node = func.inputs[i]
+            if node in selected_inputs:
+                # Accumulate the duplicated gradients here
+                cur_gx = grads.get(node, None)
+                if cur_gx is not None:
+                    g = g + cur_gx
+            else:
+                selected_inputs.add(node)
+
+            grads[node] = g
+
+            if retain_grad:
+                v = node.get_variable()
+                if v is not None:
+                    v.grad_var = g
+
+            creator = node.creator_node
+            if creator is not None:
+                push_candidate(creator)
+
+
+def _get_ordered_func_heap():
+    heap = []
+    visited_funcs = set()
+
+    def push_heap(func):
+        if func not in visited_funcs:
+            # Negate since heapq is min-heap
+            # The second element is used to make each item unique
+            ordered_func = -func.rank, len(visited_funcs), func
+            visited_funcs.add(func)
+            heapq.heappush(heap, ordered_func)
+
+    def pop_heap():
+        _, _, func = heapq.heappop(heap)
+        return func
+
+    return heap, push_heap, pop_heap

--- a/docs/source/reference/core/function.rst
+++ b/docs/source/reference/core/function.rst
@@ -10,3 +10,4 @@ Function
    chainer.FunctionNode
    chainer.force_backprop_mode
    chainer.no_backprop_mode
+   chainer.grad


### PR DESCRIPTION
This PR implements `chainer.grad` function proposed at #2871. This function implements backpropagation. The most important difference from `Variable.backward()` is that users specify the set of input variables to which the errors should be backpropagated. The resulting gradients are not accumulated to `Variable.grad_var` attribute by default, so it's easier to use when users want to compute gradients w.r.t. variables not spanning the whole parameter set. This function also skips unnecessary paths to compute gradients w.r.t. specified inputs in combination with the economical backprop API of #2970.

The usage is simple:
```py
grad_inputs = chainer.grad(outputs, inputs)
```
You can also specify the initial gradients for outputs and inputs. The initial gradients for inputs are used for gradient accumulation. If `set_grad=True` is specified, it also sets the gradients to `Variable.grad_var` of inputs like `Variable.backward()` does. The `retain_grad` option also exists.

This PR depends on #2970.