### PR TITLE
Add a missing device argument to the .to_gpu() call in the to_gpu() method.

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -367,7 +367,7 @@ Assign a Parameter object directly to an attribute within a \
         d = self.__dict__
         with cuda._get_device(device):
             for name in self._params:
-                d[name].to_gpu()
+                d[name].to_gpu(device)
             for name in self._persistent:
                 value = d[name]
                 if isinstance(value, numpy.ndarray):


### PR DESCRIPTION
This PR adds a missing `device` argument for .to_gpu() calls in the to_gpu() method in `chainer/link.py`.

The following is a case affected by this bug.
```
cnn = MyCNN() # My neural network model
model = chainer.links.Classifier(cnn)
model.to_gpu(0)
```
If I understand correctly, this code is assumed to call `.to_gpu()` method of the `cnn` instance with the `device` argument (`0` in this case) through the instance `model` of chainer.links.Classifier.  However, it actually calls `cnn.to_gpu()` without any arguments.