### PR TITLE
Fix the problem with resuming training when switching the freezing layers

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -263,6 +263,12 @@ class UpdateRule(object):
 
                 for key in self._state:
                     self._state[key] = serializer(key, None)
+                    # leave the update rule state as `None` if the keys are not
+                    # contained in the snapshot, so that these states can be
+                    # automatically initialized with the `_prepare` method
+                    if self._state[key] is None:
+                        self._state = None
+                        break
         else:
             for key in self._state:
                 self._state[key] = serializer(key, self._state[key])


### PR DESCRIPTION
This PR fixes the problem that error will occur **when resuming training from a snapshot that has different setting of `update_rule.enabled` for params**. The code reproducing the problem is here: https://github.com/jinjiren/chainer-examples/blob/master/reproducing_the_freezing_unfreezing_problem.ipynb

More specifically, when finetuning a model to a different dataset, sometimes we would like to first freeze all layers but the fc layer, and after training some epochs, we then start to train all layers. However, if we want to resume a snapshot that contains freezing layers to fully training all layers, such error will occur `KeyError: 'updater/optimizer:main/predictor/l2/W/m is not a file in the archive'`.

Full error message:
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-35-08fe7c1632c6> in <module>()
      1 args.freeze = False
      2 args.resume = 'result/snapshot_iter_3000'
----> 3 main(args)

<ipython-input-30-135de962b3f9> in main(args)
     31     if args.resume:
     32         # Resume from a snapshot
---> 33         chainer.serializers.load_npz(args.resume, trainer)
     34 
     35     if args.freeze:

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer-3.0.0b1-py3.6.egg/chainer/serializers/npz.py in load_npz(filename, obj, path, strict)
    138     with numpy.load(filename) as f:
    139         d = NpzDeserializer(f, path=path, strict=strict)
--> 140         d.load(obj)

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer-3.0.0b1-py3.6.egg/chainer/serializer.py in load(self, obj)
     80 
     81         """
---> 82         obj.serialize(self)

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer-3.0.0b1-py3.6.egg/chainer/training/trainer.py in serialize(self, serializer)
    334 
    335     def serialize(self, serializer):
--> 336         self.updater.serialize(serializer['updater'])
    337         if hasattr(self.stop_trigger, 'serialize'):
    338             self.stop_trigger.serialize(serializer['stop_trigger'])

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer-3.0.0b1-py3.6.egg/chainer/training/updater.py in serialize(self, serializer)
    244 
    245         for name, optimizer in six.iteritems(self._optimizers):
--> 246             optimizer.serialize(serializer['optimizer:' + name])
    247             optimizer.target.serialize(serializer['model:' + name])
    248 

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer-3.0.0b1-py3.6.egg/chainer/optimizer.py in serialize(self, serializer)
    448             rule = getattr(param, 'update_rule', None)
    449             if rule is not None:
--> 450                 **rule.serialize(serializer[name])**
    451 
    452 

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer-3.0.0b1-py3.6.egg/chainer/optimizer.py in serialize(self, serializer)
    263 
    264                 for key in self._state:
--> 265                     **self._state[key] = serializer(key, None)**
    266         else:
    267             for key in self._state:

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/chainer-3.0.0b1-py3.6.egg/chainer/serializers/npz.py in __call__(self, key, value)
    104             return value
    105 
--> 106         **dataset = self.npz[key]**
    107         if dataset[()] is None:
    108             return None

/home/jin/.pyenv/versions/anaconda3-4.4.0/lib/python3.6/site-packages/numpy/lib/npyio.py in __getitem__(self, key)
    235                 return self.zip.read(key)
    236         else:
--> 237             raise KeyError("%s is not a file in the archive" % key)
    238 
    239     def __iter__(self):

**KeyError: 'updater/optimizer:main/predictor/l2/W/m is not a file in the archive'**
```

Note that the `m` in the error, which is a `key` in the `_state` of the `AdamRule` class. After some investigation, I found the reason is that when serializing (saving) the snapshot, the extension automatically filter out the `state`s of `UpdateRule` with `update_rule.enabled` set to `False`. Thus when deserializing (loading) the snapshot, `dataset = self.npz[key]` will not find the corresponding `key`.

As suggested by @mitmul, I tried using  `load_npz(args.resume, trainer, strict=False)`, however, since the default behavior for this is to return `None` for the missing `key`, another problem occurs: the updater complains about the `None` type.

So I consider the proper behavior of the `serialize` method of `UpdateRule` class should be **leaving the state with missing key as None**. In this way, **the `_prepare` method will automatically handle the initialization of the UpdateRule `state` when such states are not found in the snapshot**.

The change I have made to the source code is simple, and it **should be jointly used with the `strict=False` for `load_npz` function**. I have tested it and now we can resuming snapshots freely when changing parameters to be updated.
 