### PR TITLE
Tensor-Core support for convolutions

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -94,6 +94,7 @@ global_config.keep_graph_on_report = bool(int(
 global_config.train = True
 global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
 global_config.use_cudnn = os.environ.get('CHAINER_USE_CUDNN', 'auto')
+global_config.cudnn_use_tensor_core = None
 
 
 _SHOULD_USE_CUDNN = {

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -94,7 +94,7 @@ global_config.keep_graph_on_report = bool(int(
 global_config.train = True
 global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
 global_config.use_cudnn = os.environ.get('CHAINER_USE_CUDNN', 'auto')
-global_config.cudnn_use_tensor_core = None
+global_config.use_cudnn_tensor_core = 'auto'
 
 
 _SHOULD_USE_CUDNN = {
@@ -138,6 +138,28 @@ def should_use_cudnn(level, lowest_version=0):
                          '(must be either of "always", "auto", or "never")' %
                          repr(config.use_cudnn))
     return flags[config.use_cudnn]
+
+
+def should_use_cudnn_tensor_core(dtype):
+    """Determines if Tensor Core should be used.
+
+    Args:
+        dtype (numpy.dtype): data type of input tensor.
+
+    Returns:
+        bool: ``True`` if Tensor Core should be used.
+    """
+
+    flags = {'always': True, 'auto': None, 'never': False}
+    if config.use_cudnn_tensor_core not in flags:
+        raise ValueError('invalid use_cudnn_tensor_core configuration: %s '
+                         '(must be either of "always", "auto", or "never")' %
+                         repr(config.use_cudnn))
+    use_tensor_core = flags[config.use_cudnn_tensor_core]
+    if use_tensor_core is None:
+        use_tensor_core = cuda.cudnn.is_tensor_core_available(dtype)
+
+    return use_tensor_core
 
 
 def is_debug():

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -124,9 +124,7 @@ class Convolution2DFunction(function_node.FunctionNode):
             if b is not None:
                 b = cuda.cupy.ascontiguousarray(b)
 
-            use_tensor_core = configuration.config.cudnn_use_tensor_core
-            if use_tensor_core is None:
-                use_tensor_core = cudnn.is_tensor_core_available(x.dtype)
+            use_tensor_core = chainer.should_use_cudnn_tensor_core(x.dtype)
 
             handle = cudnn.get_handle()
             x_desc = cudnn.create_tensor_descriptor(x)
@@ -242,9 +240,7 @@ class Convolution2DGradW(function_node.FunctionNode):
         x = cuda.cupy.ascontiguousarray(x)
         gy = cuda.cupy.ascontiguousarray(gy)
 
-        use_tensor_core = configuration.config.cudnn_use_tensor_core
-        if use_tensor_core is None:
-            use_tensor_core = cudnn.is_tensor_core_available(x.dtype)
+        use_tensor_core = chainer.should_use_cudnn_tensor_core(x.dtype)
 
         handle = cudnn.get_handle()
         x_desc = cudnn.create_tensor_descriptor(x)

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -147,8 +147,8 @@ class Convolution2DFunction(function_node.FunctionNode):
                 conv_desc.value, y_desc.value, _fwd_pref, workspace_size)
 
             if use_tensor_core:
-                # Only CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM supports
-                # Tensor-Core in cuDNN7.
+                # Only CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
+                # supports Tensor-Core in cuDNN7.
                 algo = libcudnn.CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM  # NOQA
 
             oz_dtype = 'd' if x.dtype == 'd' else 'f'

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -155,6 +155,10 @@ class Deconvolution2DFunction(function_node.FunctionNode):
             if b is not None:
                 b = cuda.cupy.ascontiguousarray(b)
 
+            use_tensor_core = configuration.config.cudnn_use_tensor_core
+            if use_tensor_core is None:
+                use_tensor_core = cudnn.is_tensor_core_available(x.dtype)
+
             handle = cudnn.get_handle()
             x_desc = cudnn.create_tensor_descriptor(x)
             y = cuda.cupy.empty((n, c, self.outh, self.outw),
@@ -163,7 +167,8 @@ class Deconvolution2DFunction(function_node.FunctionNode):
 
             filter_desc = cudnn.create_filter_descriptor(W)
             conv_desc = cudnn.create_convolution_descriptor(
-                (self.ph, self.pw), (self.sy, self.sx), x.dtype)
+                (self.ph, self.pw), (self.sy, self.sx), x.dtype,
+                use_tensor_core=use_tensor_core)
             if b is not None:
                 bias_desc = cudnn.create_tensor_descriptor(
                     b[None, :, None, None])
@@ -181,6 +186,11 @@ class Deconvolution2DFunction(function_node.FunctionNode):
                     handle, filter_desc.value, x_desc.value,
                     conv_desc.value, y_desc.value, _bwd_data_pref,
                     workspace_size)
+
+            if use_tensor_core:
+                # Only CUDNN_CONVOLUTION_BWD_DATA_ALGO_1 supports
+                # Tensor-Core in cuDNN7
+                algo = libcudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
 
             libcudnn.convolutionBackwardData_v3(
                 handle, one.data, filter_desc.value, W.data.ptr,

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -155,9 +155,7 @@ class Deconvolution2DFunction(function_node.FunctionNode):
             if b is not None:
                 b = cuda.cupy.ascontiguousarray(b)
 
-            use_tensor_core = configuration.config.cudnn_use_tensor_core
-            if use_tensor_core is None:
-                use_tensor_core = cudnn.is_tensor_core_available(x.dtype)
+            use_tensor_core = chainer.should_use_cudnn_tensor_core(x.dtype)
 
             handle = cudnn.get_handle()
             x_desc = cudnn.create_tensor_descriptor(x)

--- a/docs/source/reference/core/configuration.rst
+++ b/docs/source/reference/core/configuration.rst
@@ -67,6 +67,14 @@ Note that the default values are set in the global config.
        - If it is ``'never'``, Chainer will never use cuDNN anywhere.
 
    The default value is ``'auto'``.
+``chainer.config.cudnn_use_tensor_core``
+   Flag to configure whether or not to enable Tensor Core operatons in cuDNN.
+
+       - If it is ``True``, Chainer uses cuDNN's Tensor Core operations.
+       - If it is ``False``, Chainer does not use cuDNN's Tensor Core operations.
+       - If it is ``None``, Chainer checks cuDNN version, the data type of input, the compute capability of the GPU used, and configures whether or not to use cuDNN's Tensor Core operations.
+
+   The default value is ``None``.
 
 Users can also define their own configurations.
 There are two ways:

--- a/docs/source/reference/core/configuration.rst
+++ b/docs/source/reference/core/configuration.rst
@@ -70,11 +70,11 @@ Note that the default values are set in the global config.
 ``chainer.config.cudnn_use_tensor_core``
    Flag to configure whether or not to enable Tensor Core operatons in cuDNN.
 
-       - If it is ``True``, Chainer uses cuDNN's Tensor Core operations.
-       - If it is ``False``, Chainer does not use cuDNN's Tensor Core operations.
-       - If it is ``None``, Chainer checks cuDNN version, the data type of input, the compute capability of the GPU used, and configures whether or not to use cuDNN's Tensor Core operations.
+       - If it is ``always``, Chainer uses cuDNN's Tensor Core operations.
+       - If it is ``never``, Chainer does not use cuDNN's Tensor Core operations.
+       - If it is ``auto``, Chainer checks cuDNN version, the data type of input, the compute capability of the GPU used, and configures whether or not to use cuDNN's Tensor Core operations.
 
-   The default value is ``None``.
+   The default value is ``auto``.
 
 Users can also define their own configurations.
 There are two ways:


### PR DESCRIPTION
This PR adds Tensor-Core support for convolutions.

With this PR, Tensor-Core is automatically used in convolution layers when Tensor-Core is available. You can also manually enable/disable use of Tensor-Core by setting global configuration variable `cudnn_use_tensor_core` to True/False like below

    from chainer import configuration
    configuration.config.cudnn_use_tensor_core = [True|False]

Please note that https://github.com/cupy/cupy/pull/494 needs to be used in order to test this PR.
Also I would suggest that you apply #3386 first.