### PR TITLE
[WIP] Rename `xxx_pooling_nd` to `xxx_pooling`

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -273,6 +273,7 @@ from chainer.functions.pooling.average_pooling_nd import average_pooling_nd  # N
 from chainer.functions.pooling.average_pooling_nd import AveragePoolingND  # NOQA
 from chainer.functions.pooling.max_pooling_2d import max_pooling_2d  # NOQA
 from chainer.functions.pooling.max_pooling_2d import MaxPooling2D  # NOQA
+from chainer.functions.pooling.max_pooling_nd import max_pooling  # NOQA
 from chainer.functions.pooling.max_pooling_nd import max_pooling_nd  # NOQA
 from chainer.functions.pooling.max_pooling_nd import MaxPoolingND  # NOQA
 from chainer.functions.pooling.roi_pooling_2d import roi_pooling_2d  # NOQA

--- a/chainer/functions/pooling/max_pooling_nd.py
+++ b/chainer/functions/pooling/max_pooling_nd.py
@@ -118,12 +118,14 @@ class MaxPoolingND(pooling_nd._PoolingND):
             cuda.cudnn.cudnn.CUDNN_POOLING_MAX)
 
 
-def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True):
+def max_pooling(x, ksize, stride=None, pad=0, cover_all=True):
     """N-dimensionally spatial max pooling function.
 
     This function provides a N-dimensionally generalized version of
-    :func:`~functions.max_pooling_2d`. This acts similarly to
-    :class:`~functions.ConvolutionND`, but it computes the maximum of input
+    :func:`F.max_pooling_2d() <chainer.functions.max_pooling_2d>`.
+    This acts similarly to
+    :class:`F.convolution_nd() <chainer.functions.convolution_nd>`,
+    but it computes the maximum of input
     spatial patch for each channel without any parameter instead of computing
     the inner products.
 
@@ -146,3 +148,15 @@ def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True):
     """
     ndim = len(x.shape[2:])
     return MaxPoolingND(ndim, ksize, stride, pad, cover_all)(x)
+
+
+def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True):
+    """N-dimensionally spatial max pooling function.
+
+    .. deprecated:: v3.0.0
+
+        Thie feature is deprecated.
+        Use :func:`F.max_pooling() <chainer.functions.max_pooling>` instead.
+    """
+
+    return max_pooling(x, ksize, stride, pad, cover_all)

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -239,12 +239,20 @@ Spatial pooling
    chainer.functions.average_pooling_2d
    chainer.functions.average_pooling_nd
    chainer.functions.max_pooling_2d
-   chainer.functions.max_pooling_nd
+   chainer.functions.max_pooling
    chainer.functions.roi_pooling_2d
    chainer.functions.spatial_pyramid_pooling_2d
    chainer.functions.unpooling_2d
    chainer.functions.upsampling_2d
 
+Deprecated
+``````````
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.functions.max_pooling_nd
 
 Utility functions
 -----------------


### PR DESCRIPTION
- [ ] `max_pooling_nd`
- [ ] `average_pooling_nd`
- [ ] `unpooling_nd`

* Note: original functions `xxx_pooling_nd` should be kept for backward compatibility.