### PR TITLE
fix highlight error of chainer/functions/array/reshape.py

### DIFF
--- a/chainer/functions/array/reshape.py
+++ b/chainer/functions/array/reshape.py
@@ -74,7 +74,7 @@ def reshape(x, shape):
         (8,)
         >>> y.data
         array([1, 2, 3, 4, 5, 6, 7, 8])
-        >>> y = F.reshape(x, (4, -1)) # the shape of output is inferred
+        >>> y = F.reshape(x, (4, -1))  # the shape of output is inferred
         >>> y.shape
         (4, 2)
         >>> y.data
@@ -82,11 +82,10 @@ def reshape(x, shape):
                [3, 4],
                [5, 6],
                [7, 8]])
-        >>> y = F.reshape(x, (4, 3)) \
+        >>> y = F.reshape(x, (4, 3))  \
 # the shape of input and output are not consistent
         Traceback (most recent call last):
-         ...
-        chainer.utils.type_check.InvalidType:
+        ...
         Invalid operation is performed in: Reshape (Forward)
         Expect: prod(in_types[0].shape) == prod((4, 3))
         Actual: 8 != 12


### PR DESCRIPTION
related to #3242.

The example code of reshape is not highlighted. It may be occurred by the parse error.

This page said following: http://www.sphinx-doc.org/en/stable/markup/code.html

> Within Python highlighting mode, interactive sessions are recognized automatically and highlighted appropriately. Normal Python code is only highlighted if it is parseable (so you can use Python as the default, but interspersed snippets of shell commands or other code blocks will not be highlighted as Python).

And this PR, I just remove the some strings in order not to make parse error, just delete the line `chainer.utils.type_check.InvalidType:`.