### PR TITLE
Enable optimizer model setup with instantiation

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -478,10 +478,9 @@ class GradientMethod(Optimizer):
 
     """
 
-    def __init__(self, *args):
+    def __init__(self, link):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
-        link = (args or [None])[0]
         if isinstance(link, link_module.Link):
             self.setup(link)
 

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -478,7 +478,7 @@ class GradientMethod(Optimizer):
 
     """
 
-    def __init__(self, link):
+    def __init__(self, link=None):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
         if isinstance(link, link_module.Link):

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -478,9 +478,12 @@ class GradientMethod(Optimizer):
 
     """
 
-    def __init__(self):
+    def __init__(self, *args):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
+        link = (args or [None])[0]
+        if isinstance(link, link_module.Link):
+            self.setup(link)
 
     def setup(self, link):
         super(GradientMethod, self).setup(link)

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -83,9 +83,9 @@ class AdaDelta(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, rho=_default_hyperparam.rho,
+    def __init__(self, *args, rho=_default_hyperparam.rho,
                  eps=_default_hyperparam.eps):
-        super(AdaDelta, self).__init__()
+        super(AdaDelta, self).__init__(*args)
         self.hyperparam.rho = rho
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -83,9 +83,9 @@ class AdaDelta(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, rho=_default_hyperparam.rho,
-                 eps=_default_hyperparam.eps):
-        super(AdaDelta, self).__init__(*args)
+    def __init__(self, rho=_default_hyperparam.rho,
+                 eps=_default_hyperparam.eps, model=None):
+        super(AdaDelta, self).__init__(model)
         self.hyperparam.rho = rho
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -74,9 +74,9 @@ class AdaGrad(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr,
-                 eps=_default_hyperparam.eps):
-        super(AdaGrad, self).__init__(*args)
+    def __init__(self, lr=_default_hyperparam.lr,
+                 eps=_default_hyperparam.eps, model=None):
+        super(AdaGrad, self).__init__(model)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -74,7 +74,8 @@ class AdaGrad(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+    def __init__(self, *args, lr=_default_hyperparam.lr,
+                 eps=_default_hyperparam.eps):
         super(AdaGrad, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -74,8 +74,8 @@ class AdaGrad(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
-        super(AdaGrad, self).__init__()
+    def __init__(self, *args, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+        super(AdaGrad, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -95,12 +95,13 @@ class Adam(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args,
+    def __init__(self,
                  alpha=_default_hyperparam.alpha,
                  beta1=_default_hyperparam.beta1,
                  beta2=_default_hyperparam.beta2,
-                 eps=_default_hyperparam.eps):
-        super(Adam, self).__init__(*args)
+                 eps=_default_hyperparam.eps,
+                 model=None):
+        super(Adam, self).__init__(model)
         self.hyperparam.alpha = alpha
         self.hyperparam.beta1 = beta1
         self.hyperparam.beta2 = beta2

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -95,12 +95,12 @@ class Adam(optimizer.GradientMethod):
 
     """
 
