### PR TITLE
Fix decorators to allow users to filter test cases by number of GPUs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
   - cd tests
-  - CHAINER_TESTING_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:nose.importer,ignore::DeprecationWarning:site,ignore::DeprecationWarning:nose.plugins.manager' pytest -m "not slow and not cudnn" chainer_tests
+  - CHAINER_TEST_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:nose.importer,ignore::DeprecationWarning:site,ignore::DeprecationWarning:nose.plugins.manager' pytest -m "not slow and not cudnn" chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       cd ..;
       READTHEDOCS=True python setup.py develop;

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
   - cd tests
-  - PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:nose.importer,ignore::DeprecationWarning:site,ignore::DeprecationWarning:nose.plugins.manager' pytest -m "not gpu and not multi_gpu and not slow and not cudnn" chainer_tests
+  - CHAINER_TESTING_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:nose.importer,ignore::DeprecationWarning:site,ignore::DeprecationWarning:nose.plugins.manager' pytest -m "not slow and not cudnn" chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       cd ..;
       READTHEDOCS=True python setup.py develop;

--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -1,3 +1,7 @@
+import os
+import unittest
+
+
 try:
     import pytest
     _error = None
@@ -22,7 +26,8 @@ def get_error():
 
 
 if _error is None:
-    gpu = pytest.mark.gpu
+    _gpu_limit = int(os.getenv('CHAINER_TESTING_GPU_LIMIT', '-1'))
+
     cudnn = pytest.mark.cudnn
     slow = pytest.mark.slow
 
@@ -31,11 +36,32 @@ else:
         check_available()
         assert False  # Not reachable
 
-    gpu = _dummy_callable
     cudnn = _dummy_callable
     slow = _dummy_callable
 
 
 def multi_gpu(gpu_num):
+    """Decorator to indicate number of GPUs required to run the test.
+
+    Tests can be annotated with this decorator (e.g., ``@multi_gpu(2)``) to
+    declare number of GPUs required to run. When running tests, if
+    ``CHAINER_TESTING_GPU_LIMIT`` environment variable is set to value greater
+    than or equals to 0, test cases that require GPUs more than the limit will
+    be skipped.
+    """
+
     check_available()
-    return pytest.mark.multi_gpu(gpu=gpu_num)
+    return unittest.skipIf(
+        0 <= _gpu_limit and _gpu_limit < gpu_num,
+        reason='{} GPUs required'.format(gpu_num))
+
+
+def gpu(f):
+    """Decorator to indicate that GPU is required to run the test.
+
+    Tests can be annotated with this decorator (e.g., ``@gpu``) to
+    declare that one GPU is required to run.
+    """
+
+    check_available()
+    return multi_gpu(1)(pytest.mark.gpu(f))

--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -26,7 +26,7 @@ def get_error():
 
 
 if _error is None:
-    _gpu_limit = int(os.getenv('CHAINER_TESTING_GPU_LIMIT', '-1'))
+    _gpu_limit = int(os.getenv('CHAINER_TEST_GPU_LIMIT', '-1'))
 
     cudnn = pytest.mark.cudnn
     slow = pytest.mark.slow
@@ -45,7 +45,7 @@ def multi_gpu(gpu_num):
 
     Tests can be annotated with this decorator (e.g., ``@multi_gpu(2)``) to
     declare number of GPUs required to run. When running tests, if
-    ``CHAINER_TESTING_GPU_LIMIT`` environment variable is set to value greater
+    ``CHAINER_TEST_GPU_LIMIT`` environment variable is set to value greater
     than or equals to 0, test cases that require GPUs more than the limit will
     be skipped.
     """


### PR DESCRIPTION
`pytest` does not support filtering test cases based on parameters of decorators.
(`pytest -m MARKEXPR` only checks [existence of marks and does not evaluate parameters](https://github.com/pytest-dev/pytest/blob/3.2.3/_pytest/mark.py#L167-L199))

This means that filter based on number of GPUs (as documented in the [Contribution Guide](https://docs.chainer.org/en/stable/contribution.html#how-to-run-tests)):

```
$ nosetests path/to/gpu/test.py --eval-attr='gpu<2'
```

no longer work.

This PR fixes `multi_gpu` decorator so that `CHAINER_TESTING_GPU_LIMIT` environment variable can be used to limit number of GPUs used.

The above command needs to be rewritten as:

```
$ export CHAINER_TESTING_GPU_LIMIT=1
$ pytest path/to/gpu/test.py
```