### PR TITLE
Fix _make_npz for ResNetLayers

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -696,14 +696,7 @@ def _make_npz(path_npz, path_caffemodel, model, n_layers):
             'from \'https://github.com/KaimingHe/deep-residual-networks\', '
             'and place it on {}'.format(path_caffemodel))
 
-    if n_layers == 50:
-        ResNet50Layers.convert_caffemodel_to_npz(path_caffemodel, path_npz, 50)
-    elif n_layers == 101:
-        ResNet101Layers.convert_caffemodel_to_npz(
-            path_caffemodel, path_npz, 101)
-    elif n_layers == 152:
-        ResNet152Layers.convert_caffemodel_to_npz(
-            path_caffemodel, path_npz, 152)
+    ResNetLayers.convert_caffemodel_to_npz(path_caffemodel, path_npz, n_layers)
     npz.load_npz(path_npz, model)
     return model
 


### PR DESCRIPTION
`_make_npz` for `ResNetLayers` raises an error. This is because `_make_npz` calls `ResNet50Layers.convert_caffemodel_to_npz` but `ResNet50Layers.__init__` doesn't have `n_layers` argument.

```
$ rm ~/.chainer/dataset/pfnet/chainer/models/ResNet-50-model.npz
$ python -c 'from chainer.links import ResNet50Layers; ResNet50Layers()'
Now loading caffemodel (usually it may take few minutes)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "***/lib/python3.6/site-packages/chainer-3.0.0a1-py3.6.egg/chainer/links/model/vision/resnet.py", line 331, in __init__
    super(ResNet50Layers, self).__init__(pretrained_model, 50)
  File "***/lib/python3.6/site-packages/chainer-3.0.0a1-py3.6.egg/chainer/links/model/vision/resnet.py", line 112, in __init__
    pretrained_model, self)
  File "***/lib/python3.6/site-packages/chainer-3.0.0a1-py3.6.egg/chainer/links/model/vision/resnet.py", line 717, in _retrieve
    lambda path: npz.load_npz(path, model))
  File "***/lib/python3.6/site-packages/chainer-3.0.0a1-py3.6.egg/chainer/dataset/download.py", line 151, in cache_or_load_file
    content = creator(temp_path)
  File "***/lib/python3.6/site-packages/chainer-3.0.0a1-py3.6.egg/chainer/links/model/vision/resnet.py", line 716, in <lambda>
    path, lambda path: _make_npz(path, path_caffemodel, model, n_layers),
  File "***/lib/python3.6/site-packages/chainer-3.0.0a1-py3.6.egg/chainer/links/model/vision/resnet.py", line 700, in _make_npz
    ResNet50Layers.convert_caffemodel_to_npz(path_caffemodel, path_npz, 50)
  File "***/lib/python3.6/site-packages/chainer-3.0.0a1-py3.6.egg/chainer/links/model/vision/resnet.py", line 147, in convert_caffemodel_to_npz
    chainermodel = cls(pretrained_model=None, n_layers=n_layers)
TypeError: __init__() got an unexpected keyword argument 'n_layers'
```
