### PR TITLE
use test mode in ResNet predict

### DIFF
--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -10,6 +10,7 @@ except ImportError as e:
     available = False
     _import_error = e
 
+import chainer
 from chainer.dataset.convert import concat_examples
 from chainer.dataset import download
 from chainer import function
@@ -301,7 +302,7 @@ class GoogLeNet(link.Chain):
         else:
             x = x[:, :, 16:240, 16:240]
         # Use no_backprop_mode to reduce memory consumption
-        with function.no_backprop_mode():
+        with function.no_backprop_mode(), chainer.using_config('train', False):
             x = Variable(self.xp.asarray(x))
             y = self(x, layers=['prob'])['prob']
             if oversample:

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -265,13 +265,13 @@ class ResNetLayers(link.Chain):
             x = x[:, :, 16:240, 16:240]
         # Use no_backprop_mode to reduce memory consumption
         with function.no_backprop_mode(), chainer.using_config('train', False):
-                x = Variable(self.xp.asarray(x))
-                y = self(x, layers=['prob'])['prob']
-                if oversample:
-                    n = y.data.shape[0] // 10
-                    y_shape = y.data.shape[1:]
-                    y = reshape(y, (n, 10) + y_shape)
-                    y = sum(y, axis=1) / 10
+            x = Variable(self.xp.asarray(x))
+            y = self(x, layers=['prob'])['prob']
+            if oversample:
+                n = y.data.shape[0] // 10
+                y_shape = y.data.shape[1:]
+                y = reshape(y, (n, 10) + y_shape)
+                y = sum(y, axis=1) / 10
         return y
 
 

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -264,8 +264,7 @@ class ResNetLayers(link.Chain):
         else:
             x = x[:, :, 16:240, 16:240]
         # Use no_backprop_mode to reduce memory consumption
-        with function.no_backprop_mode():
-            with chainer.using_config('train', False):
+        with function.no_backprop_mode(), chainer.using_config('train', False):
                 x = Variable(self.xp.asarray(x))
                 y = self(x, layers=['prob'])['prob']
                 if oversample:

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -10,6 +10,7 @@ except ImportError as e:
     available = False
     _import_error = e
 
+import chainer
 from chainer.dataset.convert import concat_examples
 from chainer.dataset import download
 from chainer import function
@@ -264,13 +265,14 @@ class ResNetLayers(link.Chain):
             x = x[:, :, 16:240, 16:240]
         # Use no_backprop_mode to reduce memory consumption
         with function.no_backprop_mode():
-            x = Variable(self.xp.asarray(x))
-            y = self(x, layers=['prob'])['prob']
-            if oversample:
-                n = y.data.shape[0] // 10
-                y_shape = y.data.shape[1:]
-                y = reshape(y, (n, 10) + y_shape)
-                y = sum(y, axis=1) / 10
+            with chainer.using_config('train', False):
+                x = Variable(self.xp.asarray(x))
+                y = self(x, layers=['prob'])['prob']
+                if oversample:
+                    n = y.data.shape[0] // 10
+                    y_shape = y.data.shape[1:]
+                    y = reshape(y, (n, 10) + y_shape)
+                    y = sum(y, axis=1) / 10
         return y
 
 

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -10,6 +10,7 @@ except ImportError as e:
     available = False
     _import_error = e
 
+import chainer
 from chainer.dataset.convert import concat_examples
 from chainer.dataset import download
 from chainer import function
@@ -266,7 +267,7 @@ class VGG16Layers(link.Chain):
         else:
             x = x[:, :, 16:240, 16:240]
         # Use no_backprop_mode to reduce memory consumption
-        with function.no_backprop_mode():
+        with function.no_backprop_mode(), chainer.using_config('train', False):
             x = Variable(self.xp.asarray(x))
             y = self(x, layers=['prob'])['prob']
             if oversample:


### PR DESCRIPTION
Inferring from only one sample with train mode BatchNorm does not work.
I think it is necessary to use `with chainer.using_config('train', False)`.