### PR TITLE
Add function name in the debug message of NaN check

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -229,7 +229,8 @@ class FunctionNode(object):
             if any(out.dtype.kind == 'f' and
                    cuda.get_array_module(out).isnan(out).any()
                    for out in outputs):
-                msg = 'NaN is detected on forward computation'
+                msg = ('NaN is detected on forward computation of '
+                       '{}'.format(self.label))
                 raise RuntimeError(msg)
 
         ret = tuple([variable.Variable(y, requires_grad=requires_grad)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -926,7 +926,8 @@ Actual: {0}'''.format(type(data))
                     gx_data = gx.data
                     cuda.get_device_from_array(gx_data).use()
                     if cuda.get_array_module(gx_data).isnan(gx_data).any():
-                        msg = 'NaN is detected on backward computation'
+                        msg = ('NaN is detected on backward computation of '
+                               '{}'.format(func.label))
                         raise RuntimeError(msg)
 
             if not retain_grad:


### PR DESCRIPTION
This PR adds the function name, specified by `FunctionNode.label`, to the debug messages when `NaN` is detected (both in forward and backward computation).

The example code and the improved error message are as follows:

# Forward computation
Code
```
class DummyFunction(chainer.Function):

    def forward(self, inputs):
        return np.full_like(inputs[0], np.nan, dtype=np.float32),

    def backward(self, x, gy):
        return None

chainer.set_debug(True)
x = np.random.uniform(-1, 1, (10, 5)).astype(np.float32)
x = DummyFunction()(x)
```

Error message
```
Traceback (most recent call last):
  File "test2.py", line 17, in <module>
    x = DummyFunction()(x)
  File "/Users/oonokenta/sandbox/gx_check/chainer/chainer/function.py", line 211, in __call__
    ret = node.apply(inputs)
  File "/Users/oonokenta/sandbox/gx_check/chainer/chainer/function_node.py", line 234, in apply
    raise RuntimeError(msg)
RuntimeError: NaN is detected on forward computation of DummyFunction
```

# Backward computation

Code
```
class DummyFunction(chainer.Function):

    def forward(self, inputs):
        return inputs

    def backward(self, x, gy):
        return np.full_like(x, np.nan, dtype=np.float32)

chainer.set_debug(True)
x = chainer.Variable(np.random.uniform(-1, 1, (10, 5)).astype(np.float32))
x = DummyFunction()(x)
x = F.sum(x)
x.backward()
```

Error message
```
Traceback (most recent call last):
  File "test.py", line 19, in <module>
    x.backward()
  File "/Users/oonokenta/sandbox/gx_check/chainer/chainer/variable.py", line 931, in backward
    raise RuntimeError(msg)
RuntimeError: NaN is detected on backward computation of DummyFunction
```