### PR TITLE
Import example modules and util in chainer.training.__init__

### DIFF
--- a/chainer/training/__init__.py
+++ b/chainer/training/__init__.py
@@ -1,7 +1,11 @@
 from chainer.training import extension  # NOQA
+from chainer.training import extensions # NOQA
 from chainer.training import trainer  # NOQA
 from chainer.training import trigger  # NOQA
+from chainer.training import triggers  # NOQA
 from chainer.training import updater  # NOQA
+from chainer.training import updaters  # NOQA
+from chainer.training import util  # NOQA
 
 
 # import class and function

--- a/chainer/training/__init__.py
+++ b/chainer/training/__init__.py
@@ -1,5 +1,5 @@
 from chainer.training import extension  # NOQA
-from chainer.training import extensions # NOQA
+from chainer.training import extensions  # NOQA
 from chainer.training import trainer  # NOQA
 from chainer.training import trigger  # NOQA
 from chainer.training import triggers  # NOQA

--- a/chainer/training/extensions/parameter_statistics.py
+++ b/chainer/training/extensions/parameter_statistics.py
@@ -2,8 +2,8 @@ import numpy
 import six
 
 from chainer import reporter
-from chainer import training
 from chainer.training import extension
+from chainer.training import trigger
 
 
 class ParameterStatistics(extension.Extension):
@@ -75,7 +75,7 @@ class ParameterStatistics(extension.Extension):
         self._attrs = attrs
 
         self._prefix = prefix
-        self._trigger = training.trigger.get_trigger(trigger)
+        self._trigger = trigger.get_trigger(trigger)
         self._summary = reporter.DictSummary()
 
     def __call__(self, trainer):

--- a/chainer/training/extensions/parameter_statistics.py
+++ b/chainer/training/extensions/parameter_statistics.py
@@ -3,7 +3,7 @@ import six
 
 from chainer import reporter
 from chainer.training import extension
-from chainer.training import trigger
+from chainer.training import trigger as trigger_module
 
 
 class ParameterStatistics(extension.Extension):
@@ -75,7 +75,7 @@ class ParameterStatistics(extension.Extension):
         self._attrs = attrs
 
         self._prefix = prefix
-        self._trigger = trigger.get_trigger(trigger)
+        self._trigger = trigger_module.get_trigger(trigger)
         self._summary = reporter.DictSummary()
 
     def __call__(self, trainer):


### PR DESCRIPTION
Fix #2981 

This PR adds import of modules that contain example training modules and `chainer.training.util` to `chainer.training.__init__`.
