### PR TITLE
Add chainer.as_variable

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -56,6 +56,7 @@ from chainer.serializer import AbstractSerializer  # NOQA
 from chainer.serializer import Deserializer  # NOQA
 from chainer.serializer import Serializer  # NOQA
 from chainer.variable import Parameter  # NOQA
+from chainer.variable import to_variable  # NOQA
 from chainer.variable import Variable  # NOQA
 
 

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -56,7 +56,7 @@ from chainer.serializer import AbstractSerializer  # NOQA
 from chainer.serializer import Deserializer  # NOQA
 from chainer.serializer import Serializer  # NOQA
 from chainer.variable import Parameter  # NOQA
-from chainer.variable import to_variable  # NOQA
+from chainer.variable import as_variable  # NOQA
 from chainer.variable import Variable  # NOQA
 
 

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -55,8 +55,8 @@ from chainer.reporter import Summary  # NOQA
 from chainer.serializer import AbstractSerializer  # NOQA
 from chainer.serializer import Deserializer  # NOQA
 from chainer.serializer import Serializer  # NOQA
-from chainer.variable import Parameter  # NOQA
 from chainer.variable import as_variable  # NOQA
+from chainer.variable import Parameter  # NOQA
 from chainer.variable import Variable  # NOQA
 
 

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -193,7 +193,7 @@ class FunctionNode(object):
             A tuple of output :class:`Variable` objects.
 
         """
-        input_vars = [chainer.to_variable(x) for x in inputs]
+        input_vars = [chainer.as_variable(x) for x in inputs]
         in_data = tuple([x.data for x in input_vars])
         requires_grad = any([x.requires_grad for x in input_vars])
 

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -193,9 +193,7 @@ class FunctionNode(object):
             A tuple of output :class:`Variable` objects.
 
         """
-        input_vars = [x if isinstance(x, variable.Variable)
-                      else variable.Variable(x, requires_grad=False)
-                      for x in inputs]
+        input_vars = [chainer.to_variable(x) for x in inputs]
         in_data = tuple([x.data for x in input_vars])
         requires_grad = any([x.requires_grad for x in input_vars])
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1207,6 +1207,36 @@ class Parameter(Variable):
             self.update_rule.update(self)
 
 
+def to_variable(obj):
+    """Converts an array or a variable into :class:`~chainer.Variable`.
+
+    This is a convenient function to get a :class:`~chainer.Variable` object
+    transparently from a raw array or a variable.
+
+    Note that this function should only be used for type consistency (i.e., to
+    enforce the return value of an API having type :class:`~chainer.Varialbe`).
+    The :class:`~chainer.Variable.requires_grad` flag is kept as is; if ``obj``
+    is a raw array, the newly created variable has ``requires_grad = False``.
+    In order to make a variable w.r.t. which you want to compute the gradient,
+    you should use :class:`~chainer.Variable` directly.
+
+    Args:
+        obj (numpy.ndarray or cupy.ndarray or ~chainer.Variable): An array or
+            a variable that you want to convert to :class:`~chainer.Variable`.
+
+    Returns:
+        ~chainer.Variable:
+        A variable converted from ``obj``. If ``obj`` is a raw array, this is a
+        new :class:`~chainer.Variable` object that wraps the array. If ``obj``
+        is already a :class:`~chainer.Variable` object, this function returns
+        ``obj`` as is.
+
+    """
+    if isinstance(obj, Variable):
+        return obj
+    return Variable(obj, requires_grad=False)
+
+
 def _recover_parameter(data, name, grad, initializer, update_rule):
     p = Parameter(initializer=initializer, name=name)
     p.data = data

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1207,7 +1207,7 @@ class Parameter(Variable):
             self.update_rule.update(self)
 
 
-def to_variable(obj):
+def as_variable(obj):
     """Converts an array or a variable into :class:`~chainer.Variable`.
 
     This is a convenient function to get a :class:`~chainer.Variable` object

--- a/docs/source/reference/core/variable.rst
+++ b/docs/source/reference/core/variable.rst
@@ -6,6 +6,6 @@ Variable and Parameter
    :nosignatures:
 
    chainer.Variable
-   chainer.to_variable
+   chainer.as_variable
    chainer.Parameter
    chainer.variable.VariableNode

--- a/docs/source/reference/core/variable.rst
+++ b/docs/source/reference/core/variable.rst
@@ -6,5 +6,6 @@ Variable and Parameter
    :nosignatures:
 
    chainer.Variable
+   chainer.to_variable
    chainer.Parameter
    chainer.variable.VariableNode

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1392,4 +1392,26 @@ class TestVariableDoubleBackward(unittest.TestCase):
             x.grad_var.backward()
 
 
+class TestToVariable(unittest.TestCase):
+
+    def check_to_variable_from_array(self, x):
+        y = chainer.to_variable(x)
+        self.assertIsInstance(y, chainer.Variable)
+        self.assertIs(y.data, x)
+        self.assertFalse(y.requires_grad)
+
+    def test_to_variable_from_numpy(self):
+        self.check_to_variable_from_array(np.empty(1, np.float32))
+
+    @attr.gpu
+    def test_to_variable_from_cupy(self):
+        self.check_to_variable_from_array(cuda.cupy.empty(1, np.float32))
+
+    def test_to_variable_from_variable(self):
+        x = chainer.Variable(np.array(1, np.float32))
+        y = chainer.to_variable(x)
+        self.assertIs(x, y)
+        self.assertTrue(y.requires_grad)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1392,10 +1392,10 @@ class TestVariableDoubleBackward(unittest.TestCase):
             x.grad_var.backward()
 
 
-class TestToVariable(unittest.TestCase):
+class TestAsVariable(unittest.TestCase):
 
     def check_to_variable_from_array(self, x):
-        y = chainer.to_variable(x)
+        y = chainer.as_variable(x)
         self.assertIsInstance(y, chainer.Variable)
         self.assertIs(y.data, x)
         self.assertFalse(y.requires_grad)
@@ -1409,7 +1409,7 @@ class TestToVariable(unittest.TestCase):
 
     def test_to_variable_from_variable(self):
         x = chainer.Variable(np.array(1, np.float32))
-        y = chainer.to_variable(x)
+        y = chainer.as_variable(x)
         self.assertIs(x, y)
         self.assertTrue(y.requires_grad)
 


### PR DESCRIPTION
This PR adds a convenient function `chainer.to_variable`. It can be used to force a value having a type `Variable`. This function is designed to be used in differentiable functions that may skip computation; in such a case, these functions have to conditionally wrap an array by `Variable`. The `to_variable` can be used in such a case. Note that `requires_grad` is set to `False` because of assuming such usage.