### PR TITLE
Always return variable in chainer.functions.noise.dropout

### DIFF
--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -1,11 +1,11 @@
 import numpy
 
+import chainer
 from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import argument
 from chainer.utils import type_check
-from chainer.variable import as_variable
 
 
 class Dropout(function.Function):
@@ -82,4 +82,4 @@ def dropout(x, ratio=.5, **kwargs):
 
     if configuration.config.train:
         return Dropout(ratio)(x)
-    return as_variable(x)
+    return chainer.as_variable(x)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -1,5 +1,6 @@
 import numpy
 
+import chainer.functions
 from chainer import configuration
 from chainer import cuda
 from chainer import function
@@ -81,4 +82,4 @@ def dropout(x, ratio=.5, **kwargs):
 
     if configuration.config.train:
         return Dropout(ratio)(x)
-    return x
+    return chainer.functions.identity(x)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -1,6 +1,6 @@
 import numpy
 
-import chainer.functions
+import chainer
 from chainer import configuration
 from chainer import cuda
 from chainer import function
@@ -82,4 +82,4 @@ def dropout(x, ratio=.5, **kwargs):
 
     if configuration.config.train:
         return Dropout(ratio)(x)
-    return chainer.functions.identity(x)
+    return chainer.as_variable(x)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -1,11 +1,11 @@
 import numpy
 
-import chainer
 from chainer import configuration
 from chainer import cuda
 from chainer import function
 from chainer.utils import argument
 from chainer.utils import type_check
+from chainer.variable import as_variable
 
 
 class Dropout(function.Function):
@@ -82,4 +82,4 @@ def dropout(x, ratio=.5, **kwargs):
 
     if configuration.config.train:
         return Dropout(ratio)(x)
-    return chainer.as_variable(x)
+    return as_variable(x)


### PR DESCRIPTION
This is a PR to wrap the result of dropout in test mode with `Variable`.

The reason is as follows.
In general, all functions in `chainer.functions` should return `Variable`. (which is also discussed in #3191)
However, in `chainer.functions.noise.dropout`, @ronekko kindly reported unexpected outputs like below in #3116:

```python
import numpy as np
import chainer

x = numpy.ones(5, 'f')
with chainer.using_config('train', False):
    y = chainer.functions.dropout(x)
    print(type(y))  # <class 'numpy.ndarray'>
    y = chainer.functions.dropout(chainer.Variable(x))
    print(type(y))  # <class 'chainer.variable.Variable'>
```
This is because input is returned without any modification in test mode in dropout.
