### PR TITLE
Allow list, tuple and None in to_cpu and to_gpu

### DIFF
--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -237,8 +237,8 @@ def to_gpu(array, device=None, stream=None):
     """Copies the given CPU array to the specified device.
 
     Args:
-        array (numpy.ndarray, cupy.ndarray, list or tuple): Array or arrays to
-            be sent to GPU.
+        array (numpy.ndarray, cupy.ndarray, None, list or tuple):
+            Array or arrays to be sent to GPU.
         device: Device specifier.
         stream (~cupy.cuda.Stream): *(deprecated since v3.0.0)*
             CUDA stream. If not ``None``, the copy runs asynchronously.
@@ -248,6 +248,8 @@ def to_gpu(array, device=None, stream=None):
 
         If some of the arrays are already on GPU, then this function just
         returns those arrays without performing any copy.
+
+        If input arrays include `None`, it is returned as `None` as is.
 
     """
     if stream is not None:
@@ -325,8 +327,8 @@ def to_cpu(array, stream=None):
     """Copies the given GPU array to host CPU.
 
     Args:
-        array (numpy.ndarray, cupy.ndarray, list or tuple): Array or arrays to
-            be sent to CPU.
+        array (numpy.ndarray, cupy.ndarray, None, list or tuple):
+            Array or arrays to be sent to CPU.
         stream (cupy.cuda.Stream): CUDA stream.
 
     Returns:
@@ -334,6 +336,8 @@ def to_cpu(array, stream=None):
 
         If some of the arrays are already on CPU, then this function just
         returns those arrays without performing any copy.
+
+        If input arrays include `None`, it is returned as `None` as is.
 
     """
     if isinstance(array, (list, tuple)):

--- a/chainer/cuda.py
+++ b/chainer/cuda.py
@@ -237,16 +237,17 @@ def to_gpu(array, device=None, stream=None):
     """Copies the given CPU array to the specified device.
 
     Args:
-        array: Array to be sent to GPU.
+        array (numpy.ndarray, cupy.ndarray, list or tuple): Array or arrays to
+            be sent to GPU.
         device: Device specifier.
         stream (~cupy.cuda.Stream): *(deprecated since v3.0.0)*
             CUDA stream. If not ``None``, the copy runs asynchronously.
 
     Returns:
-        cupy.ndarray: Array on GPU.
+        cupy.ndarray, list or tuple: Array or arrays on GPU.
 
-        If ``array`` is already on the GPU device specified by ``device``,
-        this function just returns ``array`` without performing any copy.
+        If some of the arrays are already on GPU, then this function just
+        returns those arrays without performing any copy.
 
     """
     if stream is not None:
@@ -255,6 +256,27 @@ def to_gpu(array, device=None, stream=None):
             'Please remove it.', DeprecationWarning)
 
     check_cuda_available()
+    with Device(device) as device_:
+        if isinstance(array, (list, tuple)):
+            d = {}
+            ret = []
+            for arr in array:
+                if arr is None:
+                    ret.append(None)
+                else:
+                    arr2 = d.get(id(arr))
+                    if arr2 is None:
+                        arr2 = _array_to_gpu(arr, device_, stream)
+                        d[id(arr)] = arr2
+                    ret.append(arr2)
+            return type(array)(ret)
+        else:
+            return _array_to_gpu(array, device_, stream)
+
+
+def _array_to_gpu(array, device, stream):
+    if array is None:
+        return None
     if isinstance(array, (numpy.number, numpy.bool_)):
         array = numpy.asarray(array)
     if not isinstance(array, (cupy.ndarray, numpy.ndarray)):
@@ -303,16 +325,37 @@ def to_cpu(array, stream=None):
     """Copies the given GPU array to host CPU.
 
     Args:
-        array: Array to be sent to CPU.
+        array (numpy.ndarray, cupy.ndarray, list or tuple): Array or arrays to
+            be sent to CPU.
         stream (cupy.cuda.Stream): CUDA stream.
 
     Returns:
-        numpy.ndarray: Array on CPU.
+        numpy.ndarray, list or tuple: Array on CPU.
 
-        If given ``array`` is already on CPU, then this function just returns
-        ``array`` without performing any copy.
+        If some of the arrays are already on CPU, then this function just
+        returns those arrays without performing any copy.
 
     """
