### PR TITLE
fix typo in Link.disable_update

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -519,7 +519,7 @@ Assign a Parameter object directly to an attribute within a \
     def disable_update(self):
         """Disables update rules of all parameters under the link hierarchy.
 
-        This method sets the :attr:~chainer.UpdateRule.enabled` flag of the
+        This method sets the :attr:`~chainer.UpdateRule.enabled` flag of the
         update rule of each parameter variable to ``False``.
 
         """


### PR DESCRIPTION
Missing backquote for `:attr:`.