### PR TITLE
Add flip function

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -47,6 +47,8 @@ from chainer.functions.array.dstack import dstack  # NOQA
 from chainer.functions.array.expand_dims import expand_dims  # NOQA
 from chainer.functions.array.expand_dims import ExpandDims  # NOQA
 from chainer.functions.array.flatten import flatten  # NOQA
+from chainer.functions.array.flip import flip  # NOQA
+from chainer.functions.array.flip import Flip  # NOQA
 from chainer.functions.array.fliplr import fliplr  # NOQA
 from chainer.functions.array.fliplr import FlipLR  # NOQA
 from chainer.functions.array.flipud import flipud  # NOQA

--- a/chainer/functions/array/flip.py
+++ b/chainer/functions/array/flip.py
@@ -11,7 +11,7 @@ def _flip(array, axis):
 
 
 class Flip(function_node.FunctionNode):
-    """Flip an input variable in reverse order along the given axis."""
+    """Flips an input variable in reverse order along the given axis."""
 
     def __init__(self, axis):
         if not isinstance(axis, six.integer_types):
@@ -40,7 +40,7 @@ class Flip(function_node.FunctionNode):
 
 
 def flip(x, axis):
-    """Flip an input variable in reverse order along the given axis.
+    """Flips an input variable in reverse order along the given axis.
 
     Args:
         x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \

--- a/chainer/functions/array/flip.py
+++ b/chainer/functions/array/flip.py
@@ -1,0 +1,48 @@
+from chainer import cuda
+from chainer import function
+from chainer.utils import type_check
+import six
+
+
+class Flip(function.Function):
+    """Flip an input variable in reverse order along the given axis."""
+
+    def __init__(self, axis):
+        if not isinstance(axis, six.integer_types):
+            raise TypeError('axis must be int')
+        self.axis = axis
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 1)
+        x_type = in_types[0]
+
+        type_check.expect(x_type.ndim > 0)
+        if self.axis >= 0:
+            type_check.expect(x_type.ndim > self.axis)
+        else:
+            type_check.expect(x_type.ndim >= -self.axis)
+
+    def forward(self, inputs):
+        self.retain_inputs(())
+        xp = cuda.get_array_module(*inputs)
+        return xp.flip(inputs[0], self.axis),
+
+    def backward(self, inputs, grads):
+        xp = cuda.get_array_module(*grads)
+        return xp.flip(grads[0], self.axis),
+
+
+def flip(x, axis):
+    """Flip an input variable in reverse order along the given axis.
+
+    Args:
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable.
+        axis (int): Axis along which the input variable is reversed.
+
+    Returns:
+        ~chainer.Variable: Output variable.
+
+    """
+    return Flip(axis)(x)

--- a/chainer/functions/array/flip.py
+++ b/chainer/functions/array/flip.py
@@ -1,10 +1,10 @@
 from chainer import cuda
-from chainer import function
+from chainer import function_node
 from chainer.utils import type_check
 import six
 
 
-class Flip(function.Function):
+class Flip(function_node.FunctionNode):
     """Flip an input variable in reverse order along the given axis."""
 
     def __init__(self, axis):
@@ -23,13 +23,11 @@ class Flip(function.Function):
             type_check.expect(x_type.ndim >= -self.axis)
 
     def forward(self, inputs):
-        self.retain_inputs(())
         xp = cuda.get_array_module(*inputs)
         return xp.flip(inputs[0], self.axis),
 
-    def backward(self, inputs, grads):
-        xp = cuda.get_array_module(*grads)
-        return xp.flip(grads[0], self.axis),
+    def backward(self, indexes, grad_outputs):
+        return flip(grad_outputs[0], self.axis),
 
 
 def flip(x, axis):
@@ -45,4 +43,4 @@ def flip(x, axis):
         ~chainer.Variable: Output variable.
 
     """
-    return Flip(axis)(x)
+    return Flip(axis).apply((x,))[0]

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -65,6 +65,7 @@ Array manipulations
    chainer.functions.dstack
    chainer.functions.expand_dims
    chainer.functions.flatten
+   chainer.functions.flip
    chainer.functions.fliplr
    chainer.functions.flipud
    chainer.functions.get_item

--- a/tests/chainer_tests/functions_tests/array_tests/test_flip.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_flip.py
@@ -47,8 +47,8 @@ class TestFlip(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x), self.axis)
 
     def check_backward(self, x_data, axis, y_grad):
-        gradient_check.check_backward(
-            functions.Flip(axis), x_data, y_grad, dtype=numpy.float64)
+        gradient_check.check_backward(lambda x: functions.flip(x, axis),
+                                      x_data, y_grad, dtype=numpy.float64)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.axis, self.g)

--- a/tests/chainer_tests/functions_tests/array_tests/test_flip.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_flip.py
@@ -1,0 +1,90 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.utils import type_check
+
+
+@testing.parameterize(*testing.product_dict(
+    [
+        {'shape': (1,), 'axis': 0},
+        {'shape': (2, 3, 4), 'axis': 0},
+        {'shape': (2, 3, 4), 'axis': 1},
+        {'shape': (2, 3, 4), 'axis': 2},
+        {'shape': (2, 3, 4), 'axis': -3},
+        {'shape': (2, 3, 4), 'axis': -2},
+        {'shape': (2, 3, 4), 'axis': -1},
+    ],
+    [
+        {'dtype': numpy.float16},
+        {'dtype': numpy.float32},
+        {'dtype': numpy.float64},
+    ],
+))
+class TestFlip(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(0, 1, self.shape).astype(self.dtype)
+        self.g = numpy.random.uniform(0, 1, self.shape).astype(self.dtype)
+
+    def check_forward(self, x_data, axis):
+        x = chainer.Variable(x_data)
+        y = functions.flip(x, axis)
+
+        testing.assert_allclose(y.data, numpy.flip(x_data, axis))
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, self.axis)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x), self.axis)
+
+    def check_backward(self, x_data, axis, y_grad):
+        gradient_check.check_backward(
+            functions.Flip(axis), x_data, y_grad, dtype=numpy.float64)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.axis, self.g)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(
+            cuda.to_gpu(self.x), self.axis, cuda.to_gpu(self.g))
+
+
+@testing.parameterize(
+    {'axis': 3},
+    {'axis': -4},
+)
+class TestFlipInvalidTypeAxis(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f')
+
+    def check_type_error(self, x):
+        with self.assertRaises(type_check.InvalidType):
+            functions.flip(x, self.axis)
+
+    def test_type_error_cpu(self):
+        self.check_type_error(self.x)
+
+    @attr.gpu
+    def test_type_error_gpu(self):
+        self.check_type_error(cuda.to_gpu(self.x))
+
+
+class TestFlipInvalidTypeError(unittest.TestCase):
+
+    def test_invalid_axis(self):
+        with self.assertRaises(TypeError):
+            functions.Flip('a')
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds `F.flip(x, axis)`. (Chainer has `F.flipud`, `F.fliplr` already).
The implementation is based on `FunctionNode`.