### PR TITLE
Always cast all inputs to given dtype in gradient check

### DIFF
--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -379,7 +379,7 @@ class TestCheckBackward(unittest.TestCase):
             if self.dtype is not None:
                 # Check for correct dtypes if f is called to compute the
                 # numerical gradient
-                if numpy.linalg.norm(x.data - x1) >= eps / 2:
+                if x.data != x1:
                     self.assertEqual(x.dtype, self.dtype)
                     self.assertEqual(x.dtype, y.dtype)
             s = Ident()(x)

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -369,6 +369,25 @@ class TestCheckBackward(unittest.TestCase):
                           f, (x1, x2), g1, no_grads=[False, False])
         gradient_check.check_backward(f, (x1, x2), g1, no_grads=[False, True])
 
+    def test_no_grads_option_with_dtype(self):
+        x1 = numpy.array([1], dtype='f')
+        x2 = numpy.array([1], dtype='f')
+        g1 = numpy.array([1], dtype='f')
+        eps = 1e-3
+
+        def f(x, y):
+            if self.dtype is not None:
+                # Check for correct dtypes if f is called to compute the
+                # numerical gradient
+                if numpy.linalg.norm(x.data - x1) >= eps / 2:
+                    self.assertEqual(x.dtype, self.dtype)
+                    self.assertEqual(x.dtype, y.dtype)
+            s = Ident()(x)
+            return s,
+
+        gradient_check.check_backward(f, (x1, x2), g1, eps=eps,
+                                      no_grads=[False, True], dtype=self.dtype)
+
 
 class NewIdent(chainer.FunctionNode):
 


### PR DESCRIPTION
When passing the `no_grads` argument to the gradient check while at the same time specifying the `dtype` argument, all inputs are cast to the given `dtype` except the ones ignored by `no_grads`.
dtypes of function arguments are thus occasionally mixed, in particular, if a function that is being tested for correct gradients uses a kernel, an error is raises on mismatched dtypes on the kernel call.

This PR fixes this issue by always casting all inputs if `dtype` is specified no matter the value of `no_grads`.