### PR TITLE
Add get_variable_or_none to improve backward performance

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -800,7 +800,7 @@ def _backprop(outputs, inputs, grad_required, retain_grad, grads):
             grads[node] = g
 
             if retain_grad:
-                v = node.get_variable()
+                v = node.get_raw_variable()
                 if v is not None:
                     v.grad_var = g
 

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -800,7 +800,7 @@ def _backprop(outputs, inputs, grad_required, retain_grad, grads):
             grads[node] = g
 
             if retain_grad:
-                v = node.get_raw_variable()
+                v = node.get_variable_or_none()
                 if v is not None:
                     v.grad_var = g
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -309,8 +309,8 @@ class VariableNode(object):
         var._node = self
         return var
 
-    def get_raw_variable(self):
-        """Returns the holding :class:`Variable` object
+    def get_variable_or_none(self):
+        """Returns the holding :class:`Variable` object or ``None``.
 
         VariableNode object holds a weak reference of the variable object.If
         the reference is alive, it is returned by this property. Otherwise,
@@ -985,7 +985,7 @@ Actual: {0}'''.format(type(data))
                 for y in outputs:
                     if y is not None and y is not self.node:
                         grads[y] = None
-                        y_var = y.get_raw_variable()
+                        y_var = y.get_variable_or_none()
                         if y_var is not None:
                             y_var._grad_var = None
 
@@ -1007,7 +1007,7 @@ Actual: {0}'''.format(type(data))
                 else:
                     grads[x] = gx
 
-                x_var = x.get_raw_variable()
+                x_var = x.get_variable_or_none()
                 if x_var is not None:
                     x_var._grad_var = grads[x]
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -258,7 +258,7 @@ class VariableNode(object):
         If the variable is not available, it returns ``None``.
 
         """
-        var = self.get_variable()
+        var = self._variable()
         return None if var is None else var.grad
 
     @property
@@ -268,7 +268,7 @@ class VariableNode(object):
         If the corresponding variable is not available, it return ``None``.
 
         """
-        var = self.get_variable()
+        var = self._variable()
         return None if var is None else var._grad_var
 
     @property
@@ -308,6 +308,19 @@ class VariableNode(object):
                        requires_grad=self._requires_grad)
         var._node = self
         return var
+
+    def get_raw_variable(self):
+        """Returns the holding :class:`Variable` object
+
+        VariableNode object holds a weak reference of the variable object.If
+        the reference is alive, it is returned by this property. Otherwise,
+        returns ``None``.
+
+        Returns:
+            Variable: The variable object that refers this node.
+
+        """
+        return self._variable()
 
     def set_creator(self, creator):
         """Sets a :class:`Function` object that created this node.
@@ -972,7 +985,7 @@ Actual: {0}'''.format(type(data))
                 for y in outputs:
                     if y is not None and y is not self.node:
                         grads[y] = None
-                        y_var = y.get_variable()
+                        y_var = y.get_raw_variable()
                         if y_var is not None:
                             y_var._grad_var = None
 
@@ -994,7 +1007,7 @@ Actual: {0}'''.format(type(data))
                 else:
                     grads[x] = gx
 
-                x_var = x.get_variable()
+                x_var = x.get_raw_variable()
                 if x_var is not None:
                     x_var._grad_var = grads[x]
 


### PR DESCRIPTION
`get_variable` create `Variable` when `_variable` reference is dead.
But, some functions do not need temporary `Variable` object.
 