### PR TITLE
fix to pass test_function.py in v2

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -726,9 +726,8 @@ Actual: {0}'''.format(type(data))
                 for gx in gxs:
                     if gx is None:
                         continue
-                    gx_data = gx.data
-                    cuda.get_device_from_array(gx_data).use()
-                    if cuda.get_array_module(gx_data).isnan(gx_data).any():
+                    cuda.get_device_from_array(gx).use()
+                    if cuda.get_array_module(gx).isnan(gx).any():
                         msg = ('NaN is detected on backward computation of '
                                '{}'.format(func.label))
                         raise RuntimeError(msg)


### PR DESCRIPTION
it is backported in #3197 
According to the documents, `backward_cpu` returns `tuple of numpy.ndarray` objects.