### PR TITLE
Optimize backward of log2 and log10

### DIFF
--- a/chainer/functions/math/exponential.py
+++ b/chainer/functions/math/exponential.py
@@ -81,7 +81,7 @@ class Log2(function.Function):
     def backward(self, x, gy):
         gx = gy[0].copy()
         gx /= x[0]
-        gx /= math.log(2)
+        gx *= 1 / math.log(2)
         return gx,
 
 
@@ -117,7 +117,7 @@ class Log10(function.Function):
     def backward(self, x, gy):
         gx = gy[0].copy()
         gx /= x[0]
-        gx /= math.log(10)
+        gx *= 1 / math.log(10)
         return gx,
 
 

--- a/chainer/functions/math/exponential.py
+++ b/chainer/functions/math/exponential.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy
 
 from chainer import cuda
@@ -77,10 +79,9 @@ class Log2(function.Function):
         return utils.force_array(xp.log2(x[0])),
 
     def backward(self, x, gy):
-        xp = cuda.get_array_module(*x)
-        gx = utils.force_array(xp.reciprocal(x[0]))
-        gx /= xp.log(2)
-        gx *= gy[0]
+        gx = gy[0].copy()
+        gx /= x[0]
+        gx /= math.log(2)
         return gx,
 
 
@@ -114,10 +115,9 @@ class Log10(function.Function):
         return utils.force_array(xp.log10(x[0])),
 
     def backward(self, x, gy):
-        xp = cuda.get_array_module(*x)
-        gx = utils.force_array(xp.reciprocal(x[0]))
-        gx /= xp.log(10)
-        gx *= gy[0]
+        gx = gy[0].copy()
+        gx /= x[0]
+        gx /= math.log(10)
         return gx,
 
 


### PR DESCRIPTION
Slightly optimized backward computation of `F.log2` and `F.log10`.

Time per single `F.log2.backward` call:

CPU:
```
BEFORE: 78.110 us   +/- 3.850 us
AFTER:  70.842 us   +/- 2.635 us
```

GPU:
```
BEFORE: 192.078 us   +/- 6.653 us
AFTER:  166.129 us   +/- 7.813 us
```