### PR TITLE
run OS X test only on master/stable branch to avoid delay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,21 @@ matrix:
       - PYTHON_VERSION=2.7.10
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+      if: (branch = master OR branch = v3) AND (NOT type in (pull_request))
     - os: osx
       language: generic
       env:
       - PYTHON_VERSION=3.4.4
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+      if: (branch = master OR branch = v3) AND (NOT type in (pull_request))
     - os: osx
       language: generic
       env:
       - PYTHON_VERSION=3.5.1
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+      if: (branch = master OR branch = v3) AND (NOT type in (pull_request))
 
 before_install:
   - if [[ $TRAVIS_OS_NAME = "osx" ]]; then


### PR DESCRIPTION
As OS X container in Travis is heavy, this PR changes the config to run OS X matrix only on master/stable branch.

See also #3671 for discussion.