### PR TITLE
`FunctionTestCase` for function tests

### DIFF
--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -38,6 +38,17 @@ class Device(object):
         raise NotImplementedError(
             'Device implementation must override this property.')
 
+    @property
+    def supported_array_types(self):
+        """Array types supported by the device.
+
+        Returns:
+            tuple of array types which the device's module functions can
+            handle.
+        """
+        raise NotImplementedError(
+            'Device implementation must override this property.')
+
     def __enter__(self):
         raise RuntimeError(
             'Device class does not support runtime context using `with` '

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -21,6 +21,10 @@ class ChainerxDevice(_backend.Device):
     def xp(self):
         return chainerx
 
+    @property
+    def supported_array_types(self):
+        return (chainerx.ndarray,)
+
     @staticmethod
     def from_array(array):
         if isinstance(array, chainerx.ndarray) and array.device is not None:
@@ -122,6 +126,11 @@ def _array_to_chainerx(array, device=None):
 
     if array is None:
         return None
+
+    if array.dtype not in chainerx.all_dtypes:
+        raise TypeError(
+            'Dtype {} is not supported in ChainerX.'.format(array.dtype.name))
+
     if isinstance(array, chainerx.ndarray):
         if device is None:
             return array

--- a/chainer/backends/_cpu.py
+++ b/chainer/backends/_cpu.py
@@ -14,6 +14,10 @@ class CpuDevice(_backend.Device):
     def xp(self):
         return numpy
 
+    @property
+    def supported_array_types(self):
+        return (numpy.ndarray,)
+
     @staticmethod
     def from_array(array):
         if isinstance(array, numpy.ndarray):

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -232,6 +232,10 @@ class GpuDevice(_backend.Device):
     def xp(self):
         return cupy
 
+    @property
+    def supported_array_types(self):
+        return (ndarray,)
+
     def create_context(self):
         # Creates a new cuda.Device instance because a single cuda.Device
         # instance cannot be used across threads.

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -35,6 +35,10 @@ class Intel64Device(_backend.Device):
     def xp(self):
         return numpy
 
+    @property
+    def supported_array_types(self):
+        return (numpy.ndarray, mdarray)
+
     @staticmethod
     def from_array(array):
         if isinstance(array, mdarray):

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -79,8 +79,9 @@ class ClippedReLUGrad2(function_node.FunctionNode):
 
     def forward_cpu(self, inputs):
         gy, = inputs
+        x = self.x
         return utils.force_array(
-            gy * (0 < self.x) * (self.x < self.cap), self.x.dtype),
+            gy * (0 < x) * (x < self.cap), x.dtype),
 
     def forward_gpu(self, inputs):
         gy, = inputs

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -6,10 +6,12 @@ import six
 
 import chainer
 from chainer import backend
+from chainer.backends import _cpu
 from chainer.backends import cuda
 from chainer import configuration
 from chainer import FunctionNode
 from chainer import testing
+from chainer import utils
 from chainer import variable
 import chainerx
 
@@ -36,15 +38,11 @@ def _ones_like(arr):
 
 
 def _make_outputs_props_in_error_message(outputs, grad_outputs):
-    def format_props(arr):
-        return '{}:{}'.format(arr.shape, arr.dtype.name)
-
     return (
         'Output shapes and dtypes         : {}\n'
         'Output gradient shapes and dtypes: {}'.format(
-            ', '.join(format_props(y) for y in outputs),
-            ', '.join('None' if gy is None else format_props(gy)
-                      for gy in grad_outputs)))
+            utils._format_array_props(outputs),
+            utils._format_array_props(grad_outputs)))
 
 
 def _check_outputs_and_grad_outputs(outputs, grad_outputs):
