### PR TITLE
Fix casing of header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center"><img src="docs/image/chainer_red_h.png" width="400"/></div>
 
-# Chainer: a deep learning framework
+# Chainer: A deep learning framework
 
 [![pypi](https://img.shields.io/pypi/v/chainer.svg)](https://pypi.python.org/pypi/chainer)
 [![GitHub license](https://img.shields.io/github/license/chainer/chainer.svg)](https://github.com/chainer/chainer)


### PR DESCRIPTION
Fixed the casing of the header in the README. 

Unless it has been discussed before, I think this looks better. For reference, see http://blog.apastyle.org/apastyle/2011/06/capitalization-after-colons.html. 

Additionally, if we want to emphasize the fact that this indeed is a _deep learning framework_, I suggest we instead change the header to `Chainer: A Deep Learning Framework`.