### PR TITLE
Improve MultiprocessIterator performance, functionality and stability, using Pool

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,4 +67,6 @@ test_script:
   - "%CMD_IN_ENV% pip install nose mock hacking"
   - "flake8"
   - "cd tests\\chainer_tests"
-  - "nosetests -a \"!gpu,!slow\""
+  # Avoid interuption confirmation of cmd.exe
+  - "echo nosetests -a \"!gpu,!slow\" > tmp.bat"
+  - "call tmp.bat < nul"

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -344,9 +344,14 @@ class _PrefetchLoop(object):
 # Using `parametarized` funciton (e.g. bound method) with Pool is tricky due to
 # restrictions imposed by Pickle. Picklable types differ across versions.
 # Just using top-level function with globals seems to be safest.
-
 # it doesn't mean thread safety broken or global variables visible;
 # notice that each process uses different address space.
+# To make static linker happy, we first initialize global variables.
+_fetch_dataset = None
+_fetch_mem_size = None
+_fetch_mem_bulk = None
+
+
 def _fetch_setup(dataset, mem_size, mem_bulk):
     global _fetch_dataset, _fetch_mem_size, _fetch_mem_bulk
     _fetch_dataset = dataset

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -255,13 +255,13 @@ class _PrefetchLoop(object):
             if indices is None:  # stop iteration
                 batch = None
             elif pool is None:  # measure mode
-                batch = list(self.dataset[idx] for idx in indices)
+                batch = [self.dataset[idx] for idx in indices]
                 self.mem_size = max(map(_measure, batch))
                 self._allocate_shared_memory()
             else:
                 data_it = pool.imap(
                     _fetch_run, enumerate(indices), chunk_size)
-                batch = list(_unpack(data, self.mem_bulk) for data in data_it)
+                batch = [_unpack(data, self.mem_bulk) for data in data_it]
 
             self.comm.put(batch, self.prefetch_state, reset_count)
             return True

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -97,11 +97,11 @@ class MultiprocessIterator(iterator.Iterator):
             self.dataset, self.batch_size, self.repeat, self.shuffle,
             self.n_processes, self.n_prefetch, self.shared_mem)
 
-        comm = self._comm
-        del self._comm
-        other.__dict__.update(self.__dict__)
-        self._comm = comm
-        other.__class__ = self.__class__
+        other.current_position = self.current_position
+        other.epoch = self.epoch
+        other.is_new_epoch = self.is_new_epoch
+        other._previous_epoch_detail = self._previous_epoch_detail
+        other._order = self._order
 
         other._set_prefetch_state()
         return other

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -64,9 +64,7 @@ class MultiprocessIterator(iterator.Iterator):
         self._comm = _Communicator(self.n_prefetch)
         self.reset()
 
-        # Do not hold reference to this thread. Otherwise an unused iterator
-        # never get GC'ed whenever the thread is alive, so you lose the
-        # chance to stop the thread.
+        # don't need to hold a reference to the thread
         prefetch_loop = _PrefetchLoop(
             self.dataset, self.batch_size, self.repeat, self.shuffle,
             self.n_processes, self.n_prefetch, self.shared_mem, self._comm)
@@ -346,7 +344,7 @@ class _PrefetchLoop(object):
 # Just using top-level function with globals seems to be safest.
 # it doesn't mean thread safety broken or global variables visible;
 # notice that each process uses different address space.
-# To make static linker happy, we first initialize global variables.
+# To make static linter happy, we first initialize global variables.
 _fetch_dataset = None
 _fetch_mem_size = None
 _fetch_mem_bulk = None

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -343,21 +343,21 @@ class _PrefetchLoop(object):
 
 # To avoid restrictions with inherited states or pickled values.
 # It doesn't mean thread unsafity; each process uses different address space.
+# Note that @classmethod can't be used in Python 2.7.
+# Just stick to plain funciton.
 class _Fetch(object):
-    @classmethod
-    def setup(cls, dataset, mem_size, mem_bulk):
-        cls.dataset = dataset
-        cls.mem_size = mem_size
-        cls.mem_bulk = mem_bulk
+    def setup(dataset, mem_size, mem_bulk):
+        _Fetch.dataset = dataset
+        _Fetch.mem_size = mem_size
+        _Fetch.mem_bulk = mem_bulk
 
