### PR TITLE
test: Skip multiprocess interrupt tests

### DIFF
--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -538,7 +538,9 @@ if __name__ == '__main__':
                 was_alive = True
         return was_alive
 
+    @unittest.skip
     def test_interrupt_infinite_wait_batch(self):
+        # TODO(niboshi): See: https://github.com/chainer/chainer/issues/3383
         self.run_code(dataset='infinite_wait',
                       n_processes=2,
                       operation='it.next()')
@@ -546,7 +548,9 @@ if __name__ == '__main__':
         self.send_sigint()
         self.assertFalse(self.killall())
 
+    @unittest.skip
     def test_interrupt_no_wait_batch(self):
+        # TODO(niboshi): See: https://github.com/chainer/chainer/issues/3383
         self.run_code(dataset='no_wait',
                       n_processes=2,
                       operation='time.sleep(1000)')


### PR DESCRIPTION
These tests have several problems (see #3383).
Because this renders other PRs impossible to be tested, I want to temporarily skip them.