+    if isinstance(array, (list, tuple)):
+        d = {}
+        ret = []
+        for arr in array:
+            if arr is None:
+                ret.append(None)
+            else:
+                arr2 = d.get(id(arr))
+                if arr2 is None:
+                    arr2 = _array_to_cpu(arr, stream)
+                    d[id(arr)] = arr2
+                ret.append(arr2)
+        return type(array)(ret)
+    else:
+        return _array_to_cpu(array, stream)
+
+
+def _array_to_cpu(array, stream):
+    if array is None:
+        return None
     if isinstance(array, ndarray):
         check_cuda_available()
         with get_device_from_array(array):

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -371,6 +371,7 @@ class TestToGPU(unittest.TestCase):
         self.assertIsNot(x, y)  # Do copy
         cuda.cupy.testing.assert_array_equal(x, y)
 
+    @attr.gpu
     def test_single_none(self):
         assert cuda.to_gpu(None) is None
 

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -194,6 +194,40 @@ class TestToCPU(unittest.TestCase):
         self.assertIsInstance(y, numpy.ndarray)
         cuda.cupy.testing.assert_array_equal(self.x, y)
 
+    def test_single_none(self):
+        assert cuda.to_cpu(None) is None
+
+    def _check_list_tuple(self, typ):
+        assert typ in (list, tuple)
+        a = numpy.random.uniform(-1, 1, (0,))
+        b = numpy.random.uniform(-1, 1, (2, 3))
+        c = cuda.cupy.random.uniform(-1, 1, (0,))
+        d = cuda.cupy.random.uniform(-1, 1, (2, 2))
+        xs = typ([a, b, c, d, None, a, b, None, c, d])
+        xs_cpu = cuda.to_cpu(xs)
+
+        assert isinstance(xs_cpu, typ)
+        assert len(xs) == len(xs_cpu)
+        for i in (0, 1, 2, 3, 5, 6, 8, 9):
+            assert isinstance(xs_cpu[i], numpy.ndarray)
+            cuda.cupy.testing.assert_array_equal(xs[i], xs_cpu[i])
+        assert xs_cpu[0] is a
+        assert xs_cpu[1] is b
+        assert xs_cpu[2] is xs_cpu[8]
+        assert xs_cpu[3] is xs_cpu[9]
+        assert xs_cpu[4] is None
+        assert xs_cpu[5] is a
+        assert xs_cpu[6] is b
+        assert xs_cpu[7] is None
+
+    @attr.gpu
+    def test_list(self):
+        self._check_list_tuple(list)
+
+    @attr.gpu
+    def test_tuple(self):
+        self._check_list_tuple(tuple)
+
     def test_variable(self):
         x = chainer.Variable(self.x)
         with self.assertRaises(TypeError):
@@ -336,6 +370,40 @@ class TestToGPU(unittest.TestCase):
         self.assertIsInstance(y, cuda.ndarray)
         self.assertIsNot(x, y)  # Do copy
         cuda.cupy.testing.assert_array_equal(x, y)
+
+    def test_single_none(self):
+        assert cuda.to_gpu(None) is None
+
+    def _check_list_tuple(self, typ):
+        assert typ in (list, tuple)
+        a = numpy.random.uniform(-1, 1, (0,))
+        b = numpy.random.uniform(-1, 1, (2, 3))
+        c = cuda.cupy.random.uniform(-1, 1, (0,))
+        d = cuda.cupy.random.uniform(-1, 1, (2, 2))
+        xs = typ([a, b, c, d, None, a, b, None, c, d])
+        xs_gpu = cuda.to_gpu(xs)
+
+        assert isinstance(xs_gpu, typ)
+        assert len(xs) == len(xs_gpu)
+        for i in (0, 1, 2, 3, 5, 6, 8, 9):
+            assert isinstance(xs_gpu[i], cuda.cupy.ndarray)
+            cuda.cupy.testing.assert_array_equal(xs[i], xs_gpu[i])
+        assert xs_gpu[0] is xs_gpu[5]
+        assert xs_gpu[1] is xs_gpu[6]
+        assert xs_gpu[2] is c
+        assert xs_gpu[3] is d
+        assert xs_gpu[4] is None
+        assert xs_gpu[7] is None
+        assert xs_gpu[8] is c
+        assert xs_gpu[9] is d
+
+    @attr.gpu
+    def test_list(self):
+        self._check_list_tuple(list)
+
+    @attr.gpu
+    def test_tuple(self):
+        self._check_list_tuple(tuple)
 
     @attr.gpu
     def test_variable_gpu(self):


### PR DESCRIPTION
This PR improves `cuda.to_cpu` and `cuda.to_gpu` by accepting `None` and a sequence of arrays.