@@ -115,6 +113,12 @@ def numerical_grad(
         tuple: Numerical gradient arrays corresponding to ``inputs``.
 
     """
+    # TODO(niboshi): Deprecate `center_outputs` argument.
+    # If dtype of this argument is not float64, often the resolution is
+    # insufficient for numerical gradient calculation. We might use it only
+    # when its dtype is float64, but it would be better to simply remove it.
+    center_outputs = None
+
     assert eps > 0
     assert isinstance(inputs, (tuple, list))
     for x in inputs:
@@ -123,13 +127,19 @@ def numerical_grad(
                 'The dtype of input arrays must be kind of float')
 
     inputs = tuple(inputs)
-    grad_outputs = tuple(grad_outputs)
+    # Cast grad_outputs to float64
+    grad_outputs = tuple([
+        None if g is None
+        else numpy.float64(g) if numpy.isscalar(g)
+        else g.astype(numpy.float64)
+        for g in grad_outputs])
 
     if not chainer.is_arrays_compatible(
             [a for a in inputs + grad_outputs if not numpy.isscalar(a)]):
         raise RuntimeError('Do not mix GPU and CPU arrays in `numerical_grad`')
 
-    xp = backend.get_array_module(*(inputs + grad_outputs))
+    device = backend.get_device_from_array(*(inputs + grad_outputs))
+    xp = device.xp
 
     if xp is cuda.cupy:
         numerical_grad_kernel_1 = cuda.reduce(
@@ -222,7 +232,7 @@ def numerical_grad(
                     s.write('y[x+eps  ]: {}\n'.format(yss[4][i_out]))
                     raise NondifferentiableError(s.getvalue())
 
-                any_nonfinite |= not all(_.all() for _ in isfinites)
+                any_nonfinite |= not all((_).all() for _ in isfinites)
 
             if not any_nonfinite:
                 # Stack flattened outputs to make (5, *)-shaped 2D array
@@ -230,13 +240,13 @@ def numerical_grad(
                     [xp.hstack([y.ravel() for y in ys]) for ys in yss])
                 assert ystack.ndim == 2 and ystack.shape[0] == len(yss)
                 # Fit to quadratic
-                if xp is cuda.cupy:
-                    ystack = ystack.get()
+                if xp is not numpy:
+                    ystack = _cpu._to_cpu(ystack)
                 polyfit = numpy.polynomial.polynomial.polyfit
                 _, (residuals, _, _, _) = polyfit(
                     range(len(yss)), ystack, deg=2, full=True)
-                if xp is cuda.cupy:
-                    residuals = xp.array(residuals)
+                if xp is not numpy:
+                    residuals = device.send(residuals)
                 residuals = xp.sqrt(residuals / len(yss))
 
                 # Check for error for each output array
@@ -254,7 +264,7 @@ def numerical_grad(
                     # Restore the shape of flattened residual
                     res = residuals[cumsize - size:cumsize]
                     res = res.reshape(shape)
-                    det = xp.asarray(
+                    det = utils.force_array(
                         diff_atol + diff_rtol * (ymax - ymin) < res)
                     # Constant output = not nondifferentiable
                     det[ymax == ymin] = False
@@ -538,6 +548,7 @@ class _CheckBackward(object):
             [None if gy is None
              # Copy is needed to avoid being updated during backprop, which
              # would affect the numerical gradient.
+             # TODO(niboshi): Preserve strides, for testing purpose.
              else chainer.Variable(gy.copy(), requires_grad=False)
              for gy in self.y_grad])
 
@@ -640,7 +651,7 @@ class _CheckBackward(object):
         gx, = numerical_grad(
             g, (delta,), y_grad, eps=eps,
             detect_nondifferentiable=detect_nondifferentiable,
-            center_outputs=y0_data)
+            center_outputs=y0_data, diff_atol=0, diff_rtol=self.rtol)
 
         return gx
 

--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -2,7 +2,7 @@ from chainer.testing.array import assert_allclose  # NOQA
 from chainer.testing.backend import BackendConfig  # NOQA
 from chainer.testing.backend import inject_backend_tests  # NOQA
 from chainer.testing.distribution_test import distribution_unittest  # NOQA
-from chainer.testing.function import function_test  # NOQA
+from chainer.testing.function import FunctionTestCase  # NOQA
 from chainer.testing.function import FunctionTestError  # NOQA
 from chainer.testing.helper import assert_warns  # NOQA
 from chainer.testing.helper import patch  # NOQA

--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -2,6 +2,8 @@ from chainer.testing.array import assert_allclose  # NOQA
 from chainer.testing.backend import BackendConfig  # NOQA
 from chainer.testing.backend import inject_backend_tests  # NOQA
 from chainer.testing.distribution_test import distribution_unittest  # NOQA
+from chainer.testing.function import function_test  # NOQA
+from chainer.testing.function import FunctionTestError  # NOQA
 from chainer.testing.helper import assert_warns  # NOQA
 from chainer.testing.helper import patch  # NOQA
 from chainer.testing.helper import with_requires  # NOQA

--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -77,11 +77,11 @@ def _as_noncontiguous_array(array):
 
         device = backend.get_device_from_array(a)
         xp = device.xp
+        slices = (slice(None, None, 2),) * a.ndim
         with chainer.using_device(device):
-            ret = xp.empty(
-                (a.shape[0] * 2,) + a.shape[1:], dtype=a.dtype)
-        ret[::2] = a
-        ret = ret[::2]
+            ret = xp.empty(tuple([s * 2 for s in a.shape]), dtype=a.dtype)
+            ret[slices] = a
+            ret = ret[slices]
         if device.xp is chainerx:
             assert not ret.is_contiguous
         else:

--- a/chainer/testing/function.py
+++ b/chainer/testing/function.py
@@ -33,57 +33,57 @@ class FunctionTestError(AssertionError):
 
 
 class FunctionTestCase(unittest.TestCase):
-    """A decorator to generate function tests.
+    """A base class for function test cases.
 
-    This decorator can be applied to a base :class:`unittest.TestCase` class
-    to define a set of function tests in the class.
+    Function test cases can inherit from this class to define a set of function
+    tests.
 
     .. rubric:: Required methods
 
-    The base class must at least implement the following three methods.
+    Each concrete class must at least override the following three methods.
 
-    ``forward(inputs, device)``
+    ``forward(self, inputs, device)``
         Implements the target forward function.
         ``inputs`` is a tuple of :class:`~chainer.Variable`\\ s.
         This method is expected to return the output
         :class:`~chainer.Variable`\\ s with the same array types as the inputs.
         ``device`` is the device corresponding to the input arrays.
 
-    ``forward_expected(inputs)``
+    ``forward_expected(self, inputs)``
         Implements the expectation of the target forward function.
         ``inputs`` is a tuple of :class:`numpy.ndarray`\\ s.
         This method is expected to return the output
         :class:`numpy.ndarray`\\ s.
 
-    ``generate_inputs()``
+    ``generate_inputs(self)``
         Returns a tuple of input arrays of type :class:`numpy.ndarray`.
 
     .. rubric:: Optional methods
 
-    Additionally the base class can implement the following methods.
+    Additionally the concrete class can override the following methods.
 
-    ``before_test(test_name)``
+    ``before_test(self, test_name)``
         A callback method called before each test.
         Typically a skip logic is implemented by conditionally raising
         :class:`unittest.SkipTest`.
         ``test_name`` is one of ``'test_forward'``, ``'test_backward'``, and
         ``'test_double_backward'``.
 
-    ``generate_grad_outputs(outputs_template)``
+    ``generate_grad_outputs(self, outputs_template)``
         Returns a tuple of output gradient arrays of type
         :class:`numpy.ndarray`.
         ``outputs_template`` is a tuple of template arrays. The returned arrays
         are expected to have the same shapes and dtypes as the template arrays.
 
-    ``generate_grad_grad_inputs(inputs_template)``
+    ``generate_grad_grad_inputs(self, inputs_template)``
         Returns a tuple of the second order input gradient arrays of type
         :class:`numpy.ndarray`.
         ``input_template`` is a tuple of template arrays. The returned arrays
         are expected to have the same shapes and dtypes as the template arrays.
 
-    .. rubric:: Class attributes
+    .. rubric:: Attributes
 
-    The base class can define the following class attributes to control the
+    The concrete class can override the following attributes to control the
     behavior of the tests.
 
     ``forward_test`` (bool):
@@ -110,7 +110,7 @@ class FunctionTestCase(unittest.TestCase):
 
     .. note::
 
-       This decorator assumes :func:`chainer.testing.inject_backend_tests`
+       This class assumes :func:`chainer.testing.inject_backend_tests`
        is used together. See the example below.
 
     .. admonition:: Example
@@ -123,8 +123,7 @@ class FunctionTestCase(unittest.TestCase):
                   {},  # CPU
                   {'use_cuda': True},  # GPU
               ])
-          @chainer.testing.function_test()
-          class TestReLU(unittest.TestCase):
+          class TestReLU(chainer.testing.FunctionTestCase):
 
               # ReLU function has a non-differentiable point around zero, so
               # dodge_nondifferentiable should be set to True.

--- a/chainer/testing/function.py
+++ b/chainer/testing/function.py
@@ -86,14 +86,14 @@ class FunctionTestCase(unittest.TestCase):
     The concrete class can override the following attributes to control the
     behavior of the tests.
 
-    ``forward_test`` (bool):
-        Whether to test forward computation. ``True`` by default.
+    ``skip_forward_test`` (bool):
+        Whether to skip forward computation test. ``False`` by default.
 
-    ``backward_test`` (bool):
-        Whether to test backward computation. ``True`` by default.
+    ``skip_backward_test`` (bool):
+        Whether to skip backward computation test. ``False`` by default.
 
-    ``double_backward_test`` (bool):
-        Whether to test double-backward computation. ``True`` by default.
+    ``skip_double_backward_test`` (bool):
+        Whether to skip double-backward computation test. ``False`` by default.
 
     ``dodge_nondifferentiable`` (bool):
         Enable non-differentiable point detection in numerical gradient
@@ -148,9 +148,9 @@ class FunctionTestCase(unittest.TestCase):
     check_forward_options = {}
     check_backward_options = {}
     check_double_backward_options = {}
-    forward_test = True
-    backward_test = True
-    double_backward_test = True
+    skip_forward_test = False
+    skip_backward_test = False
+    skip_double_backward_test = False
     dodge_nondifferentiable = False
     contiguous = None
 
@@ -220,6 +220,9 @@ class FunctionTestCase(unittest.TestCase):
     def test_forward(self, backend_config):
         """Tests forward computation."""
 
+        if self.skip_forward_test:
+            raise unittest.SkipTest()
+
         self.backend_config = backend_config
         self.before_test('test_forward')
 
@@ -261,6 +264,9 @@ class FunctionTestCase(unittest.TestCase):
     def test_backward(self, backend_config):
         """Tests backward computation."""
 
+        if self.skip_backward_test:
+            raise unittest.SkipTest()
+
         # avoid cyclic import
         from chainer import gradient_check
 
@@ -300,6 +306,10 @@ class FunctionTestCase(unittest.TestCase):
 
     def test_double_backward(self, backend_config):
         """Tests double-backward computation."""
+
+        if self.skip_double_backward_test:
+            raise unittest.SkipTest()
+
         # avoid cyclic import
         from chainer import gradient_check
 

--- a/chainer/testing/function.py
+++ b/chainer/testing/function.py
@@ -1,0 +1,514 @@
+import contextlib
+import os
+
+import numpy
+
+import chainer
+from chainer import backend
+from chainer.testing import array as array_module
+from chainer.testing import condition
+from chainer import utils
+
+
+class FunctionTestError(AssertionError):
+    """Raised when the target function is implemented incorrectly."""
+
+    @staticmethod
+    def check(expr, message):
+        if not expr:
+            raise FunctionTestError(message)
+
+    @staticmethod
+    def fail(message, exc=None):
+        if exc is not None:
+            utils._raise_from(FunctionTestError, message, exc)
+        raise FunctionTestError(message)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def raise_if_fail(message, error_types=AssertionError):
+        try:
+            yield
+        except error_types as e:
+            FunctionTestError.fail(message, e)
+
+
+def function_test():
+    """A decorator to generate function tests.
+
+    This decorator can be applied to a base :class:`unittest.TestCase` class
+    to define a set of function tests in the class.
+
+    .. rubric:: Required methods
+
+    The base class must at least implement the following three methods.
+
+    ``forward(inputs, device)``
+        Implements the target forward function.
+        ``inputs`` is a tuple of :class:`~chainer.Variable`\\ s.
+        This method is expected to return the output
+        :class:`~chainer.Variable`\\ s with the same array types as the inputs.
+        ``device`` is the device corresponding to the input arrays.
+
+    ``forward_expected(inputs)``
+        Implements the expectation of the target forward function.
+        ``inputs`` is a tuple of :class:`numpy.ndarray`\\ s.
+        This method is expected to return the output
+        :class:`numpy.ndarray`\\ s.
+
+    ``generate_inputs()``
+        Returns a tuple of input arrays of type :class:`numpy.ndarray`.
+
+    .. rubric:: Optional methods
+
+    Additionally the base class can implement the following methods.
+
+    ``before_test(test_name)``
+        A callback method called before each test.
+        Typically a skip logic is implemented by conditionally raising
+        :class:`unittest.SkipTest`.
+        ``test_name`` is one of ``'test_forward'``, ``'test_backward'``, and
+        ``'test_double_backward'``.
+
+    ``generate_grad_outputs(outputs_template)``
+        Returns a tuple of output gradient arrays of type
+        :class:`numpy.ndarray`.
+        ``outputs_template`` is a tuple of template arrays. The returned arrays
+        are expected to have the same shapes and dtypes as the template arrays.
+
+    ``generate_grad_grad_inputs(inputs_template)``
+        Returns a tuple of the second order input gradient arrays of type
+        :class:`numpy.ndarray`.
+        ``input_template`` is a tuple of template arrays. The returned arrays
+        are expected to have the same shapes and dtypes as the template arrays.
+
+    .. rubric:: Class attributes
+
+    The base class can define the following class attributes to control the
+    behavior of the tests.
+
+    ``forward_test`` (bool):
+        Whether to test forward computation. ``True`` by default.
+
+    ``backward_test`` (bool):
+        Whether to test backward computation. ``True`` by default.
+
+    ``double_backward_test`` (bool):
+        Whether to test double-backward computation. ``True`` by default.
+
+    ``dodge_nondifferentiable`` (bool):
+        Enable non-differentiable point detection in numerical gradient
+        calculation. If the inputs returned by ``generate_inputs`` turns
+        out to be a non-differentiable point, the test will repeatedly resample
+        inputs until a differentiable point will be finally sampled.
+        ``False`` by default.
+
+    ``contiguous`` (None or 'C'):
+        Specifies the contiguousness of incoming arrays (i.e. inputs, output
+        gradients, and the second order input gradients). If ``None``, the
+        arrays will be non-contiguous as long as possible. If ``'C'``, the
+        arrays will be C-contiguous. ``None`` by default.
+
+    .. note::
+
+       This decorator assumes :func:`chainer.testing.inject_backend_tests`
+       is used together. See the example below.
+
+    .. admonition:: Example
+
+       .. testcode::
+
+          @chainer.testing.inject_backend_tests(
+              None,
+              [
+                  {},  # CPU
+                  {'use_cuda': True},  # GPU
+              ])
+          @chainer.testing.function_test()
+          class TestReLU(unittest.TestCase):
+
+              # ReLU function has a non-differentiable point around zero, so
+              # dodge_nondifferentiable should be set to True.
+              dodge_nondifferentiable = True
+
+              def generate_inputs(self):
+                  x = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
+                  return x,
+
+              def forward(self, inputs, device):
+                  x, = inputs
+                  return F.relu(x),
+
+              def forward_expected(self, inputs):
+                  x, = inputs
+                  expected = x.copy()
+                  expected[expected < 0] = 0
+                  return expected,
+    """
+
+    def wrap(cls):
+        # Assign class attributes
+        attrs = [
+            ('forward_test', True),
+            ('backward_test', True),
+            ('double_backward_test', True),
+            ('dodge_nondifferentiable', False),
+            ('contiguous', None),
+        ]
+        for attr_name, default_value in attrs:
+            if not hasattr(cls, attr_name):
+                setattr(cls, attr_name, default_value)
+
+        # Replace __init__
+        cls.__init__ = _FunctionTestTemplate.__dict__['__init__']
+
+        # Enumerate member methods to copy
+        method_names = []
+        for memb_name in dir(_FunctionTestTemplate):
+            obj = getattr(_FunctionTestTemplate, memb_name)
+            if not hasattr(obj, '_copy_to_test_case'):
+                continue
+            enable_attr_name, = obj._copy_to_test_case
+            if (enable_attr_name is not None
+                    and not getattr(cls, enable_attr_name)):
+                continue
+            method_names.append(memb_name)
+
+        # Copy member methods
+        for method_name in method_names:
+            if hasattr(cls, method_name):
+                # Copy only if it's not defined in the concrete class
+                continue
+            setattr(
+                cls,
+                method_name,
+                _FunctionTestTemplate.__dict__[method_name])
+
+        # Configure test repeat count
+        repeat_tests = [
+            # (test method name, environment variable)
+            ('test_forward', 'CHAINER_TEST_FORWARD_REPEAT'),
+            ('test_backward', 'CHAINER_TEST_BACKWARD_REPEAT'),
+            ('test_double_backward', 'CHAINER_TEST_DOUBLE_BACKWARD_REPEAT'),
+        ]
+        for method_name, repeat_var_name in repeat_tests:
+            if not hasattr(cls, method_name):
+                continue
+            rep = int(os.environ.get(repeat_var_name, 1))
+            if rep != 1:
+                rep_method = condition.repeat(rep)(getattr(cls, method_name))
+                setattr(cls, method_name, rep_method)
+
+        cls._func_template_wrapped_class = cls
+        return cls
+
+    return wrap
+
+
+def _copy_to_test_case(enable_attr_name=None):
+    # Mark a method with this decorator to make it transferred to the concrete
+    # test case class. If `enable_attr_name` is given, the transfer is skipped
+    # if the class has this attribute and its value is False.
+    def wrap(meth):
+        meth._copy_to_test_case = (enable_attr_name,)
+        return meth
+    return wrap
+
+
+def _check_array_types(arrays, device, func_name):
+    if not isinstance(arrays, tuple):
+        raise TypeError(
+            '`{}()` must return a tuple, '
+            'not {}.'.format(func_name, type(arrays)))
+    if not all(isinstance(a, device.supported_array_types) for a in arrays):
+        raise TypeError(
+            '{}() must return a tuple of arrays supported by device {}.\n'
+            'Actual: {}'.format(
+                func_name, device, tuple([type(a) for a in arrays])))
+
+
+def _check_variable_types(vars, device, func_name):
+    if not isinstance(vars, tuple):
+        FunctionTestError.fail(
+            '`{}()` must return a tuple, '
+            'not {}.'.format(func_name, type(vars)))
+    if not all(isinstance(a, chainer.Variable) for a in vars):
+        FunctionTestError.fail(
+            '{}() must return a tuple of Variables.\n'
+            'Actual: {}'.format(
+                func_name, ', '.join(str(type(a)) for a in vars)))
+    if not all(isinstance(a.array, device.supported_array_types)
+               for a in vars):
+        FunctionTestError.fail(
+            '{}() must return a tuple of Variables of arrays supported by '
+            'device {}.\n'
+            'Actual: {}'.format(
+                func_name, device, ', '.join(type(a.array) for a in vars)))
+
+
+def _check_forward_output_arrays_equal(
+        expected_arrays, actual_arrays, func_name, **opts):
+    # `opts` is passed through to `testing.assert_all_close`.
+    # Check all outputs are equal to expected values
+    message = None
+    while True:
+        # Check number of arrays
+        if len(expected_arrays) != len(actual_arrays):
+            message = (
+                'Number of outputs of forward() ({}, {}) does not '
+                'match'.format(
+                    len(expected_arrays), len(actual_arrays)))
+            break
+
+        # Check dtypes and shapes
+        dtypes_match = all([
+            ye.dtype == y.dtype
+            for ye, y in zip(expected_arrays, actual_arrays)])
+        shapes_match = all([
+            ye.shape == y.shape
+            for ye, y in zip(expected_arrays, actual_arrays)])
+        if not (shapes_match and dtypes_match):
+            message = (
+                'Shapes and/or dtypes of forward() do not match'.format())
+            break
+
+        # Check values
+        indices = []
+        for i, (expected, actual) in (
+                enumerate(zip(expected_arrays, actual_arrays))):
+            try:
+                array_module.assert_allclose(expected, actual, **opts)
+            except AssertionError:
+                indices.append(i)
+        if len(indices) > 0:
+            message = (
+                'Outputs of forward() do not match the expected values.\n'
+                'Indices of outputs that do not match: {}'.format(
+                    ', '.join(str(i) for i in indices)))
+            break
+        break
+
+    if message is not None:
+        FunctionTestError.fail(
+            '{}\n'
+            'Expected shapes and dtypes: {}\n'
+            'Actual shapes and dtypes:   {}\n'.format(
+                message,
+                utils._format_array_props(expected_arrays),
+                utils._format_array_props(actual_arrays)))
+
+
+class _FunctionTestTemplate(object):
+
+    backend_config = None
+
+    def __init__(self, *args, **kwargs):
+        super(
+            self._func_template_wrapped_class, self).__init__(*args, **kwargs)
+        self.check_forward_options = {}
+        self.check_backward_options = {}
+        self.check_double_backward_options = {}
+
+    @_copy_to_test_case()
+    def before_test(self, test_name):
+        pass
+
+    @_copy_to_test_case()
+    def forward(self, inputs, device):
+        raise NotImplementedError('forward() is not implemented.')
+
+    @_copy_to_test_case()
+    def forward_expected(self, inputs):
+        raise NotImplementedError('forward_expected() is not implemented.')
+
+    @_copy_to_test_case()
+    def generate_inputs(self):
+        raise NotImplementedError('generate_inputs() is not implemented.')
+
+    @_copy_to_test_case()
+    def generate_grad_outputs(self, outputs_template):
+        grad_outputs = tuple([
+            numpy.random.uniform(-1, 1, a.shape).astype(a.dtype)
+            for a in outputs_template])
+        return grad_outputs
+
+    @_copy_to_test_case()
+    def generate_grad_grad_inputs(self, inputs_template):
+        grad_grad_inputs = tuple([
+            numpy.random.uniform(-1, 1, a.shape).astype(a.dtype)
+            for a in inputs_template])
+        return grad_grad_inputs
+
+    @_copy_to_test_case()
+    def _to_noncontiguous_as_needed(self, contig_arrays):
+        if self.contiguous is None:
+            # non-contiguous
+            return array_module._as_noncontiguous_array(contig_arrays)
+        if self.contiguous == 'C':
+            # C-contiguous
+            return contig_arrays
+        assert False, (
+            'Invalid value of `contiguous`: {}'.format(self.contiguous))
+
+    @_copy_to_test_case()
+    def _generate_inputs(self):
+        inputs = self.generate_inputs()
+        _check_array_types(inputs, backend.CpuDevice(), 'generate_inputs')
+        return inputs
+
+    @_copy_to_test_case()
+    def _generate_grad_outputs(self, outputs_template):
+        grad_outputs = self.generate_grad_outputs(outputs_template)
+        _check_array_types(
+            grad_outputs, backend.CpuDevice(), 'generate_grad_outputs')
+        return grad_outputs
+
+    @_copy_to_test_case()
+    def _generate_grad_grad_inputs(self, inputs_template):
+        grad_grad_inputs = self.generate_grad_grad_inputs(inputs_template)
+        _check_array_types(
+            grad_grad_inputs, backend.CpuDevice(), 'generate_grad_grad_inputs')
+        return grad_grad_inputs
+
+    @_copy_to_test_case()
+    def _forward_expected(self, inputs):
+        outputs = self.forward_expected(inputs)
+        _check_array_types(outputs, backend.CpuDevice(), 'forward_expected')
+        return outputs
+
+    @_copy_to_test_case()
+    def _forward(self, inputs, backend_config):
+        assert all(isinstance(a, chainer.Variable) for a in inputs)
+        with backend_config:
+            outputs = self.forward(inputs, backend_config.device)
+        _check_variable_types(outputs, backend_config.device, 'forward')
+        return outputs
+
+    @_copy_to_test_case(enable_attr_name='forward_test')
+    def test_forward(self, backend_config):
+        """Tests forward computation."""
+
+        self.backend_config = backend_config
+        self.before_test('test_forward')
+
+        cpu_inputs = self._generate_inputs()
+        inputs_copied = [a.copy() for a in cpu_inputs]
+
+        # Compute expected outputs
+        cpu_expected = self._forward_expected(cpu_inputs)
+        inputs = backend_config.get_array(cpu_inputs)
+        inputs = self._to_noncontiguous_as_needed(inputs)
+
+        # Compute actual outputs
+        outputs = self._forward(
+            tuple([chainer.Variable(a) for a in inputs]),
+            backend_config)
+
+        # Check inputs has not changed
+        indices = []
+        for i in range(len(inputs)):
+            try:
+                array_module.assert_allclose(
+                    inputs_copied[i], inputs[i], atol=0, rtol=0)
+            except AssertionError:
+                indices.append(i)
+
+        if len(indices) > 0:
+            FunctionTestError.fail(
+                'Input arrays have been modified during forward.\n'
+                'Indices of modified inputs: {}\n'
+                'Input array shapes and dtypes: {}\n'.format(
+                    ', '.join(str(i) for i in indices),
+                    utils._format_array_props(inputs)))
+
+        _check_forward_output_arrays_equal(
+            cpu_expected,
+            [var.array for var in outputs],
+            'forward', **self.check_forward_options)
+
+    @_copy_to_test_case(enable_attr_name='backward_test')
+    def test_backward(self, backend_config):
+        """Tests backward computation."""
+
+        # avoid cyclic import
+        from chainer import gradient_check
+
+        self.backend_config = backend_config
+        self.before_test('test_backward')
+
+        def f(*args):
+            return self._forward(args, backend_config)
+
+        def do_check():
+            inputs = self._generate_inputs()
+            outputs = self._forward_expected(inputs)
+            grad_outputs = self._generate_grad_outputs(outputs)
+
+            inputs = backend_config.get_array(inputs)
+            grad_outputs = backend_config.get_array(grad_outputs)
+            inputs = self._to_noncontiguous_as_needed(inputs)
+            grad_outputs = self._to_noncontiguous_as_needed(grad_outputs)
+
+            with FunctionTestError.raise_if_fail(
+                    'backward is not implemented correctly'):
+                gradient_check.check_backward(
+                    f, inputs, grad_outputs, dtype=numpy.float64,
+                    detect_nondifferentiable=self.dodge_nondifferentiable,
+                    **self.check_backward_options)
+
+        if self.dodge_nondifferentiable:
+            while True:
+                try:
+                    do_check()
+                except gradient_check.NondifferentiableError:
+                    continue
+                else:
+                    break
+        else:
+            do_check()
+
+    @_copy_to_test_case(enable_attr_name='double_backward_test')
+    def test_double_backward(self, backend_config):
+        """Tests double-backward computation."""
+        # avoid cyclic import
+        from chainer import gradient_check
+
+        self.backend_config = backend_config
+        self.before_test('test_double_backward')
+
+        def f(*args):
+            return self._forward(args, backend_config)
+
+        def do_check():
+            inputs = self._generate_inputs()
+            outputs = self._forward_expected(inputs)
+            grad_outputs = self._generate_grad_outputs(outputs)
+            grad_grad_inputs = self._generate_grad_grad_inputs(inputs)
+
+            inputs = backend_config.get_array(inputs)
+            grad_outputs = backend_config.get_array(grad_outputs)
+            grad_grad_inputs = backend_config.get_array(grad_grad_inputs)
+            inputs = self._to_noncontiguous_as_needed(inputs)
+            grad_outputs = self._to_noncontiguous_as_needed(grad_outputs)
+            grad_grad_inputs = (
+                self._to_noncontiguous_as_needed(grad_grad_inputs))
+
+            with backend_config:
+                with FunctionTestError.raise_if_fail(
+                        'double backward is not implemented correctly'):
+                    gradient_check.check_double_backward(
+                        f, inputs, grad_outputs, grad_grad_inputs,
+                        dtype=numpy.float64,
+                        detect_nondifferentiable=self.dodge_nondifferentiable,
+                        **self.check_double_backward_options)
+
+        if self.dodge_nondifferentiable:
+            while True:
+                try:
+                    do_check()
+                except gradient_check.NondifferentiableError:
+                    continue
+                else:
+                    break
+        else:
+            do_check()

--- a/chainer/testing/function.py
+++ b/chainer/testing/function.py
@@ -1,4 +1,5 @@
 import contextlib
+import typing as tp  # NOQA
 import unittest
 
 import numpy
@@ -145,9 +146,9 @@ class FunctionTestCase(unittest.TestCase):
     """
 
     backend_config = None
-    check_forward_options = {}
-    check_backward_options = {}
-    check_double_backward_options = {}
+    check_forward_options = {}  # type: tp.Dict[str, tp.Any]
+    check_backward_options = {}  # type: tp.Dict[str, tp.Any]
+    check_double_backward_options = {}  # type: tp.Dict[str, tp.Any]
     skip_forward_test = False
     skip_backward_test = False
     skip_double_backward_test = False

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -1,12 +1,12 @@
 import functools
 import itertools
-import sys
 import types
 import unittest
 
 import six
 
 from chainer.testing import _bundle
+from chainer import utils
 
 
 def _parameterize_test_case_generator(base, params):
@@ -51,14 +51,7 @@ def _parameterize_test_case_generator(base, params):
                     s.write('Test parameters:\n')
                     for k, v in six.iteritems(param):
                         s.write('  {}: {}\n'.format(k, v))
-                    s.write('\n')
-                    s.write('{}: {}\n'.format(type(e).__name__, e))
-                    e_new = AssertionError(s.getvalue())
-                    if sys.version_info < (3,):
-                        six.reraise(AssertionError, e_new, sys.exc_info()[2])
-                    else:
-                        six.raise_from(
-                            e_new.with_traceback(e.__traceback__), None)
+                    utils._raise_from(e.__class__, s.getvalue(), e)
             return new_method
 
         yield (cls_name, mb, method_generator)

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,6 +1,7 @@
 import collections
 import contextlib
 import shutil
+import sys
 import tempfile
 
 import numpy
@@ -12,6 +13,7 @@ from chainer.utils.array import size_of_shape  # NOQA
 from chainer.utils.array import sum_to  # NOQA
 from chainer.utils.conv import get_conv_outsize  # NOQA
 from chainer.utils.conv import get_deconv_outsize  # NOQA
+from chainer.utils.error import _format_array_props  # NOQA
 from chainer.utils.experimental import experimental  # NOQA
 from chainer.utils.sparse import CooMatrix  # NOQA
 from chainer.utils.sparse import get_order  # NOQA
@@ -83,3 +85,16 @@ def _check_arrays_forward_compatible(arrays, label=None):
             'Actual: {}'.format(
                 ' ({})'.format(label) if label is not None else '',
                 ', '.join(str(type(a)) for a in arrays)))
