### PR TITLE
Add a stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 30
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - bug
+# Label to use when marking as stale
+staleLabel: stale
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed after 30 days if no further activity occurs.
+  Thank you for your contributions.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: >
+  This issue is closed as announced. Feel free to re-open it if needed.
+# Limit to only `issues` or `pulls`
+# only: issues


### PR DESCRIPTION
This PR adds a configuration of the stale bot: https://github.com/probot/stale. The numbers of `daysUntilStale` and `daysUntilClose` are borrowed from the configuration used at https://github.com/fchollet/keras. We can change the numbers if they are not suited to our case; feel free to propose other numbers.