### PR TITLE
Use Python 3.4.4 on Travis OSX Python 3.4 case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - os: osx
       language: generic
       env:
-      - PYTHON_VERSION=3.4.3
+      - PYTHON_VERSION=3.4.4
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
     - os: osx


### PR DESCRIPTION
Travis fails on OSX Python 3.4 case because of its inspect module.

https://travis-ci.org/chainer/chainer/builds/289372879

As far as I read the source, Python 3.4.3 inspect module looks trying to compare object identity by `==` operator and it is fixed in Python 3.4.4.

Python 3.4.3
https://github.com/python/cpython/blob/f5caf2b30bfe70e5107f816c9e7f7fe3ef5299d9/Lib/inspect.py#L383

Python 3.4.4
https://github.com/python/cpython/blob/fa7193286099f8e4164f4a795afd5ad4a8e229df/Lib/inspect.py#L382

I bump Python version used in Travis OSX Python 3.4 case from 3.4.3 to 3.4.4.