### PR TITLE
Fix the example in the document of Reporter

### DIFF
--- a/chainer/reporter.py
+++ b/chainer/reporter.py
@@ -35,13 +35,13 @@ class Reporter(object):
        >>>
        >>> reporter = Reporter()
        >>> observer = object()  # it can be an arbitrary (reference) object
-       >>> reporter.add_observer('my_observer:', observer)
+       >>> reporter.add_observer('my_observer', observer)
        >>> observation = {}
        >>> with reporter.scope(observation):
        ...     reporter.report({'x': 1}, observer)
        ...
        >>> observation
-       {'my_observer:x': 1}
+       {'my_observer/x': 1}
 
     There are also a global API to add values::
 
@@ -50,7 +50,7 @@ class Reporter(object):
        ...     report({'x': 1}, observer)
        ...
        >>> observation
-       {'my_observer:x': 1}
+       {'my_observer/x': 1}
 
     The most important application of Reporter is to report observed values
     from each link or chain in the training and validation procedures.


### PR DESCRIPTION
This PR fixes the error below and removes `:` in `reporter.add_observer('my_observer:', observer)`.

I executed the example in the readthedocs, and found that `/` is inserted between the names of the observation and the key of the reported dict.

```
>>> from chainer import Reporter, report, report_scope
>>>
>>> reporter = Reporter()
>>> observer = object()  # it can be an arbitrary (reference) object
>>> reporter.add_observer('my_observer:', observer)
>>> observation = {}
>>> with reporter.scope(observation):
...     reporter.report({'x': 1}, observer)
...
>>> observation
{'my_observer:/x': 1}
```
with Chainer v3, in Python 3.