### PR TITLE
Replace get_device

### DIFF
--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_renormalization.py
@@ -110,10 +110,10 @@ class BatchRenormalizationTest(unittest.TestCase):
     @attr.multi_gpu(2)
     @condition.retry(3)
     def test_forward_multi_gpu(self):
-        with cuda.get_device(1):
+        with cuda.get_device_from_id(1):
             self.link.to_gpu()
             x = cuda.to_gpu(self.x)
-        with cuda.get_device(0):
+        with cuda.get_device_from_id(0):
             self.check_forward(x)
 
     def check_backward(self, x_data, y_grad):


### PR DESCRIPTION
get_device is deprecated. I replaced it with get_device_from_id.