### PR TITLE
Remove "Edit on GitHub" link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -204,7 +204,7 @@ if on_rtd:
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True


### PR DESCRIPTION
Issue: #2822 

Removing "Edit on GitHub" link

* Many people (including me) often confuse it as the link to .py file
* It's often reported broken (#1034, #2822)

TODO: Port to CuPy