### PR TITLE
Improve performance of MultiprocessIterator for non tuple/dict datasets

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -489,6 +489,12 @@ def _pack(data, mem, offset, limit):
                     offset += v.nbytes
             ret[k] = v
         data = ret
+    elif t is numpy.ndarray:
+        if data.nbytes + offset > limit:
+            over = True
+        else:
+            data = _PackedNdarray(data, mem, offset)
+            offset += data.nbytes
     if over:
         expect = _measure(data)
         warnings.warn(
@@ -518,4 +524,6 @@ def _unpack(data, mem):
                 v = v.unpack(mem)
             ret[k] = v
         data = ret
+    elif t is _PackedNdarray:
+        data = data.unpack(mem)
     return data


### PR DESCRIPTION
When `type(dataset[i]) == np.ndarray`, shared memory is not used.
This PR fixes the problem.

Benchmark
```python
import chainer
import numpy as np
import time

batch_size = 128
n_batch = 5
x = np.random.randint(
    0, 2 ** 10, size=(batch_size * n_batch, 300 * 300 * 3)).astype(np.int32)

it = chainer.iterators.MultiprocessIterator(
    x, batch_size, shared_mem=300 * 300 * 3 * 4, shuffle=False)
start = time.time()
results = []
print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>')
for i in range(n_batch):
    results.append(next(it))
print('elapsed time {}s'.format(time.time() - start))

np.testing.assert_almost_equal(x, np.concatenate(results))

```

Before: elapsed time 1.141466856s
After: elapsed time 0.356211900711s