+
+
+def _raise_from(exc_type, message, orig_exc):
+    # Raises an exception that wraps another exception.
+    message = (
+        '{}\n\n'
+        '(caused by)\n'
+        '{}: {}\n'.format(message, type(orig_exc).__name__, orig_exc))
+    new_exc = exc_type(message)
+    if sys.version_info < (3,):
+        six.reraise(exc_type, new_exc, sys.exc_info()[2])
+    else:
+        six.raise_from(new_exc.with_traceback(orig_exc.__traceback__), None)

--- a/chainer/utils/error.py
+++ b/chainer/utils/error.py
@@ -1,8 +1,5 @@
 def _format_array_props(arrays):
     # Formats array shapes and dtypes for error messages.
-    def format_props(arr):
-        return '{}:{}'.format(arr.shape, arr.dtype.name)
-
     return ', '.join([
         None if arr is None
         else '{}:{}'.format(arr.shape, arr.dtype.name)

--- a/chainer/utils/error.py
+++ b/chainer/utils/error.py
@@ -1,0 +1,9 @@
+def _format_array_props(arrays):
+    # Formats array shapes and dtypes for error messages.
+    def format_props(arr):
+        return '{}:{}'.format(arr.shape, arr.dtype.name)
+
+    return ', '.join([
+        None if arr is None
+        else '{}:{}'.format(arr.shape, arr.dtype.name)
+        for arr in arrays])

--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -14,6 +14,7 @@ else:
 
 if _available:
     from numpy import dtype, bool_, int8, int16, int32, int64, uint8, float32, float64  # NOQA
+    all_dtypes = (bool_, int8, int16, int32, int64, uint8, float32, float64)
 
     from chainerx._core import *  # NOQA
 

--- a/docs/source/reference/check.rst
+++ b/docs/source/reference/check.rst
@@ -59,6 +59,7 @@ Utilities for testing functions.
    :toctree: generated/
    :nosignatures:
 
+   chainer.testing.function_test
    chainer.testing.unary_math_function_unittest
 
 Serialization testing utilities
@@ -130,4 +131,5 @@ Decorators for making a unit test parameterized.
    chainer.testing.parameterize
    chainer.testing.product
    chainer.testing.product_dict
+   chainer.testing.inject_backend_tests
    

--- a/docs/source/reference/check.rst
+++ b/docs/source/reference/check.rst
@@ -59,7 +59,6 @@ Utilities for testing functions.
    :toctree: generated/
    :nosignatures:
 
-   chainer.testing.function_test
    chainer.testing.unary_math_function_unittest
 
 Serialization testing utilities

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -28,8 +28,7 @@ from chainer import utils
         {'use_chainerx': True, 'chainerx_device': 'native:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
     ])
-@testing.function_test()
-class TestClippedReLU(unittest.TestCase):
+class TestClippedReLU(testing.FunctionTestCase):
 
     dodge_nondifferentiable = True
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -6,9 +6,9 @@ import numpy
 import chainer
 from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
+from chainer import utils
 
 
 @testing.parameterize(*testing.product({
@@ -16,102 +16,43 @@ from chainer.testing import attr
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @testing.fix_random()
+@testing.inject_backend_tests(
+    None,
+    [
+        # CPU tests
+        {},
+        # GPU tests
+        {'use_cuda': True, 'use_cudnn': 'never'},
+        {'use_cuda': True, 'use_cudnn': 'always'},
+        # ChainerX tests
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+    ])
+@testing.function_test()
 class TestClippedReLU(unittest.TestCase):
 
-    def setUp(self):
+    dodge_nondifferentiable = True
+
+    z = 0.75
+
+    def before_test(self, test_name):
+        # TODO(niboshi): Support it
+        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
+
+    def generate_inputs(self):
         x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        # Avoid values around zero and z for stability of numerical gradient
-        x[((-0.01 < x) & (x < 0.01)) | ((0.74 < x) & (x < 0.76))] = 0.5
-        self.x = x
+        return x,
 
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx = numpy.random.uniform(-1, 1, x.shape).astype(self.dtype)
-        self.z = 0.75
+    def forward(self, inputs, device):
+        x, = inputs
+        y = functions.clipped_relu(x, self.z)
+        return y,
 
-        if self.dtype == numpy.float16:
-            self.check_backward_options = {}
-            self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
-        else:
-            self.check_backward_options = {}
-            self.check_double_backward_options = {}
-
-    def check_forward(self, x_data, use_cudnn='always'):
-        x = chainer.Variable(x_data)
-        with chainer.using_config('use_cudnn', use_cudnn):
-            y = functions.clipped_relu(x, self.z)
-        self.assertEqual(y.data.dtype, self.dtype)
-
-        y_expect = self.x.clip(0, self.z)
-
-        testing.assert_allclose(y_expect, y.data)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    @attr.gpu
-    def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), 'never')
-
-    def check_backward(self, x_data, y_grad, use_cudnn='always'):
-        def f(x):
-            return functions.clipped_relu(x, self.z)
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            gradient_check.check_backward(
-                f, x_data, y_grad, dtype=numpy.float64,
-                **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    @attr.gpu
-    def test_backward_gpu_non_contiguous(self):
-        self.check_backward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
-                            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
-
-    @attr.gpu
-    def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
-
-    def check_double_backward(self, x_data, y_grad, x_grad_grad,
-                              use_cudnn='always'):
-        def f(x):
-            return functions.clipped_relu(x, self.z)
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            gradient_check.check_double_backward(
-                f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
-                **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.gy, self.ggx)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy),
-                                   cuda.to_gpu(self.ggx))
-
-    @attr.gpu
-    def test_double_backward_gpu_non_contiguous(self):
-        self.check_double_backward(
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
-
-    @attr.gpu
-    def test_double_backward_gpu_no_cudnn(self):
-        self.check_double_backward(cuda.to_gpu(self.x),
-                                   cuda.to_gpu(self.gy),
-                                   cuda.to_gpu(self.ggx),
-                                   'never')
+    def forward_expected(self, inputs):
+        x, = inputs
+        y = utils.force_array(x.clip(0, self.z))
+        return y,
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -5,124 +5,58 @@ import numpy
 import chainer
 from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import backend
 
 
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'c_contiguous': [True, False],
+    'contiguous': [None, 'C'],
 }))
 @testing.fix_random()
