### PR TITLE
[Backport] Fix errors in docstrings (2)

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -574,17 +574,23 @@ class FunctionHook(object):
 
         >>> from chainer import function_hooks
         >>> class Model(chainer.Chain):
-        ...     def __call__(self, x1):
-        ...         return F.exp(self.l(x1))
-        >>> model1 = Model(l=L.Linear(10, 10))
-        >>> model2 = Model(l=L.Linear(10, 10))
+        ...   def __call__(self, x1):
+        ...     return F.exp(self.l(x1))
+        >>> model1 = Model()
+        >>> with model1.init_scope():
+        ...   model1.l = L.Linear(10, 10)
+        >>> model2 = Model()
+        >>> with model2.init_scope():
+        ...   model2.l = L.Linear(10, 10)
         >>> x = chainer.Variable(np.zeros((1, 10), 'f'))
         >>> with chainer.function_hooks.TimerHook() as m:
-        ...     _ = model1(x)
-        ...     y = model2(x)
-        ...     print("Total time : " + str(m.total_time()))
-        ...     model3 = Model(l=L.Linear(10, 10))
-        ...     z = model3(y) # doctest:+ELLIPSIS
+        ...    _ = model1(x)
+        ...    y = model2(x)
+        ...    print("Total time : " + str(m.total_time()))
+        ...    model3 = Model()
+        ...    with model3.init_scope():
+        ...      model3.l = L.Linear(10, 10)
+        ...    z = model3(y) # doctest:+ELLIPSIS
         Total time : ...
 
         In this example, we measure the elapsed times for each forward

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -574,22 +574,19 @@ class FunctionHook(object):
 
         >>> from chainer import function_hooks
         >>> class Model(chainer.Chain):
+        ...   def __init__(self):
+        ...     with self.init_scope():
+        ...       self.l = L.Linear(10, 10)
         ...   def __call__(self, x1):
         ...     return F.exp(self.l(x1))
         >>> model1 = Model()
-        >>> with model1.init_scope():
-        ...   model1.l = L.Linear(10, 10)
         >>> model2 = Model()
-        >>> with model2.init_scope():
-        ...   model2.l = L.Linear(10, 10)
         >>> x = chainer.Variable(np.zeros((1, 10), 'f'))
         >>> with chainer.function_hooks.TimerHook() as m:
         ...    _ = model1(x)
         ...    y = model2(x)
         ...    print("Total time : " + str(m.total_time()))
         ...    model3 = Model()
-        ...    with model3.init_scope():
-        ...      model3.l = L.Linear(10, 10)
         ...    z = model3(y) # doctest:+ELLIPSIS
         Total time : ...
 


### PR DESCRIPTION
Backport of #3114

In the previous backport #3162, I discarded the change to `function_hook.py`, but I should have redirected the change to `function.py` instead.
