### PR TITLE
New style batch_normalization and fixed_batch_normalization

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -1,9 +1,9 @@
 import numpy
 
 import chainer
-from chainer import configuration
 from chainer import cuda
 from chainer import function
+from chainer import function_node
 from chainer.utils import argument
 from chainer.utils import type_check
 
@@ -12,22 +12,10 @@ if cuda.cudnn_enabled:
     libcudnn = cudnn.cudnn
 
 
-def _as4darray(arr):
-    if arr.ndim == 0:
-        return arr.reshape(1, 1, 1, 1)
-    elif arr.ndim == 4:
-        return arr
-    else:
-        return arr.reshape(arr.shape[0], -1, 1, 1)
+class BatchNormalization(function_node.FunctionNode):
 
-
-def _xhat(x, mean, std, expander):
-    x_mu = x - mean[expander]
-    x_mu /= std[expander]
-    return x_mu
-
-
-class BatchNormalizationFunction(function.Function):
+    mean = None
+    inv_std = None
 
     def __init__(self, eps=2e-5, mean=None, var=None, decay=0.9):
         self.running_mean = mean
@@ -46,12 +34,8 @@ class BatchNormalizationFunction(function.Function):
         self.decay = decay
 
     def check_type_forward(self, in_types):
-        n_in = type_check.eval(in_types.size())
-        if n_in != 3 and n_in != 5:
-            raise type_check.InvalidType(
-                '%s or %s' % (in_types.size() == 3, in_types.size() == 5),
-                '%s == %s' % (in_types.size(), n_in))
-        x_type, gamma_type, beta_type = in_types[:3]
+        type_check.expect(in_types.size() == 3)
+        x_type, gamma_type, beta_type = in_types
         M = type_check.eval(gamma_type.ndim)
         type_check.expect(
             x_type.dtype.kind == 'f',
@@ -62,55 +46,230 @@ class BatchNormalizationFunction(function.Function):
             beta_type.dtype == x_type.dtype,
             gamma_type.shape == beta_type.shape,
         )
-        if len(in_types) == 5:
-            mean_type, var_type = in_types[3:]
-            type_check.expect(
-                mean_type.dtype == x_type.dtype,
-                mean_type.shape == gamma_type.shape,
-                var_type.dtype == x_type.dtype,
-                var_type.shape == gamma_type.shape,
-            )
 
     def forward(self, inputs):
-        xp = cuda.get_array_module(*inputs)
-        x, gamma, beta = inputs[:3]
-        if configuration.config.train:
-            if self.running_mean is None:
-                self.running_mean = xp.zeros_like(gamma)
-                self.running_var = xp.zeros_like(gamma)
-            else:
-                self.running_mean = xp.array(self.running_mean)
-                self.running_var = xp.array(self.running_var)
-        elif len(inputs) == 5:
-            self.fixed_mean = inputs[3]
-            self.fixed_var = inputs[4]
+        self.retain_inputs((0, 1))
+        x, gamma, beta = inputs
+        xp = cuda.get_array_module(x)
+        if self.running_mean is None:
+            self.running_mean = xp.zeros_like(gamma)
+            self.running_var = xp.zeros_like(gamma)
+        self.mode = _BNMode(x.ndim, gamma.ndim)
 
+        # expander inserts singleton dimensions to gamma and beta so that they
+        # can be broadcasted with x.
         head_ndim = gamma.ndim + 1
         expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
-        gamma = gamma[expander]
-        beta = beta[expander]
+        self.expander = expander
+        self.axis = (0,) + tuple(range(head_ndim, x.ndim))
+        self.use_cudnn = self.mode.can_use_cudnn(xp, x.ndim)
 
-        # cuDNN only supports these tensor dimensions because they are
-        # the most commonly used. If there is a need to support other
-        # dimensions with cuDNN, we could consider reshaping the input
-        # into a 2-dim array with channels as second dim and m=<product
-        # of all dimensions except the 2nd dimension> as the first
-        # dimension.
-        cudnn_dim_ok = x.ndim == 2 or (x.ndim == 4 and head_ndim == 2)
-        # TODO(bkvogel): Check for float16 support again in next cuDNN version.
-        # cuDNN v5 batch normalization does not seem to support float16.
-        self._can_use_cudnn = cudnn_dim_ok and x[0].dtype != numpy.float16
-
-        cudnn_updated_running_stats = False
-        if (xp is not numpy and chainer.should_use_cudnn('>=auto', 5000) and
-                self._can_use_cudnn):
+        if self.use_cudnn:
             x = cuda.cupy.ascontiguousarray(x)
