### PR TITLE
Ignore DeprecationWarnig caused in theano

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,8 @@ exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 [tool:pytest]
 filterwarnings= ignore::FutureWarning
                 error::DeprecationWarning
+                # theano 0.8 causes DeprecationWarnings. It is fixed in 0.9
+                ignore::DeprecationWarning:theano.configparser
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test


### PR DESCRIPTION
Theano 0.8 causes DeprecationWarning with Python 3.6. I fixed warnings configuration to ignore them. Note that problem is fixed in theano 0.9.