### PR TITLE
[backport] Deny assigning links in ChainList.init_scope()

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -820,6 +820,13 @@ class ChainList(Link):
         for link in links:
             self.add_link(link)
 
+    def __setattr__(self, name, value):
+        if self.within_init_scope and isinstance(value, Link):
+            raise TypeError(
+                'cannot register a new link'
+                ' within a "with chainlist.init_scope():" block.')
+        super(ChainList, self).__setattr__(name, value)
+
     def __getitem__(self, index):
         """Returns the child at given index.
 

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -710,6 +710,18 @@ class TestChainList(unittest.TestCase):
         self.assertIs(self.c2[1], self.l3)
         self.assertEqual(self.l3.name, '1')
 
+    def test_assign_param_in_init_scope(self):
+        p = chainer.Parameter()
+        with self.c1.init_scope():
+            self.c1.p = p
+        self.assertIn(p, self.c1.params())
+
+    def test_assign_link_in_init_scope(self):
+        l = chainer.Link()
+        with self.c1.init_scope():
+            with self.assertRaises(TypeError):
+                self.c1.l = l
+
     def test_iter(self):
         links = list(self.c2)
         self.assertEqual(2, len(links))


### PR DESCRIPTION
This PR is backport of #3129 