### PR TITLE
doc: Docstring checker to fix returns section markup

### DIFF
--- a/chainer/datasets/ptb.py
+++ b/chainer/datasets/ptb.py
@@ -39,7 +39,7 @@ def get_ptb_words_vocabulary():
 
     Returns:
         dict: Dictionary that maps words to corresponding word IDs. The IDs are
-            used in the Penn Tree Bank long sequence datasets.
+        used in the Penn Tree Bank long sequence datasets.
 
     .. seealso::
        See :func:`get_ptb_words` for the actual datasets.

--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -91,8 +91,8 @@ def split_dataset(dataset, split_at, order=None):
 
     Returns:
         tuple: Two :class:`SubDataset` objects. The first subset represents the
-            examples of indexes ``order[:split_at]`` while the second subset
-            represents the examples of indexes ``order[split_at:]``.
+        examples of indexes ``order[:split_at]`` while the second subset
+        represents the examples of indexes ``order[split_at:]``.
 
     """
     n_examples = len(dataset)
@@ -123,9 +123,9 @@ def split_dataset_random(dataset, first_size, seed=None):
 
     Returns:
         tuple: Two :class:`SubDataset` objects. The first subset contains
-            ``first_size`` examples randomly chosen from the dataset without
-            replacement, and the second subset contains the rest of the
-            dataset.
+        ``first_size`` examples randomly chosen from the dataset without
+        replacement, and the second subset contains the rest of the
+        dataset.
 
     """
     order = numpy.random.RandomState(seed).permutation(len(dataset))
@@ -143,9 +143,9 @@ def split_dataset_n(dataset, n, order=None):
 
     Returns:
         list: List of ``n`` :class:`SubDataset` objects.
