### PR TITLE
New style log_softmax

### DIFF
--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -3,9 +3,7 @@ import numpy
 import chainer
 from chainer import cuda
 from chainer import function_node
-from chainer.functions.array import broadcast
-from chainer.functions.math import exponential
-from chainer.functions.math import sum as sum_
+import chainer.functions
 from chainer.utils import type_check
 
 if cuda.cudnn_enabled:
@@ -104,16 +102,16 @@ class LogSoftmaxGrad(function_node.FunctionNode):
     def backward(self, indexes, ggx):
         y, gy = self.get_retained_inputs()
         ret = []
-        exp_y = exponential.exp(y)
+        exp_y = chainer.functions.exp(y)
         if 0 in indexes:
-            gy_sum = sum_.sum(gy, 1, True)
-            gy_sum = broadcast.broadcast_to(gy_sum, gy.shape)
+            gy_sum = chainer.functions.sum(gy, 1, True)
+            gy_sum = chainer.functions.broadcast_to(gy_sum, gy.shape)
             g0 = -ggx[0] * exp_y * gy_sum
             ret.append(g0)
         if 1 in indexes:
-            # TODO(Kenta Oono): implement F.dot
-            a = sum_.sum(ggx[0] * exp_y, 1, True)
-            a = broadcast.broadcast_to(a, gy.shape)
+            # TODO(Kenta Oono): implement it with double-backpropable F.matmul
+            a = chainer.functions.sum(ggx[0] * exp_y, 1, True)
+            a = chainer.functions.broadcast_to(a, gy.shape)
             g1 = ggx[0] - a
             ret.append(g1)
         return ret

--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -2,7 +2,10 @@ import numpy
 
 import chainer
 from chainer import cuda
-from chainer import function
+from chainer import function_node
+from chainer.functions.array import broadcast
+from chainer.functions.math import exponential
+from chainer.functions.math import sum as sum_
 from chainer.utils import type_check
 
 if cuda.cudnn_enabled:
@@ -44,7 +47,7 @@ def _log_softmax(x):
     return y
 
 
-class LogSoftmax(function.Function):
+class LogSoftmax(function_node.FunctionNode):
 
     """Log-softmax activation function."""
 
@@ -62,12 +65,25 @@ class LogSoftmax(function.Function):
         self._x_xp = cuda.get_array_module(*xs)
         self._x_shape = xs[0].shape
         self._x_dtype = xs[0].dtype
-        self.retain_inputs(())
         self.retain_outputs((0,))
         return y,
 
-    def backward(self, x, gy):
-        y = self.output_data[0]
+    def backward(self, indexes, gy):
+        y = self.get_retained_outputs()[0]
+        return LogSoftmaxGrad(
+            self._x_xp, self._x_shape, self._x_dtype).apply((y, gy[0]))
+
+
+class LogSoftmaxGrad(function_node.FunctionNode):
+
+    def __init__(self, x_xp, x_shape, x_dtype):
+        self._x_xp = x_xp
+        self._x_shape = x_shape
+        self._x_dtype = x_dtype
+
+    def forward(self, inputs):
+        self.retain_inputs((0, 1))
+        y, gy = inputs
         xp = self._x_xp
         if xp is not numpy and chainer.should_use_cudnn('>=auto'):
             oz_dtype = 'd' if self._x_dtype == 'd' else 'f'
@@ -79,12 +95,28 @@ class LogSoftmax(function.Function):
             desc = cudnn.create_tensor_descriptor(gx_cube)
             libcudnn.softmaxBackward(
                 handle, _algorithm, _mode, one.data, desc.value,
-                y.data.ptr, desc.value, gy[0].data.ptr, zero.data,
+                y.data.ptr, desc.value, gy.data.ptr, zero.data,
                 desc.value, gx.data.ptr)
         else:
-            gx = gy[0] - xp.exp(y) * gy[0].sum(axis=1, keepdims=True)
-
+            gx = gy - xp.exp(y) * gy.sum(axis=1, keepdims=True)
         return gx,
+
+    def backward(self, indexes, ggx):
+        y, gy = self.get_retained_inputs()
+        ret = []
+        exp_y = exponential.exp(y)
+        if 0 in indexes:
+            gy_sum = sum_.sum(gy, 1, True)
+            gy_sum = broadcast.broadcast_to(gy_sum, gy.shape)
+            g0 = -ggx[0] * exp_y * gy_sum
+            ret.append(g0)
+        if 1 in indexes:
+            # TODO(Kenta Oono): implement F.dot
+            a = sum_.sum(ggx[0] * exp_y, 1, True)
+            a = broadcast.broadcast_to(a, gy.shape)
+            g1 = ggx[0] - a
+            ret.append(g1)
+        return ret
 
 
 def log_softmax(x):
@@ -132,4 +164,4 @@ def log_softmax(x):
         True
 
     """
-    return LogSoftmax()(x)
+    return LogSoftmax().apply((x,))[0]

--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -26,6 +26,7 @@ class TestLogSoftmax(unittest.TestCase):
         else:
             self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, self.x.shape).astype(self.dtype)
+        self.ggx = numpy.random.uniform(-1, 1, self.x.shape).astype(self.dtype)
 
         self.check_forward_options = {}
         self.check_backward_options = {'dtype': numpy.float64}
@@ -64,7 +65,7 @@ class TestLogSoftmax(unittest.TestCase):
     def check_backward(self, x_data, gy_data, use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
-                functions.LogSoftmax(), x_data, gy_data,
+                functions.log_softmax, x_data, gy_data,
                 **self.check_backward_options)
 
     @condition.retry(10)
@@ -80,6 +81,30 @@ class TestLogSoftmax(unittest.TestCase):
     @condition.retry(10)
     def test_backward_gpu_no_cudnn(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
+
+    def check_double_backward(self, x_data, gy_data, ggx_data,
+                              use_cudnn='always'):
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_double_backward(
+                functions.log_softmax, x_data, gy_data, ggx_data,
+                **self.check_backward_options)
+
+    @condition.retry(1)
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.gy, self.ggx)
+
+    @attr.gpu
+    @condition.retry(1)
+    def test_double_backward_gpu(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
+
+    @attr.gpu
+    @condition.retry(1)
+    def test_double_backward_gpu_no_cudnn(self):
+        self.check_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
+            'never')
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
This PR implements new-style version of `F.log_softmax` as a part of #3147. This function will be used to make `F.softmax_cross_entropy` double-backpropable.