### PR TITLE
Define dummy cuda.cupy when cupy is not available

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -56,6 +56,9 @@ except Exception as e:
     class ndarray(object):
         pass  # for type testing
 
+    # for `xp is cuda.cupy` to always work
+    cupy = object()
+
 if available:
     _cudnn_disabled_by_user = int(os.environ.get('CHAINER_CUDNN', '1')) == 0
     try:

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -110,18 +110,30 @@ class TestCuda(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 cuda.to_gpu(x)
 
-    def test_get_array_module_for_numpy(self):
-        self.assertIs(cuda.get_array_module(numpy.array([])), numpy)
-        self.assertIs(
-            cuda.get_array_module(chainer.Variable(numpy.array([]))),
-            numpy)
+    def test_get_array_module_for_numpy_array(self):
+        xp = cuda.get_array_module(numpy.array([]))
+        self.assertIs(xp, numpy)
+        self.assertIsNot(xp, cuda.cupy)
+
+    def test_get_array_module_for_numpy_variable(self):
+        xp = cuda.get_array_module(chainer.Variable(numpy.array([])))
+        self.assertIs(xp, numpy)
+        self.assertIsNot(xp, cuda.cupy)
 
     @attr.gpu
-    def test_get_array_module_for_cupy(self):
-        self.assertIs(cuda.get_array_module(cuda.cupy.array([])), cuda.cupy)
-        self.assertIs(
-            cuda.get_array_module(chainer.Variable(cuda.cupy.array([]))),
-            cuda.cupy)
+    def test_get_array_module_for_cupy_array(self):
+        xp = cuda.get_array_module(cuda.cupy.array([]))
+        self.assertIs(xp, cuda.cupy)
+        self.assertIsNot(xp, numpy)
+
+    @attr.gpu
+    def test_get_array_module_for_cupy_variable(self):
+        xp = cuda.get_array_module(chainer.Variable(cuda.cupy.array([])))
+        self.assertIs(xp, cuda.cupy)
+        self.assertIsNot(xp, numpy)
+
+    def test_cupy_is_not_none(self):
+        self.assertIsNotNone(cuda.cupy)
 
 
 @testing.parameterize(


### PR DESCRIPTION
Currently you can't write `xp is cuda.cupy` because `cuda.cupy` is not defined if CuPy is not installed.

This PR defines dummy `cuda.cupy` even when it's not installed.