### PR TITLE
call ascongituousarray in log_softmax

### DIFF
--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -32,7 +32,8 @@ def _log_softmax(x):
             one = numpy.array(1, dtype=oz_dtype).ctypes
             zero = numpy.array(0, dtype=oz_dtype).ctypes
             handle = cudnn.get_handle()
-            x_cube = x.reshape(x.shape[:2] + (-1, 1))
+            x_cube = cuda.cupy.ascontiguousarray(
+                x.reshape(x.shape[:2] + (-1, 1)))
             desc = cudnn.create_tensor_descriptor(x_cube)
             y = xp.empty_like(x)
             libcudnn.softmaxForward(
@@ -89,7 +90,9 @@ class LogSoftmaxGrad(function_node.FunctionNode):
             zero = numpy.array(0, dtype=oz_dtype).ctypes
             handle = cudnn.get_handle()
             gx = xp.empty(self._x_shape, dtype=self._x_dtype)
-            gx_cube = gx.reshape(gx.shape[:2] + (-1, 1))
+            gx_cube = cuda.cupy.ascontiguousarray(
+                gx.reshape(gx.shape[:2] + (-1, 1)))
+            gy = cuda.cupy.ascontiguousarray(gy)
             desc = cudnn.create_tensor_descriptor(gx_cube)
             libcudnn.softmaxBackward(
                 handle, _algorithm, _mode, one.data, desc.value,

--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -59,6 +59,12 @@ class TestLogSoftmax(unittest.TestCase):
 
     @attr.gpu
     @condition.retry(3)
+    def test_forward_gpu_non_contiguous(self):
+        self.check_forward(
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)))
+
+    @attr.gpu
+    @condition.retry(3)
     def test_forward_gpu_no_cudnn(self):
         self.check_forward(cuda.to_gpu(self.x), 'never')
 
@@ -76,6 +82,13 @@ class TestLogSoftmax(unittest.TestCase):
     @condition.retry(10)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    @attr.gpu
+    @condition.retry(10)
+    def test_backward_gpu_non_contiguous(self):
+        self.check_backward(
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
 
     @attr.gpu
     @condition.retry(10)


### PR DESCRIPTION
Related to #3072 
Currently, `non C-contiguous array` is not supported for activation `log_softmax`.

```python
import numpy as np
import chainer.functions as F

data = np.ones((2, 2), dtype=np.float32)
data = chainer.cuda.to_gpu(data, 0)
x = chainer.Variable(data)
ys = F.split_axis(x, 2, axis=1)
y = F.log_softmax(ys[0])
```

```
In [15]: y = F.log_softmax(ys[0])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-15-d5fb97a0352c> in <module>()
----> 1 y = F.log_softmax(ys[0])

/home/shingo/chainer/chainer/functions/activation/log_softmax.pyc in log_softmax(x)
    163
    164     """
--> 165     return LogSoftmax().apply((x,))[0]

/home/shingo/chainer/chainer/function_node.pyc in apply(self, inputs)
    217             self._input_indexes_to_retain = None
    218             self._output_indexes_to_retain = None
--> 219             outputs = self.forward(in_data)
    220             assert type(outputs) is tuple
    221

/home/shingo/chainer/chainer/functions/activation/log_softmax.pyc in forward(self, xs)
     60
     61     def forward(self, xs):
---> 62         y = _log_softmax(xs[0])
     63         self._x_xp = cuda.get_array_module(*xs)
     64         self._x_shape = xs[0].shape

/home/shingo/chainer/chainer/functions/activation/log_softmax.pyc in _log_softmax(x)
     34             handle = cudnn.get_handle()
     35             x_cube = x.reshape(x.shape[:2] + (-1, 1))
---> 36             desc = cudnn.create_tensor_descriptor(x_cube)
     37             y = xp.empty_like(x)
     38             libcudnn.softmaxForward(

/usr/local/lib/python2.7/dist-packages/cupy/cudnn.pyc in create_tensor_descriptor(arr, format)
     73                       cudnn.destroyTensorDescriptor)
     74     if not arr.flags.c_contiguous:
---> 75         raise ValueError('cupy.cudnn supports c-contiguous arrays only')
     76     data_type = get_data_type(arr.dtype)
     77     if arr.ndim == 4:

ValueError: cupy.cudnn supports c-contiguous arrays only
```
