### PR TITLE
v3: Fix CuPy intersphinx mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -328,7 +328,7 @@ autosummary_generate = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'cupy': ('https://docs-cupy.chainer.org/en/latest/', None),
+    'cupy': ('https://docs-cupy.chainer.org/en/stable/', None),
 }
 
 doctest_global_setup = '''


### PR DESCRIPTION
I think Chainer stable documentation should link to CuPy stable documentation.