### PR TITLE
Remove PyTest global option configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ python_files = test_*.py
 python_classes = Test
 python_functions = test
 minversion = 2.9
-addopts = --maxfail=2 --showlocal --doctest-modules
+addopts = --doctest-modules


### PR DESCRIPTION
Removes 2 PyTest options globallly set in `setup.cfg`.

- `--maxfail=2`: This should be controlled by the invoker. Also I think CIs should display all errors.
- `--showlocal`: This option dumps local variables. Appearance of the output should be controlled by the invoker.

(Here invoker can be either a CI agent or a developer who invokes pytest manually)