### PR TITLE
Add repeat function

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -68,6 +68,8 @@ from chainer.functions.array.pad_sequence import pad_sequence  # NOQA
 from chainer.functions.array.pad_sequence import PadSequence  # NOQA
 from chainer.functions.array.permutate import permutate  # NOQA
 from chainer.functions.array.permutate import Permutate  # NOQA
+from chainer.functions.array.repeat import repeat  # NOQA
+from chainer.functions.array.repeat import Repeat  # NOQA
 from chainer.functions.array.reshape import reshape  # NOQA
 from chainer.functions.array.reshape import Reshape  # NOQA
 from chainer.functions.array.resize_images import resize_images  # NOQA

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -69,7 +69,6 @@ from chainer.functions.array.pad_sequence import PadSequence  # NOQA
 from chainer.functions.array.permutate import permutate  # NOQA
 from chainer.functions.array.permutate import Permutate  # NOQA
 from chainer.functions.array.repeat import repeat  # NOQA
-from chainer.functions.array.repeat import Repeat  # NOQA
 from chainer.functions.array.reshape import reshape  # NOQA
 from chainer.functions.array.reshape import Reshape  # NOQA
 from chainer.functions.array.resize_images import resize_images  # NOQA

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -28,7 +28,7 @@ class Repeat(function_node.FunctionNode):
 
     def forward(self, inputs):
         self.retain_inputs((0,))
-        x = inputs[0]
+        x, = inputs
         xp = cuda.get_array_module(x)
         repeats = self.repeats
         if self.axis is None or len(self.repeats) == 1:
@@ -36,7 +36,7 @@ class Repeat(function_node.FunctionNode):
         return xp.repeat(x, repeats, self.axis),
 
     def backward(self, indexes, grad_outputs):
-        x = self.get_retained_inputs()[0]
+        x, = self.get_retained_inputs()
         return RepeatGrad(self.repeats, self.axis, x.shape, x.dtype).apply(
             grad_outputs)
 
@@ -50,7 +50,7 @@ class RepeatGrad(function_node.FunctionNode):
         self.in_dtype = in_dtype
 
     def forward(self, inputs):
-        gy = inputs[0]
+        gy, = inputs
         xp = cuda.get_array_module(gy)
         repeats = self.repeats
         axis = self.axis

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -101,24 +101,24 @@ def repeat(x, repeats, axis=None):
         >>> x = np.array([0, 1, 2])
         >>> x.shape
         (3,)
-        >>> y = np.repeat(x, 2)
+        >>> y = F.repeat(x, 2)
         >>> y.shape
         (6,)
-        >>> y
+        >>> y.data
         array([0, 0, 1, 1, 2, 2])
         >>> x = np.array([[1,2], [3,4]])
         >>> x.shape
         (2, 2)
-        >>> y = np.repeat(x, 3, axis=1)
+        >>> y = F.repeat(x, 3, axis=1)
         >>> y.shape
         (2, 6)
-        >>> y
+        >>> y.data
         array([[1, 1, 1, 2, 2, 2],
                [3, 3, 3, 4, 4, 4]])
-        >>> y = np.repeat(x, [1, 2], axis=0)
+        >>> y = F.repeat(x, (1, 2), axis=0)
         >>> y.shape
         (3, 2)
-        >>> y
+        >>> y.data
         array([[1, 2],
                [3, 4],
                [3, 4]])

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -40,7 +40,14 @@ class Repeat(function_node.FunctionNode):
         self.retain_inputs((0,))
         x, = inputs
         xp = cuda.get_array_module(x)
-        return xp.repeat(x, self.repeats, self.axis),
+        repeats = self.repeats
+
+        # Workaroud for bug in NumPy 1.9 that specifying one element list to
+        # `repeats` fails to broadcast.
+        if len(repeats) == 1:
+            repeats = repeats[0]
+
+        return xp.repeat(x, repeats, self.axis),
 
     def backward(self, indexes, grad_outputs):
         x, = self.get_retained_inputs()

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -87,7 +87,7 @@ class RepeatGrad(function_node.FunctionNode):
                 gx = gy.reshape(shape).sum(axis=axis + 1)
             return gx,
 
