### PR TITLE
Fix doc warnings

### DIFF
--- a/chainer/initializer.py
+++ b/chainer/initializer.py
@@ -7,8 +7,8 @@ class Initializer(object):
     It initializes the given array.
 
     Attributes:
-        dtype: Data type specifier. It is for type check in ``__call__``
-            function.
+        ~Initializer.dtype: Data type specifier. It is for type check in
+            ``__call__`` function.
 
     """
 

--- a/chainer/initializers/constant.py
+++ b/chainer/initializers/constant.py
@@ -13,7 +13,8 @@ class Identity(initializer.Initializer):
     Note that arrays to be passed must be 2D squared matrices.
 
     Attributes:
-        scale (scalar): A constant to be multiplied to identity matrices.
+        ~Identity.scale (scalar): A constant to be multiplied to identity
+        matrices.
 
     """
 
@@ -41,7 +42,7 @@ class Constant(initializer.Initializer):
         fill_value (scalar or numpy.ndarray or cupy.ndarray):
             A constant to be assigned to the initialized array.
             Broadcast is allowed on this assignment.
-        dtype: Data type specifier.
+        ~Constant.dtype: Data type specifier.
 
     """
 

--- a/chainer/initializers/orthogonal.py
+++ b/chainer/initializers/orthogonal.py
@@ -27,8 +27,8 @@ class Orthogonal(initializer.Initializer):
     the array).
 
     Attributes:
-        scale (float): A constant to be multiplied by.
-        dtype: Data type specifier.
+        ~Orthogonal.scale (float): A constant to be multiplied by.
+        ~Orthogonal.dtype: Data type specifier.
 
     Reference: Saxe et al., https://arxiv.org/abs/1312.6120
 

--- a/chainer/initializers/uniform.py
+++ b/chainer/initializers/uniform.py
@@ -15,9 +15,9 @@ class Uniform(initializer.Initializer):
     independently from uniform distribution :math:`[-scale, scale]`.
 
     Attributes:
-        scale (float): A constant that determines the
+        ~Uniform.scale (float): A constant that determines the
             scale of the uniform distribution.
-        dtype: Data type specifier.
+        ~Uniform.dtype: Data type specifier.
 
     """
 
@@ -46,9 +46,9 @@ class LeCunUniform(initializer.Initializer):
     http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf
 
     Attributes:
-        scale (float): A constant that determines the
+        ~LeCunUniform.scale (float): A constant that determines the
             scale of the uniform distribution.
-        dtype: Data type specifier.
+        ~LeCunUniform.dtype: Data type specifier.
 
     """
 
@@ -73,9 +73,9 @@ class GlorotUniform(initializer.Initializer):
     input and output units, respectively.
 
     Attributes:
-        scale (float): A constant that determines the
+        ~GlorotUniform.scale (float): A constant that determines the
             scale of the uniform distribution.
-        dtype: Data type specifier.
+        ~GlorotUniform.dtype: Data type specifier.
 
     """
 
@@ -101,9 +101,9 @@ class HeUniform(initializer.Initializer):
     Here, :math:`fan_{in}` is the number of input units.
 
     Attributes:
-        scale (float): A constant that determines the
+        ~HeUniform.scale (float): A constant that determines the
             scale of the uniform distribution.
-        dtype: Data type specifier.
+        ~HeUniform.dtype: Data type specifier.
 
     """
 

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -122,7 +122,8 @@ class Link(object):
             is supplied, the default dtype will be used.
 
     Attributes:
-        ~Link.name (str): Name of this link, given by the parent chain (if exists).
+        ~Link.name (str): Name of this link, given by the parent chain (if
+            exists).
 
     """
 

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -122,7 +122,7 @@ class Link(object):
             is supplied, the default dtype will be used.
 
     Attributes:
