### PR TITLE
Invoke extensions before training

### DIFF
--- a/chainer/training/extensions/log_report.py
+++ b/chainer/training/extensions/log_report.py
@@ -89,7 +89,7 @@ keys=None, trigger=(1, 'epoch'), postprocess=None, filename='log')
         else:
             summary.add({k: observation[k] for k in keys if k in observation})
 
-        if trainer.updater.iteration == 0 or self._trigger(trainer):
+        if trainer.is_before_training or self._trigger(trainer):
             # output the result
             stats = self._summary.compute_mean()
             stats_cpu = {}

--- a/chainer/training/extensions/log_report.py
+++ b/chainer/training/extensions/log_report.py
@@ -89,7 +89,7 @@ keys=None, trigger=(1, 'epoch'), postprocess=None, filename='log')
         else:
             summary.add({k: observation[k] for k in keys if k in observation})
 
-        if self._trigger(trainer):
+        if trainer.updater.iteration == 0 or self._trigger(trainer):
             # output the result
             stats = self._summary.compute_mean()
             stats_cpu = {}

--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -150,7 +150,7 @@ filename='plot.png', marker='x', grid=True)
         else:
             summary.add({k: observation[k] for k in keys if k in observation})
 
-        if trainer.updater.iteration == 0 or self._trigger(trainer):
+        if trainer.is_before_training or self._trigger(trainer):
             stats = self._summary.compute_mean()
             stats_cpu = {}
             for name, value in six.iteritems(stats):

--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -150,7 +150,7 @@ filename='plot.png', marker='x', grid=True)
         else:
             summary.add({k: observation[k] for k in keys if k in observation})
 
-        if self._trigger(trainer):
+        if trainer.updater.iteration == 0 or self._trigger(trainer):
             stats = self._summary.compute_mean()
             stats_cpu = {}
             for name, value in six.iteritems(stats):

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -311,7 +311,7 @@ class Trainer(object):
         reporter = self.reporter
         stop_trigger = self.stop_trigger
 
-        # call before training loop
+        # call extensions before training loop
         if self.updater.iteration == 0:
             self.observation = {}
             with reporter.scope(self.observation):

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -167,6 +167,10 @@ class Trainer(object):
             self.extend(ext)
 
     @property
+    def is_before_training(self):
+        return self.updater.iteration == 0
+
+    @property
     def elapsed_time(self):
         """Total time used for the training.
 
@@ -312,7 +316,7 @@ class Trainer(object):
         stop_trigger = self.stop_trigger
 
         # call extensions before training loop
-        if self.updater.iteration == 0:
+        if self.is_before_training:
             self.observation = {}
             with reporter.scope(self.observation):
                 for name, entry in extensions:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -25,10 +25,11 @@ except AttributeError:
 
 class _ExtensionEntry(object):
 
-    def __init__(self, extension, priority, trigger):
+    def __init__(self, extension, priority, trigger, call_before_training):
         self.extension = extension
         self.trigger = trigger
         self.priority = priority
+        self.call_before_training = call_before_training
 
 
 class Trainer(object):
@@ -181,7 +182,7 @@ class Trainer(object):
         return _get_time() - self._start_at + self._snapshot_elapsed_time
 
     def extend(self, extension, name=None, trigger=None, priority=None,
-               **kwargs):
+               call_before_training=False, **kwargs):
         """Registers an extension to the trainer.
 
         :class:`Extension` is a callable object which is called after each
@@ -212,6 +213,8 @@ class Trainer(object):
                 iteration by default. If the trigger is not callable, it is
                 passed to :class:`IntervalTrigger` to build an interval
                 trigger.
+            call_before_training (bool): Flag to call extension before
+                training. Default is ``False``.
             priority (int): Invocation priority of the extension. Extensions
                 are invoked in the descending order of priorities in each
                 iteration. If this is ``None``, ``extension.priority`` is used
