### PR TITLE
fix to skip GPU tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,5 +68,6 @@ test_script:
   - "%CMD_IN_ENV% pip install nose pytest pytest-timeout pytest-cov"
   - "flake8"
   # Avoid interuption confirmation of cmd.exe
-  - "echo python -m pytest --timeout=60 -m \"not gpu and not multi_gpu and not cudnn and not slow\" tests > tmp.bat"
+  - "echo SET CHAINER_TEST_GPU_LIMIT=0 > tmp.bat"
+  - "echo python -m pytest --timeout=60 -m \"not cudnn and not slow\" tests >> tmp.bat"
   - "call tmp.bat < nul"


### PR DESCRIPTION
This PR fixes a failure of AppVeyor CI introduced in https://github.com/chainer/chainer/pull/3624 .