### PR TITLE
fix F.inv test does not test type error as expected

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_inv.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_inv.py
@@ -9,6 +9,7 @@ from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
+from chainer.utils import type_check
 
 
 def _inv(x):
@@ -148,23 +149,23 @@ class BatchInvFunctionTest(unittest.TestCase):
 class InvFunctionRaiseTest(unittest.TestCase):
 
     def test_invalid_ndim(self):
-        with self.assertRaises(TypeError):
-            functions.inv(chainer.Variable(numpy.zeros(1, 2, 2)))
+        with self.assertRaises(type_check.InvalidType):
+            functions.inv(chainer.Variable(numpy.zeros((1, 2, 2), dtype=numpy.float32)))
 
     def test_invalid_shape(self):
-        with self.assertRaises(TypeError):
-            functions.inv(chainer.Variable(numpy.zeros(1, 2)))
+        with self.assertRaises(type_check.InvalidType):
+            functions.inv(chainer.Variable(numpy.zeros((1, 2), dtype=numpy.float32)))
 
 
 class BatchInvFunctionRaiseTest(unittest.TestCase):
 
     def test_invalid_ndim(self):
-        with self.assertRaises(TypeError):
-            functions.batch_inv(chainer.Variable(numpy.zeros(2, 2)))
+        with self.assertRaises(type_check.InvalidType):
+            functions.batch_inv(chainer.Variable(numpy.zeros((2, 2), dtype=numpy.float32)))
 
     def test_invalid_shape(self):
-        with self.assertRaises(TypeError):
-            functions.batch_inv(chainer.Variable(numpy.zeros(1, 2, 1)))
+        with self.assertRaises(type_check.InvalidType):
+            functions.batch_inv(chainer.Variable(numpy.zeros((1, 2, 1), dtype=numpy.float32)))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_inv.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_inv.py
@@ -149,23 +149,27 @@ class BatchInvFunctionTest(unittest.TestCase):
 class InvFunctionRaiseTest(unittest.TestCase):
 
     def test_invalid_ndim(self):
+        x = chainer.Variable(numpy.zeros((1, 2, 2), dtype=numpy.float32))
         with self.assertRaises(type_check.InvalidType):
-            functions.inv(chainer.Variable(numpy.zeros((1, 2, 2), dtype=numpy.float32)))
+            functions.inv(x)
 
     def test_invalid_shape(self):
+        x = chainer.Variable(numpy.zeros((1, 2), dtype=numpy.float32))
         with self.assertRaises(type_check.InvalidType):
-            functions.inv(chainer.Variable(numpy.zeros((1, 2), dtype=numpy.float32)))
+            functions.inv(x)
 
 
 class BatchInvFunctionRaiseTest(unittest.TestCase):
 
     def test_invalid_ndim(self):
+        x = chainer.Variable(numpy.zeros((2, 2), dtype=numpy.float32))
         with self.assertRaises(type_check.InvalidType):
-            functions.batch_inv(chainer.Variable(numpy.zeros((2, 2), dtype=numpy.float32)))
+            functions.batch_inv(x)
 
     def test_invalid_shape(self):
+        x = chainer.Variable(numpy.zeros((1, 2, 1), dtype=numpy.float32))
         with self.assertRaises(type_check.InvalidType):
-            functions.batch_inv(chainer.Variable(numpy.zeros((1, 2, 1), dtype=numpy.float32)))
+            functions.batch_inv(x)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
The current test code for `F.inv` does not test exception case correctly.

These tests are intended to test shape check logic, but it is catching the TypeError from numpy.

```
>>> numpy.zeros(1, 2, 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: data type not understood
```