### PR TITLE
Use cuDNN BN functions even when inputs data type is fp16

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -79,11 +79,11 @@ class BatchNormalization(function_node.FunctionNode):
             if dtype_param is not dtype:
                 gamma = gamma.astype(dtype_param)
                 beta = beta.astype(dtype_param)
-                _running_mean = self.running_mean.astype(dtype_param)
-                _running_var = self.running_var.astype(dtype_param)
+                running_mean = self.running_mean.astype(dtype_param)
+                running_var = self.running_var.astype(dtype_param)
             else:
-                _running_mean = self.running_mean
-                _running_var = self.running_var
+                running_mean = self.running_mean
+                running_var = self.running_var
 
             oz_dtype = 'd' if x.dtype == 'd' else 'f'
             one = numpy.array(1, dtype=oz_dtype).ctypes
@@ -108,8 +108,8 @@ class BatchNormalization(function_node.FunctionNode):
                 handle, cudnn_mode, one.data, zero.data,
                 x_desc.value, x.data.ptr, x_desc.value,
                 y.data.ptr, derivedBnDesc.value, gamma.data.ptr,
-                beta.data.ptr, factor, _running_mean.data.ptr,
-                _running_var.data.ptr, self.eps,
+                beta.data.ptr, factor, running_mean.data.ptr,
+                running_var.data.ptr, self.eps,
                 self.mean.data.ptr, self.inv_std.data.ptr)
 
             if dtype_param is not dtype:
@@ -118,12 +118,12 @@ class BatchNormalization(function_node.FunctionNode):
                 # running_var updated by batchNormalizationForwardTraining
                 # must be explicitly written back to their original fp16
                 # arrays.
-                _running_mean = _running_mean.astype(dtype)
-                _running_var = _running_var.astype(dtype)
-                self.running_mean.data.copy_from(_running_mean.data,
-                                                 _running_mean.nbytes)
-                self.running_var.data.copy_from(_running_var.data,
-                                                _running_var.nbytes)
+                running_mean = running_mean.astype(dtype)
+                running_var = running_var.astype(dtype)
+                self.running_mean.data.copy_from(running_mean.data,
+                                                 running_mean.nbytes)
+                self.running_var.data.copy_from(running_var.data,
+                                                running_var.nbytes)
         else:
             gamma = gamma[expander]
             beta = beta[expander]

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -490,7 +490,8 @@ def _zero_if_none(xp, x, shape, dtype):
 
 
 def _get_dtype_of_tensor_descriptor(desc):
-    cudnn_dtype, *_ = libcudnn.getTensor4dDescriptor(desc.value)
+    cudnn_dtype, _, _, _, _, _, _, _, _ = libcudnn.getTensor4dDescriptor(
+        desc.value)
     dtype = None
     if cudnn_dtype == libcudnn.CUDNN_DATA_DOUBLE:
         dtype = numpy.dtype(numpy.float64)

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -75,8 +75,15 @@ class BatchNormalization(function_node.FunctionNode):
             cudnn_mode = self.mode.get_cudnn_mode()
             libcudnn.deriveBNTensorDescriptor(derivedBnDesc.value,
                                               x_desc.value, cudnn_mode)
-            one = numpy.array(1, dtype=dtype).ctypes
-            zero = numpy.array(0, dtype=dtype).ctypes
+            dtype_param = _get_dtype_of_tensor_descriptor(derivedBnDesc)
+            if dtype_param is not dtype:
+                gamma = gamma.astype(dtype_param)
+                beta = beta.astype(dtype_param)
+                self.running_mean = self.running_mean.astype(dtype_param)
+                self.running_var = self.running_var.astype(dtype_param)
+            oz_dtype = 'd' if x.dtype == 'd' else 'f'
+            one = numpy.array(1, dtype=oz_dtype).ctypes
+            zero = numpy.array(0, dtype=oz_dtype).ctypes
             y = cuda.cupy.empty_like(x)
             # Factor used in the moving average
             factor = 1 - self.decay
@@ -157,8 +164,12 @@ class BatchNormalizationGrad(function.Function):
             derivedBnDesc = cudnn.create_uninitialized_tensor_descriptor()
             libcudnn.deriveBNTensorDescriptor(derivedBnDesc.value,
                                               x_desc.value, cudnn_mode)
