### PR TITLE
Prevent ZeroDivisionError in softmax_cross_entropy when input size is 0

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -113,6 +113,14 @@ class SoftmaxCrossEntropy(function.Function):
         if chainer.is_debug():
             _check_input_values(x, t, self.ignore_label)
 
+        if x.size == 0:
+            y = cupy.zeros(t.shape, dtype=x.dtype)
+            if self.cache_score:
+                self.y = y
+            if self.reduce == 'mean':
+                return y.sum(),
+            else:
+                return y,
         log_y = log_softmax._log_softmax(x)
         if self.cache_score:
             self.y = cupy.exp(log_y)
@@ -154,6 +162,8 @@ class SoftmaxCrossEntropy(function.Function):
     def backward_cpu(self, inputs, grad_outputs):
         x, t = inputs
         gloss = grad_outputs[0]
+        if x.size == 0:
+            return numpy.zeros(x.shape, dtype=x.dtype), None
         if hasattr(self, 'y'):
             y = self.y.copy()
         else:
@@ -195,6 +205,8 @@ class SoftmaxCrossEntropy(function.Function):
     def backward_gpu(self, inputs, grad_outputs):
         cupy = cuda.cupy
         x, t = inputs
+        if x.size == 0:
+            return cupy.zeros(x.shape, dtype=x.dtype), None
         if hasattr(self, 'y'):
             y = self.y
         else:

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -29,6 +29,14 @@ from chainer.testing import condition
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'weight_apply': [False, True],
     'enable_double_backprop': [False, True],
+}) + testing.product({
+    'shape': [(0, 3), (0, 3, 2), (0, 3, 2, 2)],
+    'cache_score': [True, False],
+    'normalize': [True, False],
+    'ignore_index': [None],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'weight_apply': [False, True],
+    'enable_double_backprop': [False],
 })))
 class TestSoftmaxCrossEntropy(unittest.TestCase):
 
@@ -95,7 +103,10 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
             else:
                 loss_expect /= count
         else:
-            loss_expect /= len(t_data)
+            if len(t_data) == 0:
+                loss_expect = 0.0
+            else:
+                loss_expect /= len(t_data)
 
         testing.assert_allclose(
             loss_expect, loss_value, **self.check_forward_options)


### PR DESCRIPTION
Fix #3311 
This error often happens when all the inputs are masked, and shape is like `(0, 512, 16, 16)`