### PR TITLE
Add Gumbel-Softmax sampling function

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -254,6 +254,7 @@ from chainer.functions.noise.dropout import dropout  # NOQA
 from chainer.functions.noise.dropout import Dropout  # NOQA
 from chainer.functions.noise.gaussian import gaussian  # NOQA
 from chainer.functions.noise.gaussian import Gaussian  # NOQA
+from chainer.functions.noise.gumbel_softmax import gumbel_softmax  # NOQA
 from chainer.functions.noise.simplified_dropconnect import simplified_dropconnect  # NOQA
 from chainer.functions.noise.simplified_dropconnect import SimplifiedDropconnect  # NOQA
 from chainer.functions.noise.zoneout import zoneout  # NOQA

--- a/chainer/functions/noise/gumbel_softmax.py
+++ b/chainer/functions/noise/gumbel_softmax.py
@@ -1,5 +1,5 @@
 from chainer import cuda
-from chainer.functions.activation import softmax
+import chainer.functions
 from chainer import variable
 
 
@@ -35,6 +35,6 @@ def gumbel_softmax(log_pi, tau=0.1, axis=1):
         return variable.Variable(xp.ones((), log_pi.dtype))
     dtype = log_pi.dtype
     g = xp.random.gumbel(size=log_pi.shape).astype(dtype)
-    y = softmax.softmax((log_pi + g) / tau, axis=axis)
+    y = chainer.functions.softmax((log_pi + g) / tau, axis=axis)
 
     return y

--- a/chainer/functions/noise/gumbel_softmax.py
+++ b/chainer/functions/noise/gumbel_softmax.py
@@ -1,8 +1,6 @@
-import numpy
-
-from chainer import variable
 from chainer import cuda
-from chainer.functions.activation.softmax import softmax
+from chainer.functions.activation import softmax
+from chainer import variable
 
 
 def gumbel_softmax(log_pi, tau=0.1, axis=1):
@@ -11,7 +9,7 @@ def gumbel_softmax(log_pi, tau=0.1, axis=1):
     This function draws samples :math:`y_i` from Gumbel-Softmax distribution,
 
     .. math::
