### PR TITLE
Fix doc of clipped_relu

### DIFF
--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -54,7 +54,7 @@ def clipped_relu(x, z=20.0):
 
     For a clipping value :math:`z(>0)`, it computes
 
-     .. math::`ClippedReLU(x, z) = \\min(\\max(0, x), z)`.
+    .. math:: \\text{ClippedReLU}(x, z) = \\min(\\max(0, x), z).
 
     Args:
         x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \


### PR DESCRIPTION
Documentation of `clipped_relu` is broken.
https://docs.chainer.org/en/latest/reference/generated/chainer.functions.clipped_relu.html