### PR TITLE
Avoid unwanted output of assert_allclose failure

### DIFF
--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -1,5 +1,5 @@
 import numpy
-import sys
+import six
 
 from chainer import cuda
 from chainer import utils
@@ -23,8 +23,9 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
     try:
         numpy.testing.assert_allclose(
             x, y, atol=atol, rtol=rtol, verbose=verbose)
-    except AssertionError:
-        f = sys.stdout
+    except AssertionError as e:
+        f = six.StringIO()
+        f.write(str(e) + '\n\n')
         f.write(
             'assert_allclose failed: \n' +
             '  shape: {} {}\n'.format(x.shape, y.shape) +
@@ -39,13 +40,11 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
                 '  x[i]: {}\n'.format(xx[i]) +
                 '  y[i]: {}\n'.format(yy[i]) +
                 '  err[i]: {}\n'.format(err[i]))
-        f.flush()
         opts = numpy.get_printoptions()
         try:
             numpy.set_printoptions(threshold=10000)
             f.write('x: ' + numpy.array2string(x, prefix='x: ') + '\n')
             f.write('y: ' + numpy.array2string(y, prefix='y: ') + '\n')
-            f.flush()
         finally:
             numpy.set_printoptions(**opts)
-        raise
+        raise AssertionError(f.getvalue())


### PR DESCRIPTION
Related to #2936.

If error information is dumped directly to stdout, there's a problem when using `@testing.retry`: intermediate failure information is dumped even if a subsequent trial succeeded.

I fixed so that information is put into the exception.


```
AssertionError: 
Not equal to tolerance rtol=0.0001, atol=1e-05

(mismatch 100.0%)
 x: array(-0.01787613206619142)
 y: array(-0.01786161959171295, dtype=float32)

assert_allclose failed: 
  shape: () ()
  dtype: float64 float32
  i: (0,)
  x[i]: -0.01787613206619142
  y[i]: -0.01786161959171295
  err[i]: 1.451247447846818e-05
x: -0.01787613206619142
y: -0.01786161959171295
```