### PR TITLE
Make TimerHook reentrant

### DIFF
--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -95,7 +95,6 @@ class TimerHook(function.FunctionHook):
     def total_time(self):
         """Returns total elapsed time in seconds."""
         return self._total_time
-        # return sum(t for (_, t) in self.call_history)
 
     def summary(self):
         """Returns a summary of time profiling in functions.

--- a/tests/chainer_tests/function_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/function_hooks_tests/test_timer.py
@@ -103,7 +103,7 @@ class TestTimerHookToFunction(unittest.TestCase):
     def test_reentrant(self):
         # In/grad data are random; these do not simulate the actually possible
         # cases.
-        g = functions.Identity()  # any time other than Exp is ok
+        g = functions.Identity()  # any function other than Exp is ok
 
         self.h.backward_preprocess(self.f, (self.x,), (self.gy,))
         t1 = time.time()

--- a/tests/chainer_tests/function_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/function_hooks_tests/test_timer.py
@@ -122,6 +122,22 @@ class TestTimerHookToFunction(unittest.TestCase):
         self.assertLessEqual(g_time, t2 - t1)
         self.assertGreaterEqual(f_time, t2 - t1)
 
+    def test_reentrant_total_time(self):
+        g = functions.Identity()
+
+        t0 = time.time()
+        self.h.backward_preprocess(self.f, (self.x,), (self.gy,))
+        t1 = time.time()
+        self.h.forward_preprocess(g, (self.x,))
+        time.sleep(0.001)
+        self.h.forward_postprocess(g, (self.x,))
+        t2 = time.time()
+        self.h.backward_postprocess(self.f, (self.x,), (self.gy,))
+        t3 = time.time()
+
+        self.assertLessEqual(self.h.total_time(), t3 - t0)
+        self.assertGreaterEqual(self.h.total_time(), t2 - t1)
+
 
 class TestTimerPrintReport(unittest.TestCase):
 


### PR DESCRIPTION
This PR makes `TimerHook` reentrant, i.e., the forward hook and backward hook can be nested. It is required by #2970 with which the backward of each function is written by Function calls rather than direct array computation.