### PR TITLE
New style forget

### DIFF
--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -1,63 +1,70 @@
-from chainer.backends import cuda
+import chainer
+from chainer import cuda
 from chainer import function
+from chainer import function_node
 from chainer import variable
 
 
-class _DummyFunction(function.Function):
+def _call_func(func, xs):
+    outs = func(*xs)
 
-    def __init__(self, grads):
-        self.grads = grads
+    if isinstance(outs, tuple):
+        for i, out in enumerate(outs):
+            if isinstance(out, variable.Variable):
+                continue
+            n = i + 1
+            suffix = {1: 'st', 2: 'nd', 3: 'rd'}.get(
+                n if n < 20 else n % 10, 'th')
+            msg = ('{}{} element of a returned tuple is not Variable, '
+                   'but is {}').format(n, suffix, type(out))
+            raise RuntimeError(msg)
+    elif isinstance(outs, variable.Variable):
+        outs = (outs,)
+    else:
+        msg = ('A tuple of Variables or a Variable are expected, but {} '
+               'is returned.'.format(type(outs)))
+        raise RuntimeError(msg)
+
+    return outs
+
+
+class _DummyFunction(function_node.FunctionNode):
+
+    def __init__(self, grad_var):
+        self.grad_var = grad_var
 
     def forward(self, inputs):
         xp = cuda.get_array_module(*inputs)
         return xp.array(0),
 
-    def backward(self, inputs, outputs):
-        return self.grads
+    def backward(self, indexes, grad_outputs):
+        return self.grad_var
 
 
-class Forget(function.Function):
+class Forget(function_node.FunctionNode):
 
     def __init__(self, func):
         if not callable(func):
             raise TypeError('func must be callable')
-
         self.func = func
 
-    def _call_func(self, xs):
-        outs = self.func(*xs)
-
-        if isinstance(outs, tuple):
-            for i, out in enumerate(outs):
-                if isinstance(out, variable.Variable):
-                    continue
-                n = i + 1
-                suffix = {1: 'st', 2: 'nd', 3: 'rd'}.get(
-                    n if n < 20 else n % 10, 'th')
-                msg = ('{}{} element of a returned tuple is not Variable, '
-                       'but is {}').format(n, suffix, type(out))
-                raise RuntimeError(msg)
-        elif isinstance(outs, variable.Variable):
-            outs = (outs,)
-        else:
-            msg = ('A tuple of Variables or a Variable are expected, but {} '
-                   'is returned.'.format(type(outs)))
-            raise RuntimeError(msg)
-
-        return outs
-
     def forward(self, inputs):
+        self.retain_inputs(tuple(range(len(inputs))))
         with function.no_backprop_mode():
             xs = [variable.Variable(x) for x in inputs]
-            outs = self._call_func(xs)
+            outs = _call_func(self.func, xs)
         return tuple(out.data for out in outs)
 
-    def backward(self, inputs, grads):
+    def backward(self, indexes, grad_outputs):
+        inputs = self.get_retained_inputs()
         with function.force_backprop_mode():
-            xs = [variable.Variable(x) for x in inputs]
-            outs = self._call_func(xs)
-            _DummyFunction(grads)(*outs).backward()
-        return tuple(x.grad for x in xs)
+            outs = _call_func(self.func, inputs)
+            # Set gradients of variables involed in the forward pass
+            _DummyFunction(grad_outputs).apply(outs)[0].backward()
+        # Return gradients that are further backproable
+        return chainer.grad(
+            outs, inputs, grad_outputs=grad_outputs, retain_grad=True,
+            enable_double_backprop=True)
 
 
 def forget(func, *xs):
