### PR TITLE
doc: improve debug mode documentation

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -153,12 +153,8 @@ def set_debug(debug):
 
     .. note::
 
-        This method changes global state. When you use this method on
-        multi-threading environment, it may affects other threads.
-
-    .. deprecated:: v2.0.0
-
-        Use :func:`chainer.using_config` instead. See :ref:`debug` for details.
+        This method changes the global state. When you use this method on
+        multi-threading environment, it may affect other threads.
 
     Args:
         debug (bool): New debug mode.

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -156,6 +156,10 @@ def set_debug(debug):
         This method changes global state. When you use this method on
         multi-threading environment, it may affects other threads.
 
+    .. deprecated:: v2.0.0
+
+        Use :func:`chainer.using_config` instead. See :ref:`debug` for details.
+
     Args:
         debug (bool): New debug mode.
     """
@@ -171,7 +175,8 @@ class DebugMode(object):
     mode back to the original value.
 
     .. deprecated:: v2.0.0
-       DebugMode is deprecated. Use ``using_config('debug', debug)`` instead.
+
+        Use :func:`chainer.using_config` instead. See :ref:`debug` for details.
 
     Args:
         debug (bool): Debug mode used in the context.

--- a/docs/source/reference/core/debug.rst
+++ b/docs/source/reference/core/debug.rst
@@ -10,7 +10,7 @@ However, it requires some additional overhead time.
 
 You can enable debug mode with :func:`chainer.using_config`:
 
-.. code-block:: python
+.. testcode::
 
     with chainer.using_config('debug', True):
        ...

--- a/docs/source/reference/core/debug.rst
+++ b/docs/source/reference/core/debug.rst
@@ -6,20 +6,40 @@ Debug mode
 In debug mode, Chainer checks values of variables on runtime and shows more
 detailed error messages.
 It helps you to debug your programs.
-Instead it requires additional overhead time.
+However, it requires some additional overhead time.
 
-In debug mode, Chainer checks all results of forward and backward computation, and if it founds a NaN value, it raises :class:`RuntimeError`.
+You can enable debug mode with :func:`chainer.using_config`:
+
+.. code-block:: python
+
+    with chainer.using_config('debug', True):
+       ...
+
+See :ref:`configuration` for Chainer's configuration mechanism.
+
+You can also set ``CHAINER_DEBUG`` environment variable to ``1`` to enable this mode.
+
+In debug mode, Chainer checks all results of forward and backward computation, and if it finds a NaN value, it raises :class:`RuntimeError`.
 Some functions and links also check validity of input values.
 
-As of v2.0.0, it is recommended to turn on the debug mode using ``chainer.config.debug``.
-See :ref:`configuration` for the way to use the config object.
-We leave the reference of the conventional ways (which have been available since Chainer v1) as follows.
-
+You can check if debug mode is enabled with :func:`chainer.is_debug` function.
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
    chainer.is_debug
+
+Deprecated interface
+--------------------
+
+As of v2.0.0, it is recommended to turn on the debug mode using ``chainer.config.debug``.
+See :ref:`configuration` for the way to use the config object.
+We leave the reference of the conventional ways (which have been available since Chainer v1) as follows.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
    chainer.set_debug
    chainer.DebugMode

--- a/docs/source/reference/core/debug.rst
+++ b/docs/source/reference/core/debug.rst
@@ -29,17 +29,19 @@ You can check if debug mode is enabled with :func:`chainer.is_debug` function.
    :nosignatures:
 
    chainer.is_debug
+   chainer.set_debug
+
 
 Deprecated interface
 --------------------
 
 As of v2.0.0, it is recommended to turn on the debug mode using ``chainer.config.debug``.
 See :ref:`configuration` for the way to use the config object.
-We leave the reference of the conventional ways (which have been available since Chainer v1) as follows.
+We leave the reference of the conventional way (which has been available since Chainer v1) as follows.
+
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
 
-   chainer.set_debug
    chainer.DebugMode

--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -16,3 +16,8 @@ Here are the environment variables Chainer uses.
 |                        | Otherwise type checking is enabled automatically.                        |
 |                        | See :class:`~chainer.Function` for details.                              |
 +------------------------+--------------------------------------------------------------------------+
+| ``CHAINER_DEBUG``      | Set ``1`` to enable debug mode. It is disabled by default.               |
+|                        | In debug mode, Chainer performs various runtime checks that can help     |
+|                        | debug user's code at the cost of some overhead.                          |
+|                        | For details, see :ref:`debug`.                                           |
++------------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION
Debug mode is very useful to analyze various runtime problems.
However, it's not sufficiently documented.
This PR improves documentation to some extent.