### PR TITLE
[backport] inv_std is missing in backward of FixedBatchNormalization if it use cudnn

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -231,6 +231,7 @@ class BatchNormalizationGrad(function.Function):
 
 class FixedBatchNormalization(function_node.FunctionNode):
 
+    inv_std = None
     inv_var = None
 
     def __init__(self, eps=2e-5):
@@ -313,7 +314,7 @@ class FixedBatchNormalizationGrad(function.Function):
         self.eps = eps
         self.expander = expander
         self.axis = axis
-        self.inv_std = inv_std
+        self.inv_std = inv_std  # may be None
         self.inv_var = inv_var  # may be None
 
     def forward(self, inputs):
@@ -322,8 +323,10 @@ class FixedBatchNormalizationGrad(function.Function):
         expander = self.expander
         xp = cuda.get_array_module(x)
 
-        if self.inv_var is None:
-            self.inv_var = xp.square(self.inv_std)
+        if self.inv_std is None or self.inv_var is None:
+            self.inv_var = xp.reciprocal(var + self.eps)
+            self.inv_std = xp.sqrt(self.inv_var, dtype=self.inv_var.dtype)
+
         self.gamma_over_std = gamma * self.inv_std
         x_hat = _x_hat(x, mean[expander], self.inv_std[expander])
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -165,7 +165,7 @@ class TestBatchNormalization(unittest.TestCase):
 
 
 @testing.parameterize(*(testing.product({
-    'param_shape': [(3, 4), (3, 2, 3)],
+    'param_shape': [(3,), (3, 4), (3, 2, 3)],
     'ndim': [0, 1, 2],
     'dtype': [numpy.float32],
 }) + testing.product({


### PR DESCRIPTION
This is a backport of #3468.