### PR TITLE
Fix test of to_gpu with Variable argument

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -249,6 +249,10 @@ def to_gpu(array, device=None, stream=None):
 
     """
     check_cuda_available()
+    if not isinstance(array, (cupy.ndarray, numpy.ndarray)):
+        raise TypeError(
+            'The array sent to gpu must be numpy.ndarray or cupy.ndarray.'
+            '\nActual type: {0}.'.format(type(array)))
     with _get_device(device):
         array_dev = get_device_from_array(array)
         if array_dev.id == cupy.cuda.device.get_device_id():

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -285,10 +285,10 @@ class TestToGPU(unittest.TestCase):
         self.assertIsNot(x, y)  # Do copy
         cuda.cupy.testing.assert_array_equal(x, y)
 
-    def test_variable_cpu(self):
+    def test_variable_gpu(self):
         x = chainer.Variable(self.x)
         with self.assertRaises(TypeError):
-            cuda.to_cpu(x)
+            cuda.to_gpu(x)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -285,6 +285,7 @@ class TestToGPU(unittest.TestCase):
         self.assertIsNot(x, y)  # Do copy
         cuda.cupy.testing.assert_array_equal(x, y)
 
+    @attr.gpu
     def test_variable_gpu(self):
         x = chainer.Variable(self.x)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Fixed a test of `to_gpu` with `Variable` argument.
Currently, `ValueError: Unsupported dtype object` is raised instead of `TypeError`.