### PR TITLE
Raise user-friendly error when FunctionNode is used like Function object

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -176,6 +176,25 @@ class FunctionNode(object):
     def _impl_name(self):
         return self.__class__.__name__
 
+    def __call__(self, *args, **kwargs):
+        if self.__class__.__module__.startswith('chainer.'):
+            msg = '''\
+Chainer's built-in function class object ({}) which is derived from \
+chainer.FunctionNode has been called as if it were a callable. \
+Use FunctionNode.apply() method instead.
+Furthermore, it's not recommended to use built-in function classes directly; \
+use corresponding function aliases (those with snake_case name, such as \
+F.convolution_nd) instead.\
+'''.format(self.__class__.__name__)
+        else:
+            msg = '''\
+A function class object ({}) which is derived from \
+chainer.FunctionNode has been called as if it were a callable. \
+Use apply() method instead.\
+'''.format(self.__class__.__name__)
+
+        raise RuntimeError(msg)
+
     def apply(self, inputs):
         """Computes output variables and grows the computational graph.
 


### PR DESCRIPTION
If a user were using traditional `chainer.Function` class object and the function class were converted to `chainer.FunctionNode`, the user would get an unfriendly error: ```TypeError: 'Softmax' object is not callable```.

This PR implements `FunctionNode.__call__` which simply raises an exception with more useful message.

Additionally, if the function class in question is one of Chainer's builtin functions, it adds to the message that it's not recommended to use function classes directly.

```
>>> import chainer.functions as F
>>> f = F.Softmax()
>>> f(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/work/w/repos/chainer/chainer/function_node.py", line 196, in __call__
    raise RuntimeError(msg)
RuntimeError: Chainer's built-in function class object (Softmax) which is derived from chainer.FunctionNode has been called as if it were a callable. Use FunctionNode.apply() method instead.
Furthermore, it's not recommended to use built-in function classes directly; use corresponding function aliases (those with snake_case name, such as F.convolution_nd) instead.
>>>
```