### PR TITLE
CaffeFunction to take BatchNorm scaling factor into account

### DIFF
--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -359,7 +359,7 @@ class CaffeFunction(link.Chain):
         func.avg_mean.ravel()[:] = blobs[0].data
         func.avg_var.ravel()[:] = blobs[1].data
 
-        if len(blobs) == 3:
+        if len(blobs) >= 3:
             scaling_factor = blobs[2].data
             func.avg_mean /= scaling_factor[0]
             func.avg_var /= scaling_factor[0]

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -358,6 +358,12 @@ class CaffeFunction(link.Chain):
             size, decay=decay, eps=eps, use_gamma=False, use_beta=False)
         func.avg_mean.ravel()[:] = blobs[0].data
         func.avg_var.ravel()[:] = blobs[1].data
+
+        if len(blobs) == 3:
+            scaling_factor = blobs[2].data
+            func.avg_mean /= scaling_factor[0]
+            func.avg_var /= scaling_factor[0]
+
         with self.init_scope():
             setattr(self, layer.name, func)
 

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -356,9 +356,13 @@ class CaffeFunction(link.Chain):
         # Make BatchNormalization link.
         func = batch_normalization.BatchNormalization(
             size, decay=decay, eps=eps, use_gamma=False, use_beta=False)
+
         func.avg_mean.ravel()[:] = blobs[0].data
         func.avg_var.ravel()[:] = blobs[1].data
 
+        # Scale the means and variances if a scaling factor is appended to the
+        # blobs to correctly mimic to the behavior of Caffe. See
+        # https://github.com/BVLC/caffe/issues/4885
         if len(blobs) >= 3:
             scaling_factor = blobs[2].data
             func.avg_mean /= scaling_factor[0]


### PR DESCRIPTION
A simple fix for https://github.com/chainer/chainer/issues/3260 that scales the means and variances when parsing Caffe functions if the scaling factor is included in the blob.

#### Related thread in the Caffe repository

https://github.com/BVLC/caffe/issues/4885