### PR TITLE
Fix math function test helper to support double backward test of line…

### DIFF
--- a/tests/chainer_tests/testing_tests/test_unary_math_function_test.py
+++ b/tests/chainer_tests/testing_tests/test_unary_math_function_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from chainer import function_node
 from chainer import testing
 
 
@@ -12,6 +13,30 @@ class TestNoNumpyFunction(unittest.TestCase):
     def test_no_numpy_function(self):
         with self.assertRaises(ValueError):
             testing.unary_math_function_unittest(dummy)  # no numpy.dummy
+
+
+class DummyLinear(function_node.FunctionNode):
+
+    @property
+    def label(self):
+        return 'dummy_linear'
+
+    def forward(self, x):
+        return x[0],
+
+    def backward(self, indexes, gy):
+        return gy[0],
+
+
+def dummy_linear(x):
+    return DummyLinear().apply((x,))[0]
+
+
+@testing.unary_math_function_unittest(dummy_linear,
+                                      func_expected=lambda x, dtype: x,
+                                      is_linear=True)
+class TestIsLinear(unittest.TestCase):
+    pass
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fix #3677.

`unary_math_function_unittest` decorator, which is a testing helper for math functions, now supports testing new style functions including double backward test in #3603. But it cannot perform double backward test for linear functions, which needs some getting around as described below.

https://gist.github.com/beam2d/dd87d97b8d7581f95cd19b1de86c9f4d#testing-the-new-style-function-that-supports-double-backward

This PR introduces `is_linear` argument to the decorator that tells it the target function is linear so that it can perform double backward test for linear functions.