-        name (str): Name of this link, given by the parent chain (if exists).
+        ~Link.name (str): Name of this link, given by the parent chain (if exists).
 
     """
 

--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -83,8 +83,8 @@ class GoogLeNet(link.Chain):
             but not GlorotUniform.
 
     Attributes:
-        available_layers (list of str): The list of available layer names
-            used by ``__call__`` and ``extract`` methods.
+        ~GoogLeNet.available_layers (list of str): The list of available layer
+            names used by ``__call__`` and ``extract`` methods.
 
     """
 

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -72,8 +72,8 @@ class ResNetLayers(link.Chain):
             50, 101, or 152.
 
     Attributes:
-        available_layers (list of str): The list of available layer names
-            used by ``__call__`` and ``extract`` methods.
+        ~ResNetLayers.available_layers (list of str): The list of available
+            layer names used by ``__call__`` and ``extract`` methods.
 
     """
 
@@ -320,8 +320,8 @@ class ResNet50Layers(ResNetLayers):
             ``chainer.initializers.HeNormal(scale=1.0)``.
 
     Attributes:
-        available_layers (list of str): The list of available layer names
-            used by ``__call__`` and ``extract`` methods.
+        ~ResNet50Layers.available_layers (list of str): The list of available
+            layer names used by ``__call__`` and ``extract`` methods.
 
     """
 
@@ -373,8 +373,8 @@ class ResNet101Layers(ResNetLayers):
             ``chainer.initializers.HeNormal(scale=1.0)``.
 
     Attributes:
-        available_layers (list of str): The list of available layer names
-            used by ``__call__`` and ``extract`` methods.
+        ~ResNet101Layers.available_layers (list of str): The list of available
+            layer names used by ``__call__`` and ``extract`` methods.
 
     """
 
@@ -425,8 +425,8 @@ class ResNet152Layers(ResNetLayers):
             ``chainer.initializers.HeNormal(scale=1.0)``.
 
     Attributes:
-        available_layers (list of str): The list of available layer names
-            used by ``__call__`` and ``extract`` methods.
+        ~ResNet152Layers.available_layers (list of str): The list of available
+            layer names used by ``__call__`` and ``extract`` methods.
 
     """
 

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -67,8 +67,8 @@ class VGG16Layers(link.Chain):
             ``chainer.initializers.Normal(scale=0.01)``.
 
     Attributes:
-        available_layers (list of str): The list of available layer names
-            used by ``__call__`` and ``extract`` methods.
+        ~VGG16Layers.available_layers (list of str): The list of available
+            layer names used by ``__call__`` and ``extract`` methods.
 
     """
 

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -57,8 +57,8 @@ class BatchNormalization(link.Link):
         avg_var (numpy.ndarray or cupy.ndarray): Population variance.
         N (int): Count of batches given for fine-tuning.
         decay (float): Decay rate of moving average. It is used on training.
-        ~BatchNormalization.eps (float): Epsilon value for numerical stability. This value is added
-            to the batch variances.
+        ~BatchNormalization.eps (float): Epsilon value for numerical stability.
+            This value is added to the batch variances.
 
     """
 

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -57,7 +57,7 @@ class BatchNormalization(link.Link):
         avg_var (numpy.ndarray or cupy.ndarray): Population variance.
         N (int): Count of batches given for fine-tuning.
         decay (float): Decay rate of moving average. It is used on training.
-        eps (float): Epsilon value for numerical stability. This value is added
+        ~BatchNormalization.eps (float): Epsilon value for numerical stability. This value is added
             to the batch variances.
 
     """

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -33,7 +33,7 @@ class LayerNormalization(link.Link):
     Attributes:
         gamma (~chainer.Parameter): Scaling parameter.
         beta (~chainer.Parameter): Shifting parameter.
-        eps (float): Epsilon value for numerical stability.
+        ~LayerNormalization.eps (float): Epsilon value for numerical stability.
 
     See: `Layer Normalization <https://arxiv.org/abs/1607.06450>`_
     """

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -313,8 +313,8 @@ class Optimizer(object):
         target: Target link object. It is set by the :meth:`setup` method.
         t: Number of update steps. It must be incremented by the
             :meth:`update` method.
