### PR TITLE
Fix normalization warning in F.average test

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_average.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_average.py
@@ -44,7 +44,12 @@ class TestAverage(unittest.TestCase):
 
         g_shape = self.x.sum(axis=self.axis, keepdims=self.keepdims).shape
         self.gy = numpy.random.uniform(-1, 1, g_shape).astype(self.dtype)
-        self.w = numpy.random.uniform(-1, 1, w_shape).astype(self.dtype)
+
+        # Sample weights. Weights should not sum to 0.
+        while True:
+            self.w = numpy.random.uniform(-1, 1, w_shape).astype(self.dtype)
+            if self.w.sum() > 1e-4:
+                break
 
     def check_forward(self, x_data, axis, weights):
         if self.use_weights and isinstance(self.axis, tuple):


### PR DESCRIPTION
If the sum of weights is close to zero, it emits `RuntimeWarning`.

```
tests/chainer_tests/functions_tests/math_tests/test_average.py::TestAverage_param_38::test_backward_cpu
  chainer/functions/math/basic_math.py:303: RuntimeWarning: overflow encountered in divide
    return gx0, utils.force_array(-gx0 * x[0] / x[1])
```