### PR TITLE
Clarify color order of arguments in ImageNets documentation

### DIFF
--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -286,7 +286,7 @@ class GoogLeNet(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a :class:numpy.ndarray, make sure
+                When you specify a color image as a :class:`numpy.ndarray`, make sure
                 that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the

--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -286,7 +286,7 @@ class GoogLeNet(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a numpy.ndarray, make sure
+                When you specify a color image as a :class:numpy.ndarray, make sure
                 that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the

--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -286,8 +286,8 @@ class GoogLeNet(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a :class:`numpy.ndarray`, make sure
-                that color order is RGB.
+                When you specify a color image as a :class:`numpy.ndarray`,
+                make sure that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the
                 center.

--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -286,6 +286,8 @@ class GoogLeNet(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
+                When you specify a color image as a numpy.ndarray, make sure
+                that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the
                 center.

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -249,7 +249,7 @@ class ResNetLayers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a :class:numpy.ndarray, make sure
+                When you specify a color image as a :class:`numpy.ndarray`, make sure
                 that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -169,7 +169,8 @@ class ResNetLayers(link.Chain):
            See :func:`chainer.using_config`.
 
         Args:
-            x (~chainer.Variable): Input variable.
+            x (~chainer.Variable): Input variable. It should be prepared by
+                ``prepare`` function.
             layers (list of str): The list of layer names you want to extract.
 
         Returns:
@@ -248,6 +249,8 @@ class ResNetLayers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
+                When you specify a color image as a numpy.ndarray, make sure
+                that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the
                 center.

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -249,7 +249,7 @@ class ResNetLayers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a numpy.ndarray, make sure
+                When you specify a color image as a :class:numpy.ndarray, make sure
                 that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -249,8 +249,8 @@ class ResNetLayers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a :class:`numpy.ndarray`, make sure
-                that color order is RGB.
+                When you specify a color image as a :class:`numpy.ndarray`,
+                make sure that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the
                 center.

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -252,8 +252,8 @@ class VGG16Layers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a :class:`numpy.ndarray`, make sure
-                that color order is RGB.
+                When you specify a color image as a :class:`numpy.ndarray`,
+                make sure that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the
                 center.

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -252,7 +252,7 @@ class VGG16Layers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a :class:numpy.ndarray, make sure
+                When you specify a color image as a :class:`numpy.ndarray`, make sure
                 that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -172,7 +172,8 @@ class VGG16Layers(link.Chain):
            See :func:`chainer.using_config`.
 
         Args:
-            x (~chainer.Variable): Input variable.
+            x (~chainer.Variable): Input variable. It should be prepared by
+                ``prepare`` function.
             layers (list of str): The list of layer names you want to extract.
 
         Returns:
@@ -251,6 +252,8 @@ class VGG16Layers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
+                When you specify a color image as a numpy.ndarray, make sure
+                that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the
                 center.

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -252,7 +252,7 @@ class VGG16Layers(link.Chain):
 
         Args:
             images (iterable of PIL.Image or numpy.ndarray): Input images.
-                When you specify a color image as a numpy.ndarray, make sure
+                When you specify a color image as a :class:numpy.ndarray, make sure
                 that color order is RGB.
             oversample (bool): If ``True``, it averages results across
                 center, corners, and mirrors. Otherwise, it uses only the


### PR DESCRIPTION
I suffered from RGB-BGR order difference between `__call__` and `predict` in `chainer.links.model.vison.XXX` since it's not well documented (actually it is not impossible to understand from `prepare` and `__call__` document but for beginners it's quite difficult).
Ref. https://github.com/chainer/chainer/issues/3756#issuecomment-341027872
This PR updates document just to clarify that `predict` requires RGB order and `__call__` supposes the input is converted to BGR by `prepare`.

I also wanted to put a link to `prepare` document ([here](https://docs.chainer.org/en/stable/reference/generated/chainer.links.model.vision.googlenet.prepare.html#chainer.links.model.vision.googlenet.prepare)) in `__call__` document, but I'm sorry I don't know how.