### PR TITLE
Add CUDAProfileHook and CupyMemoryProfileHook to the reference

### DIFF
--- a/docs/source/reference/function_hooks.rst
+++ b/docs/source/reference/function_hooks.rst
@@ -22,5 +22,7 @@ Concrete function hooks
    :toctree: generated/
    :nosignatures:
 
+   chainer.function_hooks.CUDAProfileHook
+   chainer.function_hooks.CupyMemoryProfileHook
    chainer.function_hooks.PrintHook
    chainer.function_hooks.TimerHook


### PR DESCRIPTION
`function_hooks.CUDAProfileHook` and `function_hooks.CupyMemoryProfileHook` are very useful features but missing in the reference manual.
