### PR TITLE
Fix for pytest migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ chainer.egg-info/
 dist/
 htmlcov/
 .idea/
+.cache/
 docs/my.model
 docs/my.state
 docs/my_mnist.model


### PR DESCRIPTION
* Remove unneeded `__init__.py`
* Add pytest cahce directory to gitignore