-        if axis == None:
+        if axis is None:
             pos = 0
             gx = xp.zeros(int(numpy.prod(shape)), dtype)
             for (i, r) in enumerate(repeats):

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -60,6 +60,9 @@ class RepeatGrad(function_node.FunctionNode):
     def __init__(self, repeats, axis, in_shape, in_dtype):
         self.repeats = repeats
         self.axis = axis
+        if axis is not None and axis < 0:
+            self.axis += len(in_shape)
+
         self.in_shape = in_shape
         self.in_dtype = in_dtype
 

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -1,0 +1,127 @@
+import six
+
+from chainer import cuda
+from chainer import function_node
+from chainer.utils import type_check
+
+
+class Repeat(function_node.FunctionNode):
+
+    """Repeat elements of an array."""
+
+    def __init__(self, repeats, axis=None):
+        if isinstance(repeats, six.integer_types):
+            self.repeats = (repeats,)
+        elif isinstance(repeats, tuple) and all(
+                isinstance(x, six.integer_types) for x in repeats):
+            self.repeats = repeats
+        else:
+            raise TypeError('repeats must be int or tuple of ints')
+
+        if not all(x >= 0 for x in self.repeats):
+            raise ValueError('all elements in repeats must be zero or larger')
+
+        self.axis = axis
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 1)
+
+    def forward(self, inputs):
+        self.retain_inputs((0,))
+        x = inputs[0]
+        xp = cuda.get_array_module(x)
+        repeats = self.repeats
+        if self.axis is None or len(self.repeats) == 1:
+            repeats = self.repeats[0]
+        return xp.repeat(x, repeats, self.axis),
+
+    def backward(self, indexes, grad_outputs):
+        x = self.get_retained_inputs()[0]
+        return RepeatGrad(self.repeats, self.axis, x.shape, x.dtype).apply(
+            grad_outputs)
+
+
+class RepeatGrad(function_node.FunctionNode):
+
+    def __init__(self, repeats, axis, in_shape, in_dtype):
+        self.repeats = repeats
+        self.axis = axis
+        self.in_shape = in_shape
+        self.in_dtype = in_dtype
+
+    def forward(self, inputs):
+        gy = inputs[0]
+        xp = cuda.get_array_module(gy)
+        repeats = self.repeats
+        axis = self.axis
+
+        if len(gy) == 0:
+            gx = xp.zeros(self.in_shape, self.in_dtype)
+            return gx,
+        elif axis is None:
+            gx = gy.reshape(-1, repeats[0]).sum(axis=1).reshape(self.in_shape)
+            return gx,
+        elif len(repeats) == 1:
+            shape = list(self.in_shape)
+            shape[axis:axis+1] = [-1, repeats[0]]
+            gx = gy.reshape(shape).sum(axis=axis+1)
+            return gx,
+
+        gx = xp.zeros(self.in_shape, self.in_dtype)
+        slices = [slice(None) for _ in six.moves.range(self.axis)]
+        pos = 0
+        for (i, r) in enumerate(repeats):
+            src = slices + [slice(pos, pos+r)]
+            dst = slices + [slice(i, i+1)]
+            gx[dst] = gy[src].sum(axis=self.axis, keepdims=True)
+            pos += r
+        return gx,
+
+    def backward(self, indexes, grad_outputs):
+        return Repeat(self.repeats, self.axis).apply(grad_outputs)
+
+
+def repeat(x, repeats, axis=None):
+    """Construct an array by repeating a given array.
+
+    Args:
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable.
+        repeats (:class:`int` or :class:`tuple` of :class:`int` s):
+            The number of times which each element of ``x`` is repeated.
+        axis (:class:`int`):
+            The axis along which to repeat values.
+
+    Returns:
+        ~chainer.Variable: The repeated output Variable.
+
+    .. admonition:: Example
+
+        >>> x = np.array([0, 1, 2])
+        >>> x.shape
+        (3,)
+        >>> y = np.repeat(x, 2)
+        >>> y.shape
+        (6,)
+        >>> y
+        array([0, 0, 1, 1, 2, 2])
+        >>> x = np.array([[1,2], [3,4]])
+        >>> x.shape
+        (2, 2)
+        >>> y = np.repeat(x, 3, axis=1)
+        >>> y.shape
+        (2, 6)
+        >>> y
+        array([[1, 1, 1, 2, 2, 2],
+               [3, 3, 3, 4, 4, 4]])
+        >>> y = np.repeat(x, [1, 2], axis=0)
+        >>> y.shape
+        (3, 2)
+        >>> y
+        array([[1, 2],
+               [3, 4],
+               [3, 4]])
+
+    """
+    return Repeat(repeats, axis).apply((x,))[0]

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -15,6 +15,10 @@ class Repeat(function_node.FunctionNode):
             self.repeats = (repeats,)
         elif isinstance(repeats, tuple) and all(
                 isinstance(x, six.integer_types) for x in repeats):
