### PR TITLE
Add ignore option to NpzDeserializer

### DIFF
--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -85,22 +85,27 @@ class NpzDeserializer(serializer.Deserializer):
         strict (bool): If ``True``, the deserializer raises an error when an
             expected value is not found in the given NPZ file. Otherwise,
             it ignores the value and skip deserialization.
+        ignore_names (list of strings): Names of parameters and persistents
+            that are going to be skipped.
 
     """
 
-    def __init__(self, npz, path='', strict=True):
+    def __init__(self, npz, path='', strict=True, ignore_names=[]):
         self.npz = npz
         self.path = path
         self.strict = strict
+        self.ignore_names = ignore_names
 
     def __getitem__(self, key):
         key = key.strip('/')
         return NpzDeserializer(
-            self.npz, self.path + key + '/', strict=self.strict)
+            self.npz, self.path + key + '/', strict=self.strict,
+            ignore_names=self.ignore_names)
 
     def __call__(self, key, value):
         key = self.path + key.lstrip('/')
-        if not self.strict and key not in self.npz:
+        if (not self.strict and key not in self.npz
+                or key in self.ignore_names):
             return value
 
         dataset = self.npz[key]

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -127,9 +127,6 @@ class NpzDeserializer(serializer.Deserializer):
                         'ignore_names needs to be a callable or '
                         'list of strings and callables.')
 
-            if key in self.ignore_names:
-                return value
-
         dataset = self.npz[key]
         if dataset[()] is None:
             return None

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -85,11 +85,13 @@ class NpzDeserializer(serializer.Deserializer):
         strict (bool): If ``True``, the deserializer raises an error when an
             expected value is not found in the given NPZ file. Otherwise,
             it ignores the value and skip deserialization.
-        ignore_names (list of strings or callable): If this is a list,
-            this is names of parameters and persistents that are going
-            to be skipped.
+        ignore_names (callable or list of strings and callables):
             If callable, it is a function that takes a name of a parameter
             and a persistent and returns ``True`` when it need to be skipped.
+            If this is a list,
+            this is callables or names of parameters and persistents that are
+            going to be skipped.
+            The callables return :obj:`True` when skipping.
 
     """
 
@@ -114,6 +116,18 @@ class NpzDeserializer(serializer.Deserializer):
                 return value
         else:
             # self.ignore_names is expected to be a list.
+            for ignore_name in self.ignore_names:
+                if isinstance(ignore_name, str):
+                    if key == ignore_name:
+                        return value
+                elif callable(ignore_name):
+                    if ignore_name(key):
+                        return value
+                else:
+                    raise ValueError(
+                        'ignore_names needs to be a callable or '
+                        'list of strings and callables.')
+
             if key in self.ignore_names:
                 return value
 

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -115,7 +115,6 @@ class NpzDeserializer(serializer.Deserializer):
             if self.ignore_names(key):
                 return value
         else:
-            # self.ignore_names is expected to be a list.
             for ignore_name in self.ignore_names:
                 if isinstance(ignore_name, str):
                     if key == ignore_name:

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -87,7 +87,7 @@ class NpzDeserializer(serializer.Deserializer):
             it ignores the value and skip deserialization.
         ignore_names (callable or list of strings and callables):
             If callable, it is a function that takes a name of a parameter
-            and a persistent and returns ``True`` when it need to be skipped.
+            and a persistent and returns ``True`` when it needs to be skipped.
             If this is a list,
             this is callables or names of parameters and persistents that are
             going to be skipped.

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -88,8 +88,8 @@ class NpzDeserializer(serializer.Deserializer):
         ignore_names (list of strings or callable): If this is a list,
             this is names of parameters and persistents that are going
             to be skipped.
