### PR TITLE
Check too small eps in Adam and RMSprop optimizers

### DIFF
--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -55,7 +55,7 @@ class AdamRule(optimizer.UpdateRule):
             return
         hp = self.hyperparam
         eps = grad.dtype.type(hp.eps)
-        if eps == 0:
+        if hp.eps != 0 and eps == 0:
             raise ValueError(
                 'eps of Adam optimizer is too small for {} ({})'.format(
                     grad.dtype.name, hp.eps))
@@ -71,7 +71,7 @@ class AdamRule(optimizer.UpdateRule):
             return
         hp = self.hyperparam
         eps = grad.dtype.type(hp.eps)
-        if eps == 0:
+        if hp.eps != 0 and eps == 0:
             raise ValueError(
                 'eps of Adam optimizer is too small for {} ({})'.format(
                     grad.dtype.name, hp.eps))

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -54,24 +54,35 @@ class AdamRule(optimizer.UpdateRule):
         if grad is None:
             return
         hp = self.hyperparam
+        eps = grad.dtype.type(hp.eps)
+        if eps == 0:
+            raise ValueError(
+                'eps of Adam optimizer is too small for {} ({})'.format(
+                    grad.dtype.name, hp.eps))
         m, v = self.state['m'], self.state['v']
 
         m += (1 - hp.beta1) * (grad - m)
         v += (1 - hp.beta2) * (grad * grad - v)
-        param.data -= self.lr * m / (numpy.sqrt(v) + hp.eps)
+        param.data -= self.lr * m / (numpy.sqrt(v) + eps)
 
     def update_core_gpu(self, param):
         grad = param.grad
         if grad is None:
             return
+        hp = self.hyperparam
+        eps = grad.dtype.type(hp.eps)
+        if eps == 0:
+            raise ValueError(
+                'eps of Adam optimizer is too small for {} ({})'.format(
+                    grad.dtype.name, hp.eps))
         cuda.elementwise(
             'T grad, T lr, T one_minus_beta1, T one_minus_beta2, T eps',
             'T param, T m, T v',
             '''m += one_minus_beta1 * (grad - m);
                v += one_minus_beta2 * (grad * grad - v);
                param -= lr * m / (sqrt(v) + eps);''',
-            'adam')(grad, self.lr, 1 - self.hyperparam.beta1,
-                    1 - self.hyperparam.beta2, self.hyperparam.eps, param.data,
+            'adam')(grad, self.lr, 1 - hp.beta1,
+                    1 - hp.beta2, eps, param.data,
                     self.state['m'], self.state['v'])
 
     @property

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -46,23 +46,34 @@ class RMSpropRule(optimizer.UpdateRule):
         if grad is None:
             return
         hp = self.hyperparam
+        eps = grad.dtype.type(hp.eps)
+        if eps == 0:
+            raise ValueError(
+                'eps of RMSprop optimizer is too small for {} ({})'.format(
+                    grad.dtype.name, hp.eps))
         ms = self.state['ms']
 
         ms *= hp.alpha
         ms += (1 - hp.alpha) * grad * grad
-        param.data -= hp.lr * grad / (numpy.sqrt(ms) + hp.eps)
+        param.data -= hp.lr * grad / (numpy.sqrt(ms) + eps)
 
     def update_core_gpu(self, param):
         grad = param.grad
         if grad is None:
             return
+        hp = self.hyperparam
+        eps = grad.dtype.type(hp.eps)
+        if eps == 0:
+            raise ValueError(
+                'eps of RMSprop optimizer is too small for {} ({})'.format(
+                    grad.dtype.name, hp.eps))
         cuda.elementwise(
             'T grad, T lr, T alpha, T eps',
             'T param, T ms',
             '''ms = alpha * ms + (1 - alpha) * grad * grad;
                param -= lr * grad / (sqrt(ms) + eps);''',
-            'rmsprop')(grad, self.hyperparam.lr, self.hyperparam.alpha,
-                       self.hyperparam.eps, param.data, self.state['ms'])
+            'rmsprop')(grad, hp.lr, hp.alpha,
+                       eps, param.data, self.state['ms'])
 
 
 class RMSprop(optimizer.GradientMethod):

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -47,7 +47,7 @@ class RMSpropRule(optimizer.UpdateRule):
             return
         hp = self.hyperparam
         eps = grad.dtype.type(hp.eps)
-        if eps == 0:
+        if hp.eps != 0 and eps == 0:
             raise ValueError(
                 'eps of RMSprop optimizer is too small for {} ({})'.format(
                     grad.dtype.name, hp.eps))

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -156,7 +156,11 @@ class TestAdaGrad(OptimizerTestBase, unittest.TestCase):
 class TestAdam(OptimizerTestBase, unittest.TestCase):
 
     def create(self):
-        return optimizers.Adam(0.05)
+        if self.dtype == numpy.float16:
+            kwargs = {'eps': 1e-6}
+        else:
+            kwargs = {}
+        return optimizers.Adam(0.05, **kwargs)
 
 
 @testing.parameterize(*testing.product({
@@ -186,7 +190,11 @@ class NesterovAG(OptimizerTestBase, unittest.TestCase):
 class TestRMSprop(OptimizerTestBase, unittest.TestCase):
 
     def create(self):
-        return optimizers.RMSprop(0.1)
+        if self.dtype == numpy.float16:
+            kwargs = {'eps': 1e-6}
+        else:
+            kwargs = {}
+        return optimizers.RMSprop(0.1, **kwargs)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
The default `eps` of `1e-8` is too small for float16.

This PR lets optimizers raise `ValueError` for such cases, and fixes unit test by explicitly specifying `eps` for float16.

`RuntimeWarning` below will be suppressed with this fix.
```
tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py::TestAdam_param_0::test_linear_model_cpu
  /data/work/w/repos/chainer/chainer/optimizers/adam.py:61: RuntimeWarning: divide by zero encountered in true_divide
    param.data -= self.lr * m / (numpy.sqrt(v) + hp.eps)
  /data/work/w/repos/chainer/chainer/functions/activation/log_softmax.py:19: RuntimeWarning: invalid value encountered in subtract
    y = x - m
```