### PR TITLE
Fix doc of leaky_relu

### DIFF
--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -59,7 +59,12 @@ def leaky_relu(x, slope=0.2):
 
     This function is expressed as
 
-    .. math:: f(x)=\\max(x, ax),
+     .. math::
+
+        f(x) = \\left \\{ \\begin{array}{ll}
+        x  & {\\rm if}~ x \\ge 0 \\\\
+        ax & {\\rm if}~ x < 0,
+        \\end{array} \\right.
 
     where :math:`a` is a configurable slope value.
 

--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -59,7 +59,7 @@ def leaky_relu(x, slope=0.2):
 
     This function is expressed as
 
-     .. math::
+    .. math::
 
         f(x) = \\left \\{ \\begin{array}{ll}
         x  & {\\rm if}~ x \\ge 0 \\\\


### PR DESCRIPTION
The definition of `leaky_relu` in the current documentation is only valid if `a <= 1`.

https://docs.chainer.org/en/latest/reference/generated/chainer.functions.leaky_relu.html