-            If callable, it is a function that takes a name of parameters
-            and persistents and returns True when they need to be skipped.
+            If callable, it is a function that takes a name of a parameter
+            and a persistent and returns ``True`` when it need to be skipped.
 
     """
 

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -173,6 +173,32 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
         self.temp_file_path = path
         with open(path, 'wb') as f:
             numpy.savez(
+                f, **{'x': numpy.asarray(10), 'y': numpy.empty((2, 3))})
+
+        self.npzfile = numpy.load(path)
+        self.deserializer = npz.NpzDeserializer(
+            self.npzfile, ignore_names=['y'])
+
+    def tearDown(self):
+        if hasattr(self, 'npzfile'):
+            self.npzfile.close()
+        if hasattr(self, 'temp_file_path'):
+            os.remove(self.temp_file_path)
+
+    def test_deserialize_partial(self):
+        y = numpy.ones((2, 3), dtype=numpy.float32)
+        ret = self.deserializer('y', y)
+        self.assertIs(ret, y)
+
+
+class TestNpzDeserializerIgnoreNames(unittest.TestCase):
+
+    def setUp(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.temp_file_path = path
+        with open(path, 'wb') as f:
+            numpy.savez(
                 f, **{'x': numpy.asarray(10)})
 
         self.npzfile = numpy.load(path)
@@ -184,7 +210,7 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
         if hasattr(self, 'temp_file_path'):
             os.remove(self.temp_file_path)
 
-    def test_deserialize_partial(self):
+    def test_deserialize_ignore_names(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         ret = self.deserializer('y', y)
         self.assertIs(ret, y)
@@ -236,6 +262,55 @@ class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):
             self.source.linear.b.data, target.linear.b.data)
         numpy.testing.assert_array_equal(
             target.child.linear2.W.data, target_child_W)
+        numpy.testing.assert_array_equal(
+            target.child.linear2.b.data, target_child_b)
+
+
+class TestNpzDeserializerIgnoreNamesGroupHierachy(unittest.TestCase):
+
+    def setUp(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.temp_file_path = path
+
+        child = link.Chain()
+        with child.init_scope():
+            child.linear2 = links.Linear(2, 3)
+        parent = link.Chain()
+        with parent.init_scope():
+            parent.linear = links.Linear(3, 2)
+            parent.child = child
+        npz.save_npz(self.temp_file_path, parent)
+        self.source = parent
+
+        self.npzfile = numpy.load(path)
+        self.deserializer = npz.NpzDeserializer(
+            self.npzfile, ignore_names=['linear/W', 'child/linear2/b'])
+
+    def tearDown(self):
+        if hasattr(self, 'npzfile'):
+            self.npzfile.close()
+        if hasattr(self, 'temp_file_path'):
+            os.remove(self.temp_file_path)
+
+    def test_deserialize_ignore_names(self):
+        child = link.Chain()
+        with child.init_scope():
+            child.linear2 = links.Linear(2, 3)
+        target = link.Chain()
+        with target.init_scope():
+            target.linear = links.Linear(3, 2)
+            target.child = child
+        target_W = numpy.copy(target.linear.W.data)
+        target_child_b = numpy.copy(child.linear2.b.data)
+        self.deserializer.load(target)
+
+        numpy.testing.assert_array_equal(
+            self.source.linear.b.data, target.linear.b.data)
+        numpy.testing.assert_array_equal(
+            self.source.child.linear2.W.data, target.child.linear2.W.data)
+        numpy.testing.assert_array_equal(
+            target.linear.W.data, target_W)
         numpy.testing.assert_array_equal(
             target.child.linear2.b.data, target_child_b)
 

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -190,6 +190,10 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
         self.assertIs(ret, y)
 
 
+@testing.parameterize(
+    {'ignore_names': ['y']},
+    {'ignore_names': lambda key: key == 'y'}
+)
 class TestNpzDeserializerIgnoreNames(unittest.TestCase):
 
     def setUp(self):
@@ -202,7 +206,7 @@ class TestNpzDeserializerIgnoreNames(unittest.TestCase):
 
         self.npzfile = numpy.load(path)
         self.deserializer = npz.NpzDeserializer(
-            self.npzfile, ignore_names=['y'])
+            self.npzfile, ignore_names=self.ignore_names)
 
     def tearDown(self):
         if hasattr(self, 'npzfile'):
@@ -211,7 +215,7 @@ class TestNpzDeserializerIgnoreNames(unittest.TestCase):
             os.remove(self.temp_file_path)
 
     def test_deserialize_ignore_names(self):
-        y = numpy.empty((2, 3), dtype=numpy.float32)
+        y = numpy.ones((2, 1), dtype=numpy.float32)
         ret = self.deserializer('y', y)
         self.assertIs(ret, y)
 
@@ -266,6 +270,10 @@ class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):
             target.child.linear2.b.data, target_child_b)
 
 
+@testing.parameterize(
+    {'ignore_names': ['linear/W', 'child/linear2/b']},
+    {'ignore_names': lambda key: key in ['linear/W', 'child/linear2/b']}
+)
 class TestNpzDeserializerIgnoreNamesGroupHierachy(unittest.TestCase):
 
     def setUp(self):
@@ -285,7 +293,7 @@ class TestNpzDeserializerIgnoreNamesGroupHierachy(unittest.TestCase):
 
         self.npzfile = numpy.load(path)
         self.deserializer = npz.NpzDeserializer(
-            self.npzfile, ignore_names=['linear/W', 'child/linear2/b'])
+            self.npzfile, ignore_names=self.ignore_names)
 
     def tearDown(self):
         if hasattr(self, 'npzfile'):

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -192,7 +192,8 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
 
 @testing.parameterize(
     {'ignore_names': ['y']},
-    {'ignore_names': lambda key: key == 'y'}
+    {'ignore_names': lambda key: key == 'y'},
+    {'ignore_names': [lambda key: key == 'y']},
 )
 class TestNpzDeserializerIgnoreNames(unittest.TestCase):
 
@@ -272,7 +273,8 @@ class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):
 
 @testing.parameterize(
     {'ignore_names': ['linear/W', 'child/linear2/b']},
-    {'ignore_names': lambda key: key in ['linear/W', 'child/linear2/b']}
+    {'ignore_names': lambda key: key in ['linear/W', 'child/linear2/b']},
+    {'ignore_names': [lambda key: key in ['linear/W', 'child/linear2/b']]},
 )
 class TestNpzDeserializerIgnoreNamesGroupHierachy(unittest.TestCase):
 

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -173,11 +173,10 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
         self.temp_file_path = path
         with open(path, 'wb') as f:
             numpy.savez(
-                f, **{'x': numpy.asarray(10), 'y': numpy.empty((2, 3))})
+                f, **{'x': numpy.asarray(10)})
 
         self.npzfile = numpy.load(path)
-        self.deserializer = npz.NpzDeserializer(
-            self.npzfile, ignore_names=['y'])
+        self.deserializer = npz.NpzDeserializer(self.npzfile, strict=False)
 
     def tearDown(self):
         if hasattr(self, 'npzfile'):
@@ -186,7 +185,7 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
             os.remove(self.temp_file_path)
 
     def test_deserialize_partial(self):
-        y = numpy.ones((2, 3), dtype=numpy.float32)
+        y = numpy.empty((2, 3), dtype=numpy.float32)
         ret = self.deserializer('y', y)
         self.assertIs(ret, y)
 
@@ -199,10 +198,11 @@ class TestNpzDeserializerIgnoreNames(unittest.TestCase):
         self.temp_file_path = path
         with open(path, 'wb') as f:
             numpy.savez(
-                f, **{'x': numpy.asarray(10)})
+                f, **{'x': numpy.asarray(10), 'y': numpy.empty((2, 3))})
 
         self.npzfile = numpy.load(path)
-        self.deserializer = npz.NpzDeserializer(self.npzfile, strict=False)
+        self.deserializer = npz.NpzDeserializer(
+            self.npzfile, ignore_names=['y'])
 
     def tearDown(self):
         if hasattr(self, 'npzfile'):

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -191,9 +191,10 @@ class TestNpzDeserializerNonStrict(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'ignore_names': ['y']},
-    {'ignore_names': lambda key: key == 'y'},
-    {'ignore_names': [lambda key: key == 'y']},
+    {'ignore_names': 'yy'},
+    {'ignore_names': ['yy']},
+    {'ignore_names': lambda key: key == 'yy'},
+    {'ignore_names': [lambda key: key == 'yy']},
 )
 class TestNpzDeserializerIgnoreNames(unittest.TestCase):
 
@@ -203,7 +204,7 @@ class TestNpzDeserializerIgnoreNames(unittest.TestCase):
         self.temp_file_path = path
         with open(path, 'wb') as f:
             numpy.savez(
-                f, **{'x': numpy.asarray(10), 'y': numpy.empty((2, 3))})
+                f, **{'x': numpy.asarray(10), 'yy': numpy.empty((2, 3))})
 
         self.npzfile = numpy.load(path)
         self.deserializer = npz.NpzDeserializer(
@@ -216,9 +217,9 @@ class TestNpzDeserializerIgnoreNames(unittest.TestCase):
             os.remove(self.temp_file_path)
 
     def test_deserialize_ignore_names(self):
-        y = numpy.ones((2, 1), dtype=numpy.float32)
-        ret = self.deserializer('y', y)
-        self.assertIs(ret, y)
+        yy = numpy.ones((2, 1), dtype=numpy.float32)
+        ret = self.deserializer('yy', yy)
+        self.assertIs(ret, yy)
 
 
 class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -274,7 +274,10 @@ class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):
 @testing.parameterize(
     {'ignore_names': ['linear/W', 'child/linear2/b']},
     {'ignore_names': lambda key: key in ['linear/W', 'child/linear2/b']},
-    {'ignore_names': [lambda key: key in ['linear/W', 'child/linear2/b']]},
+    {'ignore_names': [
+        lambda key: key in ['linear/W'],
+        lambda key: key in ['child/linear2/b']]
+     },
 )
 class TestNpzDeserializerIgnoreNamesGroupHierachy(unittest.TestCase):
 

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -276,8 +276,10 @@ class TestNpzDeserializerNonStrictGroupHierachy(unittest.TestCase):
     {'ignore_names': lambda key: key in ['linear/W', 'child/linear2/b']},
     {'ignore_names': [
         lambda key: key in ['linear/W'],
-        lambda key: key in ['child/linear2/b']]
-     },
+        lambda key: key in ['child/linear2/b']]},
+    {'ignore_names': [
+        lambda key: key in ['linear/W'],
+        'child/linear2/b']},
 )
 class TestNpzDeserializerIgnoreNamesGroupHierachy(unittest.TestCase):
 


### PR DESCRIPTION
This PR adds an option to NpzDeserializer that ignores a subset of weights stored in the given npy file.

This is useful in the case when subset of parameters do not have the same shapes as those of the corresponding parameters in the file.
`strict` can ignore copying values in the case when corresponding parameters do not exist at all.
However, there is no easy way to deal with the situation when the corresponding parameters exist, but the shapes differ. Currently, shape mismatch error is raised.

This option is originally intended to solve the above problem. However, I made it a bit more general.
This way, a user can also ignore to copy some values even if their shapes match with the ones stored in the file.