### PR TITLE
Remove the unnecessary reshape between AveragePooling and Linear layers in predefined ResNets

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -602,7 +602,6 @@ class BottleneckB(link.Chain):
 def _global_average_pooling_2d(x):
     n, channel, rows, cols = x.data.shape
     h = average_pooling_2d(x, (rows, cols), stride=1)
-    h = reshape(h, (n, channel))
     return h
 
 


### PR DESCRIPTION
Hi.
In `chainer.links.ResNetXXLayers`, there is a `Reshape` layer right before calling `LinearFunction`, which reshapes a tensor shaped `(1, 2048, 1, 1)` that is produced by `AveragePooling2D` into `(1, 2048)`.
However such a process is already done internally in `Linear` layer (see [here](https://github.com/chainer/chainer/blob/master/chainer/functions/connection/linear.py#L111)) so this `Reshape` is completely redundant.
In this PR I just removed the Reshape layer.
I haven't written any tests as this PR doesn't change any input/output behavior but if necessary please let me know I'll try.