### PR TITLE
Disable MacOSX tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,38 +13,6 @@ matrix:
     - os: linux
       python: "3.5"
 
-    - os: osx
-      language: generic
-      env:
-      - PYTHON_VERSION=2.7.10
-      - PYENV_ROOT=~/.pyenv
-      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-    - os: osx
-      language: generic
-      env:
-      - PYTHON_VERSION=3.4.4
-      - PYENV_ROOT=~/.pyenv
-      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-    - os: osx
-      language: generic
-      env:
-      - PYTHON_VERSION=3.5.1
-      - PYENV_ROOT=~/.pyenv
-      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-
-before_install:
-  - if [[ $TRAVIS_OS_NAME = "osx" ]]; then
-      brew update >/dev/null;
-      brew outdated pyenv || brew upgrade --quiet pyenv;
-      brew install homebrew/boneyard/pyenv-pip-rehash;
-
-      PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION;
-      pyenv global $PYTHON_VERSION;
-      python --version;
-
-      brew install homebrew/science/hdf5;
-    fi
-
 install:
   - pip install -U pip wheel
   - python setup.py sdist


### PR DESCRIPTION
MacOSX jobs is highly backlogged in travis-ci.org, and that is not a temporary phenomenon (https://github.com/travis-ci/travis-ci/issues/7304#issuecomment-287591291).
This delay hampers our development and review process.
We are not officially supporting MacOSX, so we'd better stop CI for MacOSX.

https://www.traviscistatus.com/