### PR TITLE
Fix Variable.__getitem__ document

### DIFF
--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -66,8 +66,8 @@ def get_item(x, slices):
             or tuple of them.
 
     Returns:
-        Variable: :class:`~chainer.Variable` object
-            which contains sliced array of ``x``.
+        A :class:`~chainer.Variable` object which contains sliced array of
+        ``x``.
 
     .. note::
 


### PR DESCRIPTION
Currently "Returns" section of `Variable.__getitem__` documentation is broken.

[`https://docs.chainer.org/en/stable/reference/core/generated/chainer.Variable.html#chainer.Variable.__getitem__`](https://docs.chainer.org/en/stable/reference/core/generated/chainer.Variable.html#chainer.Variable.__getitem__)
