### PR TITLE
Avoid running a hook on uninitialized parameters

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -185,7 +185,12 @@ class UpdateRule(object):
             return
 
         self.t += 1
+
+        if param.data is None:
+            return
+
         self._prepare(param)
+
         for hook in six.itervalues(self._hooks):
             hook(self, param)
         self.update_core(param)
@@ -422,7 +427,8 @@ class Optimizer(object):
     def _call_hook(self, hook):
         if getattr(hook, 'call_for_each_param', False):
             for param in self.target.params():
-                hook(param.update_rule, param)
+                if param.data is not None:
+                    hook(param.update_rule, param)
         else:
             hook(self)
 


### PR DESCRIPTION
Fixes #3041 
This fixes the issue in the MWE linked in the issue (https://pastebin.com/DXp4msHx).
Will add a test a bit later.