### PR TITLE
Treat sphinx warnings as errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,13 +3,13 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = sphinx-build -W
 PAPER         =
 BUILDDIR      = build
 
 # User-friendly check for sphinx-build
-ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+ifeq ($(shell which $(word 1, $(SPHINXBUILD)) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(word 1, $(SPHINXBUILD))' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
 
 # Internal variables.


### PR DESCRIPTION
(Related to #3068. Merge after it)

Sphinx warnings should be taken more seriously. This PR treats its warnings as errors.

TODO: Port to CuPy