### PR TITLE
Use python 3.5 for doctest

### DIFF
--- a/chainer/functions/array/reshape.py
+++ b/chainer/functions/array/reshape.py
@@ -86,7 +86,9 @@ def reshape(x, shape):
 # the shape of input and output are not consistent
         Traceback (most recent call last):
         ...
+        chainer.utils.type_check.InvalidType:
         Invalid operation is performed in: Reshape (Forward)
+
         Expect: prod(in_types[0].shape) == prod((4, 3))
         Actual: 8 != 12
 

--- a/chainer/functions/pooling/upsampling_2d.py
+++ b/chainer/functions/pooling/upsampling_2d.py
@@ -203,7 +203,7 @@ def upsampling_2d(
 
         >>> p = F.MaxPooling2D(2, 2)
         >>> with chainer.using_config('use_cudnn', 'never'):
-        ...     pooled_x = p(x)
+        ...     pooled_x = p.apply((x,))[0]
         >>> pooled_x.data
         array([[[[  8.,  10.,  12.],
                  [ 20.,  22.,  24.],

--- a/docs/source/tutorial/type_check.rst
+++ b/docs/source/tutorial/type_check.rst
@@ -67,7 +67,7 @@ Otherwise this code throws an exception, and the user gets a message like this:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: in_types[0].ndim == 2
+   chainer.utils.type_check.InvalidType: Expect: in_types[0].ndim == 2
    Actual: 3 != 2
 
 This error message means that "``ndim`` of the first argument expected to be ``2``, but actually it is ``3``".
@@ -102,8 +102,8 @@ And an error is like this:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: in_types[0].dtype == <type 'numpy.float64'>
-   Actual: float32 != <type 'numpy.float64'>
+   chainer.utils.type_check.InvalidType: Expect: in_types[0].dtype == <class 'numpy.float64'>
+   Actual: float32 != <class 'numpy.float64'>
 
 You can also check ``kind`` of ``dtype``.
 This code checks if the type is floating point
@@ -162,7 +162,7 @@ When ``x_type.shape[0] == 3`` and ``y_type.shape[0] == 1``, users can get the er
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: in_types[0].shape[0] == in_types[1].shape[0] * 4
+   chainer.utils.type_check.InvalidType: Expect: in_types[0].shape[0] == in_types[1].shape[0] * 4
    Actual: 3 != 4
 
 
@@ -188,14 +188,14 @@ This code can check the equivalent condition below:
 However, the latter condition doesn't know the meaning of this value.
 When this condition is not satisfied, the latter code shows unreadable error message::
 
-  InvalidType: Expect: in_types[0].shape[0] == 4  # what does '4' mean?
+  chainer.utils.type_check.InvalidType: Expect: in_types[0].shape[0] == 4  # what does '4' mean?
   Actual: 3 != 4
 
 Note that the second argument of :class:`utils.type_check.Variable` is only for readability.
 
 The former shows this message::
 
-  InvalidType: Expect: in_types[0].shape[0] == in_size  # OK, `in_size` is a value that is given to the constructor
+  chainer.utils.type_check.InvalidType: Expect: in_types[0].shape[0] == in_size  # OK, `in_size` is a value that is given to the constructor
   Actual: 3 != 4  # You can also check actual value here
 
 
@@ -222,7 +222,7 @@ The above example produces an error message like this:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: sum(in_types[0].shape) == 10
+   chainer.utils.type_check.InvalidType: Expect: sum(in_types[0].shape) == 10
    Actual: 7 != 10
 
 
@@ -255,7 +255,7 @@ This code generates the following error message:
 
    Traceback (most recent call last):
    ...
-   InvalidType: Expect: Shape is expected to be ...
+   chainer.utils.type_check.InvalidType: Expect: Shape is expected to be ...
    Actual: Shape is ...
 
 


### PR DESCRIPTION
Related: https://github.com/chainer/chainer-test/pull/342

Fixed doctest to pass with python 3.5.