### PR TITLE
Add warnings about preprocessing for dataset with both grayscale and RGB images.

### DIFF
--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -44,6 +44,13 @@ class ImageDataset(dataset_mixin.DatasetMixin):
        formats you want to use (e.g. libpng for PNG images, and libjpeg for JPG
        images).
 
+    .. note::
+       **You are responsible for preprocessing the images before feeding them to
+       a model.** For example, if your dataset contains both RGB and grayscale
+       images, make sure that you convert them to the same format. Otherwise you
+       will get errors because the input dimensions are different for RGB and
+       grayscale images.
+
     Args:
         paths (str or list of strs): If it is a string, it is a path to a text
             file that contains paths to images in distinct lines. If it is a
@@ -94,6 +101,13 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
        install Pillow``). Be careful to prepare appropriate libraries for image
        formats you want to use (e.g. libpng for PNG images, and libjpeg for JPG
        images).
+
+    .. note::
+       **You are responsible for preprocessing the images before feeding them to
+       a model.** For example, if your dataset contains both RGB and grayscale
+       images, make sure that you convert them to the same format. Otherwise you
+       will get errors because the input dimensions are different for RGB and
+       grayscale images.
 
     Args:
         pairs (str or list of tuples): If it is a string, it is a path to a

--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -45,11 +45,11 @@ class ImageDataset(dataset_mixin.DatasetMixin):
        images).
 
     .. note::
-       **You are responsible for preprocessing the images before feeding them to
-       a model.** For example, if your dataset contains both RGB and grayscale
-       images, make sure that you convert them to the same format. Otherwise you
-       will get errors because the input dimensions are different for RGB and
-       grayscale images.
+       **You are responsible for preprocessing the images before feeding them
+       to a model.** For example, if your dataset contains both RGB and
+       grayscale images, make sure that you convert them to the same format.
+       Otherwise you will get errors because the input dimensions are different
+       for RGB and grayscale images.
 
     Args:
         paths (str or list of strs): If it is a string, it is a path to a text
@@ -103,11 +103,11 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
        images).
 
     .. note::
-       **You are responsible for preprocessing the images before feeding them to
-       a model.** For example, if your dataset contains both RGB and grayscale
-       images, make sure that you convert them to the same format. Otherwise you
-       will get errors because the input dimensions are different for RGB and
-       grayscale images.
+       **You are responsible for preprocessing the images before feeding them
+       to a model.** For example, if your dataset contains both RGB and
+       grayscale images, make sure that you convert them to the same format.
+       Otherwise you will get errors because the input dimensions are different
+       for RGB and grayscale images.
 
     Args:
         pairs (str or list of tuples): If it is a string, it is a path to a

--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -44,7 +44,7 @@ class ImageDataset(dataset_mixin.DatasetMixin):
        formats you want to use (e.g. libpng for PNG images, and libjpeg for JPG
        images).
 
-    .. note::
+    .. warning::
        **You are responsible for preprocessing the images before feeding them
        to a model.** For example, if your dataset contains both RGB and
        grayscale images, make sure that you convert them to the same format.
@@ -102,7 +102,7 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
        formats you want to use (e.g. libpng for PNG images, and libjpeg for JPG
        images).
 
-    .. note::
+    .. warning::
        **You are responsible for preprocessing the images before feeding them
        to a model.** For example, if your dataset contains both RGB and
        grayscale images, make sure that you convert them to the same format.


### PR DESCRIPTION
This pull request adds a warning about preprocessing the images to the documentation of ImageDataset and LabeledImageDataset.

The problem I had is that there are **a few grayscale images** in the dataset I want to use, while I am not aware of that. Chainer does not automatically convert the images to RGB or provide an option for that. Since previously I have used this dataset with other libraries and it works just fine, I was just confused about the errors `ValueError: all the input array dimensions except for the concatenation axis must match exactly`. 

I understand the decision you made as in #1445, however, I think it will be helpful if such a warning exists in the doc, so that people like me will not spend several hours to detect such an error.

Especially for people coming from other frameworks, such friendly notes are really necessary.