@@ -253,7 +256,7 @@ class Trainer(object):
 
         extension.name = modified_name
         self._extensions[modified_name] = _ExtensionEntry(
-            extension, priority, trigger)
+            extension, priority, trigger, call_before_training)
 
     def get_extension(self, name):
         """Returns the extension of a given name.
@@ -307,6 +310,14 @@ class Trainer(object):
         update = self.updater.update
         reporter = self.reporter
         stop_trigger = self.stop_trigger
+
+        # call before training loop
+        if self.updater.iteration == 0:
+            self.observation = {}
+            with reporter.scope(self.observation):
+                for name, entry in extensions:
+                    if entry.call_before_training:
+                        entry.extension(self)
 
         # main training loop
         try:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -168,6 +168,18 @@ class Trainer(object):
 
     @property
     def is_before_training(self):
+        """Flag that represents if training has started or not.
+
+        ``True`` represents 'before training' and
+        ``False`` represents 'during/after training'.
+
+        This flag is supposed to be used in :meth:`Extension.__call__`
+        (e.g., :meth:`PlotReport.__call__`) to decide to execute its operation
+        or not. This additional condition is necessary since
+        ``Extension._trigger(trainer)`` is always ``False`` before training
+        and cannot be used.
+
+        """
         return self.updater.iteration == 0
 
     @property

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -86,7 +86,8 @@ def main():
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
 
     # Evaluate the model with the test dataset for each epoch
-    trainer.extend(extensions.Evaluator(test_iter, model, device=device))
+    trainer.extend(extensions.Evaluator(test_iter, model, device=device),
+                   call_before_training=True)
 
     # Dump a computational graph from 'loss' variable at the first iteration
     # The "main" refers to the target link of the "main" optimizer.
@@ -99,16 +100,18 @@ def main():
     trainer.extend(extensions.snapshot(), trigger=(frequency, 'epoch'))
 
     # Write a log of evaluation statistics for each epoch
-    trainer.extend(extensions.LogReport())
+    trainer.extend(extensions.LogReport(), call_before_training=True)
 
     # Save two plot images to the result dir
     trainer.extend(
         extensions.PlotReport(['main/loss', 'validation/main/loss'],
-                              'epoch', file_name='loss.png'))
+                              'epoch', file_name='loss.png'),
+        call_before_training=True)
     trainer.extend(
         extensions.PlotReport(
             ['main/accuracy', 'validation/main/accuracy'],
-            'epoch', file_name='accuracy.png'))
+            'epoch', file_name='accuracy.png'),
+        call_before_training=True)
 
     # Print selected entries of the log to stdout
     # Here "main" refers to the target link of the "main" optimizer again, and
@@ -117,7 +120,8 @@ def main():
     # either the updater or the evaluator.
     trainer.extend(extensions.PrintReport(
         ['epoch', 'main/loss', 'validation/main/loss',
-         'main/accuracy', 'validation/main/accuracy', 'elapsed_time']))
+         'main/accuracy', 'validation/main/accuracy', 'elapsed_time']),
+        call_before_training=True)
 
     # Print a progress bar to stdout
     trainer.extend(extensions.ProgressBar())

--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -119,6 +119,25 @@ class TestTrainer(unittest.TestCase):
         self.assertTrue(dummy_callable_class.is_called)
         self.assertTrue(dummy_callable_class.is_finalized)
 
+    def test_add_called_before_training_extension(self):
+
+        class MyDummyCallableClass(DummyCallableClass):
+            def __init__(self, test_case):
+                super(MyDummyCallableClass, self).__init__(test_case)
+                self.is_called_before_training = False
+
+            def __call__(self, trainer):
+                if trainer.updater.iteration == 0:
+                    self.is_called_before_training = True
+                return super(MyDummyCallableClass, self).__call__(trainer)
+
+        dummy_callable_class = MyDummyCallableClass(self)
+        self.trainer.extend(dummy_callable_class, call_before_training=True)
+        self.trainer.run()
+        self.assertTrue(dummy_callable_class.is_called)
+        self.assertTrue(dummy_callable_class.is_called_before_training)
+        self.assertTrue(dummy_callable_class.is_finalized)
+
     def test_add_lambda_extension(self):
         dummy_class = DummyClass()
         self.trainer.extend(lambda x: dummy_class.touch())

--- a/tests/chainer_tests/training_tests/test_trainer.py
+++ b/tests/chainer_tests/training_tests/test_trainer.py
@@ -127,7 +127,7 @@ class TestTrainer(unittest.TestCase):
                 self.is_called_before_training = False
 
             def __call__(self, trainer):
-                if trainer.updater.iteration == 0:
+                if trainer.is_before_training:
                     self.is_called_before_training = True
                 return super(MyDummyCallableClass, self).__call__(trainer)
 


### PR DESCRIPTION
## Why?

I sometimes need to know the loss and accuracy before the training (iteration=0), but currently I'm not sure how to do this with the Trainer class.
This PR achieves it.

## Demonstration

It writes loss and accuracy result even if the epoch is 0.

```
cd examples/mnist
python train_mnist.py
```

<img src=https://user-images.githubusercontent.com/4310419/31270340-fbfd79c6-aabe-11e7-80c3-7b8c853ff95d.png width=48% /> <img src=https://user-images.githubusercontent.com/4310419/31270353-ff0f1534-aabe-11e7-807a-5d39e62a14c4.png width=48% />

## ~Test~

```
cd tests/chainer_tests/training_tests/triggers_tests
python test_interval_trigger.py
```
