### PR TITLE
Fix doc of init_scope

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -212,8 +212,8 @@ class Link(object):
         .. deprecated:: v2.0.0
 
            Assign a :class:`~chainer.Parameter` object directly to an
-           attribute within :meth:`an initialization scope <init_scope>`
-           instead. For example, the following code
+           attribute within :meth:`~chainer.Link.init_scope` instead.
+           For example, the following code
 
            .. code-block:: python
 
@@ -223,10 +223,10 @@ class Link(object):
 
            .. code-block:: python
 
-               with self.init_scope():
+               with link.init_scope():
                    link.W = chainer.Parameter(None, (5, 3))
 
-           The latter one is easier for IDEs to keep track of the attribute's
+           The latter is easier for IDEs to keep track of the attribute's
            type.
 
         Args:
@@ -584,7 +584,7 @@ class Chain(Link):
     by slashes ``/``.
 
     A child link can be added just by assigning it to an attribute of the
-    chain within :meth:`an initialization scope <chainer.Link.init_scope>`.
+    chain within :meth:`~chainer.Chain.init_scope`.
 
     The registered child link is saved and loaded on serialization and
     deserialization, and involved in the optimization. The registered link
@@ -636,7 +636,7 @@ class Chain(Link):
 
             .. deprecated:: v2.0.0
 
-               Assign child links directly to attributes, instead.
+               Assign child links directly to attributes instead.
 
     """
 
@@ -670,7 +670,7 @@ class Chain(Link):
         .. deprecated:: v2.0.0
 
            Assign the child link directly to an attribute within
-           :meth:`an initialization scope <chainer.Link.init_scope>`, instead.
+           :meth:`~chainer.Chain.init_scope` instead.
            For example, the following code
 
            .. code-block:: python
@@ -681,10 +681,10 @@ class Chain(Link):
 
            .. code-block:: python
 
-              with self.init_scope():
+              with chain.init_scope():
                   chain.l1 = L.Linear(3, 5)
 
-           The latter one is easier for IDEs to keep track of the attribute's
+           The latter is easier for IDEs to keep track of the attribute's
            type.
 
         Args:


### PR DESCRIPTION
Fixed some documentation around `init_scope`.

* "an initialization scope" was rendered as a code fragment, which is weird. (https://docs.chainer.org/en/stable/reference/core/generated/chainer.Chain.html#chainer.Chain.add_link)
* `self` in examples should be `link` or `chain`, shouldn't they?