### PR TITLE
Fix doc reference

### DIFF
--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -33,8 +33,9 @@ class MLPConvolution2D(link.ChainList):
         pad (int or pair of ints): Spatial padding width for input arrays at
             the first convolution layer. ``pad=p`` and ``pad=(p, p)`` are
             equivalent.
-        activation (function): Activation function for internal hidden units.
-            Note that this function is not applied to the output of this link.
+        activation (~chainer.FunctionNode): Activation function for internal hidden
+            units. Note that this function is not applied to the output of this
+            link.
         conv_init: An initializer of weight matrices
             passed to the convolution layers. This option must be specified as
             a keyword argument.
@@ -51,7 +52,7 @@ class MLPConvolution2D(link.ChainList):
     See: `Network in Network <https://arxiv.org/abs/1312.4400v3>`_.
 
     Attributes:
-        activation (function): Activation function.
+        activation (~chainer.FunctionNode): Activation function.
 
     """  # NOQA
 


### PR DESCRIPTION
Fixed wrong references in the docs for the arguent type `function`.

This PR partially fixes #1587 .