### PR TITLE
doc: Add initializers.NaN

### DIFF
--- a/docs/source/reference/initializers.rst
+++ b/docs/source/reference/initializers.rst
@@ -28,6 +28,7 @@ Concrete initializers
    chainer.initializers.Constant
    chainer.initializers.Zero
    chainer.initializers.One
+   chainer.initializers.NaN
    chainer.initializers.Normal
    chainer.initializers.LeCunNormal
    chainer.initializers.GlorotNormal


### PR DESCRIPTION
`initializers.NaN` is not documented.