### PR TITLE
New style square function

### DIFF
--- a/chainer/functions/math/square.py
+++ b/chainer/functions/math/square.py
@@ -1,10 +1,10 @@
 from chainer import cuda
-from chainer import function
+from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check
 
 
-class Square(function.Function):
+class Square(function_node.FunctionNode):
 
     @property
     def label(self):
@@ -17,12 +17,14 @@ class Square(function.Function):
         )
 
     def forward(self, x):
+        self.retain_inputs((0,))
         xp = cuda.get_array_module(*x)
         return utils.force_array(xp.square(x[0], dtype=x[0].dtype)),
 
-    def backward(self, x, gy):
-        gx = gy[0] * 2.0 * x[0]
-        return utils.force_array(gx, dtype=x[0].dtype),
+    def backward(self, indexes, gy):
+        x = self.get_retained_inputs()[0]
+        gx = gy[0] * 2.0 * x
+        return gx,
 
 
 def square(x):
@@ -38,4 +40,4 @@ def square(x):
     Returns:
         ~chainer.Variable: Output variable.
     """
-    return Square()(x)
+    return Square().apply((x,))[0]

--- a/tests/chainer_tests/functions_tests/math_tests/test_square.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_square.py
@@ -4,7 +4,7 @@ import chainer.functions as F
 from chainer import testing
 
 
-@testing.unary_math_function_unittest(F.Square())
+@testing.unary_math_function_unittest(F.square)
 class TestSquare(unittest.TestCase):
     pass
 


### PR DESCRIPTION
This PR implements new style `square` function.

I also fixed `unary_math_function_test` decorator to support testing FunctionNode.
I think this is transitional; once https://github.com/chainer/chainer/pull/3499 got merged, it is better to rewrite tests with the new function test template.