### PR TITLE
Type check in chainer.grad

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -599,7 +599,7 @@ class FunctionNode(object):
 
 def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
          retain_grad=False, enable_double_backprop=False):
-    """Computes the gradient of output variables w.r.t.\\ the input variables.
+    """Computes the gradient of output variables w.r.t.\\  the input variables.
 
     This function implements the backpropagation algorithm. While
     :meth:`Variable.backward` also implements backprop, this function selects
@@ -618,19 +618,24 @@ def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
     even if it had already been set.
 
     Args:
-        outputs: A sequence of output variables from which backprop starts.
-        inputs: A sequence of input variables each of which this function
-            computes the gradient w.r.t.
-        grad_outputs: A sequence of variables that gives the initial value of
-            each output gradient. If an element is set to ``None``, an array
-            filled with 1 is used. If this argument itself is ``None``, it is
-            treated as a sequence of ``None`` s.
-        grad_inputs: A sequence of variables that gives the initial value of
-            each input gradient. The gradients computed by the backprop
+        outputs (tuple or list of :class:`~chainer.Variable`):
+            A sequence of output variables from which backprop starts.
+        inputs (tuple or list of :class:`~chainer.Variable`):
+            A sequence of input variables each of which this function computes
+            the gradient w.r.t.
+        grad_outputs (tuple or list of :class:`~chainer.Variable` or None):
+            A sequence of variables that gives the initial value of each output
+            gradient.
+            If an element is set to ``None``, an array filled with 1 is used.
+            If this argument itself is ``None``, it is treated as a sequence of
+            ``None``\\ s.
+        grad_inputs (tuple or list of :class:`~chainer.Variable` or None):
+            A sequence of variables that gives the initial value of each input
+            gradient. The gradients computed by the backprop
             algorithm are accumulated to them (not in-place). If an element
             is set to ``None``, the gradient is not accumulated to this value.
             If this argument itself is ``None``, it is treated as a sequence of
-            ``None`` s.
+            ``None``\\ s.
         set_grad (bool): If it is ``True``, the :attr:`Variable.grad_var`
             attribute of each input variable is set to the corresponding
             computed gradient variable.
@@ -647,6 +652,20 @@ def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
         A list of gradient variables w.r.t. the inputs.
 
     """
+    if not isinstance(outputs, (tuple, list)):
+        raise TypeError(
+            'outputs must be a tuple or a list, not {}.'.format(type(outputs)))
+    if not isinstance(inputs, (tuple, list)):
+        raise TypeError(
+            'inputs must be a tuple or a list, not {}.'.format(type(inputs)))
+    if not (grad_outputs is None or isinstance(grad_outputs, (tuple, list))):
+        raise TypeError(
+            'grad_outputs must be a tuple or a list or None, not {}.'.format(
+                type(grad_outputs)))
+    if not (grad_inputs is None or isinstance(grad_inputs, (tuple, list))):
+        raise TypeError(
+            'grad_inputs must be a tuple or a list or None, not {}.'.format(
+                type(grad_inputs)))
     # The implementation consists of three steps.
 
     # 1. Backward enumeration: all the nodes reachable backward from the output

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -478,6 +478,27 @@ def _get_value(x):
     return x
 
 
+class TestGradTypeCheck(unittest.TestCase):
+
+    def test_type_check(self):
+        x = chainer.Variable(numpy.random.uniform(-1, 1, (2, 3)).astype('f'))
+        y = x * x
+        gx = chainer.Variable(numpy.random.uniform(-1, 1, (2, 3)).astype('f'))
+        gy = chainer.Variable(numpy.random.uniform(-1, 1, (2, 3)).astype('f'))
+
+        chainer.grad([y], [x], [gx], [gy])
+        chainer.grad((y,), (x,), (gx,), (gy,))
+
+        with self.assertRaises(TypeError):
+            chainer.grad(y, [x], [gx], [gy])
+        with self.assertRaises(TypeError):
+            chainer.grad([y], x, [gx], [gy])
+        with self.assertRaises(TypeError):
+            chainer.grad([y], [x], gx, [gy])
+        with self.assertRaises(TypeError):
+            chainer.grad([y], [x], [gx], gy)
+
+
 class GradTestBase(object):
 
     shape = 3,


### PR DESCRIPTION
Add some type checks in `chainer.grad()`.
This prevents a pitfall like https://chainer-jp.slack.com/archives/C3UBX3V32/p1505562922000013