-    @classmethod
-    def run(cls, inputs):
+    def run(inputs):
         i, index = inputs
-        data = cls.dataset[index]
-        if cls.mem_bulk is not None:
-            offset = i * cls.mem_size
-            limit = offset + cls.mem_size
-            data = _pack(data, cls.mem_bulk, offset, limit)
+        data = _Fetch.dataset[index]
+        if _Fetch.mem_bulk is not None:
+            offset = i * _Fetch.mem_size
+            limit = offset + _Fetch.mem_size
+            data = _pack(data, _Fetch.mem_bulk, offset, limit)
         return data
 
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -262,7 +262,7 @@ class _PrefetchLoop(object):
             self.comm.put(batch, self.prefetch_state, reset_count)
             return True
 
-        if self.mem_bulk == None:
+        if self.mem_bulk is None:
             if not task(None):
                 return
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -192,7 +192,7 @@ class _Communicator(object):
         with self._lock:
             self._status = _Communicator.STATUS_RESET
             self._prefetch_state = prefetch_state
-            self._batch_queue.clear()
+            self._batch_queue = []
             self._not_full_cond.notify()
             self._reset_count += 1
 
@@ -200,7 +200,7 @@ class _Communicator(object):
     def terminate(self):
         with self._lock:
             self._status = _Communicator.STATUS_TERMINATE
-            self._batch_queue.clear()
+            self._batch_queue = []
             self._not_full_cond.notify()
             self._reset_count += 1
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -12,7 +12,7 @@ import six
 from chainer.dataset import iterator
 
 
-_long_time = 10000000
+_long_time = 1000000
 _PrefetchState = namedtuple('_PrefetchState', (
     'current_position', 'epoch', 'is_new_epoch',
     'previous_epoch_detail', 'order'))

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -353,6 +353,7 @@ def _fetch_setup(dataset, mem_size, mem_bulk):
     _fetch_mem_size = mem_size
     _fetch_mem_bulk = mem_bulk
 
+
 def _fetch_run(inputs):
     i, index = inputs
     data = _fetch_dataset[index]

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -2,7 +2,7 @@ from __future__ import division
 from collections import namedtuple
 import multiprocessing
 from multiprocessing import sharedctypes
-import queue
+from six.moves import queue
 import threading
 import warnings
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -99,16 +99,29 @@ class MultiprocessIterator(iterator.Iterator):
     next = __next__
 
     def __del__(self):
-        d = self.__dict__
-        if '_finalized' in d and not self._finalized:
-            self._finalized = True
-            if '_comm' in d:
-                self._comm.terminate()
-                if '_thread' in d:
-                    t = self._thread
-                    if t is not None:
-                        while t.is_alive():
-                            t.join(_response_time)
+        try:
+            finalized = self._finalized
+        except AttributeError:
+            return
+        if finalized:
+            return
+        self._finalized = True
+
+        try:
+            comm = self._comm
+        except AttributeError:
+            return
+        comm.terminate()
+
+        try:
+            t = self._thread
+        except AttributeError:
+            return
+        if t is None:
+            return
+
+        while t.is_alive():
+            t.join(_response_time)
 
     finalize = __del__
 

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -411,11 +411,18 @@ class TestMultiprocessIteratorConcurrency(unittest.TestCase):
 
 class TestMultiprocessIteratorInterruption(unittest.TestCase):
 
+    # unless you're debugging tests, this should be false
+    show_interruption_msg = False
+
     def setUp(self):
         self.code_path = None
         self.sys_path_appended = False
+        if not self.__class__.show_interruption_msg:
+            self.nullfd = os.open(os.devnull, os.O_WRONLY)
 
     def tearDown(self):
+        if not self.__class__.show_interruption_msg:
+            os.close(self.nullfd)
         if self.code_path is not None:
             os.remove(self.code_path)
         if self.sys_path_appended:
@@ -463,8 +470,9 @@ if __name__ == '__main__':
         self.sys_path_appended = True
 
         stdout = None if shared_mem is None else subprocess.PIPE
+        stderr = None if self.__class__.show_interruption_msg else self.nullfd
         self.p = subprocess.Popen([sys.executable, self.code_path],
-                                  stdout=stdout)
+                                  stdout=stdout, stderr=stderr)
         if stdout is None:
             self.child_pids = []
         else:

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -260,20 +260,29 @@ class TestMultiprocessIterator(unittest.TestCase):
                 self.assertRaises(StopIteration, it.next)
             it.reset()
 