@@ -128,4 +135,7 @@ def forget(func, *xs):
     """
     xs = tuple(x if isinstance(x, variable.Variable) else
                variable.Variable(x, requires_grad=True) for x in xs)
-    return Forget(func)(*xs)
+    y = Forget(func).apply(xs)
+    if len(y) == 1:
+        y, = y
+    return y

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -63,7 +63,7 @@ class Forget(function_node.FunctionNode):
             _DummyFunction(grad_outputs).apply(outs)[0].backward()
         # Return gradients that are further backproable
         return chainer.grad(
-            outs, inputs, grad_outputs=grad_outputs, retain_grad=True,
+            outs, inputs, grad_outputs=grad_outputs,
             enable_double_backprop=True)
 
 

--- a/tests/chainer_tests/functions_tests/util_tests/test_forget.py
+++ b/tests/chainer_tests/functions_tests/util_tests/test_forget.py
@@ -20,6 +20,9 @@ class TestForget(unittest.TestCase):
         self.ggx = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
         self.ggy = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
 
+        self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
+        self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
+
     def check_forward(self, x_data, y_data):
         x = chainer.Variable(x_data)
         y = chainer.Variable(y_data)
@@ -33,7 +36,8 @@ class TestForget(unittest.TestCase):
         def f(x, y):
             return functions.forget(lambda x, y: (x + y + x), x, y)
 
-        gradient_check.check_backward(f, (x_data, y_data), gz_data)
+        gradient_check.check_backward(
+            f, (x_data, y_data), gz_data, **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.y, self.gz)
@@ -49,7 +53,8 @@ class TestForget(unittest.TestCase):
             return functions.forget(lambda x, y: (x * x * 3 + y * x,), x, y)
 
         gradient_check.check_double_backward(
-            f, (x_data, y_data), gz_data, (ggx_data, ggy_data))
+            f, (x_data, y_data), gz_data, (ggx_data, ggy_data),
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.y, self.gz, self.ggx, self.ggy)

--- a/tests/chainer_tests/functions_tests/util_tests/test_forget.py
+++ b/tests/chainer_tests/functions_tests/util_tests/test_forget.py
@@ -4,8 +4,11 @@ import numpy
 import six
 
 import chainer
+from chainer import cuda
 from chainer import functions
+from chainer import gradient_check
 from chainer import testing
+from chainer.testing import attr
 
 
 class TestForget(unittest.TestCase):
@@ -14,6 +17,8 @@ class TestForget(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
         self.y = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
         self.gz = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
+        self.ggx = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
+        self.ggy = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
 
     def check_forward(self, x_data, y_data):
         x = chainer.Variable(x_data)
@@ -25,17 +30,35 @@ class TestForget(unittest.TestCase):
         self.check_forward(self.x, self.y)
 
     def check_backward(self, x_data, y_data, gz_data):
-        x = chainer.Variable(x_data)
-        y = chainer.Variable(y_data)
-        z = functions.forget(lambda x, y: (x + y + x,), x, y)
-        z.grad = gz_data
-        z.backward()
+        def f(x, y):
+            return functions.forget(lambda x, y: (x + y + x), x, y)
 
-        testing.assert_allclose(x.grad, gz_data * 2)
-        testing.assert_allclose(y.grad, gz_data)
+        gradient_check.check_backward(f, (x_data, y_data), gz_data)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.y, self.gz)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.y),
+                            cuda.to_gpu(self.gz))
+
+    def check_double_backward(self, x_data, y_data, gz_data, ggx_data,
+                              ggy_data):
+        def f(x, y):
+            return functions.forget(lambda x, y: (x * x * 3 + y * x,), x, y)
+
+        gradient_check.check_double_backward(
+            f, (x_data, y_data), gz_data, (ggx_data, ggy_data))
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.y, self.gz, self.ggx, self.ggy)
+
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.y),
+                                   cuda.to_gpu(self.gz), cuda.to_gpu(self.ggx),
+                                   cuda.to_gpu(self.ggy))
 
 
 class TestForgetError(unittest.TestCase):


### PR DESCRIPTION
New style forget to support double backprop.

~It is quite inefficient at the moment during backprop since backward is called once to set the gradients of the variables invovled in the forgotten process, and then once again to get the backpropable gradients.~