### PR TITLE
Improve example index

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,28 @@ This page contains a list of example codes written with Chainer.
 * [ImageNet: Large Scale ConvNets](https://github.com/chainer/chainer/tree/master/examples/imagenet)
 * [Evaluate a Caffe reference model](https://github.com/chainer/chainer/tree/master/examples/modelzoo)
 
+### <a name="object-detection"></a> Object Detection
+
+* [ChainerCV example: Faster R-CNN](https://github.com/chainer/chainercv/tree/master/examples/faster_rcnn)
+* [ChainerCV example: Single Shot Multibox Detector (SSD)](https://github.com/chainer/chainercv/tree/master/examples/ssd)
+
+### <a name="semantic-segmentation"></a> Semantic Segmentation
+
+* [ChainerCV example: SegNet](https://github.com/chainer/chainercv/tree/master/examples/segnet)
+
 ### <a name="generative-models"></a> Generative Models
 
 * [Variational AutoEncoder](https://github.com/chainer/chainer/tree/master/examples/vae)
 * [DCGAN](https://github.com/chainer/chainer/tree/master/examples/dcgan)
+* [pfnet-resaerch example: Chainer-GAN-lib](https://github.com/pfnet-research/chainer-gan-lib)
+* [pfnet-resaerch example: Pix2Pix](https://github.com/pfnet-research/chainer-pix2pix)
+
+### <a name="graph-cnn"></a> Graph Convolutional Network
+
+* [pfnet-resaerch example: Chainer Graph CNN](https://github.com/pfnet-research/chainer-graph-cnn)
+
+### <a name="reinforcement-learning"></a> Reinforcement Learning
+
+* [DQN and DoubleDQN on discrete-action tasks](https://github.com/chainer/chainer/tree/master/examples/reinforcement_learning)
+* [DDPG on continuous-action tasks](https://github.com/chainer/chainer/tree/master/examples/reinforcement_learning)
+* [ChainerRL examples: more examples for OpenAI Gym and Arcade Learning environments](https://github.com/chainer/chainerrl/tree/master/examples)

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,8 @@ Chainer Examples
 
 This page contains a list of example codes written with Chainer.
 
+**It should be noted that examples marked with :zzz: have not been tested with current version of Chainer and whether it can work with current version of Chainer or not is not guaranteed.**
+
 ### <a name="natual-language-processing"></a> Natural Language Processing
 
 * [Recurrent Net Language Model](https://github.com/chainer/chainer/tree/master/examples/ptb)
@@ -29,12 +31,12 @@ This page contains a list of example codes written with Chainer.
 
 * [Variational AutoEncoder](https://github.com/chainer/chainer/tree/master/examples/vae)
 * [DCGAN](https://github.com/chainer/chainer/tree/master/examples/dcgan)
-* [pfnet-resaerch example: Chainer-GAN-lib](https://github.com/pfnet-research/chainer-gan-lib)
-* [pfnet-resaerch example: Pix2Pix](https://github.com/pfnet-research/chainer-pix2pix)
+* [:zzz: pfnet-resaerch example: Chainer-GAN-lib](https://github.com/pfnet-research/chainer-gan-lib)
+* [:zzz: pfnet-resaerch example: Pix2Pix](https://github.com/pfnet-research/chainer-pix2pix)
 
 ### <a name="graph-cnn"></a> Graph Convolutional Network
 
-* [pfnet-resaerch example: Chainer Graph CNN](https://github.com/pfnet-research/chainer-graph-cnn)
+* [:zzz: pfnet-resaerch example: Chainer Graph CNN](https://github.com/pfnet-research/chainer-graph-cnn)
 
 ### <a name="reinforcement-learning"></a> Reinforcement Learning
 


### PR DESCRIPTION
Reinforcement learning examples have been added but not listed in the README in the example dir.
This PR also adds some external examples written by internal members and provided in pfnet-research, ChainerCV, and ChainerRL repositories.