### PR TITLE
Loss Scaling

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -8,6 +8,7 @@ import six
 from chainer import cuda
 from chainer import link as link_module
 from chainer import serializer as serializer_module
+from chainer import training
 from chainer import variable
 
 
@@ -526,6 +527,9 @@ class GradientMethod(Optimizer):
         if lossfun is not None:
             use_cleargrads = getattr(self, '_use_cleargrads', True)
             loss = lossfun(*args, **kwds)
+            loss_scaling_factor = training.get_loss_scaling_factor()
+            if loss_scaling_factor is not None:
+                loss *= loss_scaling_factor
             if use_cleargrads:
                 self.target.cleargrads()
             else:

--- a/chainer/training/__init__.py
+++ b/chainer/training/__init__.py
@@ -20,3 +20,38 @@ from chainer.training.trigger import IntervalTrigger  # NOQA
 from chainer.training.updater import ParallelUpdater  # NOQA
 from chainer.training.updater import StandardUpdater  # NOQA
 from chainer.training.updater import Updater  # NOQA
+
+
+from chainer.configuration import config  # NOQA
+from chainer.configuration import global_config  # NOQA
+
+import numpy
+
+
+global_config.update_parameter_in_fp32 = False
+global_config.loss_scaling_factor = None
+
+
+def set_loss_scaling_factor(val):
+    """Sets loss scaling factor."""
+    config.loss_scaling_factor = val
+    config.update_parameter_in_fp32 = True
+
+
+def get_loss_scaling_factor():
+    """Gets loss scaling factor."""
+    return config.loss_scaling_factor
+
+
+def should_update_parameter_in_fp32(dtype):
+    """Determins if the parameter should be updated in fp32.
+
+    Args:
+        dtype (numpy.dtype): data type of the parameter.
+
+    Returns:
+        bool: ``True`` if the parameter should be updated in fp32.
+    """
+    if config.update_parameter_in_fp32 and dtype == numpy.float16:
+        return True
+    return False


### PR DESCRIPTION
This PR adds a loss scaling feature: http://docs.nvidia.com/deeplearning/sdk/mixed-precision-training/index.html#lossscaling.

You can use the loss scaling feature by just setting the scaling factor using a method `set_loss_scaling_factor()` as below.

    from chainer import training
    
    training.set_loss_scaling_factor(1024.0)
    trainer.run()

When the scaling factor is set and data type of parameters is fp16, a fp32 copy of parameters are created automatically and parameters are updated with fp32.

Please note that only ``StandardUpdater`` is supported for now. After some consensus is obtained that this API is OK, I will make the loss scaling available to other Updaters.
