### PR TITLE
Function references in docs to point to FunctionNode

### DIFF
--- a/chainer/function_hook.py
+++ b/chainer/function_hook.py
@@ -4,8 +4,8 @@ import chainer
 class FunctionHook(object):
     """Base class of hooks for Functions.
 
-    :class:`~chainer.FunctionHook` is an callback object
-    that is registered to :class:`~chainer.Function`.
+    :class:`~chainer.FunctionHook` is a callback object
+    that is registered to :class:`~chainer.FunctionNode`.
     Registered function hooks are invoked before and after
     forward and backward operations of each function.
 
@@ -17,7 +17,7 @@ class FunctionHook(object):
     :meth:`~chainer.FunctionHook.backward_postprocess`.
     By default, these methods do nothing.
 
-    Specifically, when :meth:`~chainer.Function.__call__`
+    Specifically, when :meth:`~chainer.FunctionNode.__call__`
     method of some function is invoked,
     :meth:`~chainer.FunctionHook.forward_preprocess`
     (resp. :meth:`~chainer.FunctionHook.forward_postprocess`)
@@ -32,7 +32,7 @@ class FunctionHook(object):
     as a gradient are called before (resp. after) backward propagation.
 
     There are two ways to register :class:`~chainer.FunctionHook`
-    objects to :class:`~chainer.Function` objects.
+    objects to :class:`~chainer.FunctionNode` objects.
 
     First one is to use ``with`` statement. Function hooks hooked
     in this way are registered to all functions within ``with`` statement
@@ -79,12 +79,12 @@ class FunctionHook(object):
        are different depending on threads.
 
     The other one is to register directly to
-    :class:`~chainer.Function` object with
+    :class:`~chainer.FunctionNode` object with
     :meth:`~chainer.Function.add_hook` method.
     Function hooks registered in this way can be removed by
     :meth:`~chainer.Function.delete_hook` method.
     Contrary to former registration method, function hooks are registered
-    only to the function which :meth:`~chainer.Function.add_hook`
+    only to the function which :meth:`~chainer.FunctionNode.add_hook`
     is called.
 
     Args:
@@ -110,7 +110,7 @@ class FunctionHook(object):
         """Callback function invoked when a function hook is added
 
         Args:
-            function(~chainer.Function): Function object to which
+            function(~chainer.FunctionNode): Function object to which
                 the function hook is added.
         """
         pass
@@ -119,7 +119,7 @@ class FunctionHook(object):
         """Callback function invoked when a function hook is deleted
 
         Args:
-            function(~chainer.Function): Function object to which
+            function(~chainer.FunctionNode): Function object to which
                 the function hook is deleted.
         """
         pass
@@ -129,7 +129,7 @@ class FunctionHook(object):
         """Callback function invoked before forward propagation.
 
         Args:
-            function(~chainer.Function): Function object to which
+            function(~chainer.FunctionNode): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                Input data of forward propagation.
@@ -140,7 +140,7 @@ class FunctionHook(object):
         """Callback function invoked after forward propagation.
 
         Args:
-            function(~chainer.Function): Function object to which
+            function(~chainer.FunctionNode): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input data of forward propagation.
@@ -152,7 +152,7 @@ class FunctionHook(object):
         """Callback function invoked before backward propagation.
 
         Args:
-            function(~chainer.Function): Function object to which
+            function(~chainer.FunctionNode): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input data of forward propagation.
@@ -165,7 +165,7 @@ class FunctionHook(object):
         """Callback function invoked after backward propagation.
 
         Args:
-            function(~chainer.Function): Function object to which
+            function(~chainer.FunctionNode): Function object to which
                 the function hook is registered.
             in_data(tuple of numpy.ndarray or tuple of cupy.ndarray):
                 Input of forward propagation.

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -1,4 +1,8 @@
-"""Collection of :class:`~chainer.Function` implementations."""
+"""Collection of function implementations.
+
+Functions are either implemented as :class:`~chainer.Function`\s or
+:class:`~chainer.FunctionNode`\s.
+"""
 
 from chainer.functions.activation.clipped_relu import clipped_relu  # NOQA
 from chainer.functions.activation.clipped_relu import ClippedReLU  # NOQA

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -122,13 +122,18 @@ def check_backward(func, x_data, y_grad, params=(),
                    eps=1e-3, atol=1e-5, rtol=1e-4, no_grads=None, dtype=None):
     """Test backward procedure of a given function.
 