-@backend.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward'],
+@testing.inject_backend_tests(
+    None,
     # CPU tests
-    testing.product({
-        'use_cuda': [False],
-        'use_ideep': ['never', 'always'],
-    })
+    [
+        {},
+        {'use_ideep': 'always'},
+    ]
     # GPU tests
     + testing.product({
         'use_cuda': [True],
         'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
     })
     # ChainerX tests
     + [
         {'use_chainerx': True, 'chainerx_device': 'native:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
     ])
+@testing.function_test()
 class TestReLU(unittest.TestCase):
 
-    def setUp(self):
-        # Avoid unstability of numerical grad
-        x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        x[(-0.1 < x) & (x < 0.1)] = 0.5
-        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        ggx = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.inputs = [x]
-        self.grad_outputs = [gy]
-        self.grad_grad_inputs = [ggx]
-        self.check_backward_options = {}
-        self.check_double_backward_options = {}
-        if self.dtype == numpy.float16:
-            self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+    dodge_nondifferentiable = True
 
-    def forward_cpu(self, inputs):
+    def before_test(self, test_name):
+        # TODO(niboshi): Support it
+        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
+
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        return x,
+
+    def forward(self, inputs, device):
+        x, = inputs
+        return functions.relu(x),
+
+    def forward_expected(self, inputs):
         x, = inputs
         expected = x.copy()
         expected[expected < 0] = 0
         return expected,
-
-    def test_forward(self, backend_config):
-        # TODO(niboshi): Support it
-        if backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        inputs = self.inputs
-        y_expected, = self.forward_cpu(inputs)
-
-        inputs = backend_config.get_array(inputs)
-
-        if not self.c_contiguous:
-            inputs = testing.array._as_noncontiguous_array(inputs)
-
-        x_data, = inputs
-        x = chainer.Variable(x_data)
-        with backend_config:
-            y = functions.relu(x)
-        assert y.data.dtype == self.dtype
-
-        testing.assert_allclose(y_expected, y.data)
-
-    def test_backward(self, backend_config):
-        # TODO(niboshi): Support it
-        if backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        inputs = self.inputs
-        grad_outputs = self.grad_outputs
-
-        inputs = backend_config.get_array(inputs)
-        grad_outputs = backend_config.get_array(grad_outputs)
-
-        if not self.c_contiguous:
-            inputs = testing.array._as_noncontiguous_array(inputs)
-            grad_outputs = testing.array._as_noncontiguous_array(grad_outputs)
-
-        with backend_config:
-            gradient_check.check_backward(
-                functions.relu, inputs, grad_outputs, dtype=numpy.float64,
-                **self.check_backward_options)
-
-    def test_double_backward(self, backend_config):
-        # TODO(niboshi): Support it
-        if backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        inputs = self.inputs
-        grad_outputs = self.grad_outputs
-        grad_grad_inputs = self.grad_grad_inputs
-
-        inputs = backend_config.get_array(inputs)
-        grad_outputs = backend_config.get_array(grad_outputs)
-        grad_grad_inputs = backend_config.get_array(grad_grad_inputs)
-
-        if not self.c_contiguous:
-            inputs = testing.array._as_noncontiguous_array(inputs)
-            grad_outputs = testing.array._as_noncontiguous_array(grad_outputs)
-            grad_grad_inputs = (
-                testing.array._as_noncontiguous_array(grad_grad_inputs))
-
-        x, = inputs
-        gy, = grad_outputs
-        ggx, = grad_grad_inputs
-        with backend_config:
-            gradient_check.check_double_backward(
-                functions.relu, x, gy, ggx, dtype=numpy.float64,
-                **self.check_double_backward_options)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -34,8 +34,7 @@ from chainer.testing import attr
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
     ])
-@testing.function_test()
-class TestReLU(unittest.TestCase):
+class TestReLU(testing.FunctionTestCase):
 
     dodge_nondifferentiable = True
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
@@ -3,10 +3,7 @@ import unittest
 import numpy
 import six
 
-import chainer
-from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.utils import type_check
@@ -29,67 +26,44 @@ from chainer.utils import type_check
         {'dtype': numpy.float64},
     ]
 ))
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+        {'use_ideep': 'always'},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+@testing.function_test()
 class TestHstack(unittest.TestCase):
 
-    def setUp(self):
-        self.xs = [
+    def before_test(self, test_name):
+        # TODO(niboshi): Support it
+        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
+
+    def generate_inputs(self):
+        return tuple([
             numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-            for i in six.moves.range(self.xs_length)
-        ]
-        self.g = numpy.random.uniform(-1, 1, self.y_shape).astype(self.dtype)
-        self.gg = [
-            numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-            for i in six.moves.range(self.xs_length)
-        ]
-        self.check_backward_options = {}
-        if self.dtype == numpy.float16:
-            self.check_backward_options = {'atol': 3e-3, 'rtol': 5e-3}
+            for i in six.moves.range(self.xs_length)])
 
-    def check_forward(self, xs_data):
-        xs = [chainer.Variable(x) for x in xs_data]
-        y = functions.hstack(xs)
+    def forward(self, inputs, device):
+        y = functions.hstack(inputs)
+        return y,
 
-        expect = numpy.hstack(self.xs)
-        testing.assert_allclose(y.data, expect)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.xs)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward([cuda.to_gpu(x) for x in self.xs])
-
-    def check_backward(self, xs_data, g_data):
-        def func(*xs):
-            return functions.hstack(xs)
-
-        gradient_check.check_backward(
-            func, xs_data, g_data, dtype='d', **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.xs, self.g)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(
-            [cuda.to_gpu(x) for x in self.xs], cuda.to_gpu(self.g))
-
-    def check_double_backward(self, xs_data, g_data, gg_data):
-        def func(*xs):
-            return functions.hstack(xs)
-
-        gradient_check.check_double_backward(
-            func, xs_data, g_data, gg_data, dtype='d',
-            **self.check_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.xs, self.g, self.gg)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward([cuda.to_gpu(x) for x in self.xs],
-                                   cuda.to_gpu(self.g),
-                                   [cuda.to_gpu(gg) for gg in self.gg])
+    def forward_expected(self, inputs):
+        y = numpy.hstack(inputs)
+        return y,
 
 
 @testing.parameterize(

--- a/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
@@ -44,8 +44,7 @@ from chainer.utils import type_check
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
     ])
-@testing.function_test()
-class TestHstack(unittest.TestCase):
+class TestHstack(testing.FunctionTestCase):
 
     def before_test(self, test_name):
         # TODO(niboshi): Support it

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -3,16 +3,14 @@ import unittest
 import numpy
 
 import chainer