-        epoch: Current epoch. It is incremented by the :meth:`new_epoch`
-            method.
+        ~Optimizer.epoch: Current epoch. It is incremented by the
+            :meth:`new_epoch` method.
 
     """
 

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -17,8 +17,8 @@ class AdaDeltaRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         rho (float): Exponential decay rate of the first and second order
             moments.
         eps (float): Small value for the numerical stability.

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -17,8 +17,8 @@ class AdaGradRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         lr (float): Learning rate.
         eps (float): Small value for the numerical stability.
 

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -21,8 +21,8 @@ class AdamRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         alpha (float): Step size.
         beta1 (float): Exponential decay rate of the first order moment.
         beta2 (float): Exponential decay rate of the second order moment.

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -15,8 +15,8 @@ class MomentumSGDRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         lr (float): Learning rate.
         momentum (float): Exponential decay rate of the first order moment.
 

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -15,8 +15,8 @@ class NesterovAGRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         lr (float): Learning rate.
         momentum (float): Exponential decay rate of the first order moment.
 

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -18,8 +18,8 @@ class RMSpropRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         lr (float): Learning rate.
         alpha (float): Exponential decay rate of the second order moment.
         eps (float): Small value for the numerical stability.

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -19,8 +19,8 @@ class RMSpropGravesRule(optimizer.UpdateRule):
     the hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         lr (float): Learning rate.
         alpha (float): Exponential decay rate of the first and second order
             moments of the raw gradient.

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -14,8 +14,8 @@ class SGDRule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         lr (float): Learning rate.
 
     """

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -17,8 +17,8 @@ class SMORMS3Rule(optimizer.UpdateRule):
     hyperparameters.
 
     Args:
-        parent_hyperparam (~chainer.Hyperparameter): Hyperparameter that
-            provides the default values.
+        parent_hyperparam (~chainer.optimizer.Hyperparameter): Hyperparameter
+            that provides the default values.
         lr (float): Learning rate.
         eps (float): Small value for the numerical stability.
 

--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -27,9 +27,9 @@ class Extension(object):
     specifies them in :meth:`Trainer.extend` method.
 
     Attributes:
-        trigger: Default value of trigger for this extension. It is set to
-            ``(1, 'iteration')`` by default.
-        priority: Default priority of the extension. It is set to
+        ~Extension.trigger: Default value of trigger for this extension. It
+            is set to ``(1, 'iteration')`` by default.
+        ~Extension.priority: Default priority of the extension. It is set to
             ``PRIORITY_READER`` by default.
 
     """

--- a/chainer/training/extensions/parameter_statistics.py
+++ b/chainer/training/extensions/parameter_statistics.py
@@ -10,7 +10,7 @@ class ParameterStatistics(extension.Extension):
     """Trainer extension to report parameter statistics.
 
     Statistics are collected and reported for a given :class:`~chainer.Link`
-    or an iterable of :class:`~chainer.Link`s. If a link contains child links,
+    or an iterable of :class:`~chainer.Link`\s. If a link contains child links,
     the statistics are reported separately for each child.
 
     Any function that takes a one-dimensional :class:`numpy.ndarray` or a

--- a/chainer/training/triggers/__init__.py
+++ b/chainer/training/triggers/__init__.py
@@ -5,5 +5,6 @@ from chainer.training.triggers import minmax_value_trigger  # NOQA
 # import class and function
 from chainer.training.triggers.interval import IntervalTrigger  # NOQA
 from chainer.training.triggers.manual_schedule_trigger import ManualScheduleTrigger  # NOQA