-    This function automatically checks backward-process of a given function.
-    For example, when you have a :class:`~chainer.Function` class ``MyFunc``,
-    that gets two arguments and returns one value, you can make its test like
-    this::
+    This function automatically checks the backward-process of a given function
+    to ensure that the computed gradients are approximately correct.
+    For example, assuming you've defined a :class:`~chainer.FunctionNode` class
+    ``MyFunc``, that takes two arguments and returns one value, you can wrap
+    it in a ordinary function and check its gradient computations as follows::
 
     >> def test_my_func(self):
-    >>   func = MyFunc()
+    >>
+    >>     def func(xs):
+    >>         y, = MyFunc().apply(xs)
+    >>         return y
+    >>
     >>   x1_data = xp.array(...)
     >>   x2_data = xp.array(...)
     >>   gy_data = xp.array(...)
@@ -208,8 +213,9 @@ def check_backward(func, x_data, y_grad, params=(),
         func (callable): A function which gets :class:`~chainer.Variable`\\ s
             and returns :class:`~chainer.Variable`\\ s. ``func`` must returns
             a tuple of :class:`~chainer.Variable`\\ s or one
-            :class:`~chainer.Variable`. You can use :class:`~chainer.Function`
-            object, :class:`~chainer.Link` object or a function satisfying the
+            :class:`~chainer.Variable`. You can use a
+            :class:`~chainer.Function`, :class:`~chainer.FunctionNode` or a
+            :class:`~chainer.Link` object or any other function satisfying the
             condition.
         x_data (ndarray or tuple of ndarrays): A set of ``ndarray``\\ s to be
             passed to ``func``. If ``x_data`` is one ``ndarray`` object, it is

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -152,9 +152,9 @@ class Evaluator(extension.Extension):
 
             This method encloses :attr:`eval_func` calls with
             :func:`function.no_backprop_mode` context, so all calculations
-            using :class:`~chainer.Function`\ s inside :attr:`eval_func` don't
-            make computational graphs. It is for reducing the memory
-            consumption.
+            using :class:`~chainer.FunctionNode`\s inside
+            :attr:`eval_func` don't make computational graphs. It is for
+            reducing the memory consumption.
 
         Returns:
             dict: Result dictionary. This dictionary is further reported via

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -153,7 +153,7 @@ class Evaluator(extension.Extension):
             This method encloses :attr:`eval_func` calls with
             :func:`function.no_backprop_mode` context, so all calculations
             using :class:`~chainer.FunctionNode`\s inside
-            :attr:`eval_func` don't make computational graphs. It is for
+            :attr:`eval_func` do not make computational graphs. It is for
             reducing the memory consumption.
 
         Returns:

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -114,8 +114,9 @@ class VariableNode(object):
     gradient to be passed to each function.
 
     A variable node is held by the corresponding :class:`~chainer.Variable`
-    object, which is managed by users. :class:`~chainer.Function` objects that
-    take the variable as an input also hold references to the variable node.
+    object, which is managed by users. :class:`~chainer.FunctionNode` objects
+    that take the variable as an input also hold references to the variable
+    node.
 
     Note that the node does not hold a reference to the corresponding data
     array in general. The data array is actually accessible by the node in the
@@ -128,9 +129,10 @@ class VariableNode(object):
     2. If :meth:`retain_data` is called, the node holds a reference to the data
        array. It is mainly called by a function that needs the input or output
        data array in its backprop procedure.
-       See :meth:`Function.retain_inputs() <chainer.Function.retain_inputs>`
-       and :meth:`Function.retain_outputs() <chainer.Function.retain_outputs>`
-       for more details.
+       See :meth:`FunctionNode.retain_inputs()
+       <chainer.FunctionNode.retain_inputs>`
+       and :meth:`FunctionNode.retain_outputs()
+       <chainer.FunctionNode.retain_outputs>` for more details.
 
     Users usually do not need to touch this variable node object. The
     computational graph is automatically managed by Chainer, and any interface

--- a/docs/source/reference/check.rst
+++ b/docs/source/reference/check.rst
@@ -7,7 +7,7 @@ Chainer provides some facilities to make debugging easy.
 
 Type checking utilities
 -----------------------
-:class:`~chainer.Function` uses a systematic type checking of the :mod:`chainer.utils.type_check` module.
+:class:`~chainer.FunctionNode` uses a systematic type checking of the :mod:`chainer.utils.type_check` module.
 It enables users to easily find bugs of forward and backward implementations.
 You can find examples of type checking in some function implementations.
 

--- a/docs/source/reference/function_hooks.rst
+++ b/docs/source/reference/function_hooks.rst
@@ -2,7 +2,8 @@ Function hooks
 ==============
 
 Chainer provides a function-hook mechanism that enriches
-the behavior of forward and backward propagation of :class:`~chainer.Function`.
+the behavior of forward and backward propagation of
+:class:`~chainer.FunctionNode`\s.
 
 Base class
 ----------

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -3,7 +3,7 @@ Standard Function implementations
 
 .. module:: chainer.functions
 
-Chainer provides basic :class:`~chainer.Function` implementations in the
+Chainer provides basic :class:`~chainer.FunctionNode` implementations in the
 :mod:`chainer.functions` package. Most of them are wrapped by plain Python
 functions, which users should use.
 

--- a/docs/source/tutorial/convnet.rst
+++ b/docs/source/tutorial/convnet.rst
@@ -79,8 +79,8 @@ To give input images and label vectors simply by calling the model object
 like a function, :meth:`__call__` is usually defined in the model class.
 This method performs the forward computation of the model. Chainer uses
 the powerful autograd system for any computational graphs written with
-:class:`~chainer.Function`\ s and :class:`~chainer.Link`\ s (actually a
-:class:`~chainer.Link` calls a corresponding :class:`~chainer.Function`
+:class:`~chainer.FunctionNode`\ s and :class:`~chainer.Link`\ s (actually a
+:class:`~chainer.Link` calls a corresponding :class:`~chainer.FunctionNode`
 inside of it), so that you don't need to explicitly write the code for backward
 computations in the model. Just prepare the data, then give it to the model.
 The way this works is the resulting output :class:`~chainer.Variable` from the
@@ -138,18 +138,18 @@ can also write the model like in this way:
             return F.softmax(x)
 
 This code creates a list of all :class:`~chainer.Link`\ s and
-:class:`~chainer.Function`\ s after calling its superclass's constructor.
+:class:`~chainer.FunctionNode`\ s after calling its superclass's constructor.
 Then the elements of the list are registered to this model as
 trainable layers when the name of an element doesn't start with ``_``
 character. This operation can be freely replaced with many other ways because
 those names are just designed to select :class:`~chainer.Link`\ s only from the
-list ``net`` easily. :class:`~chainer.Function` doesn't have any trainable
+list ``net`` easily. :class:`~chainer.FunctionNode` doesn't have any trainable
 parameters, so that we can't register it to the model, but we want to use
-:class:`~chainer.Function`\ s for constructing a forward path. The list
+:class:`~chainer.FunctionNode`\ s for constructing a forward path. The list
 ``net`` is stored as an attribute :attr:`forward` to refer it in
 :meth:`__call__`. In :meth:`__call__`, it retrieves all layers in the network
 from :attr:`self.forward` sequentially regardless of what types of object (
-:class:`~chainer.Link` or :class:`~chainer.Function`) it is, and gives the
+:class:`~chainer.Link` or :class:`~chainer.FunctionNode`) it is, and gives the
 input variable or the intermediate output from the previous layer to the
 current layer. The last part of the :meth:`__call__` to switch its behavior
 by the training/inference mode is the same as the former way.

--- a/docs/source/tutorial/train_loop.rst
+++ b/docs/source/tutorial/train_loop.rst
@@ -148,7 +148,7 @@ The main steps are twofold:
 
         model = MyNetwork()
 
-:class:`~chainer.Link`, :class:`~chainer.Chain`, :class:`~chainer.ChainList`, and those subclass objects which contain trainable parameters should be registered to the model by assigning it as a property inside the :meth:`~chainer.Chain.init_scope`. For example, a :class:`~chainer.Function` does not contain any trainable parameters, so there is no need to keep the object as a property of your network. When you want to use :meth:`~chainer.functions.relu` in your network, using it as a function in :meth:`~chainer.Chain.__call__` works correctly.
+:class:`~chainer.Link`, :class:`~chainer.Chain`, :class:`~chainer.ChainList`, and those subclass objects which contain trainable parameters should be registered to the model by assigning it as a property inside the :meth:`~chainer.Chain.init_scope`. For example, a :class:`~chainer.FunctionNode` does not contain any trainable parameters, so there is no need to keep the object as a property of your network. When you want to use :meth:`~chainer.functions.relu` in your network, using it as a function in :meth:`~chainer.Chain.__call__` works correctly.
 
 In Chainer, the Python code that implements the forward computation itself represents the network. In other words, we can conceptually think of the computation graph for our network being constructed dynamically as this forward computation code executes. This allows Chainer to describe networks in which different computations can be performed in each iteration, such as branched networks, intuitively and with a high degree of flexibility. This is the key feature of Chainer that we call **Define-by-Run**.
 


### PR DESCRIPTION
Made a couple of changes to the docs where some references to the old style `Functions` were replaced with references to `FunctionNode`s.

Some very minor grammatical errors and relevant doc changes are also included.