### PR TITLE
Remove get_device from examples

### DIFF
--- a/examples/cifar/train_cifar_custom_loop.py
+++ b/examples/cifar/train_cifar_custom_loop.py
@@ -68,7 +68,8 @@ def main():
 
     model = L.Classifier(models.VGG.VGG(class_labels))
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()  # Make a specified GPU current
+        # Make a specified GPU current
+        chainer.cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()  # Copy the model to the GPU
 
     optimizer = chainer.optimizers.MomentumSGD(args.learnrate)

--- a/examples/reinforcement_learning/ddpg_pendulum.py
+++ b/examples/reinforcement_learning/ddpg_pendulum.py
@@ -182,7 +182,7 @@ def main():
                     env.action_space.low, env.action_space.high,
                     n_units=args.unit)
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         Q.to_gpu(args.gpu)
         policy.to_gpu(args.gpu)
     target_Q = copy.deepcopy(Q)

--- a/examples/reinforcement_learning/dqn_cartpole.py
+++ b/examples/reinforcement_learning/dqn_cartpole.py
@@ -134,7 +134,7 @@ def main():
     # Initialize a model and its optimizer
     Q = QFunction(obs_size, n_actions, n_units=args.unit)
     if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
+        chainer.cuda.get_device_from_id(args.gpu).use()
         Q.to_gpu(args.gpu)
     target_Q = copy.deepcopy(Q)
     opt = optimizers.Adam(eps=1e-2)


### PR DESCRIPTION
This PR removes `chainer.cuda.get_device` from `./examples/`, which is deprecated in Chainer v2.