### PR TITLE
Avoid zero-division warning in F.r2_score

### DIFF
--- a/chainer/functions/evaluation/r2_score.py
+++ b/chainer/functions/evaluation/r2_score.py
@@ -29,10 +29,14 @@ class R2_score(function.Function):
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
         pred, true = inputs
-        SS_res = xp.sum((pred - true) ** 2, axis=0)
-        SS_tot = xp.sum((true - xp.mean(true, axis=0)) ** 2, axis=0)
-        ret = xp.where(SS_tot != 0, 1 - SS_res / SS_tot, 0.0)\
-                .astype(pred.dtype)
+        SS_res = xp.asarray(
+            xp.sum((pred - true) ** 2, axis=0))
+        SS_tot = xp.asarray(
+            xp.sum((true - xp.mean(true, axis=0)) ** 2, axis=0))
+        SS_tot_iszero = SS_tot == 0
+        SS_tot[SS_tot_iszero] = 1  # Assign dummy value to avoid zero-division
+        ret = xp.where(
+            SS_tot_iszero, 0.0, 1 - SS_res / SS_tot).astype(pred.dtype)
         if self.multioutput == 'uniform_average':
             return xp.asarray(ret.mean()),
         elif self.multioutput == 'raw_values':

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_r2_score.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_r2_score.py
@@ -11,8 +11,10 @@ from chainer.utils import type_check
 
 
 def r2_score(pred, true, sample_weight=None, multioutput="uniform_average"):
-    SS_res = numpy.sum((pred - true) ** 2, axis=0)
-    SS_tot = numpy.sum((true - numpy.mean(true, axis=0)) ** 2, axis=0)
+    SS_res = numpy.asarray(
+        numpy.sum((pred - true) ** 2, axis=0))
+    SS_tot = numpy.asarray(
+        numpy.sum((true - numpy.mean(true, axis=0)) ** 2, axis=0))
 
     if multioutput == 'uniform_average':
         if numpy.any(SS_tot == 0):
@@ -21,7 +23,11 @@ def r2_score(pred, true, sample_weight=None, multioutput="uniform_average"):
             return (1 - SS_res / SS_tot).mean()
     elif multioutput == 'raw_values':
         if numpy.any(SS_tot == 0):
-            return numpy.where(SS_tot != 0, 1 - SS_res / SS_tot, 0.0)
+            # Assign dummy value to avoid zero-division
+            SS_tot_iszero = SS_tot == 0
+            SS_tot[SS_tot_iszero] = 1
+
+            return numpy.where(SS_tot_iszero, 0.0, 1 - SS_res / SS_tot)
         else:
             return 1 - SS_res / SS_tot
 


### PR DESCRIPTION
`F.r2_score` could emit zero-division warning.
This PR suppresses this warning.

```
tests/chainer_tests/functions_tests/evaluation_tests/test_r2_score.py::TestAccuracy_param_46::test_forward_cpu
  /work/chainer/chainer/functions/evaluation/r2_score.py:34: RuntimeWarning: divide by zero encountered in true_divide
    ret = xp.where(SS_tot != 0, 1 - SS_res / SS_tot, 0.0)\
  /work/chainer/tests/chainer_tests/functions_tests/evaluation_tests/test_r2_score.py:24: RuntimeWarning: divide by zero encountered in true_divide
    return numpy.where(SS_tot != 0, 1 - SS_res / SS_tot, 0.0)
```