### PR TITLE
Use a distinct RandomState in the prefetch thread of MultiProcessIterator

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -280,6 +280,14 @@ class _PrefetchLoop(object):
         self._allocate_shared_memory()
         self._pool = None
 
+        # Use a distinct RandomState in the thread
+        # for deterministic random number generation.
+        # To support 32-bit platform and numpy < 1.11,
+        # the seed is taken in a verbose manner.
+        seed = numpy.asscalar(
+            numpy.random.randint(-(1 << 31), 1 << 31, 1).astype('uint32'))
+        self._random = numpy.random.RandomState(seed)
+
         self._interruption_testing = _interruption_testing
 
     def measure_required(self):
@@ -385,7 +393,7 @@ class _PrefetchLoop(object):
             else:
                 indices = order[pos:n]
                 if self.repeat:
-                    order = numpy.random.permutation(n)
+                    order = self._random.permutation(n)
                     indices = \
                         numpy.concatenate((indices, order[:new_pos]))
             epoch += 1

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -408,6 +408,25 @@ class TestMultiprocessIteratorConcurrency(unittest.TestCase):
         self.assertFalse(deadlock)
 
 
+class TestMultiprocessIteratorDeterminancy(unittest.TestCase):
+
+    def setUp(self):
+        self._seed = 3141592653
+        self._random_bak = numpy.random.get_state()
+
+    def tearDown(self):
+        numpy.random.set_state(self._random_bak)
+
+    def test_reproduce_same_permutation(self):
+        dataset = [1, 2, 3, 4, 5, 6]
+        numpy.random.seed(self._seed)
+        it1 = iterators.MultiprocessIterator(dataset, 6)
+        numpy.random.seed(self._seed)
+        it2 = iterators.MultiprocessIterator(dataset, 6)
+        for _ in range(5):
+            self.assertEqual(it1.next(), it2.next())
+
+
 @testing.parameterize(*testing.product({
     'n_prefetch': [1, 2],
     'shared_mem': [None, 1000000],


### PR DESCRIPTION
Numpy shares the internal state of `numpy.random` across all threads. So if we use `numpy.random` from non-main thread, random number generation will be non-deterministic, dependent on context switch timing.

It hurts reproducibility. This PR fix the problem, by creating a distinct `RandomState` for each prefetch loop.  
