### PR TITLE
Add alias chainer.FunctionHook

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -10,6 +10,7 @@ from chainer import cuda  # NOQA
 from chainer import dataset  # NOQA
 from chainer import datasets  # NOQA
 from chainer import function  # NOQA
+from chainer import function_hook  # NOQA
 from chainer import function_node  # NOQA
 from chainer import functions  # NOQA
 from chainer import initializer  # NOQA
@@ -33,6 +34,7 @@ from chainer.configuration import using_config  # NOQA
 from chainer.function import force_backprop_mode  # NOQA
 from chainer.function import Function  # NOQA
 from chainer.function import no_backprop_mode  # NOQA
+from chainer.function_hook import FunctionHook  # NOQA
 from chainer.function_node import FunctionNode  # NOQA
 from chainer.functions import array  # NOQA
 from chainer.functions.math import basic_math  # NOQA

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -439,7 +439,7 @@ class Function(object):
         See :meth:`FunctionNode.add_hook` for the detail.
 
         Args:
-            hook(~chainer.function.FunctionHook):
+            hook(~chainer.FunctionHook):
                 Function hook to be registered.
             name(str): Name of the function hook.
                 name must be unique among function hooks

--- a/chainer/function_hook.py
+++ b/chainer/function_hook.py
@@ -4,34 +4,34 @@ import chainer
 class FunctionHook(object):
     """Base class of hooks for Functions.
 
-    :class:`~chainer.function.FunctionHook` is an callback object
+    :class:`~chainer.FunctionHook` is an callback object
     that is registered to :class:`~chainer.Function`.
     Registered function hooks are invoked before and after
     forward and backward operations of each function.
 
     Function hooks that derive :class:`FunctionHook` are required
     to implement four methods:
-    :meth:`~chainer.function.FunctionHook.forward_preprocess`,
-    :meth:`~chainer.function.FunctionHook.forward_postprocess`,
-    :meth:`~chainer.function.FunctionHook.backward_preprocess`, and
-    :meth:`~chainer.function.FunctionHook.backward_postprocess`.
+    :meth:`~chainer.FunctionHook.forward_preprocess`,
+    :meth:`~chainer.FunctionHook.forward_postprocess`,
+    :meth:`~chainer.FunctionHook.backward_preprocess`, and
+    :meth:`~chainer.FunctionHook.backward_postprocess`.
     By default, these methods do nothing.
 
     Specifically, when :meth:`~chainer.Function.__call__`
     method of some function is invoked,
-    :meth:`~chainer.function.FunctionHook.forward_preprocess`
-    (resp. :meth:`~chainer.function.FunctionHook.forward_postprocess`)
+    :meth:`~chainer.FunctionHook.forward_preprocess`
+    (resp. :meth:`~chainer.FunctionHook.forward_postprocess`)
     of all function hooks registered to this function are called before
     (resp. after) forward propagation.
 
     Likewise, when :meth:`~chainer.Variable.backward` of some
     :class:`~chainer.Variable` is invoked,
-    :meth:`~chainer.function.FunctionHook.backward_preprocess`
-    (resp. :meth:`~chainer.function.FunctionHook.backward_postprocess`)
+    :meth:`~chainer.FunctionHook.backward_preprocess`
+    (resp. :meth:`~chainer.FunctionHook.backward_postprocess`)
     of all function hooks registered to the function which holds this variable
     as a gradient are called before (resp. after) backward propagation.
 
-    There are two ways to register :class:`~chainer.function.FunctionHook`
+    There are two ways to register :class:`~chainer.FunctionHook`
     objects to :class:`~chainer.Function` objects.
 
     First one is to use ``with`` statement. Function hooks hooked
@@ -43,7 +43,7 @@ class FunctionHook(object):
         The following code is a simple example in which
         we measure the elapsed time of a part of forward propagation procedure
         with :class:`~chainer.function_hooks.TimerHook`, which is a subclass of
-        :class:`~chainer.function.FunctionHook`.
+        :class:`~chainer.FunctionHook`.
 
         >>> from chainer import function_hooks
         >>> class Model(chainer.Chain):

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -565,7 +565,7 @@ class FunctionNode(object):
         """Registers a function hook.
 
         Args:
-            hook (~chainer.function.FunctionHook): Function hook to be
+            hook (~chainer.FunctionHook): Function hook to be
                 registered.
             name (str): Name of the function hook. The name must be unique
                 among function hooks registered to this function. If ``None``,

--- a/docs/source/reference/function_hooks.rst
+++ b/docs/source/reference/function_hooks.rst
@@ -11,7 +11,7 @@ Base class
    :toctree: generated/
    :nosignatures:
 
-   chainer.function.FunctionHook
+   chainer.FunctionHook
 
 .. module:: chainer.function_hooks
 

--- a/tests/chainer_tests/test_function_hook.py
+++ b/tests/chainer_tests/test_function_hook.py
@@ -1,13 +1,13 @@
 import unittest
 
-from chainer import function
+import chainer
 from chainer import testing
 
 
 class TestFunctionHook(unittest.TestCase):
 
     def setUp(self):
-        self.h = function.FunctionHook()
+        self.h = chainer.FunctionHook()
 
     def test_name(self):
         self.assertEqual(self.h.name, 'FunctionHook')


### PR DESCRIPTION
This PR adds `chainer.FunctionHook`, which is an alias of `chainer.function_hook.FunctionHook`. This PR also fixes code so that it does not use `chainer.function.FunctionHook`, which exists for backward compatibility.