-from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import backend
 
 
-def inject_backend_tests(method_names):
+def inject_backend_tests():
     decorator = backend.inject_backend_tests(
-        method_names,
+        None,
         # CPU tests
         testing.product({
             'use_cuda': [False],
@@ -24,6 +22,7 @@ def inject_backend_tests(method_names):
         + [
             {'use_chainerx': True, 'chainerx_device': 'native:0'},
             {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+            {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
         ])
     return decorator
 
@@ -136,158 +135,86 @@ def inject_backend_tests(method_names):
         {'dtype': numpy.float64},
     ],
 ))
-@inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward'])
+@inject_backend_tests()
+@testing.function_test()
 class TestSplitAxis(unittest.TestCase):
 
-    def setUp(self):
+    def generate_inputs(self):
         shape = self.shape
         dtype = self.dtype
-
         x = numpy.arange(numpy.prod(shape), dtype=dtype).reshape(shape)
-        self.ys_expected = [x[s] for s in self.slices]
-        self.gys = [
-            numpy.random.uniform(-1, 1, y.shape).astype(self.dtype)
-            for y in self.ys_expected]
-        self.ggx = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.inputs = [x]
-        self.grad_outputs = [
-            numpy.random.uniform(-1, 1, y.shape).astype(self.dtype)
-            for y in self.ys_expected
-        ]
-        self.check_backward_options = {
-            'dtype': numpy.float64,
-            'atol': 1e-4, 'rtol': 1e-4,
-        }
+        return x,
 
-    def _forward(self, x):
+    def before_test(self, test_name):
+        # TODO(niboshi): Support it
+        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
+
+    def forward(self, inputs, device):
+        x, = inputs
         return functions.split_axis(
             x, self.ys_section, self.axis, force_tuple=True)
 
-    def check_forward(self, inputs, backend_config):
-        inputs = backend_config.get_array(inputs)
-
+    def forward_expected(self, inputs):
         x, = inputs
-        x = chainer.Variable(x)
-
-        with backend_config:
-            ys = self._forward(x)
-
-        for yd, y in zip(self.ys_expected, ys):
-            assert y.data.dtype == self.dtype
-            assert isinstance(y.data.shape, tuple)
-            testing.assert_allclose(yd, y.data, atol=0, rtol=0)
-
-    def test_forward(self, backend_config):
-        # TODO(hvy): Support it
-        if self.dtype == numpy.float16 and backend_config.use_chainerx:
-            raise unittest.SkipTest('ChainerX does not support float16')
-        self.check_forward(self.inputs, backend_config)
-
-    def check_backward(self, inputs, grad_outputs, backend_config):
-        inputs = backend_config.get_array(inputs)
-        grad_outputs = backend_config.get_array(grad_outputs)
-
-        with backend_config:
-            gradient_check.check_backward(
-                self._forward, inputs, grad_outputs,
-                **self.check_backward_options)
-
-    def test_backward(self, backend_config):
-        # TODO(hvy): Support it
-        if self.dtype == numpy.float16 and backend_config.use_chainerx:
-            raise unittest.SkipTest('ChainerX does not support float16')
-        self.check_backward(self.inputs, self.grad_outputs, backend_config)
-
-    def check_double_backward(self, inputs, backend_config):
-        def f(x):
-            return functions.split_axis(
-                x, self.ys_section, self.axis, force_tuple=True)
-
-        inputs, = backend_config.get_array(self.inputs)
-        gys = backend_config.get_array(self.gys)
-        ggx = backend_config.get_array(self.ggx)
-
-        with backend_config:
-            gradient_check.check_double_backward(
-                f, inputs, gys, ggx, dtype=numpy.float64)
-
-    def test_double_backward(self, backend_config):
-        # TODO(hvy): Support it
-        if self.dtype == numpy.float16 and backend_config.use_chainerx:
-            raise unittest.SkipTest('ChainerX does not support float16')
-        self.check_double_backward(self.inputs, backend_config)
+        return tuple([x[s] for s in self.slices])
 
 
-@inject_backend_tests(['test_backward'])
+@inject_backend_tests()
+@testing.function_test()
 class TestSplitAxisNone(unittest.TestCase):
 
-    def setUp(self):
-        self.ys_section = [1]
-        self.axis = 0
+    double_backward_test = False
 
-        self.inputs = [numpy.array([1, 2], dtype=numpy.float32)]
-        self.grad_outputs = [numpy.array([1], dtype=numpy.float32), None]
-        self.check_backward_options = {
-            'dtype': numpy.float64,
-            'atol': 1e-4, 'rtol': 1e-4,
-        }
+    axis = 0
+    ys_section = [1]
 
-    def _forward(self, x):
+    def generate_inputs(self):
+        x = numpy.array([1, 2], dtype=numpy.float32)
+        return x,
+
+    def forward(self, inputs, device):
+        x, = inputs
         return functions.split_axis(
             x, self.ys_section, self.axis)
 
-    def check_backward(self, inputs, grad_outputs, backend_config):
-        if backend_config.use_cuda:
-            inputs = cuda.to_gpu(inputs)
-            grad_outputs = cuda.to_gpu(grad_outputs)
-
-        with backend_config:
-            gradient_check.check_backward(
-                self._forward, inputs, grad_outputs,
-                **self.check_backward_options)
-
-    def test_backward(self, backend_config):
-        self.check_backward(self.inputs, self.grad_outputs, backend_config)
+    def forward_expected(self, inputs):
+        x, = inputs
+        return tuple(numpy.split(x, self.ys_section, self.axis))
 
 
-@inject_backend_tests(['test_forward_force_tuple', 'test_forward_single'])
+@testing.parameterize(
+    {'force_tuple': True},
+    {'force_tuple': False},
+)
+@inject_backend_tests()
+@testing.function_test()
 class TestSplitAxisForceArray(unittest.TestCase):
 
-    def setUp(self):
-        self.axis = 1
-        self.inputs = [numpy.arange(42, dtype=numpy.float32).reshape(2, 7, 3)]
+    backward_test = False
+    double_backward_test = False
 
-    def check_forward_force_tuple(self, inputs, backend_config):
-        if backend_config.use_cuda:
-            inputs = cuda.to_gpu(inputs)
+    axis = 1
 
-        x, = self.inputs
-        x = chainer.Variable(x)
+    def generate_inputs(self):
+        x = numpy.arange(42, dtype=numpy.float32).reshape(2, 7, 3)
+        return x,
 
-        with backend_config:
-            ys = functions.split_axis(x, 1, self.axis, force_tuple=True)
+    def forward(self, inputs, device):
+        x, = inputs
+        ret = functions.split_axis(
+            x, 1, self.axis, force_tuple=self.force_tuple)
+        if self.force_tuple:
+            assert isinstance(ret, tuple)
+            assert len(ret) == 1
+            return ret
+        else:
+            assert isinstance(ret, chainer.Variable)
+            return ret,
 
-        assert isinstance(ys, tuple)
-        assert len(ys) == 1
-
-    def test_forward_force_tuple(self, backend_config):
-        self.check_forward_force_tuple(self.inputs, backend_config)
-
-    def check_forward_single(self, inputs, backend_config):
-        if backend_config.use_cuda:
-            inputs = cuda.to_gpu(inputs)
-
-        x, = self.inputs
-        x = chainer.Variable(x)
-
-        with backend_config:
-            ys = functions.split_axis(x, 1, self.axis, force_tuple=False)
-
-        assert isinstance(ys, chainer.Variable)
-
-    def test_forward_single(self, backend_config):
-        self.check_forward_single(self.inputs, backend_config)
+    def forward_expected(self, inputs):
+        x, = inputs
+        return tuple(numpy.split(x, 1, self.axis))
 
 
 class TestSplitAxisInvalidSections(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -136,8 +136,7 @@ def inject_backend_tests():
     ],
 ))
 @inject_backend_tests()
-@testing.function_test()
-class TestSplitAxis(unittest.TestCase):
+class TestSplitAxis(testing.FunctionTestCase):
 
     def generate_inputs(self):
         shape = self.shape
@@ -161,10 +160,9 @@ class TestSplitAxis(unittest.TestCase):
 
 
 @inject_backend_tests()
-@testing.function_test()
-class TestSplitAxisNone(unittest.TestCase):
+class TestSplitAxisNone(testing.FunctionTestCase):
 
-    double_backward_test = False
+    skip_double_backward_test = True
 
     axis = 0
     ys_section = [1]
@@ -188,11 +186,10 @@ class TestSplitAxisNone(unittest.TestCase):
     {'force_tuple': False},
 )
 @inject_backend_tests()
-@testing.function_test()
-class TestSplitAxisForceArray(unittest.TestCase):
+class TestSplitAxisForceArray(testing.FunctionTestCase):
 
-    backward_test = False
-    double_backward_test = False
+    skip_backward_test = True
+    skip_double_backward_test = True
 
     axis = 1
 

--- a/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
@@ -123,7 +123,8 @@ class TestNonparameterizedLinear(unittest.TestCase):
 
         inputs = backend_config.get_array(inputs)
         if not self.c_contiguous:
-            inputs = _to_noncontiguous(inputs)
+            with backend_config:
+                inputs = _to_noncontiguous(inputs)
 
         input_vars = [chainer.Variable(x) for x in inputs]
         with backend_config:
@@ -147,8 +148,9 @@ class TestNonparameterizedLinear(unittest.TestCase):
         inputs = backend_config.get_array(inputs)
         grad_outputs = backend_config.get_array(grad_outputs)
         if not self.c_contiguous:
-            inputs = _to_noncontiguous(inputs)
-            grad_outputs = _to_noncontiguous(grad_outputs)
+            with backend_config:
+                inputs = _to_noncontiguous(inputs)
+                grad_outputs = _to_noncontiguous(grad_outputs)
 
         with backend_config:
             gradient_check.check_backward(
@@ -173,9 +175,10 @@ class TestNonparameterizedLinear(unittest.TestCase):
         grad_grad_inputs = backend_config.get_array(grad_grad_inputs)
 
         if not self.c_contiguous:
-            inputs = _to_noncontiguous(inputs)
-            grad_outputs = _to_noncontiguous(grad_outputs)
-            grad_grad_inputs = _to_noncontiguous(grad_grad_inputs)
+            with backend_config:
+                inputs = _to_noncontiguous(inputs)
+                grad_outputs = _to_noncontiguous(grad_outputs)
+                grad_grad_inputs = _to_noncontiguous(grad_grad_inputs)
 
         with backend_config:
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -192,9 +192,10 @@ class TestBatchNormalization(unittest.TestCase):
         running_var = backend_config.get_array(self.running_var)
 
         if not self.c_contiguous:
-            inputs = _as_noncontiguous_array(inputs)
-            running_mean = _as_noncontiguous_array(running_mean)
-            running_var = _as_noncontiguous_array(running_var)
+            with backend_config:
+                inputs = _as_noncontiguous_array(inputs)
+                running_mean = _as_noncontiguous_array(running_mean)
+                running_var = _as_noncontiguous_array(running_var)
 
         with backend_config:
             y = functions.batch_normalization(
@@ -223,8 +224,9 @@ class TestBatchNormalization(unittest.TestCase):
         inputs = backend_config.get_array(inputs)
         grad_outputs = backend_config.get_array(grad_outputs)
         if not self.c_contiguous:
-            inputs = _as_noncontiguous_array(inputs)
-            grad_outputs = _as_noncontiguous_array(grad_outputs)
+            with backend_config:
+                inputs = _as_noncontiguous_array(inputs)
+                grad_outputs = _as_noncontiguous_array(grad_outputs)
 
         def f(*inputs):
             y = functions.batch_normalization(
@@ -249,9 +251,10 @@ class TestBatchNormalization(unittest.TestCase):
         grad_outputs = backend_config.get_array(grad_outputs)
         grad_grad_inputs = backend_config.get_array(grad_grad_inputs)
         if not self.c_contiguous:
-            inputs = _as_noncontiguous_array(inputs)
-            grad_outputs = _as_noncontiguous_array(grad_outputs)
-            grad_grad_inputs = _as_noncontiguous_array(grad_grad_inputs)
+            with backend_config:
+                inputs = _as_noncontiguous_array(inputs)
+                grad_outputs = _as_noncontiguous_array(grad_outputs)
+                grad_grad_inputs = _as_noncontiguous_array(grad_grad_inputs)
 
         def f(*inputs):
             return functions.batch_normalization(
@@ -347,7 +350,8 @@ class TestFixedBatchNormalization(unittest.TestCase):
 
         inputs = backend_config.get_array(inputs)
         if not self.c_contiguous:
-            inputs = _as_noncontiguous_array(inputs)
+            with backend_config:
+                inputs = _as_noncontiguous_array(inputs)
 
         with chainer.using_config('enable_backprop', enable_backprop):
             with backend_config:
@@ -371,8 +375,9 @@ class TestFixedBatchNormalization(unittest.TestCase):
         inputs = backend_config.get_array(inputs)
         grad_outputs = backend_config.get_array(grad_outputs)
         if not self.c_contiguous:
-            inputs = _as_noncontiguous_array(inputs)
-            grad_outputs = _as_noncontiguous_array(grad_outputs)
+            with backend_config:
+                inputs = _as_noncontiguous_array(inputs)
+                grad_outputs = _as_noncontiguous_array(grad_outputs)
 
         def f(*inputs):
             y = functions.fixed_batch_normalization(*inputs, eps=self.eps)
@@ -396,9 +401,10 @@ class TestFixedBatchNormalization(unittest.TestCase):
         grad_outputs = backend_config.get_array(grad_outputs)
         grad_grad_inputs = backend_config.get_array(grad_grad_inputs)
         if not self.c_contiguous:
-            inputs = _as_noncontiguous_array(inputs)
-            grad_outputs = _as_noncontiguous_array(grad_outputs)
-            grad_grad_inputs = _as_noncontiguous_array(grad_grad_inputs)
+            with backend_config:
+                inputs = _as_noncontiguous_array(inputs)
+                grad_outputs = _as_noncontiguous_array(grad_outputs)
+                grad_grad_inputs = _as_noncontiguous_array(grad_grad_inputs)
 
         def f(*inputs):
             return functions.fixed_batch_normalization(*inputs, eps=self.eps)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -84,7 +84,8 @@ class TestAveragePooling2D(unittest.TestCase):
 
         inputs = backend_config.get_array(inputs)
         if not self.c_contiguous:
-            inputs = _to_fcontiguous(inputs)
+            with backend_config:
+                inputs = _to_fcontiguous(inputs)
 
         with backend_config:
             x, = inputs
@@ -107,8 +108,9 @@ class TestAveragePooling2D(unittest.TestCase):
         inputs = backend_config.get_array(inputs)
         grad_outputs = backend_config.get_array(grad_outputs)
         if not self.c_contiguous:
-            inputs = _to_fcontiguous(inputs)
-            grad_outputs = _to_fcontiguous(grad_outputs)
+            with backend_config:
+                inputs = _to_fcontiguous(inputs)
+                grad_outputs = _to_fcontiguous(grad_outputs)
 
         def f(x):
             return functions.average_pooling_2d(x, 3, 2, 1)
@@ -131,9 +133,10 @@ class TestAveragePooling2D(unittest.TestCase):
         grad_outputs = backend_config.get_array(grad_outputs)
         grad_grad_inputs = backend_config.get_array(grad_grad_inputs)
         if not self.c_contiguous:
-            inputs = _to_fcontiguous(inputs)
-            grad_outputs = _to_fcontiguous(grad_outputs)
-            grad_grad_inputs = _to_fcontiguous(grad_grad_inputs)
+            with backend_config:
+                inputs = _to_fcontiguous(inputs)
+                grad_outputs = _to_fcontiguous(grad_outputs)
+                grad_grad_inputs = _to_fcontiguous(grad_grad_inputs)
 
         def f(x):
             return functions.average_pooling_2d(x, 3, 2, 1)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -1,367 +1,105 @@
 import unittest
 
 import functools
-import math
 import numpy
 from operator import mul
 import six
 
 import chainer
-from chainer import backend
 from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import conv
 from chainer_tests.functions_tests.pooling_tests import pooling_nd_helper
-import chainerx
 
 
 @testing.parameterize(*testing.product({
-    'dims': [(4,), (4, 3), (4, 3, 2), (1, 1, 1, 1)],
+    'in_dims': [(4,), (4, 3), (4, 3, 2), (1, 1, 1, 1)],
     'cover_all': [True, False],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+        {'use_ideep': 'always'},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+@testing.function_test()
 class TestMaxPoolingND(unittest.TestCase):
 
+    dodge_nondifferentiable = True
+
     def setUp(self):
-        self.ndim = len(self.dims)
+        self.ndim = len(self.in_dims)
         self.ksize = (3,) * self.ndim
         self.stride = (2,) * self.ndim
         self.pad = (1,) * self.ndim
 
-        # Avoid unstability of numerical gradient
-        x_shape = (2, 3) + self.dims
-        self.x = numpy.arange(
-            functools.reduce(mul, x_shape), dtype=self.dtype).reshape(x_shape)
-        self.x = 2 * self.x / self.x.size - 1
-
-        outs = tuple(conv.get_conv_outsize(d, k, s, p, self.cover_all)
-                     for (d, k, s, p)
-                     in six.moves.zip(
-                         self.dims, self.ksize, self.stride, self.pad))
-        gy_shape = (2, 3) + outs
-        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
-        self.ggx = numpy.random.uniform(
-            -1, 1, x_shape).astype(self.dtype)
-
-        self.check_backward_options = {}
         if self.dtype == numpy.float16:
-            self.check_backward_options = {
-                'atol': 1e-3, 'rtol': 1e-2}
-            self.check_double_backward_options = {
-                'atol': 1e-3, 'rtol': 1e-2}
-        else:
-            self.check_backward_options = {
-                'atol': 1e-4, 'rtol': 1e-3}
-            self.check_double_backward_options = {
-                'atol': 1e-4, 'rtol': 1e-3}
+            self.check_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-2})
+            self.check_double_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-2})
 
-    def check_forward(self, x_data, use_cudnn='always'):
-        dims = self.dims
+    def before_test(self, test_name):
+        # TODO(niboshi): Support it
+        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
+
+    def generate_inputs(self):
+        x_shape = (2, 3) + self.in_dims
+        x = numpy.random.randn(*x_shape).astype(self.dtype, copy=False)
+        return x,
+
+    def forward(self, inputs, device):
         ksize = self.ksize
         stride = self.stride
         pad = self.pad
-        x = chainer.Variable(x_data)
-        with chainer.using_config('use_cudnn', use_cudnn):
-            y = functions.max_pooling_nd(x, ksize, stride=stride, pad=pad,
-                                         cover_all=self.cover_all)
-        self.assertEqual(y.data.dtype, self.dtype)
-        y_data = backend.CpuDevice().send(y.data)
+        cover_all = self.cover_all
+        x, = inputs
+        y = functions.max_pooling_nd(
+            x, ksize, stride=stride, pad=pad, cover_all=cover_all)
+        return y,
 
-        self.assertEqual(self.gy.shape, y_data.shape)
+    def _get_out_dims(self, in_dims):
+        out_dims = tuple(
+            conv.get_conv_outsize(d, k, s, p, self.cover_all)
+            for d, k, s, p
+            in six.moves.zip(in_dims, self.ksize, self.stride, self.pad))
+        return out_dims
+
+    def forward_expected(self, inputs):
+        in_dims = self.in_dims
+        ksize = self.ksize
+        stride = self.stride
+        pad = self.pad
+        cover_all = self.cover_all
         patches = pooling_nd_helper.pooling_patches(
-            dims, ksize, stride, pad, self.cover_all)
+            in_dims, ksize, stride, pad, cover_all)
+        x, = inputs
+        out_dims = self._get_out_dims(x.shape[2:])
+        y_shape = x.shape[:2] + out_dims
+        x = x.astype(numpy.float64)
+        y = numpy.empty(y_shape, numpy.float64)
         for i in six.moves.range(2):
             for c in six.moves.range(3):
-                x = self.x[i, c]
-                expect = numpy.array([x[idx].max() for idx in patches])
-                expect = expect.reshape(y_data.shape[2:])
-                testing.assert_allclose(expect, y_data[i, c])
-
-    @condition.retry(3)
-    def test_forward_cpu(self):
-        self.check_forward(self.x, use_cudnn='never')
-
-    def test_forward_cpu_wide(self):  # see #120
-        ndim = self.ndim
-        x_shape = (2, 3) + (15,) * ndim
-        x_data = numpy.random.rand(*x_shape).astype(self.dtype)
-        x = chainer.Variable(x_data)
-        ksize = stride = int(math.ceil(pow(32, 1.0 / ndim)))
-        functions.max_pooling_nd(x, ksize, stride=stride, pad=0)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_forward_gpu_non_contiguous(self):
-        self.check_forward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)))
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), 'never')
-
-    @attr.chainerx
-    def test_forward_chainerx_cpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_forward(chainerx.array(self.x))
-
-    @attr.chainerx
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_chainerx_gpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_forward(backend.to_chainerx(cuda.to_gpu(self.x)))
-
-    def check_forward_consistency_regression(self, x_data, use_cudnn='always'):
-        # Regression test to max_pooling_2d.
-
-        if len(self.dims) != 2:
-            return
-
-        ksize = self.ksize
-        stride = self.stride
-        pad = self.pad
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            y_nd = functions.max_pooling_nd(self.x, ksize, stride=stride,
-                                            pad=pad, cover_all=self.cover_all)
-            y_2d = functions.max_pooling_2d(self.x, ksize, stride=stride,
-                                            pad=pad, cover_all=self.cover_all)
-        testing.assert_allclose(y_nd.data, y_2d.data)
-
-    @condition.retry(3)
-    def test_forward_consistency_regression_cpu(self):
-        self.check_forward_consistency_regression(self.x)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_forward_consistency_regression_gpu(self):
-        self.check_forward_consistency_regression(cuda.to_gpu(self.x))
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_consistency_regression_no_cudnn(self):
-        self.check_forward_consistency_regression(cuda.to_gpu(self.x), 'never')
-
-    @attr.chainerx
-    @condition.retry(3)
-    def test_forward_consistency_regression_chainerx_cpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_forward_consistency_regression(chainerx.array(self.x))
-
-    @attr.chainerx
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_consistency_regression_chainerx_gpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_forward_consistency_regression(
-            backend.to_chainerx(cuda.to_gpu(self.x)))
-
-    def check_backward(self, x_data, y_grad, use_cudnn='always'):
-        def f(x):
-            return functions.max_pooling_nd(
-                x, self.ksize, stride=self.stride, pad=self.pad,
-                cover_all=self.cover_all)
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            gradient_check.check_backward(
-                f, x_data, y_grad, dtype='d', **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_backward_gpu_non_contiguous(self):
-        self.check_backward(
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
-
-    @attr.chainerx
-    @condition.retry(3)
-    def test_backward_chainerx_cpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_backward(chainerx.array(self.x), chainerx.array(self.gy))
-
-    @attr.chainerx
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_chainerx_gpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_backward(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.gy)))
-
-    def check_backward_consistency_regression(self, x_data, gy_data,
-                                              use_cudnn='always'):
-        # Regression test to two-dimensional max pooling layer.
-
-        if len(self.dims) != 2:
-            return
-
-        ksize = self.ksize
-        stride = self.stride
-        pad = self.pad
-
-        # Backward computation for N-dimensional max pooling layer.
-        x_nd = chainer.Variable(x_data.copy())
-        with chainer.using_config('use_cudnn', use_cudnn):
-            y_nd = functions.max_pooling_nd(
-                x_nd, ksize, stride=stride, pad=pad, cover_all=self.cover_all)
-
-        y_nd.grad = gy_data
-        y_nd.backward()
-
-        # Backward computation for two-dimensional max pooling layer.
-        x_2d = chainer.Variable(x_data.copy())
-        with chainer.using_config('use_cudnn', use_cudnn):
-            y_2d = functions.max_pooling_2d(
-                x_2d, ksize, stride=stride, pad=pad, cover_all=self.cover_all)
-
-        y_2d.grad = gy_data
-        y_2d.backward()
-
-        # Test that the two result gradients are close enough.
-        testing.assert_allclose(x_nd.grad, x_2d.grad)
-
-    @condition.retry(3)
-    def test_backward_consistency_regression_cpu(self):
-        self.check_backward_consistency_regression(self.x, self.gy)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_backward_consistency_regression_gpu(self):
-        self.check_backward_consistency_regression(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_consistency_regression_no_cudnn(self):
-        self.check_backward_consistency_regression(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), use_cudnn='never')
-
-    @attr.chainerx
-    @condition.retry(3)
-    def test_backward_consistency_regression_chainerx_cpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_backward_consistency_regression(
-            chainerx.array(self.x), chainerx.array(self.gy))
-
-    @attr.chainerx
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_consistency_regression_chainerx_gpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_backward_consistency_regression(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.gy)))
-
-    def test_backward_cpu_more_than_once(self):
-        func = functions.pooling.max_pooling_nd.MaxPoolingND(
-            self.ndim, self.ksize, stride=self.stride, pad=self.pad,
-            cover_all=self.cover_all)
-        func.apply((self.x,))
-        func.backward((self.x,), (self.gy,))
-        func.backward((self.x,), (self.gy,))
-
-    def check_double_backward(self, x_data, y_grad, x_grad_grad,
-                              use_cudnn='always'):
-        def f(x):
-            return functions.max_pooling_nd(
-                x, self.ksize, stride=self.stride, pad=self.pad,
-                cover_all=self.cover_all)
-        with chainer.using_config('use_cudnn', use_cudnn):
-            gradient_check.check_double_backward(
-                f, x_data, y_grad, x_grad_grad,
-                dtype='d',
-                **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.gy, self.ggx, 'never')
-
-    @attr.cudnn
-    def test_double_backward_gpu(self):
-        self.check_double_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
-
-    @attr.cudnn
-    def test_double_backward_gpu_non_contiguous(self):
-        self.check_double_backward(
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
-
-    @attr.gpu
-    def test_double_backward_gpu_no_cudnn(self):
-        self.check_double_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
-            'never')
-
-    @attr.chainerx
-    def test_double_backward_chainerx_cpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_double_backward(
-            chainerx.array(self.x),
-            chainerx.array(self.gy),
-            chainerx.array(self.ggx))
-
-    @attr.chainerx
-    @attr.gpu
-    def test_double_backward_chainerx_gpu(self):
-        # TODO(sonots): Support it
-        if self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
-        self.check_double_backward(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.gy)),
-            backend.to_chainerx(cuda.to_gpu(self.ggx)))
+                d = numpy.array([x[i, c][idx].max() for idx in patches])
+                y[i, c, ...] = d.reshape(out_dims)
+        return y.astype(self.dtype),
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -38,8 +38,7 @@ from chainer_tests.functions_tests.pooling_tests import pooling_nd_helper
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
     ])