-            Each subset contains the examples of indexes
-            ``order[i * (len(dataset) // n):(i + 1) * (len(dataset) // n)]``
-            .
+        Each subset contains the examples of indexes
+        ``order[i * (len(dataset) // n):(i + 1) * (len(dataset) // n)]``
+        .
 
     """
     n_examples = len(dataset)

--- a/chainer/functions/activation/tree_lstm.py
+++ b/chainer/functions/activation/tree_lstm.py
@@ -238,7 +238,7 @@ def tree_lstm(*inputs):
 
     Returns:
         tuple: Two :class:`~chainer.Variable` objects ``c`` and ``h``. ``c`` is
-            the updated cell state. ``h`` indicates the outgoing signal.
+        the updated cell state. ``h`` indicates the outgoing signal.
 
     See the papers for details: `Improved Semantic Representations From \
     Tree-Structured Long Short-Term Memory Networks \

--- a/chainer/functions/array/pad_sequence.py
+++ b/chainer/functions/array/pad_sequence.py
@@ -90,8 +90,8 @@ def pad_sequence(xs, length=None, padding=0):
         padding (int or float): Value to fill.
 
     Returns:
-        ~chainer.Variable: It returns a padded matrix. Its shape is
-            ``(n, length, ...)``, where ``n == len(xs)``.
+        ~chainer.Variable: A padded matrix. Its shape is
+        ``(n, length, ...)``, where ``n == len(xs)``.
 
     """
     return PadSequence(length, padding)(*xs)

--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -76,10 +76,10 @@ def split_axis(x, indices_or_sections, axis, force_tuple=True):
 
     Returns:
         tuple or Variable: Tuple of :class:`~chainer.Variable` objects
-             if the number of outputs is more than 1 or
-             :class:`~chainer.Variable` otherwise.
-             When ``force_tuple`` is ``True``, returned value is always a tuple
-             regardless of the number of outputs.
+        if the number of outputs is more than 1 or
+        :class:`~chainer.Variable` otherwise.
+        When ``force_tuple`` is ``True``, returned value is always a tuple
+        regardless of the number of outputs.
 
     .. note::
         This function raises :class:`ValueError` if at least

--- a/chainer/functions/connection/n_step_gru.py
+++ b/chainer/functions/connection/n_step_gru.py
@@ -107,14 +107,14 @@ def n_step_gru(
 
     Returns:
         tuple: This functions returns a tuple concaining three elements,
-            ``hy`` and ``ys``.
+        ``hy`` and ``ys``.
 
-            - ``hy`` is an updated hidden states whose shape is same as ``hx``.
-            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
-              ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
-              mini-batch size for time ``t``, and ``N`` is size of hidden
-              units. Note that ``B_t`` is the same value as ``xs[t]``.
+        - ``hy`` is an updated hidden states whose shape is same as ``hx``.
+        - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+          ``ys[t]`` holds hidden states of the last layer corresponding
+          to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
+          mini-batch size for time ``t``, and ``N`` is size of hidden
+          units. Note that ``B_t`` is the same value as ``xs[t]``.
 
     """
 
@@ -210,14 +210,14 @@ def n_step_bigru(
 
     Returns:
         tuple: This functions returns a tuple concaining three elements,
-            ``hy`` and ``ys``.
+        ``hy`` and ``ys``.
 
-            - ``hy`` is an updated hidden states whose shape is same as ``hx``.
-            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
-              ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
-              mini-batch size for time ``t``, and ``N`` is size of hidden
-              units. Note that ``B_t`` is the same value as ``xs[t]``.
+        - ``hy`` is an updated hidden states whose shape is same as ``hx``.
+        - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+          ``ys[t]`` holds hidden states of the last layer corresponding
+          to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
+          mini-batch size for time ``t``, and ``N`` is size of hidden
+          units. Note that ``B_t`` is the same value as ``xs[t]``.
 
     """
 

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -115,15 +115,15 @@ def n_step_lstm(
         tuple: This functions returns a tuple concaining three elements,
         ``hy``, ``cy`` and ``ys``.
 
-            - ``hy`` is an updated hidden states whose shape is the same as
-              ``hx``.
-            - ``cy`` is an updated cell states whose shape is the same as
-              ``cx``.
-            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
-              ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
-              the mini-batch size for time ``t``, and ``N`` is size of hidden
-              units. Note that ``B_t`` is the same value as ``xs[t]``.
+        - ``hy`` is an updated hidden states whose shape is the same as
+          ``hx``.
+        - ``cy`` is an updated cell states whose shape is the same as
+          ``cx``.
+        - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+          ``ys[t]`` holds hidden states of the last layer corresponding
+          to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
+          the mini-batch size for time ``t``, and ``N`` is size of hidden
+          units. Note that ``B_t`` is the same value as ``xs[t]``.
 
     .. note::
 
@@ -281,16 +281,15 @@ def n_step_bilstm(
         tuple: This functions returns a tuple concaining three elements,
         ``hy``, ``cy`` and ``ys``.
 
-            - ``hy`` is an updated hidden states whose shape is the same as
-              ``hx``.
-            - ``cy`` is an updated cell states whose shape is the same as
-              ``cx``.
-            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
-              ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, 2N)`` where ``B_t``
-              is the mini-batch size for time ``t``, and ``N`` is size of
-              hidden
-              units. Note that ``B_t`` is the same value as ``xs[t]``.
+        - ``hy`` is an updated hidden states whose shape is the same as
+          ``hx``.
+        - ``cy`` is an updated cell states whose shape is the same as
+          ``cx``.
+        - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+          ``ys[t]`` holds hidden states of the last layer corresponding
+          to an input ``xs[t]``. Its shape is ``(B_t, 2N)`` where ``B_t``
+          is the mini-batch size for time ``t``, and ``N`` is size of
+          hidden units. Note that ``B_t`` is the same value as ``xs[t]``.
 
     .. admonition:: Example
 

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -615,14 +615,14 @@ def n_step_rnn(
 
     Returns:
         tuple: This functions returns a tuple concaining three elements,
-            ``hy`` and ``ys``.
+        ``hy`` and ``ys``.
 
-            - ``hy`` is an updated hidden states whose shape is same as ``hx``.
-            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
-              ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
-              mini-batch size for time ``t``, and ``N`` is size of hidden
-              units. Note that ``B_t`` is the same value as ``xs[t]``.
+        - ``hy`` is an updated hidden states whose shape is same as ``hx``.
+        - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+          ``ys[t]`` holds hidden states of the last layer corresponding
+          to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t`` is
+          mini-batch size for time ``t``, and ``N`` is size of hidden
+          units. Note that ``B_t`` is the same value as ``xs[t]``.
 
     """
     return n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
@@ -724,14 +724,14 @@ def n_step_birnn(
 
     Returns:
         tuple: This functions returns a tuple concaining three elements,
-            ``hy`` and ``ys``.
+        ``hy`` and ``ys``.
 
-            - ``hy`` is an updated hidden states whose shape is same as ``hx``.
-            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
-              ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t``
-              is mini-batch size for time ``t``, and ``N`` is size of hidden
-              units. Note that ``B_t`` is the same value as ``xs[t]``.
+        - ``hy`` is an updated hidden states whose shape is same as ``hx``.
+        - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+          ``ys[t]`` holds hidden states of the last layer corresponding
+          to an input ``xs[t]``. Its shape is ``(B_t, N)`` where ``B_t``
+          is mini-batch size for time ``t``, and ``N`` is size of hidden
+          units. Note that ``B_t`` is the same value as ``xs[t]``.
 
     """
     return n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,

--- a/chainer/functions/loss/crf1d.py
+++ b/chainer/functions/loss/crf1d.py
@@ -90,7 +90,7 @@ def crf1d(cost, xs, ys, reduce='mean'):
 
     Returns:
         ~chainer.Variable: A variable holding the average negative
-            log-likelihood of the input sequences.
+        log-likelihood of the input sequences.
 
     .. note::
 
@@ -165,16 +165,16 @@ def argmax_crf1d(cost, xs):
 
     Returns:
         tuple: A tuple of :class:`~chainer.Variable` object ``s`` and a
-            :class:`list` ``ps``.
-            The shape of ``s`` is ``(B,)``, where ``B`` is the mini-batch size.
-            i-th element of ``s``, ``s[i]``, represents log-likelihood of i-th
-            data.
-            ``ps`` is a list of :class:`numpy.ndarray` or
-            :class:`cupy.ndarray`, and denotes the state that maximizes the
-            point probability.
-            ``len(ps)`` is equal to ``len(xs)``, and shape of each ``ps[i]`` is
-            the mini-batch size of the corresponding ``xs[i]``. That means,
-            ``ps[i].shape == xs[i].shape[0:1]``.
+        :class:`list` ``ps``.
+        The shape of ``s`` is ``(B,)``, where ``B`` is the mini-batch size.
+        i-th element of ``s``, ``s[i]``, represents log-likelihood of i-th
+        data.
+        ``ps`` is a list of :class:`numpy.ndarray` or
+        :class:`cupy.ndarray`, and denotes the state that maximizes the
+        point probability.
+        ``len(ps)`` is equal to ``len(xs)``, and shape of each ``ps[i]`` is
+        the mini-batch size of the corresponding ``xs[i]``. That means,
+        ``ps[i].shape == xs[i].shape[0:1]``.
     """
     alpha = xs[0]
     alphas = []

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -226,7 +226,7 @@ def batch_matmul(a, b, transa=False, transb=False):
 
     Returns:
         ~chainer.Variable: The result of the batch matrix multiplications as a
-            3-D array.
+        3-D array.
 
     .. deprecated:: v3.0.0
        batch_matmul is deprecated. Use ``matmul`` instead.

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -43,9 +43,9 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class):
 
     Returns:
         ~chainer.Variable: Output variable. The shape of the output variable
-            will be :math:`(batchsize, c \\sum_{h=0}^{H-1} 2^{2h}, 1, 1)`,
-            where :math:`c` is the number of channels of input variable ``x``
-            and :math:`H` is the number of pyramid levels.
+        will be :math:`(batchsize, c \\sum_{h=0}^{H-1} 2^{2h}, 1, 1)`,
+        where :math:`c` is the number of channels of input variable ``x``
+        and :math:`H` is the number of pyramid levels.
 
     .. note::
 

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -227,7 +227,7 @@ def check_backward(func, x_data, y_grad, params=(),
             to this dtype when calculating numerical gradients. Only float
             types and ``None`` are allowed.
 
-    See:
+    .. seealso::
        :func:`numerical_grad`
     """
     x_data = _as_tuple(x_data)

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -153,7 +153,7 @@ class CaffeFunction(link.Chain):
 
         Returns:
             tuple: A tuple of output :class:`~chainer.Variable` objects
-                corresponding to elements of the  `outputs` argument.
+            corresponding to elements of the  `outputs` argument.
 
         """
         argument.check_unexpected_kwargs(

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -121,8 +121,8 @@ class StatelessLSTM(LSTMBase):
 
         Returns:
             tuple of ~chainer.Variable: Returns ``(c_new, h_new)``, where
-                ``c_new`` represents new cell state, and ``h_new`` is updated
-                output of LSTM units.
+            ``c_new`` represents new cell state, and ``h_new`` is updated
+            output of LSTM units.
 
         """
         if self.upward.W.data is None:

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -68,9 +68,9 @@ class ChildSumTreeLSTM(link.Chain):
 
         Returns:
             tuple of ~chainer.Variable: Returns
-                :math:`(c_{new}, h_{new})`, where :math:`c_{new}` represents
-                new cell state vector, and :math:`h_{new}` is new output
-                vector.
+            :math:`(c_{new}, h_{new})`, where :math:`c_{new}` represents
+            new cell state vector, and :math:`h_{new}` is new output
+            vector.
 
         """
 
@@ -196,8 +196,8 @@ class NaryTreeLSTM(link.Chain):
 
         Returns:
             tuple of ~chainer.Variable: Returns :math:`(c_{new}, h_{new})`,
-                where :math:`c_{new}` represents new cell state vector,
-                and :math:`h_{new}` is new output vector.
+            where :math:`c_{new}` represents new cell state vector,
+            and :math:`h_{new}` is new output vector.
 
         """
 

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -35,7 +35,7 @@ class CRF1d(link.Link):
 
         Returns:
             tuple: A tuple of :class:`~chainer.Variable` representing each
-                log-likelihood and a list representing the argmax path.
+            log-likelihood and a list representing the argmax path.
 
         .. seealso:: See :func:`~chainer.frunctions.crf1d_argmax` for more
            detail.

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -118,7 +118,7 @@ class Evaluator(extension.Extension):
 
         Returns:
             dict: Result dictionary that contains mean statistics of values
-                reported by the evaluation function.
+            reported by the evaluation function.
 
         """
         # set up a reporter
@@ -150,7 +150,7 @@ class Evaluator(extension.Extension):
 
         Returns:
             dict: Result dictionary. This dictionary is further reported via
-                :func:`~chainer.report` without specifying any observer.
+            :func:`~chainer.report` without specifying any observer.
 
         """
         iterator = self._iterators['main']

--- a/chainer/training/triggers/interval_trigger.py
+++ b/chainer/training/triggers/interval_trigger.py
@@ -43,7 +43,7 @@ class IntervalTrigger(object):
 
         Returns:
             bool: True if the corresponding extension should be invoked in this
-                iteration.
+            iteration.
 
         """
         updater = trainer.updater

--- a/chainer/training/triggers/manual_schedule_trigger.py
+++ b/chainer/training/triggers/manual_schedule_trigger.py
@@ -38,7 +38,7 @@ class ManualScheduleTrigger(object):
 
         Returns:
             bool: True if the corresponding extension should be invoked in this
-                iteration.
+            iteration.
 
         """
         updater = trainer.updater

--- a/chainer/training/triggers/minmax_value_trigger.py
+++ b/chainer/training/triggers/minmax_value_trigger.py
@@ -35,7 +35,7 @@ class BestValueTrigger(object):
 
         Returns:
             bool: ``True`` if the corresponding extension should be invoked in
-                this iteration.
+            this iteration.
 
         """
 

--- a/docs/source/_docstring_check.py
+++ b/docs/source/_docstring_check.py
@@ -21,7 +21,7 @@ class DocstringCheckContext(object):
 
     def nextline(self):
         if self.iline >= len(self.lines):
-            raise StopIteration()
+            raise StopIteration
         line = self.lines[self.iline]
         self.iline += 1
         return line
@@ -72,7 +72,7 @@ def _docstring_check_returns_indent(ctx):
         while len(line) == 0:
             line = ctx.nextline()
     except StopIteration:
-        raise ctx.error('`Returns` sections has no content')
+        ctx.error('`Returns` section has no content')
 
     # Find the indentation of the first line
     # (note: line should have at least one non-space character)

--- a/docs/source/_docstring_check.py
+++ b/docs/source/_docstring_check.py
@@ -1,0 +1,90 @@
+import math
+
+
+def check(app, what, name, obj, options, lines):
+    ctx = DocstringCheckContext(app, what, name, obj, options, lines)
+
+    if what in ('function', 'method'):
+        _docstring_check_returns_indent(ctx)
+
+
+class DocstringCheckContext(object):
+    def __init__(self, app, what, name, obj, options, lines):
+        self.app = app
+        self.what = what
+        self.name = name
+        self.obj = obj
+        self.options = options
+        self.lines = lines
+
+        self.iline = 0
+
+    def nextline(self):
+        if self.iline >= len(self.lines):
+            raise StopIteration()
+        line = self.lines[self.iline]
+        self.iline += 1
+        return line
+
+    def error(self, msg, include_line=True, include_source=True):
+        lines = self.lines
+        iline = self.iline - 1
+        msg = ('{}\n\n'
+               'on {}'.format(msg, self.name))
+
+        if include_line and 0 <= iline < len(lines):
+            line = lines[iline]
+            msg += '\n' + 'at line {}: "{}"\n'.format(iline, line)
+
+        if include_source:
+            msg += '\n'
+            msg += 'docstring:\n'
+            digits = int(math.floor(math.log10(len(lines)))) + 1
+            linum_fmt = '{{:0{}d}} '.format(digits)
+            for i, line in enumerate(lines):
+                msg += linum_fmt.format(i) + line + '\n'
+        raise InvalidDocstringError(msg, self, iline)
+
+
+class InvalidDocstringError(Exception):
+    def __init__(self, msg, ctx, iline):
+        super(InvalidDocstringError, self).__init__(self, msg)
+        self.msg = msg
+        self.ctx = ctx
+        self.iline = iline
+
+    def __str__(self):
+        return self.msg
+
+
+def _docstring_check_returns_indent(ctx):
+    # Seek the :returns: header
+    try:
+        line = ctx.nextline()
+        while line != ':returns:':
+            line = ctx.nextline()
+    except StopIteration:
+        return  # No `Returns` section
+
+    # Skip empty lines and seek the first line of the content
+    try:
+        line = ctx.nextline()
+        while len(line) == 0:
+            line = ctx.nextline()
+    except StopIteration:
+        raise ctx.error('`Returns` sections has no content')
+
+    # Find the indentation of the first line
+    # (note: line should have at least one non-space character)
+    nindent = next(i for i, c in enumerate(line) if c != ' ')
+
+    # Check the indentation of the following lines
+    try:
+        line = ctx.nextline()
+        while line.startswith(' '):
+            if (not line.startswith(' ' * nindent) or
+                    line[nindent:].startswith(' ')):
+                ctx.error('Invalid indentation of `Returns` section')
+            line = ctx.nextline()
+    except StopIteration:
+        pass

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,10 @@ import six
 import sys
 
 
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+import _docstring_check
+
+
 __version__ = pkg_resources.get_distribution('chainer').version
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -342,6 +346,14 @@ np.random.seed(0)
 
 spelling_lang = 'en_US'
 spelling_word_list_filename = 'spelling_wordlist.txt'
+
+
+def setup(app):
+    app.connect('autodoc-process-docstring', _autodoc_process_docstring)
+
+
+def _autodoc_process_docstring(app, what, name, obj, options, lines):
+    _docstring_check.check(app, what, name, obj, options, lines)
 
 
 def _import_object_from_name(module_name, fullname):


### PR DESCRIPTION
Fixes #3397.

Fixed corrupted "Returns" section.

I introduced the docstring checker which is triggered by sphinx autodoc.
It can perform arbitrary check if we implement a rule.