### PR TITLE
Fix backprop dim for unused lstm states on gpu

### DIFF
--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -435,7 +435,8 @@ class BaseNStepRNN(function.Function):
         dy_list = list(grads[self._n_cell:])
         for i in six.moves.range(len(dy_list)):
             if dy_list[i] is None:
-                dy_list[i] = cuda.cupy.zeros_like(x_list[i])
+                shape = (x_list[i].shape[0], self.rnn_direction * hx.shape[2])
+                dy_list[i] = cuda.cupy.zeros(shape, dtype='f')
 
         xs = cuda.cupy.concatenate(x_list, axis=0)
         length = len(x_list)


### PR DESCRIPTION
I discovered this when I didn't use all the states of the rnn
encoding further down the pipeline. My code ran fine on cpu but I
got the following error when using gpu.

```
"python3.5/site-packages/chainer/functions/connection/n_step_rnn.py",
line 449, in backward
    dys = cuda.cupy.concatenate(dy_list, axis=0)

cupy.core.core.concatenate_method (cupy/core/core.cpp:64040)
ValueError: All arrays must have same shape except the axis to
concatenate
```

I think x_list[i] has correct 0th dimension (batch size) but
incorrect 1st dimension (num units). This change got my code
working - and I checked it both for a unidirectional and a
bidirectional rnn.


Thank you for creating a pull request!

Please double-check the following.

- Read [our contribution guide](http://docs.chainer.org/en/stable/contribution.html).
  - Does you code conform to our coding guidelines?
  - Did you write sufficient test code?
  - Did you write sufficient documentation?
- Also take a look at [our compatibility policy](http://docs.chainer.org/en/stable/compatibility.html).