-@testing.function_test()
-class TestMaxPoolingND(unittest.TestCase):
+class TestMaxPoolingND(testing.FunctionTestCase):
 
     dodge_nondifferentiable = True
 

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -129,7 +129,8 @@ class OptimizerTestBase(object):
             # TODO(niboshi): This is temporary workaround.
             # See the comment on Skipped.
             return
-        assert accuracy.data > 0.9
+        with backend_config:
+            assert accuracy.data > 0.9
 
     @attr.multi_gpu(2)
     @condition.retry(10)

--- a/tests/chainer_tests/testing_tests/test_function.py
+++ b/tests/chainer_tests/testing_tests/test_function.py
@@ -201,7 +201,7 @@ class FuncWithIncorrectBackward(chainer.FunctionNode):
         gy1, gy2 = grad_outputs
         x1, x2 = self.get_retained_inputs()
         ggx1, ggx2 = _backward_correct(x1, x2, gy1, gy2)
-        ggx2 = ggx2 + 1  # ! make incorrect
+        ggx2 = ggx2 + 10000  # ! make incorrect
         return utils.force_array(ggx1), utils.force_array(ggx2)
 
 
@@ -258,8 +258,8 @@ class FuncGradWithIncorrectDoubleBackward(chainer.FunctionNode):
         x1, x2, gy1, gy2 = self.get_retained_inputs()
         gx1, gx2, ggy1, ggy2 = _double_backward_correct(
             x1, x2, gy1, gy2, ggx1, ggx2)
-        ggy2 = ggy2 + 1  # ! make incorrect
-        return ggx1, ggx2, ggy1, ggy2
+        ggy2 = ggy2 + 10000  # ! make incorrect
+        return gx1, gx2, ggy1, ggy2
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/testing_tests/test_function.py
+++ b/tests/chainer_tests/testing_tests/test_function.py
@@ -133,8 +133,7 @@ class FuncGradCorrectlyImplemented(chainer.FunctionNode):
     'shape': [(3, 2), (2,), (1,), (), (2, 0, 3)],
 }))
 @_inject_backend_tests
-@testing.function_test()
-class TestFunctionTestSuccessful(unittest.TestCase):
+class TestFunctionTestSuccessful(testing.FunctionTestCase):
 
     def generate_inputs(self):
         x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
@@ -170,8 +169,7 @@ class FuncWithIncorrectForward(chainer.FunctionNode):
 }))
 @_inject_backend_tests
 @pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
-@testing.function_test()
-class TestFunctionTestIncorrectForward(unittest.TestCase):
+class TestFunctionTestIncorrectForward(testing.FunctionTestCase):
     backward_test = False
     double_backward_test = False
 
@@ -212,8 +210,7 @@ class FuncWithIncorrectBackward(chainer.FunctionNode):
 }))
 @_inject_backend_tests
 @pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
-@testing.function_test()
-class TestFunctionTestIncorrectBackward(unittest.TestCase):
+class TestFunctionTestIncorrectBackward(testing.FunctionTestCase):
     forward_test = False
     double_backward_test = False
 
@@ -270,8 +267,7 @@ class FuncGradWithIncorrectDoubleBackward(chainer.FunctionNode):
 }))
 @_inject_backend_tests
 @pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
-@testing.function_test()
-class TestFunctionTestIncorrectDoubleBackward(unittest.TestCase):
+class TestFunctionTestIncorrectDoubleBackward(testing.FunctionTestCase):
     forward_test = False
     backward_test = False
 
@@ -420,8 +416,7 @@ class FuncGradWithContiguousnessCheck(chainer.FunctionNode):
     ]}))
 @_inject_backend_tests
 @pytest.mark.xfail(strict=True, raises=_ContiguousnessMatched)
-@testing.function_test()
-class FunctionTestCaseArrayContiguousnessTest(unittest.TestCase):
+class FunctionTestCaseArrayContiguousnessTest(testing.FunctionTestCase):
     def generate_inputs(self):
         x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
         x2 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)

