### PR TITLE
Avoid to import matplotlib to set its backend Agg in code

### DIFF
--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -2,12 +2,6 @@
 
 from __future__ import print_function
 
-try:
-    import matplotlib
-    matplotlib.use('Agg')
-except ImportError:
-    pass
-
 import argparse
 
 import chainer

--- a/examples/vae/README.md
+++ b/examples/vae/README.md
@@ -5,3 +5,9 @@ This is a sample implementation of variational autoencoder.
 This method is proposed by Kingma and Welling, Auto-Encoding Variational Bayes, 2014.
 
 If you want to run this example on the N-th GPU, pass `--gpu=N` to the script.
+
+If you run this script on Linux, setting the environmental variable `MPLBACKEND` to `Agg` may be required to use `matplotlib`. For example,
+
+```
+MPLBACKEND=Agg python train_vae.py
+```

--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -4,9 +4,6 @@
 from __future__ import print_function
 import argparse
 
-import matplotlib
-# Disable interactive backend
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import six


### PR DESCRIPTION
Setting `matplotlib.use('Agg')` inside code might cause errors in some environments other than linux.
Using `MPLBACKEND=Agg` environmental variable is more preferable I think.