### PR TITLE
[backport] interval_trigger using previous_epoch_detail

### DIFF
--- a/chainer/testing/training.py
+++ b/chainer/testing/training.py
@@ -6,7 +6,7 @@ from chainer import training
 
 
 def get_trainer_with_mock_updater(
-    stop_trigger=(10, 'iteration'), iter_per_epoch=10):
+        stop_trigger=(10, 'iteration'), iter_per_epoch=10):
     """Returns a :class:`~chainer.training.Trainer` object with mock updater.
 
     The returned trainer can be used for testing the trainer itself and the

--- a/chainer/testing/training.py
+++ b/chainer/testing/training.py
@@ -5,7 +5,8 @@ import mock
 from chainer import training
 
 
-def get_trainer_with_mock_updater(stop_trigger=(10, 'iteration')):
+def get_trainer_with_mock_updater(
+    stop_trigger=(10, 'iteration'), iter_per_epoch=10):
     """Returns a :class:`~chainer.training.Trainer` object with mock updater.
 
     The returned trainer can be used for testing the trainer itself and the

--- a/chainer/testing/training.py
+++ b/chainer/testing/training.py
@@ -26,14 +26,17 @@ def get_trainer_with_mock_updater(stop_trigger=(10, 'iteration')):
     updater.epoch = 0
     updater.epoch_detail = 0
     updater.is_new_epoch = True
-    iter_per_epoch = 10
+    updater.previous_epoch_detail = None
 
     def update():
         updater.update_core()
         updater.iteration += 1
         updater.epoch = updater.iteration // iter_per_epoch
         updater.epoch_detail = updater.iteration / iter_per_epoch
-        updater.is_new_epoch = updater.epoch == updater.epoch_detail
+        updater.is_new_epoch = (updater.iteration - 1) // \
+            iter_per_epoch != updater.epoch
+        updater.previous_epoch_detail = (updater.iteration - 1) \
+            / iter_per_epoch
 
     updater.update = update
     trainer = training.Trainer(updater, stop_trigger)

--- a/tests/chainer_tests/testing_tests/test_training.py
+++ b/tests/chainer_tests/testing_tests/test_training.py
@@ -1,8 +1,15 @@
+from __future__ import division
+
+import math
 import unittest
 
 from chainer import testing
 
 
+@testing.parameterize(*testing.product({
+    'stop_trigger': [(5, 'iteration'), (5, 'epoch')],
+    'iter_per_epoch': [0.5, 1, 1.5, 5],
+}))
 class TestGetTrainerWithMockUpdater(unittest.TestCase):
 
     def setUp(self):
@@ -32,13 +39,12 @@ class TestGetTrainerWithMockUpdater(unittest.TestCase):
         self.trainer.extend(check)
         self.trainer.run()
 
-        def check_count(trainer):
-            count[0] += 1
-            self.assertEqual(trainer.updater.iteration, count[0])
-
-        self.trainer.extend(check_count)
-        self.trainer.run()
-        self.assertEqual(count[0], 5)
+        if self.stop_trigger[1] == 'iteration':
+            self.assertEqual(iteration[0], self.stop_trigger[0])
+        elif self.stop_trigger[1] == 'epoch':
+            self.assertEqual(
+                iteration[0],
+                math.ceil(self.stop_trigger[0] * self.iter_per_epoch))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/testing_tests/test_training.py
+++ b/tests/chainer_tests/testing_tests/test_training.py
@@ -6,10 +6,31 @@ from chainer import testing
 class TestGetTrainerWithMockUpdater(unittest.TestCase):
 
     def setUp(self):
-        self.trainer = testing.get_trainer_with_mock_updater((5, 'iteration'))
+        self.trainer = testing.get_trainer_with_mock_updater(
+            self.stop_trigger, self.iter_per_epoch)
 
-    def test_update_count(self):
-        count = [0]
+    def test_run(self):
+        iteration = [0]
+
+        def check(trainer):
+            iteration[0] += 1
+
+            self.assertEqual(trainer.updater.iteration, iteration[0])
+            self.assertEqual(
+                trainer.updater.epoch, iteration[0] // self.iter_per_epoch)
+            self.assertEqual(
+                trainer.updater.epoch_detail,
+                iteration[0] / self.iter_per_epoch)
+            self.assertEqual(
+                trainer.updater.is_new_epoch,
+                (iteration[0] - 1) // self.iter_per_epoch !=
+                iteration[0] // self.iter_per_epoch)
+            self.assertEqual(
+                trainer.updater.previous_epoch_detail,
+                (iteration[0] - 1) / self.iter_per_epoch)
+
+        self.trainer.extend(check)
+        self.trainer.run()
 
         def check_count(trainer):
             count[0] += 1


### PR DESCRIPTION
Backport of #2484

Be careful that this PR changes existing APIs. Specifically, this PR:

* adds `iter_per_epoch` argument with the default value to `get_trainer_with_mock_updater`.
* adds `serialize` method to `IntervalTrigger`.

As we declared in [the contribution guide](https://docs.chainer.org/en/stable/contribution.html#issue-pr-labels), we do not add any feature to revision updates basically. But as this PR introduced new features to fix bugs in stable versions. We propose to backport the PR. In order to make it clear that newly-added APIs are not documented (therefore not officially supported), we do not add documents to these APIs intentionally.