### PR TITLE
Update comparison.rst (Web interface)

### DIFF
--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -31,7 +31,7 @@ This table compares Chainer with other actively developed deep learning framewor
    "Misc","Runtime debugging","debug mode, typechecking, pdb","pdb","tfdbg",,,,"Monitor","pdb",,"Java debuggers","cntk.debugging",,"Gallium.jl","gdb","pdb"
    ,"Trainer abstraction","native","`tnt <https://github.com/pytorch/tnt>`_",,"`Blocks <https://github.com/mila-udem/blocks>`_, `Lasagne <https://github.com/Lasagne/Lasagne>`_, `Keras <https://github.com/fchollet/keras>`_","native","`torchnet <https://github.com/torchnet/torchnet>`_",,,"native","native","native","native",,,"native"
    ,"Reporter abstraction","native","tnt","native",,,"torchnet","native",,,"native","native",,,,
-   ,"Web interface",,,"`TensorBoard <https://github.com/tensorflow/tensorboard>`_",,,,,,,"DL4J-UI",,"Nervana Cloud",,,
+   ,"Web interface","`tensorboardX <https://github.com/lanpa/tensorboard-pytorch>`_","`tensorboardX <https://github.com/lanpa/tensorboard-pytorch>`_, `visdom <https://github.com/lanpa/tensorboard-pytorch>`_","`TensorBoard <https://github.com/tensorflow/tensorboard>`_",,,,,,,"DL4J-UI",,"Nervana Cloud",,,
    ,"Graph compilation engine",,2017,"`XLA <https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/>`_",,2017,,"`NNVM <https://github.com/dmlc/nnvm>`_",,,,,"ngraph",,,
 
 .. [1] Define-by-run is in development as of June 2017 and tracked in `dmlc/mxnet#5705 <https://github.com/dmlc/mxnet/pull/5705>`_. It is also possible using the much slower MinPy extension.


### PR DESCRIPTION
tensorboardX can also be used with chainer without much modification.

And the following is an example of chainer extension that uses tensorboard to log data.
https://github.com/lanpa/chainer/commit/33f0c6c1d414fd4e866179d77455ee8739e1f6d2
<img width="700" alt="screen shot 2017-10-20 at 12 44 27 am" src="https://user-images.githubusercontent.com/2005323/31783198-04e58ff8-b530-11e7-8765-dfe8d92278a0.png">
<img width="372" alt="screen shot 2017-10-20 at 12 44 50 am" src="https://user-images.githubusercontent.com/2005323/31783199-0511a386-b530-11e7-91d3-7957c9e67cba.png">

