### PR TITLE
[backport] fix cupy overview link not working

### DIFF
--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -17,7 +17,7 @@ The compiled binaries are cached to the ``$(HOME)/.cupy/kernel_cache`` directory
 If you see that compilations run every time you run the same script, then the caching is failed.
 Please check that the directory is kept as is between multiple executions of the script.
 If your home directory is not suited to caching the kernels (e.g. in case that it uses NFS), change the kernel caching directory by setting the ``CUPY_CACHE_DIR`` environment variable to an appropriate path.
-See `CuPy Overview <https://docs-cupy.chainer.org/en/stable/overview.html>` for more details.
+See `CuPy Overview <https://docs-cupy.chainer.org/en/stable/overview.html>`_ for more details.
 
 
 mnist example does not converge in CPU mode on Mac OS X


### PR DESCRIPTION
Backport of #3659