### PR TITLE
Avoid using deprecated stream option in to_gpu

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -303,8 +303,8 @@ def _gather(link, target):
         i += 1
     info[0] = num
 
-    ptrs = cuda.to_gpu(ptrs, stream=cuda.Stream.null)
-    info = cuda.to_gpu(info, stream=cuda.Stream.null)
+    ptrs = cuda.to_gpu(ptrs)
+    info = cuda.to_gpu(info)
 
     return _batch_memcpy()(ptrs, info, size=size)
 

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -233,13 +233,15 @@ class TestToGPU(unittest.TestCase):
 
     @attr.gpu
     def test_numpy_array_async(self):
-        y = cuda.to_gpu(self.x, stream=cuda.Stream.null)
+        with testing.assert_warns(DeprecationWarning):
+            y = cuda.to_gpu(self.x, stream=cuda.Stream.null)
         self.assertIsInstance(y, cuda.ndarray)
         cuda.cupy.testing.assert_array_equal(self.x, y)
 
     @attr.multi_gpu(2)
     def test_numpy_array_async2(self):
-        y = cuda.to_gpu(self.x, device=1, stream=cuda.Stream.null)
+        with testing.assert_warns(DeprecationWarning):
+            y = cuda.to_gpu(self.x, device=1, stream=cuda.Stream.null)
         self.assertIsInstance(y, cuda.ndarray)
         cuda.cupy.testing.assert_array_equal(self.x, y)
         self.assertEqual(int(y.device), 1)
@@ -247,7 +249,8 @@ class TestToGPU(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_numpy_array_async3(self):
         with cuda.Device(1):
-            y = cuda.to_gpu(self.x, stream=cuda.Stream.null)
+            with testing.assert_warns(DeprecationWarning):
+                y = cuda.to_gpu(self.x, stream=cuda.Stream.null)
         self.assertIsInstance(y, cuda.ndarray)
         cuda.cupy.testing.assert_array_equal(self.x, y)
         self.assertEqual(int(y.device), 1)


### PR DESCRIPTION
Avoid using deprecated `stream` option in `to_gpu` (#2238)