### PR TITLE
Use pytest-warnings to set warnings configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
   - cd tests
-  - CHAINER_TEST_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:site' pytest -m "not slow and not cudnn" chainer_tests
+  - CHAINER_TEST_GPU_LIMIT=0 pytest -m "not slow and not cudnn" chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       cd ..;
       READTHEDOCS=True python setup.py develop;

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 
 [tool:pytest]
+filterwarnings= ignore::FutureWarning
+                error::DeprecationWarning
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test

--- a/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
@@ -127,10 +127,11 @@ class TestGatherScatter(unittest.TestCase):
 class SimpleNetRawArray(chainer.Chain):
 
     def __init__(self, testcase):
-        super(SimpleNetRawArray, self).__init__(
-            conv=chainer.links.Convolution2D(2, 2, 3),
-            fc=chainer.links.Linear(18, 2),
-        )
+        super(SimpleNetRawArray, self).__init__()
+        with self.init_scope():
+            self.conv = chainer.links.Convolution2D(2, 2, 3)
+            self.fc = chainer.links.Linear(18, 2)
+
         self.train = True
         self.call_called = 0
         self.testcase = testcase


### PR DESCRIPTION
I fix setup.cfg to use pytest-warnings instead of changing PYTHONWARNINGS environment variable.