### PR TITLE
Fix Variable.backward for manually edited requires_grad

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -861,6 +861,11 @@ Actual: {0}'''.format(type(data))
         while cand_funcs:
             _, _, func = heapq.heappop(cand_funcs)
             inputs = func.inputs
+            target_input_indexes = [
+                i for i, x in enumerate(inputs) if x.requires_grad
+            ]
+            if not target_input_indexes:
+                continue
             outputs = [y() for y in func.outputs]  # access via weak ref
 
             in_data = tuple([x.data for x in inputs])
@@ -891,9 +896,6 @@ Actual: {0}'''.format(type(data))
             # input gradient passed to the ``backward_accumulate`` method is
             # ``(gx, None)`` where ``gx`` is the current gradient of ``x``.
             # See also the docstring of ``FunctionNode.backward_accumulate``.
-            target_input_indexes = [
-                i for i, x in enumerate(inputs) if x.requires_grad
-            ]
             target_inputs = [inputs[i] for i in target_input_indexes]
             in_grad = []
             for i, index_i in enumerate(target_input_indexes):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -221,6 +221,18 @@ class TestVariable(unittest.TestCase):
     def test_double_backprop_gpu(self):
         self.check_double_backprop(True)
 
+    def test_backward_no_grad_required(self):
+        class DummyId(F.Identity):
+
+            def backward(self, a, b):
+                raise Exception('backward should not be called on inputs that '
+                                'do not require grads')
+
+        x = chainer.Variable(self.x)
+        y1, y2 = DummyId().apply((x, x))
+        x.node._requires_grad = False
+        y1.backward()
+
     def test_unchain(self):
         ret = self.create_linear_chain(3, False)
         old_rank = ret[1].rank


### PR DESCRIPTION
I added a quick check to `Variable.backward` to skip backward when no grad is required. Such a case does not happen usually (because the output has `requires_grad=False` when all the inputs have `requires_grad=False`); this PR rather makes it clear when one reads the implementation fo `Variable.backward`.