### PR TITLE
imporve copyright of docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import datetime
 import inspect
 import os
 import pkg_resources
@@ -72,8 +73,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Chainer'
-copyright = u'2015, Preferred Networks, inc. and Preferred Infrastructure, inc.'
-author = u'Preferred Networks, inc. and Preferred Infrastructure, inc.'
+copyright = u'2015-{}, Preferred Networks, Inc. and Preferred Infrastructure, Inc.'.format(
+    datetime.datetime.now().year)
+author = u'Preferred Networks, Inc. and Preferred Infrastructure, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Currently copyright year of the document footer is not updated.
Users may confuse if they are reading old version of docs.

It is a common convention to write copyright years in 'XXXX-YYYY' where XXXX is a first-authored year and YYYY is a last-modified year, as seen in other docs like [Read the Docs](http://docs.readthedocs.io/en/latest/).
In this PR last-modified year is automatically generated when publishing docs.

I also replaced `inc.` to `Inc.` which I believe is an official representation.