### PR TITLE
Use CuPy default memory pool

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -127,8 +127,9 @@ DummyDevice = DummyDeviceType()
 # Global states
 # ------------------------------------------------------------------------------
 if available:
-    memory_pool = cupy.default_memory_pool
-    pinned_memory_pool = cupy.default_pinned_memory_pool
+    # This is for backward compatibility
+    memory_pool = cupy.get_default_memory_pool()
+    pinned_memory_pool = cupy.get_default_pinned_memory_pool()
 
 
 if six.PY2:

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -127,10 +127,8 @@ DummyDevice = DummyDeviceType()
 # Global states
 # ------------------------------------------------------------------------------
 if available:
-    memory_pool = cuda.MemoryPool()
-    cuda.set_allocator(memory_pool.malloc)
-    pinned_memory_pool = cuda.PinnedMemoryPool()
-    cuda.set_pinned_memory_allocator(pinned_memory_pool.malloc)
+    memory_pool = cupy.default_memory_pool
+    pinned_memory_pool = cupy.default_pinned_memory_pool
 
 
 if six.PY2:


### PR DESCRIPTION
Please merge cupy/cupy#472 first.
CuPy provides default memory pool in cupy/cupy#472.
So, this PR uses CuPy default memory pool.