+            # Although it is not explicitly documented, NumPy/CuPy allows
+            # specifying bool or tuple of bools as `repeats`.
+            # Thus we just check type against `six.integer_types`, without
+            # excluding `bool`.
             self.repeats = repeats
         else:
             raise TypeError('repeats must be int or tuple of ints')
@@ -25,6 +29,7 @@ class Repeat(function_node.FunctionNode):
         if axis is not None and (
                 not isinstance(axis, six.integer_types) or
                 isinstance(axis, bool)):
+            # `axis` cannot be bool, in contrast to `repeats`.
             raise TypeError('axis must be int or None')
         self.axis = axis
 

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -63,16 +63,16 @@ class RepeatGrad(function_node.FunctionNode):
             return gx,
         elif len(repeats) == 1:
             shape = list(self.in_shape)
-            shape[axis:axis+1] = [-1, repeats[0]]
-            gx = gy.reshape(shape).sum(axis=axis+1)
+            shape[axis:axis + 1] = [-1, repeats[0]]
+            gx = gy.reshape(shape).sum(axis=axis + 1)
             return gx,
 
         gx = xp.zeros(self.in_shape, self.in_dtype)
         slices = [slice(None) for _ in six.moves.range(self.axis)]
         pos = 0
         for (i, r) in enumerate(repeats):
-            src = slices + [slice(pos, pos+r)]
-            dst = slices + [slice(i, i+1)]
+            src = slices + [slice(pos, pos + r)]
+            dst = slices + [slice(i, i + 1)]
             gx[dst] = gy[src].sum(axis=self.axis, keepdims=True)
             pos += r
         return gx,

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -21,6 +21,10 @@ class Repeat(function_node.FunctionNode):
         if not all(x >= 0 for x in self.repeats):
             raise ValueError('all elements in repeats must be zero or larger')
 
+        if axis is not None and (
+                not isinstance(axis, six.integer_types) or
+                isinstance(axis, bool)):
+            raise TypeError('axis must be int or None')
         self.axis = axis
 
     def check_type_forward(self, in_types):

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -68,11 +68,12 @@ class RepeatGrad(function_node.FunctionNode):
             return gx,
 
         gx = xp.zeros(self.in_shape, self.in_dtype)
-        slices = [slice(None) for _ in six.moves.range(self.axis)]
         pos = 0
+        src = [slice(None)] * self.axis + [None]
+        dst = [slice(None)] * self.axis + [None]
         for (i, r) in enumerate(repeats):
-            src = slices + [slice(pos, pos + r)]
-            dst = slices + [slice(i, i + 1)]
+            src[-1] = slice(pos, pos + r)
+            dst[-1] = slice(i, i + 1)
             gx[dst] = gy[src].sum(axis=self.axis, keepdims=True)
             pos += r
         return gx,

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -74,6 +74,7 @@ Array manipulations
    chainer.functions.pad
    chainer.functions.pad_sequence
    chainer.functions.permutate
+   chainer.functions.repeat
    chainer.functions.reshape
    chainer.functions.resize_images
    chainer.functions.rollaxis

