### PR TITLE
User-friendly error checks for pooling input

### DIFF
--- a/chainer/functions/pooling/pooling_nd.py
+++ b/chainer/functions/pooling/pooling_nd.py
@@ -21,6 +21,10 @@ class _PoolingND(function.Function):
         if stride is None:
             stride = ksize
 
+        if ndim <= 0:
+            raise ValueError(
+                'pooling operation requires at least one spatial dimension.')
+
         self.ndim = ndim
         self.ksize = conv_nd.as_tuple(ksize, ndim)
         self.stride = conv_nd.as_tuple(stride, ndim)
@@ -33,7 +37,8 @@ class _PoolingND(function.Function):
         type_check.expect(
             in_types.size() == 1,
             in_types[0].dtype.kind == 'f',
-            in_types[0].ndim == 2 + self.ndim
+            in_types[0].ndim == 2 + self.ndim,
+            in_types[0].size > 0,
         )
 
     def forward_gpu(self, x):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -38,7 +38,10 @@ class TypeInfo(object):
         self.shape = shape
         self.dtype = dtype
         self.ndim = len(shape)
-        self.size = functools.reduce(operator.mul, shape, 1)
+
+    @property
+    def size(self):
+        return functools.reduce(operator.mul, self.shape, 1)
 
 
 class TypeInfoTuple(tuple):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import operator
 import sys
 import threading
@@ -37,6 +38,7 @@ class TypeInfo(object):
         self.shape = shape
         self.dtype = dtype
         self.ndim = len(shape)
+        self.size = functools.reduce(operator.mul, shape, 1)
 
 
 class TypeInfoTuple(tuple):


### PR DESCRIPTION
Fixes #3554 
* Check if the spatial dimension does not include `0`
* Check if the spatial dimension is not empty `()`