### PR TITLE
Change the way to refer stop_trigger

### DIFF
--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -300,11 +300,10 @@ class Trainer(object):
 
         update = self.updater.update
         reporter = self.reporter
-        stop_trigger = self.stop_trigger
 
         # main training loop
         try:
-            while not stop_trigger(self):
+            while not self.stop_trigger(self):
                 self.observation = {}
                 with reporter.scope(self.observation):
                     update()


### PR DESCRIPTION
## Motivation
I want to implement the Extension "Early Stopping".
If I set a early_stopping_trigger function as Trainer.stop_trigger, I have to set a training_length properly.
But if it can update stop_trigger in extension, I can implement Early Stopping as the Extension.
If early stopping should be implemented as Trigger, this PR may be unnecessary.

## Detail
I think it is good to be able to stop training loop in extension to update stop_trigger in each extension.
This is the [early stopping implementation](https://github.com/himkt/chainer/blob/add-early-stopping/chainer/training/extensions/early_stopping.py) and [example](https://gist.github.com/himkt/ea2c3c624b2e9b42ff6b5931bf97cf2b#file-train_mnist_with_early_stopping-py-L120).

But I noticed that [stop_trigger](https://github.com/chainer/chainer/compare/master...himkt:update-trainer?expand=1#diff-768d99d739390d9a9a936299d6fa7fceL307) is not updated in this way.
So I editted the line to be able to call the updated stop_trigger.

## Question
1. Is this behavior (stop_strigger can't be updated) is expected ?
2. If this PR is valid, what tests do I have to write.
3. If someone create PRs about extension, are these considered to merge? (contribution welcome?) 