### PR TITLE
Remove requirements for unit testing

### DIFF
--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -1,9 +1,41 @@
-import pytest
+try:
+    import pytest
+    _error = None
+except ImportError as e:
+    _error = e
 
-gpu = pytest.mark.gpu
-cudnn = pytest.mark.cudnn
-slow = pytest.mark.slow
+
+def is_available():
+    return _error is None
+
+
+def check_available():
+    if _error is not None:
+        raise RuntimeError('''\
+{} is not available.
+
+Reason: {}: {}'''.format(__name__, type(_error).__name__, _error))
+
+
+def get_error():
+    return _error
+
+
+if _error is None:
+    gpu = pytest.mark.gpu
+    cudnn = pytest.mark.cudnn
+    slow = pytest.mark.slow
+
+else:
+    def _dummy_callable(*args, **kwargs):
+        check_available()
+        assert False  # Not reachable
+
+    gpu = _dummy_callable
+    cudnn = _dummy_callable
+    slow = _dummy_callable
 
 
 def multi_gpu(gpu_num):
+    check_available()
     return pytest.mark.multi_gpu(gpu=gpu_num)

--- a/chainer/testing/training.py
+++ b/chainer/testing/training.py
@@ -1,8 +1,29 @@
 from __future__ import division
 
-import mock
-
 from chainer import training
+
+
+try:
+    import mock
+    _error = None
+except ImportError as e:
+    _error = e
+
+
+def is_available():
+    return _error is None
+
+
+def check_available():
+    if _error is not None:
+        raise RuntimeError('''\
+{} is not available.
+
+Reason: {}: {}'''.format(__name__, type(_error).__name__, _error))
+
+
+def get_error():
+    return _error
 
 
 def get_trainer_with_mock_updater(
@@ -22,6 +43,7 @@ def get_trainer_with_mock_updater(
         Trainer object with a mock updater.
 
     """
+    check_available()
     updater = mock.Mock()
     updater.get_all_optimizers.return_value = {}
     updater.iteration = 0

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -2,9 +2,26 @@ import numpy
 import unittest
 
 from chainer import cuda
-from chainer.testing import attr
 from chainer.testing import condition
 from chainer import variable
+
+try:
+    from chainer.testing import attr
+    _error = attr.get_error()
+except ImportError as e:
+    _error = e
+
+
+def is_available():
+    return _error is None
+
+
+def check_available():
+    if _error is not None:
+        raise RuntimeError('''\
+{} is not available.
+
+Reason: {}: {}'''.format(__name__, type(_error).__name__, _error))
 
 
 def _make_data_default(shape, dtype):
@@ -106,6 +123,7 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
        defined, then passed to the decorator's ``make_data`` parameter.
 
     """
+    check_available()
 
     # TODO(takagi) In the future, the Chainer functions that could be tested
     #     with the decorator would be extended as:

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ set CHAINER_PYTHON_350_FORCE environment variable to 1."""
 setup_requires = []
 install_requires = [
     'filelock',
-    'mock',
-    'pytest',
     'numpy>=1.9.0',
     'protobuf>=3.0.0',
     'six>=1.9.0',


### PR DESCRIPTION
Note: **Even though I put no-compat label, this PR does not break backward-compatibility.** Backward compatibility was broken when testing framework was replaced with PyTest. I put the label simply to signify that.


This PR removes pytest and mock requirements from Chainer normal installation.
That would reduce the possibility of trouble for users resulting from migration to PyTest.

OTOH, some parts of `chainer.testing` package depend on `pytest` and `mock`. Simply removing requirements would result in `ImportError`s when importing `chainer.testing`. To avoid that, I introduced `is_available()` functions to such modules.

This PR should be backported, because PyTest has introduced to stable branch as well.