### PR TITLE
Make caffe model loading faster (~2.4 times on my benchmark)

### DIFF
--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -258,9 +258,9 @@ class CaffeFunction(link.Chain):
         n_out = num
 
         func = convolution_2d.Convolution2D(
-                n_in, n_out, ksize, stride, pad, nobias=not bias_term,
-                initialW=_ConvolutionBlob(blobs[0], param.group),
-                initial_bias=_Blob(blobs[1]) if bias_term else None)
+            n_in, n_out, ksize, stride, pad, nobias=not bias_term,
+            initialW=_ConvolutionBlob(blobs[0], param.group),
+            initial_bias=_Blob(blobs[1]) if bias_term else None)
 
         with self.init_scope():
             setattr(self, layer.name, func)


### PR DESCRIPTION
Currently `CaffeFunction` unnecessary performs normal distribution initializations on some layers.

Furthermore, directly accessing Protobuf fields from Python is slow. [Protobuf Python extension efficiently converts repeated scalar values into a python list when slice-indexed](https://github.com/google/protobuf/blob/v3.4.0/python/google/protobuf/pyext/repeated_scalar_container.cc#L290), so using an intermediate list is faster.

This PR fixed the two inefficiencies.  I performed a benchmark loading the VGG-19 caffemodel, on my Linux desktop machine equipped with Core i5-3550 CPU.

```py
from chainer.links.caffe import CaffeFunction
from time import perf_counter

COUNT = 5
holder = [None] * COUNT

t1 = perf_counter()
for i in range(COUNT):
    holder[i] = CaffeFunction('VGG_ILSVRC_19_layers.caffemodel')
t2 = perf_counter()

print("avg: {} seconds".format((t2 - t1) / COUNT,))
```

The result shows ~2.4 times improvement:

- original: `avg: 34.08330419499835 seconds`,
- after the changes: `14.347811671401724 seconds`.