### PR TITLE
[backport] Fix typo in Chainer's configuration documentation

### DIFF
--- a/docs/source/reference/core/configuration.rst
+++ b/docs/source/reference/core/configuration.rst
@@ -37,7 +37,7 @@ Note that the default values are set in the global config.
    The default value is given by ``CHAINER_DEBUG`` environment variable (set to 0 or 1) if available, otherwise uses ``False``.
 ``chainer.config.enable_backprop``
    Flag to enable backpropagation support.
-   If it is ``True``, :class:`Function` makes a computaitonal graph of :class:`Variable` for back-propagation.
+   If it is ``True``, :class:`Function` makes a computational graph of :class:`Variable` for back-propagation.
    Otherwise, it does not make a computational graph.
    So a user cannot call :func:`~chainer.Variable.backward` method to results of the function.
    The default value is ``True``.


### PR DESCRIPTION
Backport of #3166