-            one = numpy.array(1, dtype=dtype).ctypes
-            zero = numpy.array(0, dtype=dtype).ctypes
+            dtype_param = _get_dtype_of_tensor_descriptor(derivedBnDesc)
+            if dtype_param is not dtype:
+                gamma = gamma.astype(dtype_param)
+            oz_dtype = 'd' if x.dtype == 'd' else 'f'
+            one = numpy.array(1, dtype=oz_dtype).ctypes
+            zero = numpy.array(0, dtype=oz_dtype).ctypes
             gx = cuda.cupy.empty_like(x)
             ggamma = cuda.cupy.empty_like(gamma)
             gbeta = cuda.cupy.empty_like(gamma)
@@ -169,6 +180,10 @@ class BatchNormalizationGrad(function.Function):
                 derivedBnDesc.value, gamma.data.ptr,
                 ggamma.data.ptr, gbeta.data.ptr,
                 self.eps, self.mean.data.ptr, self.inv_std.data.ptr)
+
+            if dtype_param is not dtype:
+                ggamma = ggamma.astype(dtype)
+                gbeta = gbeta.astype(dtype)
         else:
             gbeta = gy.sum(axis=self.axis)
             x_hat = _x_hat(x, self.mean[expander], self.inv_std[expander])
@@ -279,8 +294,15 @@ class FixedBatchNormalization(function_node.FunctionNode):
             cudnn_mode = mode.get_cudnn_mode()
             libcudnn.deriveBNTensorDescriptor(derivedBnDesc.value,
                                               x_desc.value, cudnn_mode)
-            one = numpy.array(1, dtype=dtype).ctypes
-            zero = numpy.array(0, dtype=dtype).ctypes
+            dtype_param = _get_dtype_of_tensor_descriptor(derivedBnDesc)
+            if dtype_param is not dtype:
+                gamma = gamma.astype(dtype_param)
+                beta = beta.astype(dtype_param)
+                mean = mean.astype(dtype_param)
+                var = var.astype(dtype_param)
+            oz_dtype = 'd' if x.dtype == 'd' else 'f'
+            one = numpy.array(1, dtype=oz_dtype).ctypes
+            zero = numpy.array(0, dtype=oz_dtype).ctypes
             y = cuda.cupy.empty_like(x)
 
             libcudnn.batchNormalizationForwardInference(
@@ -389,7 +411,8 @@ class _BNMode(object):
         self.is_for_conv2d = x.ndim == 4 and is_gamma_1d
         self.is_for_linear = x.ndim == 2 and is_gamma_1d
         self.cudnn_dim_ok = self.is_for_conv2d or self.is_for_linear
-        self.cudnn_dtype_ok = x.dtype != numpy.float16
+        # self.cudnn_dtype_ok = x.dtype != numpy.float16
+        self.cudnn_dtype_ok = self.is_for_conv2d or (x.dtype != numpy.float16)
 
     def get_cudnn_mode(self):
         assert self.cudnn_dim_ok
@@ -447,6 +470,22 @@ def _zero_if_none(xp, x, shape, dtype):
     if x is None:
         return xp.zeros(shape, dtype=dtype)
     return x
+
+
+def _get_dtype_of_tensor_descriptor(desc):
+    cudnn_dtype, _, _, _, _, _, _, _, _ = libcudnn.getTensor4dDescriptor(
+        desc.value)
+    dtype = None
+    if cudnn_dtype == libcudnn.CUDNN_DATA_DOUBLE:
+        dtype = numpy.dtype(numpy.float64)
+    elif cudnn_dtype == libcudnn.CUDNN_DATA_FLOAT:
+        dtype = numpy.dtype(numpy.float32)
+    elif cudnn_dtype == libcudnn.CUDNN_DATA_HALF:
+        dtype = numpy.dtype(numpy.float16)
+    else:
+        msg = 'Unknow cudnn data type {} '.format(cudnn_dtype)
+        raise RuntimeError(msg)
+    return dtype
 
 
 def batch_normalization(x, gamma, beta, **kwargs):

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -79,8 +79,12 @@ class BatchNormalization(function_node.FunctionNode):
             if dtype_param is not dtype:
                 gamma = gamma.astype(dtype_param)
                 beta = beta.astype(dtype_param)
-                self.running_mean = self.running_mean.astype(dtype_param)
-                self.running_var = self.running_var.astype(dtype_param)
+                _running_mean = self.running_mean.astype(dtype_param)
+                _running_var = self.running_var.astype(dtype_param)
+            else:
+                _running_mean = self.running_mean
+                _running_var = self.running_var
+
             oz_dtype = 'd' if x.dtype == 'd' else 'f'
             one = numpy.array(1, dtype=oz_dtype).ctypes
             zero = numpy.array(0, dtype=oz_dtype).ctypes
@@ -104,9 +108,22 @@ class BatchNormalization(function_node.FunctionNode):
                 handle, cudnn_mode, one.data, zero.data,
                 x_desc.value, x.data.ptr, x_desc.value,
                 y.data.ptr, derivedBnDesc.value, gamma.data.ptr,
-                beta.data.ptr, factor, self.running_mean.data.ptr,
-                self.running_var.data.ptr, self.eps,
+                beta.data.ptr, factor, _running_mean.data.ptr,
+                _running_var.data.ptr, self.eps,
                 self.mean.data.ptr, self.inv_std.data.ptr)
