### PR TITLE
Add minor version policy and feature backport policy

### DIFF
--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -26,7 +26,7 @@ Versioning and Backward Compatibility
 The versioning of Chainer follows the `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_ and a part of `Semantic versioning <http://semver.org/>`_.
 See :ref:`contrib` for details of versioning.
 
-The backward compatibility is kept for **revision updates**, which are applied to the stable version.
+The backward compatibility is kept for **revision updates** and **minor updates**, which are applied to the stable version.
 A **major update** from the latest release candidate basically keeps the backward compatibility, although it is not guaranteed.
 Any **pre-releases** may break the backward compatibility.
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -62,22 +62,25 @@ Then, the timeline of the updates is depicted by the following table.
 ========== =========== =========== ============
   0 weeks    X.0.0rc1    --         --
   4 weeks    X.0.0       Y.0.0a1    --
-  8 weeks    X.0.1       Y.0.0b1    --
- 12 weeks    X.0.2       Y.0.0rc1   --
+  8 weeks    X.1.0*      Y.0.0b1    --
+ 12 weeks    X.2.0*      Y.0.0rc1   --
  16 weeks    --          Y.0.0      Z.0.0a1
 ========== =========== =========== ============
 
-The dates shown in the left-most column are relative to the release of ``X.0.0rc1``.
-In particular, each revision release is made four weeks after the previous one of the same major version, and the pre-release of the upcoming major version is made at the same time.
+(* These might be revision releases)
 
-Note that the development of ``X.0.x`` stops at ``X.0.2``.
+The dates shown in the left-most column are relative to the release of ``X.0.0rc1``.
+In particular, each revision/minor release is made four weeks after the previous one of the same major version, and the pre-release of the upcoming major version is made at the same time.
+Whether these releases are revision or minor is determined based on the contents of each update.
+
+Note that there are only three stable releases for the versions ``X.x.x``.
 During the parallel development of ``Y.0.0`` and ``Z.0.0a1``, the version ``Y`` is treated as an **almost-stable version** and ``Z`` is treated as a development version.
 
-If there is a critical bug found in ``X.0.2`` after stopping the development of version ``X``, we may release a hot-fix for this version at any time.
+If there is a critical bug found in ``X.x.x`` after stopping the development of version ``X``, we may release a hot-fix for this version at any time.
 
 .. note::
 
-   The release cycle of ``2.0.x`` and ``3.0.0x`` are slightly different from this table because we do not have ``3.0.0a1`` at the timing of the release of ``2.0.0``.
+   The release cycle of ``2.x.x`` and ``3.0.0x`` are slightly different from this table because we do not have ``3.0.0a1`` at the timing of the release of ``2.0.0``.
    In this case, the releases of ``3.0.0x`` are shifted four weeks behind the usual timeline, that is, ``3.0.0a1`` will be released at the same time with ``2.0.1``.
 
 As you can see in the above table, we basically do not have any minor releases from v2.
@@ -105,8 +108,30 @@ If the change can also be applied to the stable version, a core team member will
 If the change is only applicable to the stable version and not to the ``master`` branch, please send it to the versioned branch.
 We basically only accept changes to the latest versioned branch (where the stable version is developed) unless the fix is critical.
 
+If you want to make a new feature of the ``master`` branch available in the current stable version, please send a *backport PR* to the stable version (the latest ``vN`` branch).
+See the next section for details.
+
 *Note: a change that can be applied to both branches should be sent to the* ``master`` *branch.*
 *Each release of the stable version is also merged to the development version so that the change is also reflected to the next major version.*
+
+Feature Backport PRs
+~~~~~~~~~~~~~~~~~~~~
+
+We basically do not backport any new features of the development version to the stable versions.
+If you desire to include the feature to the current stable version and you can work on the backport work, we welcome such a contribution.
+In such a case, you have to send a backport PR to the latest ``vN`` branch.
+**Note that we do not accept any feature backport PRs to older versions because we are not running quality assurance workflows (e.g. CI) for older versions so that we cannot ensure that the PR is correctly ported.**
+
+There are some rules on sending a backport PR.
+
+- Start the PR title from the prefix **[backport]**.
+- Clarify the original PR number in the PR description (something like "This is a backport of #XXXX").
+- (optional) Write to the PR description the motivation of backporting the feature to the stable version.
+
+Please follow these rules when you create a feature backport PR.
+
+Note: PRs that do not include any changes/additions to APIs (e.g. bug fixes, documentation improvements) are usually backported by core dev members.
+It is also appreciated to make such a backport PR by any contributors, though, so that the overall development proceeds more smoothly!
 
 Issues and Pull Requests
 ------------------------

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -78,9 +78,6 @@ During the parallel development of ``Y.0.0`` and ``Z.0.0a1``, the version ``Y`` 
 
 If there is a critical bug found in ``X.x.x`` after stopping the development of version ``X``, we may release a hot-fix for this version at any time.
 
-As you can see in the above table, we basically do not have any minor releases from v2.
-All changes that add and/or modify APIs should be made by the pre-release updates.
-
 We create a milestone for each upcoming release at GitHub.
 The GitHub milestone is basically used for collecting the issues and PRs resolved in the release.
 

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -78,11 +78,6 @@ During the parallel development of ``Y.0.0`` and ``Z.0.0a1``, the version ``Y`` 
 
 If there is a critical bug found in ``X.x.x`` after stopping the development of version ``X``, we may release a hot-fix for this version at any time.
 
-.. note::
-
-   The release cycle of ``2.x.x`` and ``3.0.0x`` are slightly different from this table because we do not have ``3.0.0a1`` at the timing of the release of ``2.0.0``.
-   In this case, the releases of ``3.0.0x`` are shifted four weeks behind the usual timeline, that is, ``3.0.0a1`` will be released at the same time with ``2.0.1``.
-
 As you can see in the above table, we basically do not have any minor releases from v2.
 All changes that add and/or modify APIs should be made by the pre-release updates.
 


### PR DESCRIPTION
This is an update on the contribution guide that allows one to make a feature backport to the stable version.