### PR TITLE
New style select_item

### DIFF
--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -3,11 +3,11 @@ import six
 
 import chainer
 from chainer import cuda
-from chainer import function
+from chainer import function_node
 from chainer.utils import type_check
 
 
-class SelectItem(function.Function):
+class SelectItem(function_node.FunctionNode):
 
     """Select elements stored in given indices."""
 
@@ -47,24 +47,41 @@ class SelectItem(function.Function):
             )(t, x)
             return y,
 
-    def backward_cpu(self, inputs, grad_outputs):
-        t = inputs[1]
-        gloss = grad_outputs[0]
-        gx = numpy.zeros(self._in_shape, self._in_dtype)
-        gx[six.moves.range(t.size), t] = gloss
-        return gx, None
+    def backward(self, indexes, gy):
+        t = self.get_retained_inputs()[0]
+        ret = []
+        if 0 in indexes:
+            ggx = Assign(self._in_shape, self._in_dtype, t).apply(gy)[0]
+            ret.append(ggx)
+        if 1 in indexes:
+            ret.append(None)
+        return ret
 
-    def backward_gpu(self, inputs, grad_outputs):
-        t = inputs[1]
-        gloss = grad_outputs[0]
-        gx = cuda.cupy.zeros(self._in_shape, self._in_dtype)
+
+class Assign(function_node.FunctionNode):
+
+    def __init__(self, shape, dtype, t):
+        self.shape = shape
+        self.dtype = dtype
+        self.t = t.data
+
+    def forward_cpu(self, inputs):
+        gx = numpy.zeros(self.shape, self.dtype)
+        gx[six.moves.range(self.t.size), self.t] = inputs[0]
+        return gx,
+
+    def forward_gpu(self, inputs):
+        gx = cuda.cupy.zeros(self.shape, self.dtype)
         gx = cuda.elementwise(
             'S t, T gloss',
             'raw T gx',
             'int ind[] = {i, t}; gx[ind] = gloss;',
             'getitem_bwd'
-        )(t, gloss, gx)
-        return gx, None
+        )(self.t, inputs[0], gx)
+        return gx,
+
+    def backward(self, indexes, gy):
+        return SelectItem().apply((gy, self.t))
 
 
 def select_item(x, t):
@@ -81,4 +98,4 @@ def select_item(x, t):
         ~chainer.Variable: Variable that holds ``t``-th element of ``x``.
 
     """
-    return SelectItem()(x, t)
+    return SelectItem().apply((x, t))[0]

--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -81,7 +81,7 @@ class Assign(function_node.FunctionNode):
         return gx,
 
     def backward(self, indexes, gy):
-        return SelectItem().apply((gy, self.t))
+        return SelectItem().apply((gy[0], self.t))
 
 
 def select_item(x, t):

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -86,10 +86,10 @@ class TestSelectItem(unittest.TestCase):
 
     @attr.gpu
     def test_double_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x_data),
-                            cuda.to_gpu(self.t_data),
-                            cuda.to_gpu(self.gy_data),
-                            cuda.to_gpu(self.ggx_data))
+        self.check_double_backward(cuda.to_gpu(self.x_data),
+                                   cuda.to_gpu(self.t_data),
+                                   cuda.to_gpu(self.gy_data),
+                                   cuda.to_gpu(self.ggx_data))
 
 
 @testing.parameterize(

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -56,7 +56,7 @@ class TestSelectItem(unittest.TestCase):
 
     def check_backward(self, x_data, t_data, gy_data):
         gradient_check.check_backward(
-            functions.SelectItem(),
+            functions.select_item,
             (x_data, t_data), gy_data, eps=0.01, dtype='d',
             **self.check_backward_options)
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -33,6 +33,8 @@ class TestSelectItem(unittest.TestCase):
             0, 2, self.out_shape).astype(numpy.int32)
         self.gy_data = numpy.random.uniform(
             -1, 1, self.out_shape).astype(self.dtype)
+        self.ggx_data = numpy.random.uniform(
+            -1, 1, self.in_shape).astype(self.dtype)
         self.check_backward_options = {'atol': 0.01, 'rtol': 0.01}
         if self.dtype == numpy.float16:
             self.check_backward_options = {'atol': 0.1, 'rtol': 0.1}
@@ -68,6 +70,26 @@ class TestSelectItem(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x_data),
                             cuda.to_gpu(self.t_data),
                             cuda.to_gpu(self.gy_data))
+
+    def check_double_backward(self, x_data, t_data, gy_data, ggx_data):
+        def f(x):
+            y = functions.select_item(x, t_data)
+            return y * y
+
+        gradient_check.check_double_backward(
+            f, x_data, gy_data, ggx_data, eps=0.01, dtype='d',
+            **self.check_backward_options)
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x_data, self.t_data,
+                                   self.gy_data, self.ggx_data)
+
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x_data),
+                            cuda.to_gpu(self.t_data),
+                            cuda.to_gpu(self.gy_data),
+                            cuda.to_gpu(self.ggx_data))
 
 
 @testing.parameterize(


### PR DESCRIPTION
This PR applies new-style function API to `F.select_item`, as a part of #3147. Double-backpropable version of this function is used in #3296.