### PR TITLE
Richer gradient check output

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -345,8 +345,14 @@ def check_backward(func, x_data, y_grad, params=(),
         f.write('check_backward failed (eps={} atol={} rtol={})\n'.format(
             eps, atol, rtol))
         for i, x_ in enumerate(xs):
-            f.write('input[{}]:\n'.format(i))
+            f.write('inputs[{}]:\n'.format(i))
             f.write('{}\n'.format(x_))
+        for i, gy_ in enumerate(y_grad):
+            f.write('grad_outputs[{}]:\n'.format(i))
+            f.write('{}\n'.format(gy_))
+        for i, d_ in enumerate(directions):
+            f.write('directions[{}]:\n'.format(i))
+            f.write('{}\n'.format(d_))
         f.write('gradients (numeric):  {}\n'.format(gx))
         f.write('gradients (backward): {}\n'.format(gx_accum))
         f.write('\n')

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -338,7 +338,20 @@ def check_backward(func, x_data, y_grad, params=(),
     for g, direction in six.moves.zip(grads, directions):
         gx_accum += (g.astype('d') * direction).sum()
 
-    testing.assert_allclose(gx, gx_accum, atol=atol, rtol=rtol)
+    try:
+        testing.assert_allclose(gx, gx_accum, atol=atol, rtol=rtol)
+    except AssertionError as e:
+        f = six.StringIO()
+        f.write('check_backward failed (eps={} atol={} rtol={})\n'.format(
+            eps, atol, rtol))
+        for i, x_ in enumerate(xs):
+            f.write('input[{}]:\n'.format(i))
+            f.write('{}\n'.format(x_))
+        f.write('gradients (numeric):  {}\n'.format(gx))
+        f.write('gradients (backward): {}\n'.format(gx_accum))
+        f.write('\n')
+        f.write(str(e))
+        raise AssertionError(f.getvalue())
 
 
 def check_double_backward(func, x_data, y_grad, x_grad_grad, params=(),
@@ -376,6 +389,9 @@ def check_double_backward(func, x_data, y_grad, x_grad_grad, params=(),
     """
     x_data = _as_tuple(x_data)
     params = _as_tuple(params)
+    y_grad = _as_tuple(y_grad)
+    x_grad_grad = _as_tuple(x_grad_grad)
+    params_grad_grad = _as_tuple(params_grad_grad)
     n_x = len(x_data)
 
     def first_order_grad(*inputs):
@@ -392,11 +408,31 @@ def check_double_backward(func, x_data, y_grad, x_grad_grad, params=(),
 
         return tuple([x.grad_var for x in xs] + [p.grad_var for p in params])
 
-    inputs = x_data + _as_tuple(y_grad)
-    grad_grad = _as_tuple(x_grad_grad) + _as_tuple(params_grad_grad)
-    check_backward(first_order_grad, inputs, grad_grad, params=params,
-                   eps=eps, atol=atol, rtol=rtol, no_grads=no_grads,
-                   dtype=dtype)
+    inputs = x_data + y_grad
+    grad_grad = x_grad_grad + params_grad_grad
+    try:
+        check_backward(first_order_grad, inputs, grad_grad, params=params,
+                       eps=eps, atol=atol, rtol=rtol, no_grads=no_grads,
+                       dtype=dtype)
+    except AssertionError as e:
+        f = six.StringIO()
+        f.write('check_double_backward failed '
+                '(eps={} atol={} rtol={})\n'.format(eps, atol, rtol))
+        for i, x_ in enumerate(x_data):
+            f.write('input[{}]:\n'.format(i))
+            f.write('{}\n'.format(x_))
+        for i, gy_ in enumerate(y_grad):
+            f.write('grad_output[{}]:\n'.format(i))
+            f.write('{}\n'.format(gy_))
+        for i, ggx_ in enumerate(x_grad_grad):
+            f.write('grad_grad_input[{}]:\n'.format(i))
+            f.write('{}\n'.format(ggx_))
+        for i, ggp_ in enumerate(params_grad_grad):
+            f.write('grad_grad_param[{}]:\n'.format(i))
+            f.write('{}\n'.format(ggp_))
+        f.write('\n')
+        f.write(str(e))
+        raise AssertionError(f.getvalue())
 
 
 def _set_y_grad(y, y_grad):


### PR DESCRIPTION
Currently, if `gradient_check` fails, only two values (namely the numerical gradient and the gradient computed by `backward`) are displayed.
```
Not equal to tolerance rtol=0.0001, atol=1e-05

(mismatch 100.0%)
 x: array(-1.3064368690828785)
 y: array(-1.3061777353286743)
```

With this PR, more informative output that can help investigate the cause will be displayed.
```
AssertionError: check_double_backward failed (eps=0.001 atol=0.001 rtol=0.01)
input[0]:
[[ -3.11279297e-01  -2.77832031e-01]
 [  8.89160156e-01  -5.12207031e-01]
 [ -2.27689743e-04   5.35644531e-01]]
grad_output[0]:
[[ 0.62451172 -0.03820801]
 [-0.06088257 -0.52685547]
 [ 0.02798462  0.08563232]]
grad_grad_input[0]:
[[-0.83984375  0.171875  ]
 [ 0.19604492 -0.65527344]
 [-0.37939453  0.23974609]]

check_backward failed (eps=0.001 atol=0.001 rtol=0.01)
inputs[0]:
variable([[ -3.11279297e-01  -2.77832031e-01]
          [  8.89160156e-01  -5.12207031e-01]
          [ -2.27689743e-04   5.35644531e-01]])
inputs[1]:
variable([[ 0.62451172 -0.03820801]
          [-0.06088257 -0.52685547]
          [ 0.02798462  0.08563232]])
grad_outputs[0]:
[[-0.83984375  0.171875  ]
 [ 0.19604492 -0.65527344]
 [-0.37939453  0.23974609]]
directions[0]:
[[ 0.21636355  0.28775263]
 [ 0.43225531  0.27918149]
 [ 0.5351952   0.10163526]]
directions[1]:
[[ 0.27479015 -0.0392605 ]
 [-0.01231503  0.29568345]
 [-0.37974042  0.00069394]]
gradients (numeric):  -0.01348112336172684
gradients (backward): -0.010259122468148205


Not equal to tolerance rtol=0.01, atol=0.001

(mismatch 100.0%)
 x: array(-0.01348112336172684)
 y: array(-0.010259122468148205)

assert_allclose failed: 
  shape: () ()
  dtype: float64 float64
  i: (0,)
  x[i]: -0.01348112336172684
  y[i]: -0.010259122468148205
  err[i]: 0.0032220008935786356
x: -0.01348112336172684
y: -0.010259122468148205
```

This is especially useful to check if the failed input is a non-differentiable point or not.