### PR TITLE
doc: Fix type-check reference

### DIFF
--- a/docs/source/reference/environment.rst
+++ b/docs/source/reference/environment.rst
@@ -14,5 +14,5 @@ Here are the environment variables Chainer uses.
 +------------------------+--------------------------------------------------------------------------+
 | ``CHAINER_TYPE_CHECK`` | Set ``0`` to disable type checking.                                      |
 |                        | Otherwise type checking is enabled automatically.                        |
-|                        | See :class:`~chainer.Function` for details.                              |
+|                        | See :ref:`type-check-utils` for details.                                 |
 +------------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION
Currently, `chainer.Function` is referred to from `CHAINER_TYPE_CHECK` documentation, but it's better to link to [Assert and Testing](https://docs.chainer.org/en/stable/reference/check.html) page instead.