-    def __init__(self,
+    def __init__(self, *args,
                  alpha=_default_hyperparam.alpha,
                  beta1=_default_hyperparam.beta1,
                  beta2=_default_hyperparam.beta2,
                  eps=_default_hyperparam.eps):
-        super(Adam, self).__init__()
+        super(Adam, self).__init__(*args)
         self.hyperparam.alpha = alpha
         self.hyperparam.beta1 = beta1
         self.hyperparam.beta2 = beta2

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -68,9 +68,9 @@ class MomentumSGD(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr,
-                 momentum=_default_hyperparam.momentum):
-        super(MomentumSGD, self).__init__(*args)
+    def __init__(self, lr=_default_hyperparam.lr,
+                 momentum=_default_hyperparam.momentum, model=None):
+        super(MomentumSGD, self).__init__(model)
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -68,9 +68,9 @@ class MomentumSGD(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr,
+    def __init__(self, *args, lr=_default_hyperparam.lr,
                  momentum=_default_hyperparam.momentum):
-        super(MomentumSGD, self).__init__()
+        super(MomentumSGD, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -75,9 +75,9 @@ class NesterovAG(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr,
+    def __init__(self, *args, lr=_default_hyperparam.lr,
                  momentum=_default_hyperparam.momentum):
-        super(NesterovAG, self).__init__()
+        super(NesterovAG, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -75,9 +75,9 @@ class NesterovAG(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr,
-                 momentum=_default_hyperparam.momentum):
-        super(NesterovAG, self).__init__(*args)
+    def __init__(self, lr=_default_hyperparam.lr,
+                 momentum=_default_hyperparam.momentum, model=None):
+        super(NesterovAG, self).__init__(model)
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -79,9 +79,10 @@ class RMSprop(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr,
-                 alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps):
-        super(RMSprop, self).__init__(*args)
+    def __init__(self, lr=_default_hyperparam.lr,
+                 alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps,
+                 model=None):
+        super(RMSprop, self).__init__(model)
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.eps = eps

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -79,9 +79,9 @@ class RMSprop(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr,
+    def __init__(self, *args, lr=_default_hyperparam.lr,
                  alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps):
-        super(RMSprop, self).__init__()
+        super(RMSprop, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.eps = eps

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -99,11 +99,12 @@ class RMSpropGraves(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr,
+    def __init__(self, lr=_default_hyperparam.lr,
                  alpha=_default_hyperparam.alpha,
                  momentum=_default_hyperparam.momentum,
-                 eps=_default_hyperparam.eps):
-        super(RMSpropGraves, self).__init__(*args)
+                 eps=_default_hyperparam.eps,
+                 model=None):
+        super(RMSpropGraves, self).__init__(model)
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.momentum = momentum

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -99,11 +99,11 @@ class RMSpropGraves(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr,
+    def __init__(self, *args, lr=_default_hyperparam.lr,
                  alpha=_default_hyperparam.alpha,
                  momentum=_default_hyperparam.momentum,
                  eps=_default_hyperparam.eps):
-        super(RMSpropGraves, self).__init__()
+        super(RMSpropGraves, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.momentum = momentum

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -50,8 +50,8 @@ class SGD(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr):
-        super(SGD, self).__init__(*args)
+    def __init__(self, lr=_default_hyperparam.lr, model=None):
+        super(SGD, self).__init__(model)
         self.hyperparam.lr = lr
 
     lr = optimizer.HyperparameterProxy('lr')

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -50,8 +50,8 @@ class SGD(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr):
-        super(SGD, self).__init__()
+    def __init__(self, *args, lr=_default_hyperparam.lr):
+        super(SGD, self).__init__(*args)
         self.hyperparam.lr = lr
 
     lr = optimizer.HyperparameterProxy('lr')

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -87,9 +87,9 @@ class SMORMS3(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr,
-                 eps=_default_hyperparam.eps):
-        super(SMORMS3, self).__init__(*args)
+    def __init__(self, lr=_default_hyperparam.lr,
+                 eps=_default_hyperparam.eps, model=None):
+        super(SMORMS3, self).__init__(model)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -87,8 +87,8 @@ class SMORMS3(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
-        super(SMORMS3, self).__init__()
+    def __init__(self, *args, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+        super(SMORMS3, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -87,7 +87,8 @@ class SMORMS3(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, *args, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+    def __init__(self, *args, lr=_default_hyperparam.lr,
+                 eps=_default_hyperparam.eps):
         super(SMORMS3, self).__init__(*args)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps


### PR DESCRIPTION
Code to close issue #3211 .

Allow models to be passed as an argument to an optimizer, so
```
optimizer = chainer.optimizers.SGD()
optimizer.setup(model)
```
becomes:
```
optimizer = chainer.optimizers.SGD(model)
```

Change added to all `optimizers`. Old two-line method also still valid.

Tested by running new one-line method and old method on SGD, then running new method on all `optimizers` after changing code.
