### PR TITLE
Remove unnecessary branch in minimum forward.

### DIFF
--- a/chainer/functions/math/minimum.py
+++ b/chainer/functions/math/minimum.py
@@ -22,10 +22,7 @@ class Minimum(function_node.FunctionNode):
         self.retain_inputs((0, 1))
         x1, x2 = inputs
         xp = cuda.get_array_module(x1, x2)
-        if xp is numpy:
-            return utils.force_array(numpy.minimum(x1, x2)),
-        else:
-            return xp.minimum(x1, x2),
+        return utils.force_array(xp.minimum(x1, x2)),
 
     def backward(self, indexes, grad_outputs):
         x1, x2 = self.get_retained_inputs()

--- a/chainer/functions/math/minimum.py
+++ b/chainer/functions/math/minimum.py
@@ -1,5 +1,3 @@
-import numpy
-
 from chainer import cuda
 from chainer import function_node
 import chainer.functions


### PR DESCRIPTION
This PR removes an unnecessary branch in `chainer.functions.minimum` forward computation, which might cause slight cost but  it would be enough to ignore. 