### PR TITLE
fix typo in chainer doc

### DIFF
--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -52,7 +52,7 @@ The following list shows an example of what we can do to reduce the cost (*Note:
 .. note::
 
    Since Chainer v2, we have stopped adopting any solid processes to break backward compatibilities (e.g. a solid schedule for deprecating and removing a feature) in order to keep the development fast enough to support the cutting-edge research.
-   **It does not mean we stop taking care of maintenability of user codes.**
+   **It does not mean we stop taking care of maintainability of user codes.**
    We are still paying much attention to not breaking user codes.
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -111,9 +111,9 @@ Once CuPy is correctly set up, Chainer will automatically enable CUDA support.
 You can refer to the following flags to confirm if CUDA/cuDNN support is actually available.
 
 ``chainer.cuda.available``
-   ``True`` iff Chainer successfully imports :mod:`cupy`.
+   ``True`` if Chainer successfully imports :mod:`cupy`.
 ``chainer.cuda.cudnn_enabled``
-   ``True`` iff cuDNN support is available.
+   ``True`` if cuDNN support is available.
 
 
 Support image dataset

--- a/docs/source/reference/core/configuration.rst
+++ b/docs/source/reference/core/configuration.rst
@@ -29,7 +29,7 @@ Note that the default values are set in the global config.
    Flag to configure deterministic computations in cuDNN APIs.
    If it is ``True``, convolution functions that use cuDNN use the deterministic mode (i.e, the computation is reproducible).
    Otherwise, the results of convolution functions using cuDNN may be non-deterministic in exchange for the performance.
-   The defualt value is ``False``.
+   The default value is ``False``.
 ``chainer.config.debug``
    Debug mode flag.
    If it is ``True``, Chainer runs in the debug mode.


### PR DESCRIPTION
`defualt` -> `default`