### PR TITLE
Fix document of functions.linear

### DIFF
--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -64,6 +64,7 @@ def linear(x, W, b=None):
 
     It accepts two or three arguments: an input minibatch ``x``, a weight
     matrix ``W``, and optionally a bias vector ``b``. It computes
+
     .. math:: Y = xW^\\top + b.
 
     Args:


### PR DESCRIPTION
Documentation of `functions.linear` is broken.
https://docs.chainer.org/en/latest/reference/generated/chainer.functions.linear.html#chainer.functions.linear 