### PR TITLE
Make F.cast return the input as is if no cast is needed

### DIFF
--- a/chainer/functions/array/cast.py
+++ b/chainer/functions/array/cast.py
@@ -1,3 +1,4 @@
+import chainer
 from chainer import function_node
 from chainer.utils import type_check
 
@@ -51,5 +52,5 @@ def cast(x, typ):
 
     """
     if x.dtype == typ:
-        return x
+        return chainer.as_variable(x)
     return Cast(typ).apply((x,))[0]

--- a/chainer/functions/array/cast.py
+++ b/chainer/functions/array/cast.py
@@ -50,4 +50,6 @@ def cast(x, typ):
         dtype('float16')
 
     """
+    if x.dtype == typ:
+        return x
     return Cast(typ).apply((x,))[0]

--- a/tests/chainer_tests/functions_tests/array_tests/test_cast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_cast.py
@@ -65,13 +65,18 @@ class TestNoCast(unittest.TestCase):
 
     def check_forward_no_cast(self, x_data):
         y = functions.cast(x_data, self.dtype)
-        self.assertIs(y, x_data)
+        self.assertIsInstance(y, chainer.Variable)
+        self.assertIs(y.data, x_data)
 
     def test_forward_no_cast_array(self):
-        self.check_forward_no_cast(self.x)
+        y = functions.cast(self.x, self.dtype)
+        self.assertIsInstance(y, chainer.Variable)
+        self.assertIs(y.data, self.x)
 
     def test_forward_no_cast_variable(self):
-        self.check_forward_no_cast(chainer.Variable(self.x))
+        x = chainer.Variable(self.x)
+        y = functions.cast(x, self.dtype)
+        self.assertIs(y, x)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_cast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_cast.py
@@ -57,4 +57,21 @@ class TestCast(unittest.TestCase):
         self.check_backward(self.x, self.g)
 
 
+class TestNoCast(unittest.TestCase):
+
+    def setUp(self):
+        self.dtype = numpy.float32
+        self.x = numpy.empty(1, self.dtype)
+
+    def check_forward_no_cast(self, x_data):
+        y = functions.cast(x_data, self.dtype)
+        self.assertIs(y, x_data)
+
+    def test_forward_no_cast_array(self):
+        self.check_forward_no_cast(self.x)
+
+    def test_forward_no_cast_variable(self):
+        self.check_forward_no_cast(chainer.Variable(self.x))
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
We will use `F.cast` in backward of functions supporting mixed-use dtypes after introducing new style functions. This change removes the overhead in the "usual pass" that does not require casting.