### PR TITLE
Make double backprop support optional

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -374,7 +374,7 @@ def check_double_backward(func, x_data, y_grad, x_grad_grad, params=(),
         y = identity.Identity().apply(y)
 
         _set_y_grad(y, gys)
-        y[0].backward()
+        y[0].backward(enable_backprop=True)
 
         ret = tuple([x.grad_var for x in xs])
         for x in xs:

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -374,7 +374,7 @@ def check_double_backward(func, x_data, y_grad, x_grad_grad, params=(),
         y = identity.Identity().apply(y)
 
         _set_y_grad(y, gys)
-        y[0].backward(enable_backprop=True)
+        y[0].backward(enable_double_backprop=True)
 
         ret = tuple([x.grad_var for x in xs])
         for x in xs:

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -809,7 +809,7 @@ Actual: {0}'''.format(type(data))
         """
         self._node.set_creator_node(fnode)
 
-    def backward(self, retain_grad=False):
+    def backward(self, retain_grad=False, enable_backprop=False):
         """Runs error backpropagation (a.k.a.\\  backprop) from this variable.
 
         On backprop, :meth:`FunctionNode.backward` is called on each
@@ -839,8 +839,19 @@ Actual: {0}'''.format(type(data))
                 In most cases of training some models, the purpose of backprop
                 is to compute gradients of parameters, not of all variables,
                 and therefore it is recommended to set this flag ``False``.
+            enable_backprop (bool): *(Added in v3.0)* If ``True``,
+                computational trace of the whole backpropagation procedure is
+                recorded to the computational graph so that one can further do
+                backpropagation from the resulting gradients. Note that
+                enabling it results in larger memory consumption needed to
+                store the gradients w.r.t intermediate variables that are
+                required for the second gradient computation.
 
         """
+        with chainer.using_config('enable_backprop', enable_backprop):
+            self._backward_main(retain_grad)
+
+    def _backward_main(self, retain_grad):
         self._node._check_old_style_gradient()
         if self.creator_node is None:
             return

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -809,7 +809,7 @@ Actual: {0}'''.format(type(data))
         """
         self._node.set_creator_node(fnode)
 
-    def backward(self, retain_grad=False, enable_backprop=False):
+    def backward(self, retain_grad=False, enable_double_backprop=False):
         """Runs error backpropagation (a.k.a.\\  backprop) from this variable.
 
         On backprop, :meth:`FunctionNode.backward` is called on each
@@ -839,7 +839,7 @@ Actual: {0}'''.format(type(data))
                 In most cases of training some models, the purpose of backprop
                 is to compute gradients of parameters, not of all variables,
                 and therefore it is recommended to set this flag ``False``.
-            enable_backprop (bool): *(Added in v3.0)* If ``True``,
+            enable_double_backprop (bool): *(Added in v3.0)* If ``True``,
                 computational trace of the whole backpropagation procedure is
                 recorded to the computational graph so that one can further do
                 backpropagation from the resulting gradients. Note that
@@ -848,7 +848,7 @@ Actual: {0}'''.format(type(data))
                 required for the second gradient computation.
 
         """
-        with chainer.using_config('enable_backprop', enable_backprop):
+        with chainer.using_config('enable_backprop', enable_double_backprop):
             self._backward_main(retain_grad)
 
     def _backward_main(self, retain_grad):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -207,7 +207,7 @@ class TestVariable(unittest.TestCase):
 
         y = x * x * x
         y.grad = xp.ones_like(y.data)
-        y.backward()
+        y.backward(enable_backprop=True)
         gx = x.grad_var
         x.grad_var = None  # clear grad
         gx.grad = xp.ones_like(x.data)
@@ -1393,10 +1393,18 @@ class IdentityFunction(chainer.Function):
 
 class TestVariableDoubleBackward(unittest.TestCase):
 
+    def test_default_backward(self):
+        x = chainer.Variable(np.empty(1, np.float32))
+        y = F.identity(x)
+        y.backward()
+        self.assertIsNone(x.grad_var.creator)
+        x.grad_var.backward()
+        self.assertIsNone(y.grad_var.grad_var)
+
     def test_raise_double_backprop(self):
         x = chainer.Variable(np.empty(1, np.float32))
         y = IdentityFunction()(x)
-        y.backward()
+        y.backward(enable_backprop=True)
         with self.assertRaises(RuntimeError):
             x.grad_var.backward()
 
@@ -1404,7 +1412,7 @@ class TestVariableDoubleBackward(unittest.TestCase):
         x = chainer.Variable(np.empty(1, np.float32))
         z = F.identity(x)  # new style
         y = IdentityFunction()(z)  # old style
-        y.backward()
+        y.backward(enable_backprop=True)
         with self.assertRaises(RuntimeError):
             x.grad_var.backward()
 

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -207,7 +207,7 @@ class TestVariable(unittest.TestCase):
 
         y = x * x * x
         y.grad = xp.ones_like(y.data)
-        y.backward(enable_backprop=True)
+        y.backward(enable_double_backprop=True)
         gx = x.grad_var
         x.grad_var = None  # clear grad
         gx.grad = xp.ones_like(x.data)
@@ -1404,7 +1404,7 @@ class TestVariableDoubleBackward(unittest.TestCase):
     def test_raise_double_backprop(self):
         x = chainer.Variable(np.empty(1, np.float32))
         y = IdentityFunction()(x)
-        y.backward(enable_backprop=True)
+        y.backward(enable_double_backprop=True)
         with self.assertRaises(RuntimeError):
             x.grad_var.backward()
 
@@ -1412,7 +1412,7 @@ class TestVariableDoubleBackward(unittest.TestCase):
         x = chainer.Variable(np.empty(1, np.float32))
         z = F.identity(x)  # new style
         y = IdentityFunction()(z)  # old style
-        y.backward(enable_backprop=True)
+        y.backward(enable_double_backprop=True)
         with self.assertRaises(RuntimeError):
             x.grad_var.backward()
 


### PR DESCRIPTION
This PR makes the double backprop support of `Variable.backward()` optional so that existing code does not suffer from increasing memory consumption and possible slow down. It replaces #3271 because this PR automatically stops creating computational graph in `backward` called from `GradientMethod.update()`.