-    def test_unsupported_reset_middle(self):
+    def test_reset_middle(self):
         dataset = [1, 2, 3, 4, 5]
         it = iterators.MultiprocessIterator(
             dataset, 2, repeat=False, **self.options)
-        it.next()
-        self.assertRaises(NotImplementedError, it.reset)
 
-    def test_unsupported_reset_repeat(self):
+        for trial in range(4):
+            it.next()
+            it.reset()
+            batches = sum([it.next() for _ in range(3)], [])
+            self.assertEqual(sorted(batches), dataset)
+            for _ in range(2):
+                self.assertRaises(StopIteration, it.next)
+            it.reset()
+
+    def test_reset_repeat(self):
         dataset = [1, 2, 3, 4]
         it = iterators.MultiprocessIterator(
             dataset, 2, repeat=True, **self.options)
-        it.next()
-        it.next()
-        self.assertRaises(NotImplementedError, it.reset)
+
+        for trial in range(4):
+            batches = sum([it.next() for _ in range(4)], [])
+            self.assertEqual(sorted(batches), sorted(2 * dataset))
+            it.reset()
 
     def test_unsupported_reset_finalized(self):
         dataset = [1, 2, 3, 4]

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -450,7 +450,7 @@ class NoWaitDataSet(object):
 no_wait = NoWaitDataSet()
 
 if __name__ == '__main__':
-    if {shared_mem} is not None:
+    if {shared_mem} is not None and {dataset} is infinite_wait:
         iterators.MultiprocessIterator._interruption_testing = True
     it = iterators.MultiprocessIterator({dataset}, 100,
                                         n_processes={n_processes},
@@ -469,7 +469,10 @@ if __name__ == '__main__':
         sys.path.append(os.path.dirname(self.code_path))
         self.sys_path_appended = True
 
-        stdout = None if shared_mem is None else subprocess.PIPE
+        if shared_mem is not None and dataset is 'infinite_wait':
+            stdout = subprocess.PIPE
+        else:
+            stdout = None
         stderr = None if self.__class__.show_interruption_msg else self.nullfd
         self.p = subprocess.Popen([sys.executable, self.code_path],
                                   stdout=stdout, stderr=stderr)

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -503,11 +503,13 @@ if __name__ == '__main__':
 
     def killall(self):
         # try waiting the root process
-        try:
-            self.p.wait(10)
-        except subprocess.TimeoutExpired:
-            # the remained process will be killed later
-            pass
+        # Python 2.7 doesn't have `subprocess.TimeoutExpired`,
+        # so we couldn't use `p.wait(10)`.
+        for _ in range(10):
+            time.sleep(1)
+            if self.p.poll() is not None:
+                self.p.wait()
+                break
 
         pids = [self.p.pid] + self.child_pids
 

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -415,7 +415,7 @@ class TestMultiprocessIteratorConcurrency(unittest.TestCase):
 class TestMultiprocessIteratorInterruption(unittest.TestCase):
 
     # unless you're debugging tests, this should be false
-    show_interruption_msg = True
+    show_interruption_msg = False
 
     def setUp(self):
         self.code_path = None


### PR DESCRIPTION
I rewrote the `MultiprocessIterator` using Python's `Pool` functionality. It makes codes simpler and faster, as well as making orphan/zombie process less likely.

Instead of previous "one prefetch invoked at one fetch" implementation, in my implementation background thread invokes prefetch freely, only if the maximum prefetch number allows. I think this strategy is better for utilizing idle CPU/IO time.

Resetting an iterator in the mid of iteration is also supported. Tests are changed accordingly.

The second commit changes per-batch-item shared memory allocation to the bulk allocation. This improved performance a little. 

I took a benchmark of `examples/mnist/train_mnist.py`, with `SerialIterator` changed to `MultiprocessIterator`.  It was done on EC2 g3.4xlarge instance.

```
time python train_mnist.py -g 0
baseline:          537.91s user 170.63s system 263% cpu 4:28.87 total
before bulk alloc: 234.32s user 27.87s  system 215% cpu 2:01.85 total
after bulk alloc:  227.92s user 26.92s  system 215% cpu 1:58.23 total
```