### PR TITLE
Add seealso link in using_config

### DIFF
--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -111,6 +111,9 @@ def using_config(name, value, config=config):
         config (~chainer.configuration.LocalConfig): Configuration object.
             Chainer's thread-local configuration is used by default.
 
+    .. seealso::
+        :ref:`configuration`
+
     """
     if hasattr(config._local, name):
         old_value = getattr(config, name)


### PR DESCRIPTION
I think #2862 can be closed with this fix, because configuration page contains an example of `using_config`.