### PR TITLE
Reduce Numpy RuntimeWarnings

### DIFF
--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -7,6 +7,7 @@ from chainer.testing import unary_math_function_test  # NOQA
 
 from chainer.testing.array import assert_allclose  # NOQA
 from chainer.testing.helper import assert_warns  # NOQA
+from chainer.testing.helper import NumpyError  # NOQA
 from chainer.testing.helper import with_requires  # NOQA
 from chainer.testing.parameterized import parameterize  # NOQA
 from chainer.testing.parameterized import product  # NOQA

--- a/chainer/testing/helper.py
+++ b/chainer/testing/helper.py
@@ -4,6 +4,8 @@ import sys
 import unittest
 import warnings
 
+import numpy
+
 
 def with_requires(*requirements):
     """Run a test case only when given requirements are satisfied.
@@ -50,3 +52,16 @@ def assert_warns(expected):
                 exc_name = str(expected)
 
             raise AssertionError('%s not triggerred' % exc_name)
+
+
+class NumpyError(object):
+
+    def __init__(self, **kw):
+        self.kw = kw
+
+    def __enter__(self):
+        self.err = numpy.geterr()
+        numpy.seterr(**self.kw)
+
+    def __exit__(self, *_):
+        numpy.seterr(**self.err)

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_r2_score.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_r2_score.py
@@ -18,12 +18,11 @@ def r2_score(pred, true, sample_weight=None, multioutput="uniform_average"):
         if numpy.any(SS_tot == 0):
             return 0.0
         else:
-            return (1 - SS_res / SS_tot).mean()
+            with testing.NumpyError(divide='ignore'):
+                return (1 - SS_res / SS_tot).mean()
     elif multioutput == 'raw_values':
-        if numpy.any(SS_tot == 0):
+        with testing.NumpyError(divide='ignore'):
             return numpy.where(SS_tot != 0, 1 - SS_res / SS_tot, 0.0)
-        else:
-            return 1 - SS_res / SS_tot
 
 
 @testing.parameterize(
@@ -59,8 +58,9 @@ class TestAccuracy(unittest.TestCase):
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
         t = chainer.Variable(t_data)
-        y = chainer.functions.r2_score(x, t, self.sample_weight,
-                                       self.multioutput)
+        with testing.NumpyError(divide='ignore'):
+            y = chainer.functions.r2_score(x, t, self.sample_weight,
+                                           self.multioutput)
         self.assertEqual(y.data.dtype, self.dtype)
         if self.multioutput == 'uniform_average':
             self.assertEqual((), y.data.shape)


### PR DESCRIPTION
We got following message in test.
```
tests/chainer_tests/functions_tests/evaluation_tests/test_r2_score.py::TestAccuracy_param_42::test_forward_cpu
/work/chainer/chainer/functions/evaluation/r2_score.py:34: RuntimeWarning: divide by zero encountered in true_divide
ret = xp.where(SS_tot != 0, 1 - SS_res / SS_tot, 0.0)\
```
This PR suppress warning message.