### PR TITLE
Add train.rst to the docs/tutorial dir

### DIFF
--- a/docs/source/tutorial/train.rst
+++ b/docs/source/tutorial/train.rst
@@ -1,0 +1,8 @@
+How to train your network
+-------------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   train_loop
+   trainer


### PR DESCRIPTION
`docs/source/tutorial/train.rst` is missing so that the two tutorials about how to write the custom training loop and how to use Trainer don't appear on the document site. This PR adds the missing file to fix it.