--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -1,0 +1,113 @@
+import unittest
+
+import numpy
+
+from chainer import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+
+
+@testing.parameterize(*testing.product({
+    'shape_repeats_axis': [
+        (2, 0, None),
+        (2, 1, None),
+        (2, 2, None),
+        (2, 2, 0),
+        ((3, 2), (2,), 0),
+        ((3, 2), 2, 0),
+        ((3, 2), 2, 1),
+        ((3, 2), (3, 4, 3), 0),
+        ((3, 2), (3, 2), 1),
+        ((3, 2, 3), (3, 2, 1), 0),
+        ((3, 2, 3), (3, 4), 1),
+        ((3, 2, 3), (3, 2, 1), 2),
+        ((3, 4, 3, 2), 3, 1),
+        ((3, 4, 3, 2), (2, 2, 3, 3), 1),
+    ],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestRepeat(unittest.TestCase):
+
+    def setUp(self):
+        (self.in_shape, self.repeats, self.axis) = self.shape_repeats_axis
+        self.x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+        out_shape = numpy.repeat(self.x, self.repeats, self.axis).shape
+        self.gy = numpy.random.uniform(-1, 1, out_shape).astype(self.dtype)
+        self.ggx = numpy.random.uniform(-1, 1, self.in_shape) \
+            .astype(self.dtype)
+
+        self.check_forward_options = {}
+        self.check_backward_options = {'dtype': numpy.float64}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+
+    def check_forward(self, x_data):
+        y = functions.repeat(x_data, self.repeats, self.axis)
+        y_expected = numpy.repeat(self.x, self.repeats, self.axis)
+        self.assertEqual(y.dtype, y_expected.dtype)
+        testing.assert_allclose(
+            y.data, y_expected, **self.check_forward_options)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x_data, y_grad):
+        def f(x):
+            return functions.repeat(x, self.repeats, self.axis)
+
+        gradient_check.check_backward(
+            f, x_data, y_grad, **self.check_backward_options)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    def check_double_backward(self, x_data, y_grad, x_grad_grad):
+        def f(x):
+            y = functions.repeat(x, self.repeats, self.axis)
+            return y * y
+
+        gradient_check.check_double_backward(
+            f, x_data, y_grad, x_grad_grad, **self.check_backward_options)
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.gy, self.ggx)
+
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy),
+                                   cuda.to_gpu(self.ggx))
+
+
+@testing.parameterize(*testing.product({
+    'repeats': [-1, (-1, -1)],
+    'axis': [-1],
+}))
+class TestRepeatValueError(unittest.TestCase):
+
+    def test_value_error(self):
+        x = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
+        with self.assertRaises(ValueError):
+            functions.repeat(x, self.repeats, self.axis)
+
+
+class TestRepeatTypeError(unittest.TestCase):
+
+    def test_type_error(self):
+        x = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
+        with self.assertRaises(TypeError):
+            functions.repeat(x, 'a')
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -37,11 +37,11 @@ from chainer.testing import attr
             'repeats': [5, (5,), (5,) * 2],
             'axis': [1],
         }) +
-        # Repeats 3-D array (with axis=1)
+        # Repeats 3-D array (with axis=-2)
         testing.product({
             'shape': [(3, 2, 4)],
             'repeats': [5, (5,), (5,) * 2],
-            'axis': [1],
+            'axis': [-2],
         })
     ),
     'dtype': [numpy.float16, numpy.float32, numpy.float64],

--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -10,21 +10,29 @@ from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product({
+    # repeats is any of (int, bool or tuple) and
+    # axis is any of (int or None).
     'shape_repeats_axis': [
+        # 1-D
         (2, 0, None),
         (2, 1, None),
-        (2, 2, None),
         (2, 2, 0),
-        ((3, 2), (2,), 0),
+        (2, True, None),
+        (2, (2,), None),
+        (2, (True,), 0),
+        (2, (1, 2), None),
+        (2, (True, 2), 0),
+        # 2-D
         ((3, 2), 2, 0),
+        ((3, 2), (2,), None),
         ((3, 2), 2, 1),
         ((3, 2), (3, 4, 3), 0),
-        ((3, 2), (3, 2), 1),
-        ((3, 2, 3), (3, 2, 1), 0),
+        ((3, 2), (3, True), 1),
+        ((3, 2), (True,) * 6, None),
+        # 3-D
+        ((3, 2, 3), (3, 2, True), 0),
         ((3, 2, 3), (3, 4), 1),
         ((3, 2, 3), (3, 2, 1), 2),
-        ((3, 4, 3, 2), 3, 1),
-        ((3, 4, 3, 2), (2, 2, 3, 3), 1),
     ],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))

--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -104,10 +104,20 @@ class TestRepeatValueError(unittest.TestCase):
 
 class TestRepeatTypeError(unittest.TestCase):
 
-    def test_type_error(self):
+    def test_type_error_repeats_str(self):
         x = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
         with self.assertRaises(TypeError):
             functions.repeat(x, 'a')
