### PR TITLE
[backport] Fix decorators to allow users to filter test cases by number of GPUs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
   - cd tests
-  - PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:site' pytest -m "not gpu and not multi_gpu and not slow and not cudnn" chainer_tests
+  - CHAINER_TEST_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:site' pytest -m "not slow and not cudnn" chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       cd ..;
       READTHEDOCS=True python setup.py develop;

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - autopep8 -r . --global-config .pep8 --diff | tee check_autopep8
   - test ! -s check_autopep8
   - cd tests
-  - CHAINER_TEST_GPU_LIMIT=0 PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:site' pytest -m "not gpu and not multi_gpu and not slow and not cudnn" chainer_tests
+  - PYTHONWARNINGS='ignore::FutureWarning,error::DeprecationWarning,ignore::DeprecationWarning:site' pytest -m "not gpu and not multi_gpu and not slow and not cudnn" chainer_tests
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
       cd ..;
       READTHEDOCS=True python setup.py develop;

--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -1,7 +1,3 @@
-import os
-import unittest
-
-
 try:
     import pytest
     _error = None
@@ -26,8 +22,7 @@ def get_error():
 
 
 if _error is None:
-    _gpu_limit = int(os.getenv('CHAINER_TEST_GPU_LIMIT', '-1'))
-
+    gpu = pytest.mark.gpu
     cudnn = pytest.mark.cudnn
     slow = pytest.mark.slow
 
@@ -36,32 +31,11 @@ else:
         check_available()
         assert False  # Not reachable
 
+    gpu = _dummy_callable
     cudnn = _dummy_callable
     slow = _dummy_callable
 
 
 def multi_gpu(gpu_num):
-    """Decorator to indicate number of GPUs required to run the test.
-
-    Tests can be annotated with this decorator (e.g., ``@multi_gpu(2)``) to
-    declare number of GPUs required to run. When running tests, if
-    ``CHAINER_TEST_GPU_LIMIT`` environment variable is set to value greater
-    than or equals to 0, test cases that require GPUs more than the limit will
-    be skipped.
-    """
-
     check_available()
-    return unittest.skipIf(
-        0 <= _gpu_limit and _gpu_limit < gpu_num,
-        reason='{} GPUs required'.format(gpu_num))
-
-
-def gpu(f):
-    """Decorator to indicate that GPU is required to run the test.
-
-    Tests can be annotated with this decorator (e.g., ``@gpu``) to
-    declare that one GPU is required to run.
-    """
-
-    check_available()
-    return multi_gpu(1)(pytest.mark.gpu(f))
+    return pytest.mark.multi_gpu(gpu=gpu_num)

--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -1,3 +1,7 @@
+import os
+import unittest
+
+
 try:
     import pytest
     _error = None
@@ -22,7 +26,8 @@ def get_error():
 
 
 if _error is None:
-    gpu = pytest.mark.gpu
+    _gpu_limit = int(os.getenv('CHAINER_TEST_GPU_LIMIT', '-1'))
+
     cudnn = pytest.mark.cudnn
     slow = pytest.mark.slow
 
@@ -31,11 +36,32 @@ else:
         check_available()
         assert False  # Not reachable
 
-    gpu = _dummy_callable
     cudnn = _dummy_callable
     slow = _dummy_callable
 
 
 def multi_gpu(gpu_num):
+    """Decorator to indicate number of GPUs required to run the test.
+
+    Tests can be annotated with this decorator (e.g., ``@multi_gpu(2)``) to
+    declare number of GPUs required to run. When running tests, if
+    ``CHAINER_TEST_GPU_LIMIT`` environment variable is set to value greater
+    than or equals to 0, test cases that require GPUs more than the limit will
+    be skipped.
+    """
+
     check_available()
-    return pytest.mark.multi_gpu(gpu=gpu_num)
+    return unittest.skipIf(
+        0 <= _gpu_limit and _gpu_limit < gpu_num,
+        reason='{} GPUs required'.format(gpu_num))
+
+
+def gpu(f):
+    """Decorator to indicate that GPU is required to run the test.
+
+    Tests can be annotated with this decorator (e.g., ``@gpu``) to
+    declare that one GPU is required to run.
+    """
+
+    check_available()
+    return multi_gpu(1)(pytest.mark.gpu(f))


### PR DESCRIPTION
Backport #3624.

The backport of #3624 was once merged to v3 branch in #3683, but I find that the backport PR was not made properly. This PR reverts #3683 and backports #3624 again. Please see the diff for the problem line.