-            if x.ndim == 4 and head_ndim == 2:
-                # for convolutional layer
-                self.mode = libcudnn.CUDNN_BATCHNORM_SPATIAL
+            cudnn_mode = self.mode.get_cudnn_mode()
+
+            gamma = cuda.cupy.ascontiguousarray(gamma)
+            beta = cuda.cupy.ascontiguousarray(beta)
+            dtype = x.dtype
+            handle = cudnn.get_handle()
+            x_desc = cudnn.create_tensor_descriptor(_as4darray(x))
+            derivedBnDesc = cudnn.create_uninitialized_tensor_descriptor()
+            libcudnn.deriveBNTensorDescriptor(derivedBnDesc.value,
+                                              x_desc.value, cudnn_mode)
+            one = numpy.array(1, dtype=dtype).ctypes
+            zero = numpy.array(0, dtype=dtype).ctypes
+            y = cuda.cupy.empty_like(x)
+            # Factor used in the moving average
+            factor = 1 - self.decay
+
+            if self.mean is None:
+                # Output cache to speed up backward pass.
+                self.mean = xp.empty_like(gamma)
+                # Output cache to speed up backward pass.
+                self.inv_std = xp.empty_like(gamma)
+            # Note: cuDNN computes the mini-batch mean and variance
+            # internally. We can simply (optionally) pass
+            # it the running-average mean and variance arrays.
+            # Note: This API seems to set the inverse of the standard deviation
+            # (instead of variance) to resultSaveInvVariance argument. The
+            # current implementation of our BN depends on this behavior so that
+            # we can reduce the number of reduction kernels.
+            libcudnn.batchNormalizationForwardTraining(
+                handle, cudnn_mode, one.data, zero.data,
+                x_desc.value, x.data.ptr, x_desc.value,
+                y.data.ptr, derivedBnDesc.value, gamma.data.ptr,
+                beta.data.ptr, factor, self.running_mean.data.ptr,
+                self.running_var.data.ptr, self.eps,
+                self.mean.data.ptr, self.inv_std.data.ptr)
+        else:
+            gamma = gamma[expander]
+            beta = beta[expander]
+            self.mean = x.mean(axis=self.axis)
+            var = x.var(axis=self.axis)
+            var += self.eps
+            self.inv_std = var ** (-0.5)
+            y = _apply_bn_fwd(xp, x, self.mean[expander],
+                              self.inv_std[expander], gamma, beta)
+            # Update running statistics
+            m = x.size // gamma.size
+            adjust = m / max(m - 1., 1.)  # unbiased estimation
+            self.running_mean *= self.decay
+            self.running_mean += (1 - self.decay) * self.mean
+            self.running_var *= self.decay
+            self.running_var += (1 - self.decay) * adjust * var
+
+        return y,
+
+    def backward(self, indexes, grad_outputs):
+        x, gamma = self.get_retained_inputs()
+        gy, = grad_outputs
+        f = BatchNormalizationGrad(
+            self.eps, self.use_cudnn, self.mode, self.expander, self.axis,
+            self.mean, self.inv_std)
+        return f(x, gamma, gy)
+
+
+class BatchNormalizationGrad(function.Function):
+
+    def __init__(self, eps, use_cudnn, mode, expander, axis, mean, inv_std):
+        self.eps = eps
+        self.use_cudnn = use_cudnn
+        self.mode = mode
+        self.expander = expander
+        self.axis = axis
+        self.mean = mean
+        self.inv_std = inv_std
+
+    def forward(self, inputs):
+        self.retain_inputs((0, 1, 2))
+        x, gamma, gy = inputs
+        expander = self.expander
+        inv_m = gamma.dtype.type(1. / (x.size // gamma.size))
+        xp = cuda.get_array_module(x)
+
+        if self.use_cudnn:
+            cudnn_mode = self.mode.get_cudnn_mode()
+            x = cuda.cupy.ascontiguousarray(x)
+            gamma = cuda.cupy.ascontiguousarray(gamma)
+            gy = cuda.cupy.ascontiguousarray(gy)
+            dtype = x.dtype
+            handle = cudnn.get_handle()
+            x_desc = cudnn.create_tensor_descriptor(_as4darray(x))
+            derivedBnDesc = cudnn.create_uninitialized_tensor_descriptor()
+            libcudnn.deriveBNTensorDescriptor(derivedBnDesc.value,
+                                              x_desc.value, cudnn_mode)
+            one = numpy.array(1, dtype=dtype).ctypes
+            zero = numpy.array(0, dtype=dtype).ctypes
+            gx = cuda.cupy.empty_like(x)
+            ggamma = cuda.cupy.empty_like(gamma)
+            gbeta = cuda.cupy.empty_like(gamma)
+            libcudnn.batchNormalizationBackward(
+                handle, cudnn_mode, one.data, zero.data,
+                one.data, zero.data, x_desc.value, x.data.ptr,
+                x_desc.value, gy.data.ptr, x_desc.value, gx.data.ptr,
+                derivedBnDesc.value, gamma.data.ptr,
+                ggamma.data.ptr, gbeta.data.ptr,
+                self.eps, self.mean.data.ptr, self.inv_std.data.ptr)
+        else:
+            gbeta = gy.sum(axis=self.axis)
+            x_hat = _x_hat(x, self.mean[expander], self.inv_std[expander])
+            ggamma = (gy * x_hat).sum(axis=self.axis)
+            if xp is numpy:
+                gx = (gamma * self.inv_std)[expander] * (
+                    gy - (x_hat * ggamma[expander] + gbeta[expander]) * inv_m)
             else:
-                # for linear layer
-                self.mode = libcudnn.CUDNN_BATCHNORM_PER_ACTIVATION
+                gx = cuda.elementwise(
+                    '''
+                    T gy, T x_hat, T gamma, T inv_std, T ggamma, T gbeta,
+                    T inv_m
+                    ''',
+                    'T gx',
+                    '''
+                    gx = (gamma * inv_std) * (
+                        gy - (x_hat * ggamma + gbeta) * inv_m)
+                    ''', 'bn_bwd')(gy, x_hat, gamma[expander],
+                                   self.inv_std[expander], ggamma[expander],
+                                   gbeta[expander], inv_m)
+        self.retain_outputs((0, 1))
+        return gx, ggamma, gbeta
+
+    def backward(self, inputs, grad_outputs):
+        expander = self.expander
+
+        x, gamma, gy = inputs
+        gx1, ggamma1, _ = self.output_data
+        ggx1, gggamma1, ggbeta1 = grad_outputs
+        xp = cuda.get_array_module(x)
+
+        # auxiliary values
+        inv_m = gamma.dtype.type(1. / (x.size // gamma.size))
+        r = 0 if ggx1 is None else (gx1 * ggx1).sum(axis=self.axis)
+        coeff = gamma * self.inv_std
+        coeff_m = coeff * inv_m
+        x_hat = _x_hat(x, self.mean[expander], self.inv_std[expander])
+
+        # handle None in output gradients
+        ggx1 = _zero_if_none(xp, ggx1, x.shape, x.dtype)
+        gggamma1 = _zero_if_none(xp, gggamma1, gamma.shape, gamma.dtype)
+        ggbeta1 = _zero_if_none(xp, ggbeta1, gamma.shape, gamma.dtype)
+
+        gggamma2 = gggamma1 - coeff_m * (x_hat * ggx1).sum(axis=self.axis)
+        ggbeta2 = ggbeta1 - coeff_m * ggx1.sum(axis=self.axis)
+
+        ggamma2 = r / gamma
+
+        gx_hat2 = (gggamma2[expander] * gy -
+                   (coeff_m * ggamma1)[expander] * ggx1)
+        gstd2 = -self.inv_std * (r + (x_hat * gx_hat2).sum(axis=self.axis))
+        gmean2 = -self.inv_std * gx_hat2.sum(axis=self.axis)
+        gx2 = self.inv_std[expander] * gx_hat2 + inv_m * (
+            gmean2[expander] + x_hat * gstd2[expander])
+        ggy2 = (gggamma2[expander] * x_hat + ggbeta2[expander] +
+                coeff[expander] * ggx1)
+
+        return gx2, ggamma2, ggy2
+
+
+class FixedBatchNormalization(function_node.FunctionNode):
+
+    inv_var = None
+
+    def __init__(self, eps=2e-5):
+        self.eps = eps
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 5)
+        x_type, gamma_type, beta_type, mean_type, var_type = in_types
+        M = type_check.eval(gamma_type.ndim)
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            x_type.ndim >= gamma_type.ndim + 1,
+            x_type.shape[1:1 + M] == gamma_type.shape,
+            # TODO(beam2d): Check shape
+            gamma_type.dtype == x_type.dtype,
+            beta_type.dtype == x_type.dtype,
+            gamma_type.shape == beta_type.shape,
+            mean_type.dtype == x_type.dtype,
+            mean_type.shape == gamma_type.shape,
+            var_type.dtype == x_type.dtype,
+            var_type.shape == gamma_type.shape,
+        )
+
+    def forward(self, inputs):
+        self.retain_inputs((0, 1, 3, 4))
+        x, gamma, beta, mean, var = inputs
+        xp = cuda.get_array_module(x)
+
+        # expander inserts singleton dimensions to gamma and beta so that they
+        # can be broadcasted with x.
+        head_ndim = gamma.ndim + 1
+        expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
+        self.expander = expander
+        self.axis = (0,) + tuple(range(head_ndim, x.ndim))
+
+        mode = _BNMode(x.ndim, gamma.ndim)
+        if mode.can_use_cudnn(xp, x.ndim):
+            x = cuda.cupy.ascontiguousarray(x)
 
             gamma = cuda.cupy.ascontiguousarray(gamma)
             beta = cuda.cupy.ascontiguousarray(beta)
@@ -123,147 +282,170 @@ class BatchNormalizationFunction(function.Function):
             one = numpy.array(1, dtype=dtype).ctypes
             zero = numpy.array(0, dtype=dtype).ctypes
             y = cuda.cupy.empty_like(x)
-            # Factor used in the moving average
-            factor = 1 - self.decay
 
-            if configuration.config.train:
-                if self.mean_cache is None:
-                    # Output cache to speed up backward pass.
-                    self.mean_cache = xp.empty_like(gamma)
-                    # Output cache to speed up backward pass.
-                    self.var_cache = xp.empty_like(gamma)
-                # Note: cuDNN computes the mini-batch mean and variance
-                # internally. We can simply (optionally) pass
-                # it the running-average mean and variance arrays.
-                libcudnn.batchNormalizationForwardTraining(
-                    handle, self.mode, one.data, zero.data,
-                    x_desc.value, x.data.ptr, x_desc.value,
-                    y.data.ptr, derivedBnDesc.value, gamma.data.ptr,
-                    beta.data.ptr, factor, self.running_mean.data.ptr,
-                    self.running_var.data.ptr, self.eps,
-                    self.mean_cache.data.ptr, self.var_cache.data.ptr)
-                cudnn_updated_running_stats = True
-            else:
-                libcudnn.batchNormalizationForwardInference(
-                    handle, self.mode, one.data, zero.data,
-                    x_desc.value, x.data.ptr, x_desc.value, y.data.ptr,
-                    derivedBnDesc.value, gamma.data.ptr, beta.data.ptr,
-                    self.fixed_mean.data.ptr, self.fixed_var.data.ptr,
-                    self.eps)
+            libcudnn.batchNormalizationForwardInference(
+                handle, self.mode.get_cudnn_mode(), one.data, zero.data,
+                x_desc.value, x.data.ptr, x_desc.value, y.data.ptr,
+                derivedBnDesc.value, gamma.data.ptr, beta.data.ptr,
+                mean.data.ptr, var.data.ptr, self.eps)
         else:
-            if configuration.config.train:
-                axis = (0,) + tuple(range(head_ndim, x.ndim))
-                mean = x.mean(axis=axis)
-                var = x.var(axis=axis)
-                var += self.eps
-            else:
-                mean = self.fixed_mean
-                var = self.fixed_var + self.eps
-            self.std = xp.sqrt(var, dtype=var.dtype)
-            if xp is numpy:
-                self.x_hat = _xhat(x, mean, self.std, expander)
-                y = gamma * self.x_hat
-                y += beta
-            else:
-                self.x_hat, y = cuda.elementwise(
-                    'T x, T mean, T std, T gamma, T beta', 'T x_hat, T y',
-                    '''
-                    x_hat = (x - mean) / std;
-                    y = gamma * x_hat + beta;
-                    ''',
-                    'bn_fwd')(x, mean[expander], self.std[expander], gamma,
-                              beta)
+            gamma = gamma[expander]
+            beta = beta[expander]
+            var = var + self.eps
+            self.inv_var = xp.reciprocal(var)
+            self.inv_std = xp.sqrt(self.inv_var, dtype=self.inv_var.dtype)
+            y = _apply_bn_fwd(xp, x, mean[expander], self.inv_std[expander],
+                              gamma, beta)
 
-        if configuration.config.train and (not cudnn_updated_running_stats):
-            # Note: If in training mode, the cuDNN forward training function
-            # will do this for us, so
-            # only run following code if cuDNN was not used.
-            # Update running statistics:
-            m = x.size // gamma.size
-            adjust = m / max(m - 1., 1.)  # unbiased estimation
-            self.running_mean *= self.decay
-            temp_ar = xp.array(mean)
-            temp_ar *= (1 - self.decay)
-            self.running_mean += temp_ar
-            del temp_ar
-            self.running_var *= self.decay
-            temp_ar = xp.array(var)
-            temp_ar *= (1 - self.decay) * adjust
-            self.running_var += temp_ar
-            del temp_ar
         return y,
 
-    def backward(self, inputs, grad_outputs):
-        x, gamma = inputs[:2]
-        gy = grad_outputs[0]
-        head_ndim = gamma.ndim + 1
-        expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
-        m = gamma.dtype.type(x.size // gamma.size)
-        axis = (0,) + tuple(range(head_ndim, x.ndim))
-        xp = cuda.get_array_module(x)
-        if len(inputs) == 5:
-            # This case is unlikely to be used in practice and so does not
-            # need to be optimized for performance.
-            mean = inputs[3]
-            var = inputs[4]
-            std = xp.sqrt(var, dtype=var.dtype)
-            gs = gamma / std
-            gbeta = gy.sum(axis=axis)
-            x_hat = _xhat(x, mean, std, expander)
-            ggamma = (gy * x_hat).sum(axis=axis)
-            gmean = -gs * gbeta
-            gvar = -0.5 * gamma / var * ggamma
-            gx = gs[expander] * gy
-            return gx, ggamma, gbeta, gmean, gvar
+    def backward(self, indexes, grad_outputs):
+        x, gamma, mean, var = self.get_retained_inputs()
+        gy, = grad_outputs
+        f = FixedBatchNormalizationGrad(
+            self.eps, self.expander, self.axis, self.inv_std, self.inv_var)
+        return f(x, gamma, mean, var, gy)
 
-        # Note: If length of inputs is not 5, we must be in train mode.
-        assert configuration.config.train
-        if (xp is not numpy and chainer.should_use_cudnn('>=auto', 5000) and
-                self._can_use_cudnn):
-            # Note: cuDNN batch normalization backward only works in
-            # "training mode." That is, it does not support
-            # computing gradients in fixed-mean-variance mode, because there
-            # is normally no reason to call backward()
-            # while in test/evaluation mode.
-            x = cuda.cupy.ascontiguousarray(x)
-            gamma = cuda.cupy.ascontiguousarray(gamma)
-            gy = cuda.cupy.ascontiguousarray(gy)
-            dtype = x.dtype
-            handle = cudnn.get_handle()
-            x_desc = cudnn.create_tensor_descriptor(_as4darray(x))
-            derivedBnDesc = cudnn.create_uninitialized_tensor_descriptor()
-            libcudnn.deriveBNTensorDescriptor(derivedBnDesc.value,
-                                              x_desc.value, self.mode)
-            one = numpy.array(1, dtype=dtype).ctypes
-            zero = numpy.array(0, dtype=dtype).ctypes
-            gx = cuda.cupy.empty_like(x)
-            ggamma = cuda.cupy.empty_like(gamma)
-            gbeta = cuda.cupy.empty_like(gamma)
-            libcudnn.batchNormalizationBackward(
-                handle, self.mode, one.data, zero.data,
-                one.data, zero.data, x_desc.value, x.data.ptr,
-                x_desc.value, gy.data.ptr, x_desc.value, gx.data.ptr,
-                derivedBnDesc.value, gamma.data.ptr,
-                ggamma.data.ptr, gbeta.data.ptr,
-                self.eps, self.mean_cache.data.ptr, self.var_cache.data.ptr)
-        else:
-            gbeta = gy.sum(axis=axis)
-            ggamma = (gy * self.x_hat).sum(axis=axis)
-            if xp is numpy:
-                gx = (gamma / self.std)[expander] * (
-                    gy - (self.x_hat * ggamma[expander] + gbeta[expander]) / m)
-            else:
-                inv_m = numpy.float32(1) / m
-                gx = cuda.elementwise(
-                    'T gy, T x_hat, T gamma, T std, T ggamma, T gbeta, \
-                    T inv_m',
-                    'T gx',
-                    'gx = (gamma / std) * (gy - (x_hat * ggamma + gbeta) * \
-                    inv_m)',
-                    'bn_bwd')(gy, self.x_hat, gamma[expander],
-                              self.std[expander], ggamma[expander],
-                              gbeta[expander], inv_m)
-        return gx, ggamma, gbeta
+
+class FixedBatchNormalizationGrad(function.Function):
+
+    def __init__(self, eps, expander, axis, inv_std, inv_var):
+        self.eps = eps
+        self.expander = expander
+        self.axis = axis
+        self.inv_std = inv_std
+        self.inv_var = inv_var  # may be None
+
+    def forward(self, inputs):
+        self.retain_inputs((0, 1, 2, 4))
+        x, gamma, mean, var, gy = inputs
+        expander = self.expander
+        xp = cuda.get_array_module(x)
+
+        if self.inv_var is None:
+            self.inv_var = xp.square(self.inv_std)
+        self.gamma_over_std = gamma * self.inv_std
+        x_hat = _x_hat(x, mean[expander], self.inv_std[expander])
+
+        gx = self.gamma_over_std[expander] * gy
+        gbeta = gy.sum(axis=self.axis)
+        ggamma = (x_hat * gy).sum(axis=self.axis)
+        gmean = -self.gamma_over_std * gbeta
+        gvar = - 0.5 * gamma * self.inv_var * ggamma
+
+        self.retain_outputs((0, 1, 2, 3, 4))
+        return gx, ggamma, gbeta, gmean, gvar
+
+    def backward(self, inputs, grad_outputs):
+        x, gamma, mean, _, gy = inputs
+        ggx1, gggamma1, ggbeta1, ggmean1, ggvar1 = grad_outputs
+        gx1, ggamma1, gbeta1, gmean1, gvar1 = self.output_data
+
+        # Handle None in output gradients.
+        xp = cuda.get_array_module(x)
+        ggx1 = _zero_if_none(xp, ggx1, x.shape, x.dtype)
+        gggamma1 = _zero_if_none(xp, gggamma1, gamma.shape, gamma.dtype)
+        ggbeta1 = _zero_if_none(xp, ggbeta1, gamma.shape, gamma.dtype)
+        ggmean1 = _zero_if_none(xp, ggmean1, mean.shape, mean.dtype)
+        ggvar1 = _zero_if_none(xp, ggvar1, mean.shape, mean.dtype)
+
+        expander = self.expander
+
+        x_hat = _x_hat(x, mean[expander], self.inv_std[expander])
+        tmp = -0.5 * ggvar1
+
+        gamma_over_var = gamma * self.inv_var
+        g_gamma_over_var = tmp * ggamma1
+
+        gggamma2 = gggamma1 + tmp * gamma_over_var
+        gx_hat = gy * gggamma2[expander]
+        gx2 = self.inv_std[expander] * gx_hat
+        gmean2 = -self.inv_std * gx_hat.sum(axis=self.axis)
+
+        g_gamma_over_std = (ggx1 * gy).sum(axis=self.axis) - ggmean1 * gbeta1
+        ggbeta2 = ggbeta1 - ggmean1 * self.gamma_over_std
+        ggy2 = (gggamma2[expander] * x_hat + ggbeta2[expander] +
+                self.gamma_over_std[expander] * ggx1)
+
+        ggamma2 = (self.inv_var * g_gamma_over_var +
+                   self.inv_std * g_gamma_over_std)
+        gvar2 = -(ggamma2 * gamma_over_var + 0.5 * self.inv_var * (
+            (x_hat * gx_hat).sum(axis=self.axis) -
+            self.gamma_over_std * g_gamma_over_std))
+
+        return gx2, ggamma2, gmean2, gvar2, ggy2
+
+
+class _BNMode(object):
+
+    def __init__(self, x_ndim, gamma_ndim):
+        is_gamma_1d = gamma_ndim == 1
+        # cuDNN only supports these tensor dimensions because they are
+        # the most commonly used. If there is a need to support other
+        # dimensions with cuDNN, we could consider reshaping the input
+        # into a 2-dim array with channels as second dim and m=<product
+        # of all dimensions except the 2nd dimension> as the first
+        # dimension.
+        self.is_for_conv2d = x_ndim == 4 and is_gamma_1d
+        self.is_for_linear = x_ndim == 2 and is_gamma_1d
+        self.cudnn_dim_ok = self.is_for_conv2d or self.is_for_linear
+
+    def get_cudnn_mode(self):
+        assert self.cudnn_dim_ok
+        if self.is_for_conv2d:
+            return libcudnn.CUDNN_BATCHNORM_SPATIAL
+        return libcudnn.CUDNN_BATCHNORM_PER_ACTIVATION
+
+    def can_use_cudnn(self, xp, x_dtype):
+        # TODO(bkvogel): Check for float16 support again in next cuDNN version.
+        # cuDNN v5 batch normalization does not seem to support float16.
+        return (xp is not numpy and
+                chainer.should_use_cudnn('>=auto', 5000) and
+                self.cudnn_dim_ok and
+                x_dtype != numpy.float16)
+
+
+def _as4darray(arr):
+    if arr.ndim == 0:
+        return arr.reshape(1, 1, 1, 1)
+    elif arr.ndim == 4:
+        return arr
+    else:
+        return arr.reshape(arr.shape[0], -1, 1, 1)
+
+
+def _get_mode(x, gamma):
+    if x.ndim == 4 and gamma.ndim == 1:
+        return libcudnn.CUDNN_BATCHNORM_SPATIAL
+    return libcudnn.CUDNN_BATCHNORM_PER_ACTIVATION
+
+
+def _x_hat(x, mean, inv_std):
+    x_mu = x - mean
+    x_mu *= inv_std
+    return x_mu
+
+
+def _apply_bn_fwd(xp, x, mean, inv_std, gamma, beta):
+    # NOTE: all arguments should be broadcasted to x.shape
+    # (mean, inv_std, gamma, and beta have to already be expanded)
+    if xp is numpy:
+        x_hat = _x_hat(x, mean, inv_std)
+        y = gamma * x_hat
+        y += beta
+    else:
+        y = cuda.elementwise(
+            'T x, T mean, T inv_std, T gamma, T beta', 'T y',
+            'y = gamma * (x - mean) * inv_std + beta', 'bn_fwd'
+        )(x, mean, inv_std, gamma, beta)
+    return y
+
+
+def _zero_if_none(xp, x, shape, dtype):
+    # TODO (Tokui): Return broadcasted 0 instead of a zeroed array.
+    if x is None:
+        return xp.zeros(shape, dtype=dtype)
+    return x
 
 
 def batch_normalization(x, gamma, beta, **kwargs):
@@ -338,8 +520,8 @@ def batch_normalization(x, gamma, beta, **kwargs):
         kwargs, ('eps', 2e-5), ('running_mean', None),
         ('running_var', None), ('decay', 0.9))
 
-    return BatchNormalizationFunction(eps, running_mean, running_var,
-                                      decay)(x, gamma, beta)
+    return BatchNormalization(eps, running_mean, running_var, decay).apply(
+        (x, gamma, beta))[0]
 
 
 def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5):
@@ -363,6 +545,4 @@ def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5):
        :class:`links.BatchNormalization`
 
     """
-    with configuration.using_config('train', False):
-        return BatchNormalizationFunction(eps, None, None, 0.0)(
-            x, gamma, beta, mean, var)
+    return FixedBatchNormalization(eps).apply((x, gamma, beta, mean, var))[0]

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -442,7 +442,7 @@ def _apply_bn_fwd(xp, x, mean, inv_std, gamma, beta):
 
 
 def _zero_if_none(xp, x, shape, dtype):
-    # TODO (Tokui): Return broadcasted 0 instead of a zeroed array.
+    # TODO(Tokui): Return broadcasted 0 instead of a zeroed array.
     if x is None:
         return xp.zeros(shape, dtype=dtype)
     return x

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -224,8 +224,8 @@ class BatchNormalizationGrad(function.Function):
         gmean2 = -self.inv_std * gx_hat2.sum(axis=self.axis)
         gx2 = self.inv_std[expander] * gx_hat2 + inv_m * (
             gmean2[expander] + x_hat * gstd2[expander])
-        ggy2 = (gggamma2[expander] * x_hat + ggbeta2[expander] +
-                coeff[expander] * ggx1)
+        ggy2 = (gggamma2[expander] * x_hat + ggbeta2[expander]
+                + coeff[expander] * ggx1)
 
         return gx2, ggamma2, ggy2
 
@@ -364,14 +364,14 @@ class FixedBatchNormalizationGrad(function.Function):
 
         g_gamma_over_std = (ggx1 * gy).sum(axis=self.axis) - ggmean1 * gbeta1
         ggbeta2 = ggbeta1 - ggmean1 * self.gamma_over_std
-        ggy2 = (gggamma2[expander] * x_hat + ggbeta2[expander] +
-                self.gamma_over_std[expander] * ggx1)
+        ggy2 = (gggamma2[expander] * x_hat + ggbeta2[expander]
+                + self.gamma_over_std[expander] * ggx1)
 
-        ggamma2 = (self.inv_var * g_gamma_over_var +
-                   self.inv_std * g_gamma_over_std)
+        ggamma2 = (self.inv_var * g_gamma_over_var
+                   + self.inv_std * g_gamma_over_std)
         gvar2 = -(ggamma2 * gamma_over_var + 0.5 * self.inv_var * (
-            (x_hat * gx_hat).sum(axis=self.axis) -
-            self.gamma_over_std * g_gamma_over_std))
+            (x_hat * gx_hat).sum(axis=self.axis)
+            - self.gamma_over_std * g_gamma_over_std))
 
         return gx2, ggamma2, gmean2, gvar2, ggy2
 

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -2,7 +2,7 @@ import numpy
 
 from chainer import configuration
 from chainer import cuda
-from chainer.functions.normalization import batch_normalization
+from chainer import functions
 from chainer import initializers
 from chainer import link
 from chainer.utils import argument
@@ -138,17 +138,14 @@ class BatchNormalization(link.Link):
             else:
                 decay = self.decay
 
-            func = batch_normalization.BatchNormalizationFunction(
-                self.eps, self.avg_mean, self.avg_var, decay)
-            ret = func(x, gamma, beta)
-
-            self.avg_mean[:] = func.running_mean
-            self.avg_var[:] = func.running_var
+            ret = functions.batch_normalization(
+                x, gamma, beta, eps=self.eps, running_mean=self.avg_mean,
+                running_var=self.avg_var, decay=decay)
         else:
             # Use running average statistics or fine-tuned statistics.
             mean = variable.Variable(self.avg_mean)
             var = variable.Variable(self.avg_var)
-            ret = batch_normalization.fixed_batch_normalization(
+            ret = functions.fixed_batch_normalization(
                 x, gamma, beta, mean, var, self.eps)
         return ret
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -292,22 +292,6 @@ class TestFixedBatchNormalization(unittest.TestCase):
     def test_double_backward_cpu(self):
         self.check_double_backward(self.args, self.gy, self.ggargs)
 
-    # @attr.gpu
-    # @condition.retry(3)
-    # def test_double_backward_gpu(self):
-    #     self.check_double_backward(
-    #         [cuda.to_gpu(x) for x in self.args], cuda.to_gpu(self.gy),
-    #         [cuda.to_gpu(ggx) for ggx in self.ggargs])
-    #
-    # @attr.cudnn
-    # @condition.retry(3)
-    # def test_double_backward_gpu_non_contiguous(self):
-    #     self.check_double_backward(
-    #         [cuda.cupy.asfortranarray(cuda.to_gpu(x)) for x in self.args],
-    #         cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
-    #         [cuda.cupy.asfortranarray(cuda.to_gpu(ggx)) for ggx in self.ggargs]
-    #     )
-
 
 @testing.parameterize(*testing.product({
     'use_cudnn': ['always', 'auto', 'never'],


### PR DESCRIPTION
This PR is a part of #3147. It adds double backprop support of `F.batch_normalization` and `F.fixed_batch_normalization`. Currently, the second gradient is written down with plain numpy/cupy APIs without any fusion. It would be better for performance to fuse kernels in CUDA, which is future work.