+
+    def test_type_error_axis_str(self):
+        x = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
+        with self.assertRaises(TypeError):
+            functions.repeat(x, 1, 'a')
+
+    def test_type_error_axis_bool(self):
+        x = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
+        with self.assertRaises(TypeError):
+            functions.repeat(x, 1, True)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -12,34 +12,46 @@ from chainer.testing import attr
 @testing.parameterize(*testing.product({
     # repeats is any of (int, bool or tuple) and
     # axis is any of (int or None).
-    'shape_repeats_axis': [
-        # 1-D
-        (2, 0, None),
-        (2, 1, None),
-        (2, 2, 0),
-        (2, True, None),
-        (2, (2,), None),
-        (2, (True,), 0),
-        (2, (1, 2), None),
-        (2, (True, 2), 0),
-        # 2-D
-        ((3, 2), 2, 0),
-        ((3, 2), (2,), None),
-        ((3, 2), 2, 1),
-        ((3, 2), (3, 4, 3), 0),
-        ((3, 2), (3, True), 1),
-        ((3, 2), (True,) * 6, None),
-        # 3-D
-        ((3, 2, 3), (3, 2, True), 0),
-        ((3, 2, 3), (3, 4), 1),
-        ((3, 2, 3), (3, 2, 1), 2),
-    ],
+    'params': (
+        # Repeats 1-D array
+        testing.product({
+            'shape': [(2,)],
+            'repeats': [0, 1, 2, True, (0,), (1,), (2,), (True,)],
+            'axis': [None, 0],
+        }) +
+        # Repeats 2-D array (with axis=None)
+        testing.product({
+            'shape': [(3, 2)],
+            'repeats': [4, (4,), (4,) * 6, (True,) * 6],
+            'axis': [None],
+        }) +
+        # Repeats 2-D array (with axis=0)
+        testing.product({
+            'shape': [(3, 2)],
+            'repeats': [5, (5,), (5,) * 3],
+            'axis': [0],
+        }) +
+        # Repeats 2-D array (with axis=1)
+        testing.product({
+            'shape': [(3, 2)],
+            'repeats': [5, (5,), (5,) * 2],
+            'axis': [1],
+        }) +
+        # Repeats 3-D array (with axis=1)
+        testing.product({
+            'shape': [(3, 2, 4)],
+            'repeats': [5, (5,), (5,) * 2],
+            'axis': [1],
+        })
+    ),
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestRepeat(unittest.TestCase):
 
     def setUp(self):
-        (self.in_shape, self.repeats, self.axis) = self.shape_repeats_axis
+        self.in_shape = self.params['shape']
+        self.repeats = self.params['repeats']
+        self.axis = self.params['axis']
         self.x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
         out_shape = numpy.repeat(self.x, self.repeats, self.axis).shape
         self.gy = numpy.random.uniform(-1, 1, out_shape).astype(self.dtype)

--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -53,7 +53,7 @@ class TestRepeat(unittest.TestCase):
         self.repeats = self.params['repeats']
         self.axis = self.params['axis']
         self.x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
-        out_shape = numpy.repeat(self.x, self.repeats, self.axis).shape
+        out_shape = self._repeat(self.x, self.repeats, self.axis).shape
         self.gy = numpy.random.uniform(-1, 1, out_shape).astype(self.dtype)
         self.ggx = numpy.random.uniform(-1, 1, self.in_shape) \
             .astype(self.dtype)
@@ -65,9 +65,16 @@ class TestRepeat(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 2 ** -4, 'rtol': 2 ** -4}
 
+    @classmethod
+    def _repeat(cls, arr, repeats, axis=None):
+        # Workaround NumPy 1.9 issue.
+        if isinstance(repeats, tuple) and len(repeats) == 1:
+            repeats = repeats[0]
+        return numpy.repeat(arr, repeats, axis)
+
     def check_forward(self, x_data):
         y = functions.repeat(x_data, self.repeats, self.axis)
-        y_expected = numpy.repeat(self.x, self.repeats, self.axis)
+        y_expected = self._repeat(self.x, self.repeats, self.axis)
         self.assertEqual(y.dtype, y_expected.dtype)
         testing.assert_allclose(
             y.data, y_expected, **self.check_forward_options)


### PR DESCRIPTION
Implemented `F.repeat` (Variable version of `xp.repeat`).

This feature was requested in #3632.
It is also needed to migrate `prod` function to FunctionNode.