### PR TITLE
fixed document of F.dropout into more explanatory

### DIFF
--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -59,7 +59,7 @@ def dropout(x, ratio=.5, **kwargs):
     .. warning::
 
        ``train`` argument is not supported anymore since v2.
-       Instead, use ``chainer.using_config('train', train)``.
+       Instead, use ``chainer.using_config('train', boolean)``.
        See :func:`chainer.using_config`.
 
     Args:


### PR DESCRIPTION
#3181 In the original "chainer.using_config('train', train)", the word "train" is duplicated. So I converted the latter one to boolean. 