### PR TITLE
[WIP] device.is_cpu and device.is_cuda

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -9,6 +9,7 @@ from chainer import configuration  # NOQA
 from chainer import cuda  # NOQA
 from chainer import dataset  # NOQA
 from chainer import datasets  # NOQA
+from chainer import device  # NOQA
 from chainer import function  # NOQA
 from chainer import function_hook  # NOQA
 from chainer import function_hooks  # NOQA

--- a/chainer/device.py
+++ b/chainer/device.py
@@ -1,0 +1,42 @@
+import six
+
+from chainer import cuda
+
+
+def is_cpu(device):
+    """Determines if the specified device is a CPU device.
+
+    .. note::
+        This function does not check whether the specified device is actually
+        available.
+
+    Args:
+        device (device specifier): Device specifier.
+
+    Returns:
+        ``True`` if ``device`` is a CPU device. ``False`` otherwise.
+    """
+    if isinstance(device, six.integer_types):
+        return device == -1
+    elif isinstance(device, cuda.DummyDeviceType):
+        return True
+    elif isinstance(device, cuda.Device):
+        return False
+    else:
+        raise TypeError('Invalid device specifier type: {}'.format(type(device)))
+
+
+def is_cuda(device):
+    """Determines if the specified device is a CUDA device.
+
+    .. note::
+        This function does not check whether the specified device is actually
+        available.
+
+    Args:
+        device (device specifier): Device specifier.
+
+    Returns:
+        ``True`` if ``device`` is a CUDA device. ``False`` otherwise.
+    """
+    return not is_cpu(device)

--- a/chainer/device.py
+++ b/chainer/device.py
@@ -23,7 +23,8 @@ def is_cpu(device):
     elif isinstance(device, cuda.Device):
         return False
     else:
-        raise TypeError('Invalid device specifier type: {}'.format(type(device)))
+        raise TypeError(
+            'Invalid device specifier type: {}'.format(type(device)))
 
 
 def is_cuda(device):


### PR DESCRIPTION
This is a proposal (thus WIP).

Currently, to test whether a device is CPU or CUDA, you compare with the hardcoded device ID: e.g. `dev.id == -1` or `int(dev) == -1`. This is not neccessarily intuitive.

This PR offers an uniform method to check the device type.