### PR TITLE
doc: Remove obsolete statement in to_gpu

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -232,7 +232,7 @@ def _get_device(*args):
 # ------------------------------------------------------------------------------
 
 def to_gpu(array, device=None, stream=None):
-    """Copies the given CPU array to specified device.
+    """Copies the given CPU array to the specified device.
 
     Args:
         array: Array to be sent to GPU.
@@ -243,9 +243,8 @@ def to_gpu(array, device=None, stream=None):
     Returns:
         cupy.ndarray: Array on GPU.
 
-        If ``array`` is already on GPU, then this function just returns
-        ``array`` without performing any copy. Note that this function does not
-        copy :class:`cupy.ndarray` into specified device.
+        If ``array`` is already on the GPU device specified by ``device``,
+        this function just returns ``array`` without performing any copy.
 
     """
     if stream is not None:


### PR DESCRIPTION
Array is copied if it is on a different device.