+
+            if dtype_param is not dtype:
+                # When data type of prameters is converted, say, from fp16
+                # to fp32, the values of fp32 arrays of running_mean and
+                # running_var updated by batchNormalizationForwardTraining
+                # must be explicitly written back to their original fp16
+                # arrays.
+                _running_mean = _running_mean.astype(dtype)
+                _running_var = _running_var.astype(dtype)
+                self.running_mean.data.copy_from(_running_mean.data,
+                                                 _running_mean.nbytes)
+                self.running_var.data.copy_from(_running_var.data,
+                                                _running_var.nbytes)
         else:
             gamma = gamma[expander]
             beta = beta[expander]
@@ -473,8 +490,7 @@ def _zero_if_none(xp, x, shape, dtype):
 
 
 def _get_dtype_of_tensor_descriptor(desc):
-    cudnn_dtype, _, _, _, _, _, _, _, _ = libcudnn.getTensor4dDescriptor(
-        desc.value)
+    cudnn_dtype, *_ = libcudnn.getTensor4dDescriptor(desc.value)
     dtype = None
     if cudnn_dtype == libcudnn.CUDNN_DATA_DOUBLE:
         dtype = numpy.dtype(numpy.float64)


### PR DESCRIPTION
The aim of this PR is to use cuDNN's batch-normalization (BN) functions safely when data type of input is fp16.

The cuDNN's BN functions support fp16 data type, but they are not used in Chainer now when data type of input is fp16. As far as I know, that is mainly because data types of some parameters like `gamma` and `beta` in BN layer must be fp32 in cuDNN's BN functions when data type of inputs is fp16 though Chainer assumes data types of inputs and parameters are the same.

Actually I've already sent a PR about this issue before (#2299). The solution of the previous PR is to decide what data type should be used for parameters like `gamma` and `beta` at the `Link` object, and keep the variables with the decided data type. With the previous PR, in case of fp16 input, the parameters data type become fp32 when cuDNN is selected to use, otherwise fp16. However there are mainly two problems:

- It is less flexible. For example, a use case like using cuDNN for forward and backward and using CuPY for backward of backward is not available with the previous solution.
- It is not easy-to-maintain. Both the `Link` and `Function` class are modified so they should be maintained in sync.

Thus, I would like to propose simple solution with this PR as follows.

- To keep the data type of parameters like `gamma` and `beta` the same as the data type of inputs, even when cuDNN is likely to be used. --> No modification to the `Link` class is necessary and it is easier-to-maintain.
- To convert the data type of parameters from fp16 to fp32 or vice versa on demand before or after calling cuDNN's BN functions. --> It is more flexible and the use case like using cuDNN for forward and backward and using CuPY for backward of backward gets available.

Please note that https://github.com/cupy/cupy/pull/492 needs to be used in order to test this PR.