### PR TITLE
remove nose dependency in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - pip install dist/*.tar.gz
   - pip install h5py pillow
   - travis_wait pip install theano
-  - pip install nose pytest hacking mock
+  - pip install pytest hacking mock
   - pip install autopep8
 
 script:
@@ -62,7 +62,7 @@ script:
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
   - cd tests
-  - CHAINER_TEST_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:nose.importer,ignore::DeprecationWarning:site,ignore::DeprecationWarning:nose.plugins.manager' pytest -m "not slow and not cudnn" chainer_tests
+  - CHAINER_TEST_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:site' pytest -m "not slow and not cudnn" chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       cd ..;
       READTHEDOCS=True python setup.py develop;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ build_script:
 test_script:
   # Run the project tests
   - "%CMD_IN_ENV% pip install mock hacking"
-  - "%CMD_IN_ENV% pip install nose pytest pytest-timeout pytest-cov"
+  - "%CMD_IN_ENV% pip install pytest pytest-timeout pytest-cov"
   - "flake8"
   # Avoid interuption confirmation of cmd.exe
   - "echo SET CHAINER_TEST_GPU_LIMIT=0 > tmp.bat"

--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -1,5 +1,3 @@
-import pytest
-
 from chainer.testing import array  # NOQA
 from chainer.testing import helper  # NOQA
 from chainer.testing import parameterized  # NOQA
@@ -31,5 +29,5 @@ def run_module(name, file):
     """
 
     if name == '__main__':
-
+        import pytest
         pytest.main([file, '-vvs', '-x', '--pdb'])

--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -1,4 +1,4 @@
-import nose
+import pytest
 
 from chainer.testing import array  # NOQA
 from chainer.testing import helper  # NOQA
@@ -32,5 +32,4 @@ def run_module(name, file):
 
     if name == '__main__':
 
-        nose.runmodule(argv=[file, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                       exit=False)
+        pytest.main([file, '-vvs', '-x', '--pdb'])

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -106,15 +106,6 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
        Because the test methods are implicitly injected to ``TestSin`` class by
        the decorator, it is enough to place ``pass`` in the class definition.
 
-       Now the test is run with ``nose`` module.
-
-       .. doctest::
-
-          >>> import nose
-          >>> nose.run(
-          ...     defaultTest=__name__, argv=['', '-a', '!gpu'], exit=False)
-          True
-
        To customize test data, ``make_data`` optional parameter can be used.
        The following is an example of testing ``sqrt`` Chainer function, which
        is tested in positive value domain here instead of the default input.
@@ -133,10 +124,6 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
           ...                                       make_data=make_data)
           ... class TestSqrt(unittest.TestCase):
           ...     pass
-          ...
-          >>> nose.run(
-          ...     defaultTest=__name__, argv=['', '-a', '!gpu'], exit=False)
-          True
 
        ``make_data`` function which returns input, gradient and double gradient
        data generated in proper value domains with given ``shape`` and

--- a/tests/chainer_tests/functions_tests/pooling_tests/pooling_nd_helper.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/pooling_nd_helper.py
@@ -1,11 +1,9 @@
 import itertools
-import nose.tools
 import six
 
 from chainer import testing
 
 
-@nose.tools.nottest
 def pooling_patches(dims, ksize, stride, pad, cover_all):
     """Return tuples of slices that indicate pooling patches."""
     # Left-top indexes of each pooling patch.


### PR DESCRIPTION
`run_module` function still depends on `nose`.
I changed to use `pytest`.