### PR TITLE
New style rollaxis

### DIFF
--- a/chainer/functions/array/rollaxis.py
+++ b/chainer/functions/array/rollaxis.py
@@ -1,11 +1,11 @@
 import six
 
 from chainer import cuda
-from chainer import function
+from chainer import function_node
 from chainer.utils import type_check
 
 
-class Rollaxis(function.Function):
+class Rollaxis(function_node.FunctionNode):
 
     """Roll axis of an array."""
 
@@ -38,8 +38,7 @@ class Rollaxis(function.Function):
         xp = cuda.get_array_module(*inputs)
         return xp.rollaxis(inputs[0], self.axis, self.start),
 
-    def backward(self, inputs, grads):
-        xp = cuda.get_array_module(*grads)
+    def backward(self, indexes, gy):
         axis = self.axis
         if axis < 0:
             axis += self._in_ndim
@@ -52,7 +51,7 @@ class Rollaxis(function.Function):
         else:
             start -= 1
 
-        return xp.rollaxis(grads[0], start, axis),
+        return Rollaxis(start, axis).apply(gy)
 
 
 def rollaxis(x, axis, start=0):
@@ -66,4 +65,4 @@ def rollaxis(x, axis, start=0):
     Returns:
         ~chainer.Variable: Variable whose axis is rolled.
     """
-    return Rollaxis(axis, start)(x)
+    return Rollaxis(axis, start).apply((x,))[0]

--- a/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
@@ -28,6 +28,7 @@ class TestRollaxis(unittest.TestCase):
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
         self.g = numpy.random.uniform(-1, 1, self.out_shape).astype(self.dtype)
+        self.gg = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
@@ -56,6 +57,21 @@ class TestRollaxis(unittest.TestCase):
     @attr.gpu
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g))
+
+    def check_double_backward(self, x_data, g_data, gg_data):
+        def f(x):
+            y = functions.rollaxis(x, self.axis, self.start)
+            return y * y
+
+        gradient_check.check_double_backward(f, x_data, g_data, gg_data)
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.g, self.gg)
+
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g),
+                                   cuda.to_gpu(self.gg))
 
 
 @testing.parameterize(

--- a/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
@@ -44,9 +44,11 @@ class TestRollaxis(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, g_data):
+        def f(x):
+            return functions.rollaxis(x, self.axis, self.start)
+
         gradient_check.check_backward(
-            functions.Rollaxis(self.axis, self.start), x_data, g_data,
-            dtype='d')
+            f, x_data, g_data, dtype='d')
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.g)


### PR DESCRIPTION
This PR applies new-style function API to `F.rollaxis`, as a part of #3147. Double-backpropable version of this function is used in #3296.