### PR TITLE
doc: Avoid table scroll

### DIFF
--- a/docs/source/_static/css/modified_theme.css
+++ b/docs/source/_static/css/modified_theme.css
@@ -36,6 +36,12 @@
 }
 
 
+/* Avoid horizontal scroll of tables */
+.rst-content table.docutils td {
+    white-space: normal;
+}
+
+
 /* code style */
 .rst-content table.longtable.docutils code {
     font-size: 100% !important;


### PR DESCRIPTION
In current documentation, tables cause horizontal scroll when the content is large (e.g. [1](https://docs.chainer.org/en/v2.0.2/reference/links.html), [2](https://docs.chainer.org/en/v2.0.2/reference/environment.html)), which makes it hard to read.

This PR enables the contents of tables to wrap.


TODO: Apply to CuPy documentation