### PR TITLE
Add get_conv_outsize and get_deconv_outsize to doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,6 @@ docs/my.model
 docs/my.state
 docs/my_mnist.model
 docs/*.png
-docs/source/reference/core
+docs/source/reference/core/generated
 docs/source/reference/generated
-docs/source/reference/util
+docs/source/reference/util/generated

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,6 @@ docs/my.model
 docs/my.state
 docs/my_mnist.model
 docs/*.png
-docs/source/reference/core/generated
+docs/source/reference/core
 docs/source/reference/generated
-docs/source/reference/util/generated
+docs/source/reference/util

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -4,6 +4,8 @@ from chainer.utils import walker_alias  # NOQA
 
 
 # import class and function
+from chainer.utils.conv import get_conv_outsize
+from chainer.utils.conv import get_deconv_outsize
 from chainer.utils.experimental import experimental  # NOQA
 from chainer.utils.walker_alias import WalkerAlias  # NOQA
 

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -4,8 +4,8 @@ from chainer.utils import walker_alias  # NOQA
 
 
 # import class and function
-from chainer.utils.conv import get_conv_outsize
-from chainer.utils.conv import get_deconv_outsize
+from chainer.utils.conv import get_conv_outsize  # NOQA
+from chainer.utils.conv import get_deconv_outsize  # NOQA
 from chainer.utils.experimental import experimental  # NOQA
 from chainer.utils.walker_alias import WalkerAlias  # NOQA
 

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -8,7 +8,8 @@ def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
     """Calculates output size of convolution.
 
     This function takes the size of input feature map, kernel, stride, and
-    pooling, then calculates the output feature map size.
+    pooling of one particular dimension, then calculates the output feature
+    map size of that dimension.
 
     .. seealso:: :func:`~chainer.utils.get_deconv_outsize`
 
@@ -18,7 +19,7 @@ def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
         k (int): The size of convolution kernel.
         s (int): The size of stride.
         p (int): The size of padding.
-        ``cover_all`` (bool): Use cover_all option or not.
+        cover_all (bool): Use ``cover_all`` option or not.
         d (int): The size of dilation.
 
     Returns:
@@ -47,7 +48,7 @@ def get_deconv_outsize(size, k, s, p, cover_all=False):
         k (int): The size of deconvolution kernel.
         s (int): The size of stride.
         p (int): The size of padding.
-        ``cover_all`` (bool): Use cover_all option or not.
+        cover_all (bool): Use ``cover_all`` option or not.
 
     Returns:
         int: The expected output size of the deconvolution operation.

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -5,6 +5,24 @@ from chainer import cuda
 
 
 def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
+    """Calculate output size of convolution.
+
+    This functions takes the size of input feature map, kernel, stride, and
+    pooling, then calculate the output feature map size.
+
+    Args:
+        size (int): The size of input feature map. It usually is the length of
+            a side of feature map.
+        k (int): The size of convolution kernel.
+        s (int): The size of stride.
+        p (int): The size of padding.
+        cover_all (bool): Use cover_all option or not.
+        d (int): The size of dilation.
+
+    Returns:
+        int: The expected output size of the convolution operation.
+
+    """
     dk = k + (k - 1) * (d - 1)
     if cover_all:
         return (size + p * 2 - dk + s - 1) // s + 1
@@ -13,6 +31,23 @@ def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
 
 
 def get_deconv_outsize(size, k, s, p, cover_all=False):
+    """Calculate output size of deconvolution.
+
+    This functions takes the size of input feature map, kernel, stride, and
+    pooling, then calculate the output feature map size.
+
+    Args:
+        size (int): The size of input feature map. It usually is the length of
+            a side of feature map.
+        k (int): The size of deconvolution kernel.
+        s (int): The size of stride.
+        p (int): The size of padding.
+        cover_all (bool): Use cover_all option or not.
+
+    Returns:
+        int: The expected output size of the deconvolution operation.
+
+    """
     if cover_all:
         return s * (size - 1) + k - s + 1 - 2 * p
     else:

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -36,7 +36,8 @@ def get_deconv_outsize(size, k, s, p, cover_all=False):
     """Calculates output size of deconvolution.
 
     This function takes the size of input feature map, kernel, stride, and
-    pooling, then calculates the output feature map size.
+    pooling of one particular dimension, then calculates the output feature
+    map size of that dimension.
 
     .. seealso:: :func:`~chainer.utils.get_conv_outsize`
 

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -10,6 +10,8 @@ def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
     This function takes the size of input feature map, kernel, stride, and
     pooling, then calculates the output feature map size.
 
+    .. seealso:: :func:`~chainer.utils.get_deconv_outsize`
+
     Args:
         size (int): The size of input feature map. It usually is the length of
             a side of feature map.
@@ -35,6 +37,8 @@ def get_deconv_outsize(size, k, s, p, cover_all=False):
 
     This function takes the size of input feature map, kernel, stride, and
     pooling, then calculates the output feature map size.
+
+    .. seealso:: :func:`~chainer.utils.get_conv_outsize`
 
     Args:
         size (int): The size of input feature map. It usually is the length of

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -5,10 +5,10 @@ from chainer import cuda
 
 
 def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
-    """Calculate output size of convolution.
+    """Calculates output size of convolution.
 
-    This functions takes the size of input feature map, kernel, stride, and
-    pooling, then calculate the output feature map size.
+    This function takes the size of input feature map, kernel, stride, and
+    pooling, then calculates the output feature map size.
 
     Args:
         size (int): The size of input feature map. It usually is the length of
@@ -16,7 +16,7 @@ def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
         k (int): The size of convolution kernel.
         s (int): The size of stride.
         p (int): The size of padding.
-        cover_all (bool): Use cover_all option or not.
+        ``cover_all`` (bool): Use cover_all option or not.
         d (int): The size of dilation.
 
     Returns:
@@ -31,10 +31,10 @@ def get_conv_outsize(size, k, s, p, cover_all=False, d=1):
 
 
 def get_deconv_outsize(size, k, s, p, cover_all=False):
-    """Calculate output size of deconvolution.
+    """Calculates output size of deconvolution.
 
-    This functions takes the size of input feature map, kernel, stride, and
-    pooling, then calculate the output feature map size.
+    This function takes the size of input feature map, kernel, stride, and
+    pooling, then calculates the output feature map size.
 
     Args:
         size (int): The size of input feature map. It usually is the length of
@@ -42,7 +42,7 @@ def get_deconv_outsize(size, k, s, p, cover_all=False):
         k (int): The size of deconvolution kernel.
         s (int): The size of stride.
         p (int): The size of padding.
-        cover_all (bool): Use cover_all option or not.
+        ``cover_all`` (bool): Use cover_all option or not.
 
     Returns:
         int: The expected output size of the deconvolution operation.

--- a/docs/source/reference/util.rst
+++ b/docs/source/reference/util.rst
@@ -4,6 +4,7 @@ Utilities
 .. toctree::
    :maxdepth: 2
 
+   util/conv
    util/cuda
    util/algorithm
    util/reporter

--- a/docs/source/reference/util/conv.rst
+++ b/docs/source/reference/util/conv.rst
@@ -1,0 +1,9 @@
+Convolution/Deconvolution utilities
+-----------------------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.utils.get_conv_outsize
+   chainer.utils.get_deconv_outsize


### PR DESCRIPTION
`get_conv_outsize` and `get_deconv_outsize` is useful to check the output size before actual forward computations.
This PR adds them to the docs.
