### PR TITLE
Fix sigmoid_cross_entropy doc about t

### DIFF
--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -77,9 +77,10 @@ def sigmoid_cross_entropy(
             (i, j)-th element indicates the unnormalized log probability of
             the j-th unit at the i-th example.
         t (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
-        :class:`cupy.ndarray`): Variable holding a signed integer vector of
-            ground truth labels. If ``t[i] == -1``, corresponding ``x[i]`` is
-            ignored.
+        :class:`cupy.ndarray`): A variable object holding a matrix whose
+            (i, j)-th element indicates a signed integer vector of
+            ground truth labels 0 or 1.
+            If ``t[i, j] == -1``, corresponding ``x[i, j]`` is ignored.
             Loss is zero if all ground truth labels are ``-1``.
         normalize (bool): Variable holding a boolean value which
             determines the normalization constant. If true, this function


### PR DESCRIPTION
functions.sigmoid_cross_entropy 's document has a wrong description about `t`. This PR fixes it.