### PR TITLE
doc: Fix truncated summary line

### DIFF
--- a/chainer/functions/math/batch_l2_norm_squared.py
+++ b/chainer/functions/math/batch_l2_norm_squared.py
@@ -43,7 +43,7 @@ class BatchL2NormSquared(function.Function):
 
 
 def batch_l2_norm_squared(x):
-    """L2 norm (a.k.a. Euclidean norm) squared.
+    """L2 norm (a.k.a.\\  Euclidean norm) squared.
 
     This function implements the square of L2 norm on a vector. No reduction
     along batch axis is done.

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -45,7 +45,7 @@ class NormalizeL2(function.Function):
 
 
 def normalize(x, eps=1e-5, axis=1):
-    """L2 norm squared (a.k.a. Euclidean norm).
+    """L2 norm squared (a.k.a.\\  Euclidean norm).
 
     This function implements L2 normalization on a vector along the given axis.
     No reduction is done along the normalization axis.

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -6,7 +6,7 @@ from chainer import variable
 
 class Linear(link.Link):
 
-    """Linear layer (a.k.a. fully-connected layer).
+    """Linear layer (a.k.a.\\  fully-connected layer).
 
     This is a link that wraps the :func:`~chainer.functions.linear` function,
     and holds a weight matrix ``W`` and optionally a bias vector ``b`` as

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -791,7 +791,7 @@ Actual: {0}'''.format(type(data))
         self._node.set_creator_node(fnode)
 
     def backward(self, retain_grad=False):
-        """Runs error backpropagation (a.k.a. backprop) from this variable.
+        """Runs error backpropagation (a.k.a.\\  backprop) from this variable.
 
         On backprop, :meth:`FunctionNode.backward` is called on each
         :class:`FunctionNode` object appearing in the backward graph starting

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@
 import inspect
 import os
 import pkg_resources
+import re
 import six
 import sys
 
@@ -388,6 +389,47 @@ def _get_source_relative_path(source_abs_path):
     return os.path.relpath(source_abs_path, _find_source_root(source_abs_path))
 
 
+def _is_docstring_autosummary_compliant(docstring):
+    doc = docstring.split('\n')
+
+    # Extract until the first blank line if any.
+    try:
+        doc = doc[:doc.index('')]
+    except ValueError:
+        pass
+
+    # Taken from https://github.com/sphinx-doc/sphinx/blob/1.6.3/sphinx/ext/autosummary/__init__.py#L341
+    m = re.search(r'^([A-Z].*?\.)(?:\s|$)', ' '.join(doc).strip())
+    if m:
+        summary = m.group(1).strip()
+    else:
+        summary = doc[0].strip()
+
+    return summary == ' '.join(doc)
+
+
+def _check_object_validity(obj):
+    # Check whether the docstring is compliant with autosummary's restriction.
+    # Autosummary extracts the "first sentence", which ends at the first period
+    # followed by a whitespace or an EOL. This scheme incorrectly treats
+    # abbreviation such as "a.k.a. SOMETHING" as the end of sentence, which
+    # leads to a truncated summary line. We detect such non-compliant docstring
+    # here.
+    # TODO(niboshi):
+    #   It's definitely a wrong place to check it. It should be checked at
+    #   autosummary template, for example.
+    try:
+        doc = obj.__doc__
+    except AttributeError:
+        doc = None
+
+    if doc is not None:
+        if not _is_docstring_autosummary_compliant(doc):
+            raise RuntimeError(
+                'docstring of {} is not autosummary-compliant: {}\n'
+                ''.format(obj, repr(doc)))
+
+
 def linkcode_resolve(domain, info):
     if domain != 'py' or not info['module']:
         return None
@@ -425,6 +467,8 @@ def linkcode_resolve(domain, info):
 
     filename = os.path.realpath(filename)
     relpath = _get_source_relative_path(filename)
+
+    _check_object_validity(obj)
 
     return 'https://github.com/chainer/chainer/blob/{}/{}#L{}'.format(
         tag, relpath, linenum)


### PR DESCRIPTION
Fixes #3234.

The problem is in autosummary's algorithm on parsing docstring: https://github.com/sphinx-doc/sphinx/blob/1.6.3/sphinx/ext/autosummary/__init__.py#L341
It treats the substring which ends with a period followed by a space (or a EOL) as the "first sentence", which trucate the string at e.g. "a.k.a. SOMETHING".

This PR interferes that algorithm by placing `\` followed by an extra space before the existing space, which translates to an empty string. (I'm not sure if this is the correct use of the sequence. But at least it works)

Additionally I put a code to check if docstrings are compliant with autosummary's algorithm.

TODO: Port to CuPy
