### PR TITLE
inv_std is missing in backward of FixedBatchNormalization if it use cudnn.

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -301,6 +301,12 @@ class FixedBatchNormalization(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         x, gamma, mean, var = self.get_retained_inputs()
+
+        if not hasattr(self, 'inv_std'):
+            xp = cuda.get_array_module(x)
+            self.inv_var = xp.reciprocal(var.data + self.eps)
+            self.inv_std = xp.sqrt(self.inv_var, dtype=self.inv_var.dtype)
+
         gy, = grad_outputs
         f = FixedBatchNormalizationGrad(
             self.eps, self.expander, self.axis, self.inv_std, self.inv_var)

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -324,7 +324,7 @@ class FixedBatchNormalizationGrad(function.Function):
         xp = cuda.get_array_module(x)
 
         if self.inv_std is None or self.inv_var is None:
-            self.inv_var = xp.reciprocal(var.data + self.eps)
+            self.inv_var = xp.reciprocal(var + self.eps)
             self.inv_std = xp.sqrt(self.inv_var, dtype=self.inv_var.dtype)
 
         self.gamma_over_std = gamma * self.inv_std

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -231,6 +231,7 @@ class BatchNormalizationGrad(function.Function):
 
 class FixedBatchNormalization(function_node.FunctionNode):
 
+    inv_std = None
     inv_var = None
 
     def __init__(self, eps=2e-5):
@@ -301,12 +302,6 @@ class FixedBatchNormalization(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         x, gamma, mean, var = self.get_retained_inputs()
-
-        if not hasattr(self, 'inv_std'):
-            xp = cuda.get_array_module(x)
-            self.inv_var = xp.reciprocal(var.data + self.eps)
-            self.inv_std = xp.sqrt(self.inv_var, dtype=self.inv_var.dtype)
-
         gy, = grad_outputs
         f = FixedBatchNormalizationGrad(
             self.eps, self.expander, self.axis, self.inv_std, self.inv_var)
@@ -319,7 +314,7 @@ class FixedBatchNormalizationGrad(function.Function):
         self.eps = eps
         self.expander = expander
         self.axis = axis
-        self.inv_std = inv_std
+        self.inv_std = inv_std  # may be None
         self.inv_var = inv_var  # may be None
 
     def forward(self, inputs):
@@ -328,8 +323,10 @@ class FixedBatchNormalizationGrad(function.Function):
         expander = self.expander
         xp = cuda.get_array_module(x)
 
-        if self.inv_var is None:
-            self.inv_var = xp.square(self.inv_std)
+        if self.inv_std is None or self.inv_var is None:
+            self.inv_var = xp.reciprocal(var.data + self.eps)
+            self.inv_std = xp.sqrt(self.inv_var, dtype=self.inv_var.dtype)
+
         self.gamma_over_std = gamma * self.inv_std
         x_hat = _x_hat(x, mean[expander], self.inv_std[expander])
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -165,7 +165,7 @@ class TestBatchNormalization(unittest.TestCase):
 
 
 @testing.parameterize(*(testing.product({
-    'param_shape': [(3, 4), (3, 2, 3)],
+    'param_shape': [(3,), (3, 4), (3, 2, 3)],
     'ndim': [0, 1, 2],
     'dtype': [numpy.float32],
 }) + testing.product({


### PR DESCRIPTION
If we can use cudnn, the code below raises AttributeError because of missing inv_std.
```
import chainer
import numpy as np
X = np.random.uniform(0, 1, (1, 1))
gamma, beta = np.ones(1), np.zeros(1)
mean, var = np.mean(X, axis=0), np.var(X, axis=0)
X, gamma, beta, mean, var = [chainer.cuda.to_gpu(e, 0) for e in [X, gamma, beta, mean, var]]
X, gamma, beta = [chainer.Variable(e) for e in [X, gamma, beta]]
y = chainer.functions.fixed_batch_normalization(X, gamma, beta, mean, var)
num = chainer.functions.sum(y)
num.backward()
# AttributeError: 'FixedBatchNormalization' object has no attribute 'inv_std'
```

The test of fixed_batch_normalization can not detect the error because `param_shape` used in the test does not make `can_use_cudnn` true in forward computation.

Therefore, I added a shape to the test and fixed it.