### PR TITLE
doc: Add experimental warning in docstring

### DIFF
--- a/chainer/functions/pooling/average_pooling_nd.py
+++ b/chainer/functions/pooling/average_pooling_nd.py
@@ -14,7 +14,13 @@ from chainer.utils import conv_nd
 
 class AveragePoolingND(pooling_nd._PoolingND):
 
-    """Average pooling over a set of N-dimensional planes."""
+    """Average pooling over a set of N-dimensional planes.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
+
+    """
 
     def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=False):
         utils.experimental('chainer.functions.pooling.AveragePoolingND')
@@ -107,6 +113,10 @@ class AveragePoolingND(pooling_nd._PoolingND):
 
 def average_pooling_nd(x, ksize, stride=None, pad=0):
     """N-dimensionally spatial average pooling function.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
 
     This function provides a N-dimensionally generalized version of
     :func:`~functions.average_pooling_2d`. This acts similarly to

--- a/chainer/functions/pooling/max_pooling_nd.py
+++ b/chainer/functions/pooling/max_pooling_nd.py
@@ -14,7 +14,13 @@ from chainer.utils import conv_nd
 
 class MaxPoolingND(pooling_nd._PoolingND):
 
-    """Max pooling over a set of N-dimensional planes."""
+    """Max pooling over a set of N-dimensional planes.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
+
+    """
 
     def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=True):
         utils.experimental('chainer.functions.pooling.MaxPoolingND')
@@ -120,6 +126,10 @@ class MaxPoolingND(pooling_nd._PoolingND):
 
 def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True):
     """N-dimensionally spatial max pooling function.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
 
     This function provides a N-dimensionally generalized version of
     :func:`~functions.max_pooling_2d`. This acts similarly to

--- a/chainer/functions/pooling/unpooling_nd.py
+++ b/chainer/functions/pooling/unpooling_nd.py
@@ -10,7 +10,13 @@ from chainer.utils import type_check
 
 
 class UnpoolingND(function.Function):
-    """Unpooling over a set of N-dimensional planes."""
+    """Unpooling over a set of N-dimensional planes.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
+
+    """
 
     def __init__(self, ndim, ksize, stride=None, pad=0, outsize=None,
                  cover_all=True):
@@ -86,6 +92,10 @@ class UnpoolingND(function.Function):
 
 def unpooling_nd(x, ksize, stride=None, pad=0, outsize=None, cover_all=True):
     """Inverse operation of N-dimensional spatial pooling.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
 
     This function acts similary to :class:`~functions.DeconvolutionND`, but
     it spreads input N-dimensional array's value without any parameter instead

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -10,6 +10,10 @@ from chainer import utils
 class ChildSumTreeLSTM(link.Chain):
     """Child-Sum TreeLSTM unit.
 
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
+
     This is a Child-Sum TreeLSTM unit as a chain.
     This link is a variable arguments function, which compounds
     the states of all children nodes into the new states of
@@ -120,6 +124,10 @@ class ChildSumTreeLSTM(link.Chain):
 
 class NaryTreeLSTM(link.Chain):
     """N-ary TreeLSTM unit.
+
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
 
     This is a N-ary TreeLSTM unit as a chain.
     This link is a fixed-length arguments function, which compounds

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -8,6 +8,10 @@ class LayerNormalization(link.Link):
 
     """Layer normalization layer on outputs of linear functions.
 
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
+
     This link implements a "layer normalization" layer
     which normalizes the input units by statistics
     that are computed along the second axis,

--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -25,6 +25,10 @@ class TheanoFunction(link.Link):
 
     """Theano function wrapper.
 
+    .. warning::
+
+        This feature is experimental. The interface can change in the future.
+
     This function wraps Theano function as a :class:`chainer.Link`.
     A user needs to make input Theano variables and output Theano variables.
     This function automatically creates Theano function for forward calculation


### PR DESCRIPTION
Currently, users cannot tell if a feature is experimental until they use it.