+from chainer.training.triggers.minmax_value_trigger import BestValueTrigger  # NOQA
 from chainer.training.triggers.minmax_value_trigger import MaxValueTrigger  # NOQA
 from chainer.training.triggers.minmax_value_trigger import MinValueTrigger  # NOQA

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -138,9 +138,9 @@ class VariableNode(object):
         name (str): Name of the variable node.
 
     Attributes:
-        dtype: Data type of the data array.
-        shape: Shape of the data array.
-        name (str): Name of the variable node.
+        ~VariableNode.dtype: Data type of the data array.
+        ~VariableNode.shape: Shape of the data array.
+        ~VariableNode.name (str): Name of the variable node.
 
     """
 
@@ -414,7 +414,7 @@ class Variable(object):
             in backward calculation.
 
     Attributes:
-        data: Data array of type either :class:`numpy.ndarray` or
+        ~Variable.data: Data array of type either :class:`numpy.ndarray` or
             :class:`cupy.ndarray`. If it is None, the variable is left in an
             uninitialized state.
         grad_var (Variable): Gradient variable.

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -417,7 +417,7 @@ class Variable(object):
         ~Variable.data: Data array of type either :class:`numpy.ndarray` or
             :class:`cupy.ndarray`. If it is None, the variable is left in an
             uninitialized state.
-        grad_var (Variable): Gradient variable.
+        ~Variable.grad_var (Variable): Gradient variable.
 
     """  # NOQA
 

--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -34,8 +34,8 @@ This table compares Chainer with other actively developed deep learning framewor
    ,"Web interface",,,"`TensorBoard <https://github.com/tensorflow/tensorboard>`_",,,,,,,"DL4J-UI",,"Nervana Cloud",,,
    ,"Graph compilation engine",,2017,"`XLA <https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/>`_",,2017,,"`NNVM <https://github.com/dmlc/nnvm>`_",,,,,"ngraph",,,
 
-.. [1] Define-by-run is in development as of June 2017 and tracked in `this PR <https://github.com/dmlc/mxnet/pull/5705>`_. It is also possible using the much slower MinPy extension.
-.. [2] Symbolic autograd is in development as of June 2017 and tracked in `this PR <https://github.com/deeplearning4j/nd4j/pull/1750>`_.
+.. [1] Define-by-run is in development as of June 2017 and tracked in `dmlc/mxnet#5705 <https://github.com/dmlc/mxnet/pull/5705>`_. It is also possible using the much slower MinPy extension.
+.. [2] Symbolic autograd is in development as of June 2017 and tracked in `deeplearning4j/nd4j#1750 <https://github.com/deeplearning4j/nd4j/pull/1750>`_.
 .. [3] Symbolic autograd is available only with ngraph backend (experimental).
 .. [4] Nervana provides kernels that are meant to compete with cuDNN.
 .. [5] Multiprocessing provides a significant performance improvement only for frameworks that use Python at runtime.

--- a/docs/source/reference/core/optimizer.rst
+++ b/docs/source/reference/core/optimizer.rst
@@ -5,7 +5,7 @@ Optimizer
    :toctree: generated/
    :nosignatures:
 
-   chainer.Hyperparameter
+   chainer.optimizer.Hyperparameter
    chainer.UpdateRule
    chainer.Optimizer
    chainer.GradientMethod

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -17,7 +17,7 @@ The compiled binaries are cached to the ``$(HOME)/.cupy/kernel_cache`` directory
 If you see that compilations run every time you run the same script, then the caching is failed.
 Please check that the directory is kept as is between multiple executions of the script.
 If your home directory is not suited to caching the kernels (e.g. in case that it uses NFS), change the kernel caching directory by setting the ``CUPY_CACHE_DIR`` environment variable to an appropriate path.
-See :ref:`cupy-overview` for more details.
+See `CuPy Overview <https://docs-cupy.chainer.org/en/stable/overview.html>` for more details.
 
 
 mnist example does not converge in CPU mode on Mac OS X


### PR DESCRIPTION
Documentation build has been emitting a number of warnings, each of which generating invalid (corrupt) documentation.