-        y_i = {\\exp((g_i + \\log\\pi_i)/\\tau) 
+        y_i = {\\exp((g_i + \\log\\pi_i)/\\tau)
         \\over \\sum_{j}\\exp((g_j + \\log\\pi_j)/\\tau)},
 
     where :math:`\\tau` is a temperature parameter and
@@ -37,6 +35,6 @@ def gumbel_softmax(log_pi, tau=0.1, axis=1):
         return variable.Variable(xp.ones((), log_pi.dtype))
     dtype = log_pi.dtype
     g = xp.random.gumbel(size=log_pi.shape).astype(dtype)
-    y = softmax((log_pi + g) / tau, axis=axis)
+    y = softmax.softmax((log_pi + g) / tau, axis=axis)
 
     return y

--- a/chainer/functions/noise/gumbel_softmax.py
+++ b/chainer/functions/noise/gumbel_softmax.py
@@ -1,3 +1,6 @@
+import numpy
+
+from chainer import variable
 from chainer import cuda
 from chainer.functions.activation.softmax import softmax
 
@@ -27,6 +30,8 @@ def gumbel_softmax(log_pi, tau=0.1, axis=1):
 
     """
     xp = cuda.get_array_module(log_pi)
+    if log_pi.ndim < 1:
+        return variable.Variable(xp.ones((), log_pi.dtype))
     dtype = log_pi.dtype
     g = xp.random.gumbel(size=log_pi.shape).astype(dtype)
     y = softmax((log_pi + g) / tau, axis=axis)

--- a/chainer/functions/noise/gumbel_softmax.py
+++ b/chainer/functions/noise/gumbel_softmax.py
@@ -9,9 +9,9 @@ def gumbel_softmax(log_pi, tau=0.1, axis=1):
     """Gumbel-Softmax sampling function.
 
     This function draws samples :math:`y_i` from Gumbel-Softmax distribution,
-        :math:`y_i = {\\exp((g_i + \\log\\pi_i)/\\tau) \
+        :math:`y_i = {\\exp((g_i + \\log\\pi_i)/\\tau)
                     \\over \\sum_{j}\\exp((g_j + \\log\\pi_j)/\\tau)}`,
-        where :math:`\\tau` is a temperature parameter and \
+        where :math:`\\tau` is a temperature parameter and
             :math:`g_i` s are samples drawn from \
             Gumbel distribution :math:`Gumbel(0, 1)`
 

--- a/chainer/functions/noise/gumbel_softmax.py
+++ b/chainer/functions/noise/gumbel_softmax.py
@@ -1,0 +1,34 @@
+from chainer import cuda
+from chainer.functions.activation.softmax import softmax
+
+
+def gumbel_softmax(log_pi, tau=0.1, axis=1):
+    """Gumbel-Softmax sampling function.
+
+    This function draws samples :math:`y_i` from Gumbel-Softmax distribution,
+        :math:`y_i = {\\exp((g_i + \\log\\pi_i)/\\tau) \
+                    \\over \\sum_{j}\\exp((g_j + \\log\\pi_j)/\\tau)}`,
+        where :math:`\\tau` is a temperature parameter and \
+            :math:`g_i` s are samples drawn from \
+            Gumbel distribution :math:`Gumbel(0, 1)`
+
+    See `Categorical Reparameterization with Gumbel-Softmax \
+    <https://arxiv.org/abs/1611.01144>`_.
+
+    Args:
+        log_pi (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Input variable representing pre-normalized
+            log-probability :math:`\\log\\pi`.
+        tau (:class:`~float`): Input variable representing \
+            temperature :math:`\\tau`.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+
+    """
+    xp = cuda.get_array_module(log_pi)
+    dtype = log_pi.dtype
+    g = xp.random.gumbel(size=log_pi.shape).astype(dtype)
+    y = softmax((log_pi + g) / tau, axis=axis)
+
+    return y

--- a/chainer/functions/noise/gumbel_softmax.py
+++ b/chainer/functions/noise/gumbel_softmax.py
@@ -9,21 +9,24 @@ def gumbel_softmax(log_pi, tau=0.1, axis=1):
     """Gumbel-Softmax sampling function.
 
     This function draws samples :math:`y_i` from Gumbel-Softmax distribution,
-        :math:`y_i = {\\exp((g_i + \\log\\pi_i)/\\tau)
-                    \\over \\sum_{j}\\exp((g_j + \\log\\pi_j)/\\tau)}`,
-        where :math:`\\tau` is a temperature parameter and
-            :math:`g_i` s are samples drawn from \
-            Gumbel distribution :math:`Gumbel(0, 1)`
+
+    .. math::
+        y_i = {\\exp((g_i + \\log\\pi_i)/\\tau) 
+        \\over \\sum_{j}\\exp((g_j + \\log\\pi_j)/\\tau)},
+
+    where :math:`\\tau` is a temperature parameter and
+    :math:`g_i` s are samples drawn from
+    Gumbel distribution :math:`Gumbel(0, 1)`
 
     See `Categorical Reparameterization with Gumbel-Softmax \
     <https://arxiv.org/abs/1611.01144>`_.
 
     Args:
         log_pi (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
-        :class:`cupy.ndarray`): Input variable representing pre-normalized
+            :class:`cupy.ndarray`): Input variable representing pre-normalized
             log-probability :math:`\\log\\pi`.
-        tau (:class:`~float`): Input variable representing \
-            temperature :math:`\\tau`.
+        tau (:class:`~float` or :class:`~chainer.Variable`): \
+            Input variable representing temperature :math:`\\tau`.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -215,6 +215,7 @@ Noise injections
 
    chainer.functions.dropout
    chainer.functions.gaussian
+   chainer.functions.gumbel_softmax
    chainer.functions.simplified_dropconnect
 
 Normalization functions

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gumbel_softmax.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gumbel_softmax.py
@@ -1,0 +1,41 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+from chainer import functions
+from chainer import testing
+from chainer.testing import attr
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), ],
+}))
+class TestGumbelSoftmax(unittest.TestCase):
+
+    def setUp(self):
+        self.log_pi = numpy.random.uniform(
+            -1, 1, self.shape).astype(numpy.float32)
+        self.tau = numpy.float32(numpy.random.uniform(0.1, 10.0))
+
+    def check_forward(self, log_pi_data, tau):
+        log_pi = chainer.Variable(log_pi_data)
+        y = functions.gumbel_softmax(log_pi, tau=tau)
+
+        # Only checks dtype and shape because its result contains noise
+        self.assertEqual(y.dtype, numpy.float32)
+        self.assertEqual(y.shape, log_pi.shape)
+        self.assertEqual(
+            cuda.get_array_module(y),
+            cuda.get_array_module(log_pi))
+
+    def test_forward_cpu(self):
+        self.check_forward(self.log_pi, self.tau)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.log_pi), self.tau)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gumbel_softmax.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gumbel_softmax.py
@@ -10,7 +10,8 @@ from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(3, 2), ],
+    'shape': [(3, 2), ()],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestGumbelSoftmax(unittest.TestCase):
 


### PR DESCRIPTION
This PR adds function which draws samples from Gumbel-Softmax distribution, described in [Categorical Reparameterization with Gumbel-Softmax](https://arxiv.org/abs/1611.01144).