### PR TITLE
Stabilize unit tests for F.Ceil and F.Floor

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_ceil.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_ceil.py
@@ -54,7 +54,8 @@ class UnaryFunctionsTestBase(unittest.TestCase):
 class TestCeil(UnaryFunctionsTestBase):
 
     def make_data(self):
-        x = numpy.random.uniform(-10.0, 10.0, self.shape).astype(self.dtype)
+        x = numpy.random.randint(-10, 10, self.shape) + numpy.random.normal(
+            0.5, 0.3, self.shape).astype(self.dtype)
         gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         return x, gy
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_ceil.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_ceil.py
@@ -8,7 +8,6 @@ import chainer.functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 class UnaryFunctionsTestBase(unittest.TestCase):
@@ -17,7 +16,11 @@ class UnaryFunctionsTestBase(unittest.TestCase):
         raise NotImplementedError
 
     def setUp(self):
-        self.x, self.gy = self.make_data()
+        self.eps = 1e-3
+        while True:
+            self.x, self.gy = self.make_data()
+            if (numpy.abs(self.x - numpy.round(self.x)) > self.eps * 10).all():
+                break
 
     def check_forward(self, op, op_xp, x_data):
         x = chainer.Variable(x_data)
@@ -35,7 +38,8 @@ class UnaryFunctionsTestBase(unittest.TestCase):
 
     def check_backward(self, op, x_data, y_grad):
         gradient_check.check_backward(op, x_data, y_grad, atol=5e-4,
-                                      rtol=5e-3, dtype=numpy.float64)
+                                      rtol=5e-3, dtype=numpy.float64,
+                                      eps=self.eps)
 
     def check_backward_cpu(self, op):
         self.check_backward(op, self.x, self.gy)
@@ -54,26 +58,21 @@ class UnaryFunctionsTestBase(unittest.TestCase):
 class TestCeil(UnaryFunctionsTestBase):
 
     def make_data(self):
-        x = numpy.random.randint(-10, 10, self.shape) + numpy.random.normal(
-            0.5, 0.3, self.shape).astype(self.dtype)
+        x = numpy.random.uniform(-10.0, 10.0, self.shape).astype(self.dtype)
         gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         return x, gy
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward_cpu(F.ceil, numpy.ceil)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward_gpu(F.ceil, cuda.cupy.ceil)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward_cpu(F.ceil)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward_gpu(F.ceil)
 


### PR DESCRIPTION
This PR changes the distribution from which inputs are sampled in TestCeil so that tests for the function are likely to pass more. Specifically, we sample less likely from discontinuous points (i.e. integer points).