--- a/tests/chainer_tests/testing_tests/test_function.py
+++ b/tests/chainer_tests/testing_tests/test_function.py
@@ -1,0 +1,449 @@
+import unittest
+
+import numpy
+import pytest
+
+import chainer
+from chainer import testing
+from chainer import utils
+import chainerx
+
+
+_inject_backend_tests = testing.inject_backend_tests(
+    None,
+    [
+        # CPU tests
+        {},
+        {'use_ideep': 'always'},
+        # GPU tests
+        {'use_cuda': True},
+        {'use_cuda': True, 'cuda_device': 1},
+        # ChainerX tests
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+
+
+def _forward_correct(x1, x2):
+    dt = x1.dtype.type
+    y1 = (x1 + x2) ** dt(2)
+    y2 = (x1 ** dt(2)) * (x2 ** dt(2))
+    return utils.force_array(y1), utils.force_array(y2)
+
+
+def _backward_correct(x1, x2, gy1, gy2):
+    dt = x1.dtype.type
+    ggx1 = (
+        + gy1 * dt(2) * (x1 + x2)
+        + gy2 * dt(2) * x1 * x2 ** dt(2))
+    ggx2 = (
+        + gy1 * dt(2) * (x1 + x2)
+        + gy2 * dt(2) * x1 ** dt(2) * x2)
+    return ggx1, ggx2
+
+
+def _double_backward_correct(x1, x2, gy1, gy2, ggx1, ggx2):
+    dt = x1.dtype.type
+    ggy1 = (ggx1 + ggx2) * dt(2) * (x1 + x2)
+    ggy2 = (ggx1 * x2 + ggx2 * x1) * dt(2) * x1 * x2
+    gx1 = (
+        + ggx1 * (dt(2) * gy1 + dt(2) * x2 ** dt(2) * gy2)
+        + ggx2 * (dt(2) * gy1 + dt(4) * x1 * x2 * gy2))
+    gx2 = (
+        + ggx1 * (dt(2) * gy1 + dt(4) * x1 * x2 * gy2)
+        + ggx2 * (dt(2) * gy1 + dt(2) * x1 ** dt(2) * gy2))
+    return gx1, gx2, ggy1, ggy2
+
+
+# TestFunctionTestSuccessful
+#
+# This test checks for successfull case.
+# Incoming array types are also checked.
+
+class FuncCorrectlyImplemented(chainer.FunctionNode):
+    def __init__(self, device):
+        self.device = device
+
+    def forward(self, inputs):
+        device = self.device
+        x1, x2 = inputs
+        if device.xp is chainerx:
+            fallback_device = device.fallback_device
+            assert isinstance(x1, fallback_device.supported_array_types)
+            assert isinstance(x2, fallback_device.supported_array_types)
+
+        self.retain_inputs((0, 1))
+        y1, y2 = _forward_correct(x1, x2)
+        return utils.force_array(y1), utils.force_array(y2)
+
+    def backward(self, indexes, grad_outputs):
+        device = self.device
+        x1, x2 = self.get_retained_inputs()
+        gy1, gy2 = grad_outputs
+        assert isinstance(x1.array, device.supported_array_types)
+        assert isinstance(x2.array, device.supported_array_types)
+        assert isinstance(gy1.array, device.supported_array_types)
+        assert isinstance(gy2.array, device.supported_array_types)
+
+        grad_func = FuncGradCorrectlyImplemented(device)
+        return grad_func.apply((x1, x2, gy1, gy2))
+
+
+class FuncGradCorrectlyImplemented(chainer.FunctionNode):
+    def __init__(self, device):
+        self.device = device
+
+    def forward(self, inputs_and_grad_outputs):
+        device = self.device
+        x1, x2, gy1, gy2 = inputs_and_grad_outputs
+        if device.xp is chainerx:
+            fallback_device = device.fallback_device
+            assert isinstance(gy1, fallback_device.supported_array_types)
+            assert isinstance(gy2, fallback_device.supported_array_types)
+
+        self.retain_inputs((0, 1, 2, 3))
+
+        ggx1, ggx2 = _backward_correct(x1, x2, gy1, gy2)
+        return utils.force_array(ggx1), utils.force_array(ggx2)
+
+    def backward(self, indexes, grad_grad_inputs):
+        device = self.device
+        ggx1, ggx2 = grad_grad_inputs
+        assert isinstance(ggx1, chainer.Variable)
+        assert isinstance(ggx2, chainer.Variable)
+        assert isinstance(ggx1.array, device.supported_array_types)
+        assert isinstance(ggx2.array, device.supported_array_types)
+        x1, x2, gy1, gy2 = self.get_retained_inputs()
+        assert isinstance(x1, chainer.Variable)
+        assert isinstance(x2, chainer.Variable)
+        assert isinstance(gy1, chainer.Variable)
+        assert isinstance(gy2, chainer.Variable)
+        assert isinstance(x1.array, device.supported_array_types)
+        assert isinstance(x2.array, device.supported_array_types)
+        assert isinstance(gy1.array, device.supported_array_types)
+        assert isinstance(gy2.array, device.supported_array_types)
+
+        gx1, gx2, ggy1, ggy2 = _double_backward_correct(
+            x1, x2, gy1, gy2, ggx1, ggx2)
+        return gx1, gx2, ggy1, ggy2
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), (2,), (1,), (), (2, 0, 3)],
+}))
+@_inject_backend_tests
+@testing.function_test()
+class TestFunctionTestSuccessful(unittest.TestCase):
+
+    def generate_inputs(self):
+        x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        x2 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        return x1, x2
+
+    def forward(self, inputs, device):
+        func = FuncCorrectlyImplemented(device)
+        return func.apply(inputs)
+
+    def forward_expected(self, inputs):
+        return _forward_correct(*inputs)
+
+
+# TestFunctionTestIncorrectForward
+#
+# This test checks if it can detect incorrect forward implementation.
+
+class FuncWithIncorrectForward(chainer.FunctionNode):
+    def forward(self, inputs):
+        x1, x2 = inputs
+        y1, y2 = _forward_correct(x1, x2)
+        y1, y2 = utils.force_array(y1), utils.force_array(y2)
+        y2[...] += 1  # ! make incorrect
+        return y1, y2
+
+    def backward(self, *args, **kwargs):
+        assert False  # should never be called
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), (2,), (1,), ()],
+}))
+@_inject_backend_tests
+@pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
+@testing.function_test()
+class TestFunctionTestIncorrectForward(unittest.TestCase):
+    backward_test = False
+    double_backward_test = False
+
+    def generate_inputs(self):
+        x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        x2 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        return x1, x2
+
+    def forward(self, inputs, device):
+        func = FuncWithIncorrectForward()
+        return func.apply(inputs)
+
+    def forward_expected(self, inputs):
+        return _forward_correct(*inputs)
+
+
+# TestFunctionTestIncorrectBackward
+#
+# This test checks if it can detect incorrect backward implementation.
+
+class FuncWithIncorrectBackward(chainer.FunctionNode):
+    def forward(self, inputs):
+        x1, x2 = inputs
+        y1, y2 = _forward_correct(x1, x2)
+        self.retain_inputs((0, 1))
+        return utils.force_array(y1), utils.force_array(y2)
+
+    def backward(self, indexes, grad_outputs):
+        gy1, gy2 = grad_outputs
+        x1, x2 = self.get_retained_inputs()
+        ggx1, ggx2 = _backward_correct(x1, x2, gy1, gy2)
+        ggx2 = ggx2 + 1  # ! make incorrect
+        return utils.force_array(ggx1), utils.force_array(ggx2)
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), (2,), (1,), ()],
+}))
+@_inject_backend_tests
+@pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
+@testing.function_test()
+class TestFunctionTestIncorrectBackward(unittest.TestCase):
+    forward_test = False
+    double_backward_test = False
+
+    def generate_inputs(self):
+        x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        x2 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        return x1, x2
+
+    def forward(self, inputs, device):
+        func = FuncWithIncorrectBackward()
+        return func.apply(inputs)
+
+    def forward_expected(self, inputs):
+        return _forward_correct(*inputs)
+
+
+# TestFunctionTestIncorrectDoubleBackward
+#
+# This test checks if it can detect incorrect double backward implementation.
+
+class FuncWithIncorrectDoubleBackward(chainer.FunctionNode):
+    def forward(self, inputs):
+        x1, x2 = inputs
+        y1, y2 = _forward_correct(x1, x2)
+        self.retain_inputs((0, 1))
+        return utils.force_array(y1), utils.force_array(y2)
+
+    def backward(self, indexes, grad_outputs):
+        x1, x2 = self.get_retained_inputs()
+        gy1, gy2 = grad_outputs
+        grad_func = FuncGradWithIncorrectDoubleBackward()
+        return grad_func.apply((x1, x2, gy1, gy2))
+
+
+class FuncGradWithIncorrectDoubleBackward(chainer.FunctionNode):
+    def forward(self, inputs_and_grad_outputs):
+        x1, x2, gy1, gy2 = inputs_and_grad_outputs
+        self.retain_inputs((0, 1, 2, 3))
+
+        ggx1, ggx2 = _backward_correct(x1, x2, gy1, gy2)
+        return utils.force_array(ggx1), utils.force_array(ggx2)
+
+    def backward(self, indexes, grad_grad_inputs):
+        ggx1, ggx2 = grad_grad_inputs
+        x1, x2, gy1, gy2 = self.get_retained_inputs()
+        gx1, gx2, ggy1, ggy2 = _double_backward_correct(
+            x1, x2, gy1, gy2, ggx1, ggx2)
+        ggy2 = ggy2 + 1  # ! make incorrect
+        return ggx1, ggx2, ggy1, ggy2
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), (2,), (1,), ()],
+}))
+@_inject_backend_tests
+@pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
+@testing.function_test()
+class TestFunctionTestIncorrectDoubleBackward(unittest.TestCase):
+    forward_test = False
+    backward_test = False
+
+    def generate_inputs(self):
+        x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        x2 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        return x1, x2
+
+    def forward(self, inputs, device):
+        func = FuncWithIncorrectDoubleBackward()
+        return func.apply(inputs)
+
+    def forward_expected(self, inputs):
+        return _forward_correct(*inputs)
+
+
+# FunctionTestCaseArrayContiguousnessTest
+#
+# This test checks incoming array contiguousness.
+# As it's not possible to assume contiguousness of incoming arrays consistently
+# (because gradient_check passes contiguous arrays in numerical_grad),
+# we instead simulate the test failure. The function implementation raises an
+# error if an incoming array matches the expected contiguousness and we expect
+# the failure.
+
+
+class _ContiguousnessMatched(Exception):
+    pass
+
+
+def _is_f_contiguous(shape, strides, itemsize):
+    if numpy.prod(shape) <= 1:
+        return True
+    for sh, st in zip(shape, reversed(strides)):
+        if sh == 1:
+            continue
+        if st != itemsize:
+            return False
+        itemsize *= sh
+    return True
+
+
+def _get_contiguousness(arr):
+    if isinstance(arr, chainerx.ndarray):
+        c_contig = arr.is_contiguous
+        f_contig = _is_f_contiguous(
+            arr.shape, arr.strides, arr.itemsize)
+        return (c_contig, f_contig)
+    return (arr.flags.c_contiguous, arr.flags.f_contiguous)
+
+
+def _check_contiguousness(arr, expected_contiguous):
+    if isinstance(arr, chainer.Variable):
+        _check_contiguousness(arr.array, expected_contiguous)
+        return
+
+    c_contig, f_contig = _get_contiguousness(arr)
+    if numpy.prod(arr.shape) <= 1:
+        return  # not applicable for this shape
+
+    if expected_contiguous is None:
+        # expected to be non-contiguous
+        if not c_contig and not f_contig:
+            raise _ContiguousnessMatched()
+    elif expected_contiguous == 'C':
+        # expected to be C-contiguous
+        if c_contig:
+            raise _ContiguousnessMatched()
+    else:
+        assert False
+
+
+class FuncWithContiguousnessCheck(chainer.FunctionNode):
+    def __init__(self, contiguous, check_on):
+        self.contiguous = contiguous
+        self.check_on = check_on
+
+    def _check_contiguousness(self, arr):
+        assert isinstance(arr, chainer.get_array_types())
+        _check_contiguousness(arr, self.contiguous)
+
+    def forward(self, inputs):
+        x1, x2 = inputs
+        if self.check_on == 'forward_input':
+            self._check_contiguousness(x1)
+            self._check_contiguousness(x2)
+
+        self.retain_inputs((0, 1))
+        y1, y2 = _forward_correct(x1, x2)
+        return utils.force_array(y1), utils.force_array(y2)
+
+    def backward(self, indexes, grad_outputs):
+        x1, x2 = self.get_retained_inputs()
+        gy1, gy2 = grad_outputs
+        if self.check_on == 'backward_retained_input':
+            self._check_contiguousness(x1.array)
+            self._check_contiguousness(x2.array)
+        elif self.check_on == 'backward_grad_output':
+            self._check_contiguousness(gy1.array)
+            self._check_contiguousness(gy2.array)
+
+        grad_func = FuncGradWithContiguousnessCheck(
+            self.contiguous, self.check_on)
+        return grad_func.apply((x1, x2, gy1, gy2))
+
+
+class FuncGradWithContiguousnessCheck(chainer.FunctionNode):
+    def __init__(self, contiguous, check_on):
+        self.contiguous = contiguous
+        self.check_on = check_on
+
+    def _check_contiguousness(self, arr):
+        _check_contiguousness(arr, self.contiguous)
+
+    def forward(self, inputs_and_grad_outputs):
+        x1, x2, gy1, gy2 = inputs_and_grad_outputs
+        self.retain_inputs((0, 1, 2, 3))
+
+        ggx1, ggx2 = _backward_correct(x1, x2, gy1, gy2)
+        return utils.force_array(ggx1), utils.force_array(ggx2)
+
+    def backward(self, indexes, grad_grad_inputs):
+        ggx1, ggx2 = grad_grad_inputs
+        if self.check_on == 'double_backward_grad_grad_input':
+            self._check_contiguousness(ggx1)
+            self._check_contiguousness(ggx2)
+        x1, x2, gy1, gy2 = self.get_retained_inputs()
+
+        gx1, gx2, ggy1, ggy2 = _double_backward_correct(
+            x1, x2, gy1, gy2, ggx1, ggx2)
+        return gx1, gx2, ggy1, ggy2
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), (2,), (1, 2)],
+    'contiguous': [None, 'C'],
+    'check_on': [  # Check points in which cotiguousness is probed.
+        'forward_input',
+        # TODO(niboshi): As gradient_check.check_backward currently copies the
+        # grads without preserving strides, they cannot be non-contiguous.
+        # Enable this check after check_backward will be fixed.
+        # 'backward_grad_output',
+        'backward_retained_input',
+        # TODO(niboshi): Enable this check after check_backward will be fixed.
+        # 'double_backward_grad_grad_input',
+    ]}))
+@_inject_backend_tests
+@pytest.mark.xfail(strict=True, raises=_ContiguousnessMatched)
+@testing.function_test()
+class FunctionTestCaseArrayContiguousnessTest(unittest.TestCase):
+    def generate_inputs(self):
+        x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        x2 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        return x1, x2
+
+    def forward(self, inputs, device):
+        func = FuncWithContiguousnessCheck(self.contiguous, self.check_on)
+        return func.apply(inputs)
+
+    def forward_expected(self, inputs):
+        return _forward_correct(*inputs)
+
+    def before_test(self, test_name):
+        # Some combinations of test methods and check points are irrelevant.
+        # Skip such combinations.
+        # For example, `test_forward` method does not generate grad_outputs.
+        if test_name == 'test_forward':
+            if self.check_on != 'forward_input':
+                raise unittest.SkipTest()
+        if test_name == 'test_backward':
+            if self.check_on == 'double_backward_grad_grad_input':
+                raise unittest.SkipTest()
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/testing_tests/test_function.py
+++ b/tests/chainer_tests/testing_tests/test_function.py
@@ -170,8 +170,8 @@ class FuncWithIncorrectForward(chainer.FunctionNode):
 @_inject_backend_tests
 @pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
 class TestFunctionTestIncorrectForward(testing.FunctionTestCase):
-    backward_test = False
-    double_backward_test = False
+    skip_backward_test = True
+    skip_double_backward_test = True
 
     def generate_inputs(self):
         x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
@@ -211,8 +211,8 @@ class FuncWithIncorrectBackward(chainer.FunctionNode):
 @_inject_backend_tests
 @pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
 class TestFunctionTestIncorrectBackward(testing.FunctionTestCase):
-    forward_test = False
-    double_backward_test = False
+    skip_forward_test = True
+    skip_double_backward_test = True
 
     def generate_inputs(self):
         x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
@@ -268,8 +268,8 @@ class FuncGradWithIncorrectDoubleBackward(chainer.FunctionNode):
 @_inject_backend_tests
 @pytest.mark.xfail(strict=True, raises=testing.FunctionTestError)
 class TestFunctionTestIncorrectDoubleBackward(testing.FunctionTestCase):
-    forward_test = False
-    backward_test = False
+    skip_forward_test = True
+    skip_backward_test = True
 
     def generate_inputs(self):
         x1 = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)


### PR DESCRIPTION
This is an attempt to ease writing tests for functions.

### Required methods
When you write a new function, you need to write 3 things in the corresponding test:
* `forward`: Forward implementation which simply calls the new function.
* `forward_expected`: Forward reference implementation that returns the expected outputs.
* `generate_inputs`: Generates input arrays to test.

### Environment variables
(this feature has been removed from this PR)

~To easily check numerical stability, the following environment variables can be used (set large number to repeatedly run the corresponding test)~
* ~```CHAINER_TEST_FORWARD_REPEAT```~
* ~```CHAINER_TEST_BACKWARD_REPEAT```~
* ~```CHAINER_TEST_DOUBLE_BACKWARD_REPEAT```~

### PR dependency:
* (merged) ~Needs https://github.com/cupy/cupy/pull/580 to run some example tests~
* (merged) ~Depends on #3551 (non-differentiable point detection)~

* ~#5777~
* ~#5779~
* ~#5781~
* ~#5788~