### PR TITLE
New style dropout function

### DIFF
--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -44,7 +44,7 @@ class Dropout(function_node.FunctionNode):
         return y,
 
     def backward(self, x, gy):
-        return DropoutGrad(self.mask).apply((gy[0],))
+        return DropoutGrad(self.mask).apply(gy)
 
 
 class DropoutGrad(function_node.FunctionNode):
@@ -58,7 +58,7 @@ class DropoutGrad(function_node.FunctionNode):
         return y,
 
     def backward(self, indexes, gy):
-        return DropoutGrad(self.mask).apply((gy[0],))
+        return DropoutGrad(self.mask).apply(gy)
 
 
 def dropout(x, ratio=.5, **kwargs):
@@ -94,6 +94,5 @@ def dropout(x, ratio=.5, **kwargs):
     argument.assert_kwargs_empty(kwargs)
 
     if configuration.config.train:
-        y, = Dropout(ratio).apply((x,))
-        return y
+        return Dropout(ratio).apply((x,))[0]
     return chainer.as_variable(x)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -48,6 +48,7 @@ class Dropout(function_node.FunctionNode):
 
 
 class DropoutGrad(function_node.FunctionNode):
+    """Computes the gradient of the Dropout function."""
 
     def __init__(self, mask):
         self.mask = mask

--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -52,8 +52,7 @@ class TestDropout(unittest.TestCase):
         dropout = functions.Dropout(self.ratio)
 
         def f(x):
-            x, = dropout.apply((x,))
-            return x
+            return dropout.apply((x,))[0]
 
         gradient_check.check_backward(
             f, x_data, y_grad,


### PR DESCRIPTION
This PR implements new-style version of `F.dropout`.
It supports double backward for Chainer v3.
It is related to #3147 .