### PR TITLE
Forget inputs as Variables

### DIFF
--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -118,4 +118,8 @@ def forget(func, *xs):
         the method returns a tuple too.
 
     """
+    # Guarantee that backward is called by wrapping bare ndarrays as
+    # ``Variable`` s with ``requires_grad`` set to ``True``.
+    xs = tuple(x if isinstance(x, variable.Variable) else
+               variable.Variable(x, requires_grad=True) for x in xs)
     return Forget(func)(*xs)

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -101,10 +101,18 @@ def forget(func, *xs):
 
     .. note::
 
-      ``F.forget`` does not support functions which behave differently in
-      multiple calls with the same inputs, such as
-      :meth:`F.dropout() <chainer.functions.dropout>` and
-      :meth:`F.negative_sampling() <chainer.functions.negative_sampling>`.
+        ``F.forget`` does not support functions which behave differently in
+        multiple calls with the same inputs, such as
+        :meth:`F.dropout() <chainer.functions.dropout>` and
+        :meth:`F.negative_sampling() <chainer.functions.negative_sampling>`.
+
+    .. note::
+
+        In case input argument variables are of class :class:`numpy.ndarray` or
+        :class:`cupy.ndarray` objects, arguments will automatically be
+        converted to :class:`~chainer.Variable`\ s. This conversion takes place
+        to ensure that this function is included in the computational graph to
+        enable backward computations.
 
     Args:
         func (callable): A function to call. It needs to be called with
@@ -118,8 +126,6 @@ def forget(func, *xs):
         the method returns a tuple too.
 
     """
-    # Guarantee that backward is called by wrapping bare ndarrays as
-    # ``Variable`` s with ``requires_grad`` set to ``True``.
     xs = tuple(x if isinstance(x, variable.Variable) else
                variable.Variable(x, requires_grad=True) for x in xs)
     return Forget(func)(*xs)


### PR DESCRIPTION
Fixes #3449 .

Basically, it wraps all ndarray inputs to `F.forget` as Variables to ensure that backward is called.