### PR TITLE
Fix split_axis documentation

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -63,7 +63,9 @@ def split_axis(x, indices_or_sections, axis, force_tuple=True):
     """Splits given variables along an axis.
 
     Args:
-        x (tuple of Variables): Variables to be split.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            A variable to be split.
         indices_or_sections (int or 1-D array): If this argument is an integer,
             N, the array will be divided into N equal arrays along axis.
             If it is a 1-D array of sorted integers, it


### PR DESCRIPTION
`x` argument of `F.split_axis` should be a variable or an array, not a tuple of them.