### PR TITLE
fixed :module: to :mod:

### DIFF
--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -20,7 +20,8 @@ class Updater(object):
 
     The first line is processed by :meth:`chainer.dataset.Iterator.__next__`.
     The second and third are processed by :meth:`~chainer.Optimizer.update`.
-    Users can also implement original :meth:`update` by overiding it.
+    Users can also implement their original updating iteration by overriding
+    :meth:`update`.
 
     """
 

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -11,9 +11,7 @@ class Updater(object):
     """Interface of updater objects for trainers.
 
     :class:`~chainer.training.Updater` implements a training iteration
-    as :meth:`update`.
-
-    Typically, the updating iteration proceeds as follows.
+    as :meth:`update`.Typically, the updating iteration proceeds as follows.
 
     - Fetch a minibatch from :mod:`~chainer.dataset`
         via :class:`~chainer.dataset.Iterator`.
@@ -22,7 +20,6 @@ class Updater(object):
 
     The first line is processed by :meth:`chainer.dataset.Iterator.__next__`.
     The second and third are processed by :meth:`~chainer.Optimizer.update`.
-
     Users can also implement original :meth:`update` by overiding it.
 
     """

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -20,9 +20,10 @@ class Updater(object):
 
     The first line is processed by
     :meth:`Iterator.__next__ <chainer.dataset.Iterator.__next__>`.
-    The second and third are processed by :meth:`~chainer.Optimizer.update`.
+    The second and third are processed by
+    :meth:`Optimizer.update <chainer.Optimizer.update>`.
     Users can also implement their original updating iteration by overriding
-    :meth:`update`.
+    :meth:`Updater.update <chainer.training.Updater.update>`.
 
     """
 

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -14,7 +14,7 @@ class Updater(object):
     as :meth:`update`. Typically, the updating iteration proceeds as follows.
 
     - Fetch a minibatch from :mod:`~chainer.dataset`
-    via :class:`~chainer.dataset.Iterator`.
+      via :class:`~chainer.dataset.Iterator`.
     - Run forward and backward process of :class:`~chainer.Chain`.
     - Update parameters according to their :class:`~chainer.UpdateRule`.
 

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -15,7 +15,7 @@ class Updater(object):
 
     Typically, the updating iteration proceeds as follows.
 
-    - Fetch a minibatch from :module:`~chainer.dataset`
+    - Fetch a minibatch from :mod:`~chainer.dataset`
         via :class:`~chainer.dataset.Iterator`.
     - Run forward and backward process of :class:`~chainer.Chain`.
     - Update parameters according to their :class:`~chainer.UpdateRule`.

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -18,7 +18,8 @@ class Updater(object):
     - Run forward and backward process of :class:`~chainer.Chain`.
     - Update parameters according to their :class:`~chainer.UpdateRule`.
 
-    The first line is processed by :meth:`chainer.dataset.Iterator.__next__`.
+    The first line is processed by
+    :meth:`Iterator.__next__ <chainer.dataset.Iterator.__next__>`.
     The second and third are processed by :meth:`~chainer.Optimizer.update`.
     Users can also implement their original updating iteration by overriding
     :meth:`update`.

--- a/chainer/training/updater.py
+++ b/chainer/training/updater.py
@@ -11,10 +11,10 @@ class Updater(object):
     """Interface of updater objects for trainers.
 
     :class:`~chainer.training.Updater` implements a training iteration
-    as :meth:`update`.Typically, the updating iteration proceeds as follows.
+    as :meth:`update`. Typically, the updating iteration proceeds as follows.
 
     - Fetch a minibatch from :mod:`~chainer.dataset`
-        via :class:`~chainer.dataset.Iterator`.
+    via :class:`~chainer.dataset.Iterator`.
     - Run forward and backward process of :class:`~chainer.Chain`.
     - Update parameters according to their :class:`~chainer.UpdateRule`.
 


### PR DESCRIPTION
Shamefully I mistook the sphinx's domain markup in the pull request [#3012](https://github.com/chainer/chainer/pull/3012).
:module: was not sphinx's domain. :mod: was correct.

I would like chainer's developer to merge this PR as soon as possible. (I'm really shamed...)