### PR TITLE
Warn about vecLib on Mac OS X

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -1,7 +1,6 @@
 import collections
 import os
 import pkg_resources
-import sys
 import threading
 import warnings
 
@@ -62,16 +61,11 @@ from chainer.variable import Parameter  # NOQA
 from chainer.variable import Variable  # NOQA
 
 
-if sys.version_info[:3] == (3, 5, 0):
-    if not int(os.getenv('CHAINER_PYTHON_350_FORCE', '0')):
-        msg = """
-Chainer does not work with Python 3.5.0.
+from chainer import _environment_check
 
-We strongly recommend to use another version of Python.
-If you want to use Chainer with Python 3.5.0 at your own risk,
-set 1 to CHAINER_PYTHON_350_FORCE environment variable."""
 
-        raise Exception(msg)
+# Check environment conditions
+_environment_check.check()
 
 
 __version__ = pkg_resources.get_distribution('chainer').version

--- a/chainer/_environment_check.py
+++ b/chainer/_environment_check.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import warnings
+
+import numpy.distutils.system_info
+
+
+def _check_python_350():
+    if sys.version_info[:3] == (3, 5, 0):
+        if not int(os.getenv('CHAINER_PYTHON_350_FORCE', '0')):
+            msg = """
+    Chainer does not work with Python 3.5.0.
+
+    We strongly recommend to use another version of Python.
+    If you want to use Chainer with Python 3.5.0 at your own risk,
+    set 1 to CHAINER_PYTHON_350_FORCE environment variable."""
+
+            raise Exception(msg)
+
+
+def _check_osx_numpy_backend():
+    if sys.platform != 'darwin':
+        return
+
+    blas_opt_info = numpy.distutils.system_info.get_info('blas_opt')
+    if blas_opt_info:
+        extra_link_args = blas_opt_info.get('extra_link_args')
+        if extra_link_args and '-Wl,Accelerate' in extra_link_args:
+            warnings.warn('''\
+Accelerate has been detected as a NumPy backend library.
+vecLib, which is a part of Accelerate, is known not to work correctly with Chainer.
+We recommend using other BLAS libraries such as OpenBLAS.
+For details of the issue, please see
+https://docs.chainer.org/en/stable/tips.html#mnist-example-does-not-converge-in-cpu-mode-on-mac-os-x.
+
+Also note that Chainer does not officially support Mac OS X.
+Please use it at your own risk.
+''')  # NOQA
+
+
+def check():
+    _check_python_350()
+    _check_osx_numpy_backend()

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -23,17 +23,18 @@ See `CuPy Overview <https://docs-cupy.chainer.org/en/stable/overview.html>` for 
 mnist example does not converge in CPU mode on Mac OS X
 -------------------------------------------------------
 
-Many users reported that mnist example does not work correctly on Mac OS X.
-We are suspecting it is caused by vecLib, that is a default BLAS library installed on Mac OS X.
-
 .. note::
 
    Mac OS X is not officially supported.
-   I mean it is not tested continuously on our test server.
+   Please use it at your own risk.
 
-We recommend to use other BLAS libraries such as `OpenBLAS <http://www.openblas.net/>`_.
-We empirically found that it fixes this problem.
-It is necessary to reinstall NumPy to use replaced BLAS library.
+Many users have reported that MNIST example does not work correctly
+when using vecLib as NumPy backend on Mac OS X.
+vecLib is the default BLAS library installed on Mac OS X.
+
+We recommend using other BLAS libraries such as `OpenBLAS <http://www.openblas.net/>`_.
+
+To use an alternative BLAS library, it is necessary to reinstall NumPy.
 Here is an instruction to install NumPy with OpenBLAS using `Homebrew <http://brew.sh/>`_.
 
 ::
@@ -44,34 +45,4 @@ Here is an instruction to install NumPy with OpenBLAS using `Homebrew <http://br
 
 If you want to install NumPy with pip, use `site.cfg <https://github.com/numpy/numpy/blob/master/site.cfg.example>`_ file.
 
-You can check if NumPy uses OpenBLAS with ``numpy.show_config`` method.
-Check if `blas_opt_info` refers to `openblas`.
-
-::
-
-   >>> import numpy
-   >>> numpy.show_config()
-   lapack_opt_info:
-       libraries = ['openblas', 'openblas']
-       library_dirs = ['/usr/local/opt/openblas/lib']
-       define_macros = [('HAVE_CBLAS', None)]
-       language = c
-   blas_opt_info:
-       libraries = ['openblas', 'openblas']
-       library_dirs = ['/usr/local/opt/openblas/lib']
-       define_macros = [('HAVE_CBLAS', None)]
-       language = c
-   openblas_info:
-       libraries = ['openblas', 'openblas']
-       library_dirs = ['/usr/local/opt/openblas/lib']
-       define_macros = [('HAVE_CBLAS', None)]
-       language = c
-   openblas_lapack_info:
-       libraries = ['openblas', 'openblas']
-       library_dirs = ['/usr/local/opt/openblas/lib']
-       define_macros = [('HAVE_CBLAS', None)]
-       language = c
-   blas_mkl_info:
-       NOT AVAILABLE
-
-See detail about this problem in `issue #704 <https://github.com/chainer/chainer/issues/704>`_.
+For details of this problem, see `issue #704 <https://github.com/chainer/chainer/issues/704>`_.


### PR DESCRIPTION
Fixes #3621.

vecLib does not work correctly in MNIST example.
In this PR, we detect it and show warning.

* Along with this check, I moved Python 3.5.0 check into `chainer._environment_check` for cleanliness of code.
* Relevant section in Tips has been removed, as it's no longer needed.

I haven't tested this PR because I don't have Mac OS X...
When reviwing, please test that it can actually detect vecLib.