### PR TITLE
 Refactor unit tests for various backend configuration

### DIFF
--- a/chainer/testing/backend.py
+++ b/chainer/testing/backend.py
@@ -18,7 +18,8 @@ class BackendConfig(object):
     ]
 
     def __init__(self, params):
-        assert isinstance(params, dict)
+        if not isinstance(params, dict):
+            raise TypeError('params must be a dict.')
         self._contexts = []
 
         # Default values
@@ -105,9 +106,12 @@ def _wrap_backend_test_method(impl, param, method_name):
 
 
 def inject_backend_tests(method_names, params):
-    assert isinstance(method_names, list)
-    assert isinstance(params, list)
-    assert all(isinstance(_, dict) for _ in params)
+    if not isinstance(method_names, list):
+        raise TypeError('method_names must be a list.')
+    if not isinstance(params, list):
+        raise TypeError('params must be a list of dicts.')
+    if not all(isinstance(d, dict) for d in params):
+        raise TypeError('params must be a list of dicts.')
 
     def wrap(case):
         assert issubclass(case, unittest.TestCase)

--- a/chainer/testing/backend.py
+++ b/chainer/testing/backend.py
@@ -1,0 +1,126 @@
+import functools
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+from chainer.testing import attr
+
+
+class BackendConfig(object):
+
+    _props = [
+        ('use_cuda', False),
+        ('use_cudnn', 'never'),
+        ('cudnn_deterministic', False),
+        ('autotune', False),
+    ]
+
+    def __init__(self, params):
+        assert isinstance(params, dict)
+        self._contexts = []
+
+        # Default values
+        for k, v in self._props:
+            setattr(self, k, v)
+        # Specified values
+        for k, v in params.items():
+            if not hasattr(self, k):
+                raise ValueError('Parameter {} is not defined'.format(k))
+            setattr(self, k, v)
+
+    @property
+    def xp(self):
+        if self.use_cuda:
+            return cuda.cupy
+        else:
+            return numpy
+
+    def __enter__(self):
+        self._contexts = [
+            chainer.using_config(
+                'use_cudnn', self.use_cudnn),
+            chainer.using_config(
+                'cudnn_deterministic', self.cudnn_deterministic),
+            chainer.using_config(
+                'autotune', self.autotune),
+        ]
+        for c in self._contexts:
+            c.__enter__()
+        return self
+
+    def __exit__(self, typ, value, traceback):
+        for c in reversed(self._contexts):
+            c.__exit__(typ, value, traceback)
+
+    def __repr__(self):
+        lst = []
+        for k, _ in self._props:
+            lst.append('{}={!r}'.format(k, getattr(self, k)))
+        return '<BackendConfig {}>'.format(' '.join(lst))
+
+    def get_func_str(self):
+        """Returns a string that can be used in method name"""
+        lst = []
+        for k, _ in self._props:
+            val = getattr(self, k)
+            if val is True:
+                val = 'true'
+            elif val is False:
+                val = 'false'
+            else:
+                val = str(val)
+            lst.append('{}_{}'.format(k, val))
+        return '__'.join(lst)
+
+    def get_pytest_marks(self):
+        marks = []
+        if self.use_cuda:
+            marks.append(attr.gpu)
+            if self.use_cudnn != 'never':
+                marks.append(attr.cudnn)
+
+        assert all(callable(_) for _ in marks)
+        return marks
+
+
+def _wrap_backend_test_method(impl, param, method_name):
+    backend_config = BackendConfig(param)
+    marks = backend_config.get_pytest_marks()
+    new_method_name = '{}__{}'.format(
+        method_name, backend_config.get_func_str())
+
+    @functools.wraps(impl)
+    def func(self, *args, **kwargs):
+        impl(self, backend_config, *args, **kwargs)
+
+    func.__name__ = new_method_name
+
+    # Apply test marks
+    for mark in marks:
+        func = mark(func)
+
+    return func, new_method_name
+
+
+def inject_backend_tests(method_names, params):
+    assert isinstance(method_names, list)
+    assert isinstance(params, list)
+    assert all(isinstance(_, dict) for _ in params)
+
+    def wrap(case):
+        assert issubclass(case, unittest.TestCase)
+        for method_name in method_names:
+            impl = getattr(case, method_name)
+            delattr(case, method_name)
+            for i_param, param in enumerate(params):
+                new_impl, new_method_name = _wrap_backend_test_method(
+                    impl, param, method_name)
+                if hasattr(case, new_method_name):
+                    raise RuntimeError(
+                        'Test fixture already exists: {}'.format(
+                            new_method_name))
+                setattr(case, new_method_name, new_impl)
+        return case
+    return wrap

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -98,9 +98,8 @@ def product(parameter):
         if not all(isinstance(_, dict) for l in parameter for _ in l):
             raise TypeError('parameter must be list of lists of dicts')
 
-        product = list(itertools.product(*parameter))
         lst = []
-        for dict_lst in product:
+        for dict_lst in itertools.product(*parameter):
             a = {}
             for d in dict_lst:
                 a.update(d)

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -85,10 +85,32 @@ def parameterize(*params):
 
 
 def product(parameter):
-    keys = sorted(parameter)
-    values = [parameter[key] for key in keys]
-    values_product = itertools.product(*values)
-    return [dict(zip(keys, vals)) for vals in values_product]
+    if isinstance(parameter, dict):
+        keys = sorted(parameter)
+        values = [parameter[key] for key in keys]
+        values_product = itertools.product(*values)
+        return [dict(zip(keys, vals)) for vals in values_product]
+
+    elif isinstance(parameter, list):
+        # list of lists of dicts
+        if not all(isinstance(_, list) for _ in parameter):
+            raise TypeError('parameter must be list of lists of dicts')
+        if not all(isinstance(_, dict) for l in parameter for _ in l):
+            raise TypeError('parameter must be list of lists of dicts')
+
+        product = list(itertools.product(*parameter))
+        lst = []
+        for dict_lst in product:
+            a = {}
+            for d in dict_lst:
+                a.update(d)
+            lst.append(a)
+        return lst
+
+    else:
+        raise TypeError(
+            'parameter must be either dict or list. Actual: {}'.format(
+                type(parameter)))
 
 
 def product_dict(*parameters):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -9,6 +9,7 @@ import chainer.functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
+from chainer.testing import backend
 from chainer.testing import condition
 from chainer.testing import parameterize
 from chainer.utils import conv
@@ -20,27 +21,44 @@ def _pair(x):
     return x, x
 
 
-@parameterize(*(testing.product({
-    'c_contiguous': [True],
-    'test_outsize': [True, False],
-    'nobias': [True],
-    'stride': [1, 2],
-    'use_cudnn': ['always'],
-    'cudnn_deterministic': [True, False],
-    'x_dtype': [numpy.float32],
-    'W_dtype': [numpy.float32],
-    'autotune': [True, False],
-}) + testing.product({
-    'c_contiguous': [False],
-    'test_outsize': [True],
-    'nobias': [False],
-    'stride': [1, 2],
-    'use_cudnn': ['always', 'never'],
-    'cudnn_deterministic': [False],
-    'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'autotune': [False],
-})))
+@parameterize(*(testing.product([
+    testing.product({
+        'c_contiguous': [True],
+        'test_outsize': [True, False],
+        'nobias': [True],
+        'stride': [1, 2],
+        'x_dtype': [numpy.float32],
+        'W_dtype': [numpy.float32],
+    })
+    + testing.product({
+        'c_contiguous': [False],
+        'test_outsize': [True],
+        'nobias': [False],
+        'stride': [1, 2],
+        'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
+        'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
+    }),
+])))
+@backend.inject_backend_tests(
+    ['test_forward', 'test_backward', 'test_double_backward'],
+    # CPU tests
+    [{
+        'use_cuda': False,
+    }]
+    # GPU tests
+    + testing.product([
+        [{'use_cuda': True}],
+
+        # Without cuDNN
+        testing.product({
+            'use_cudnn': ['never'],
+        })
+        # With cuDNN
+        + testing.product({
+            'use_cudnn': ['always'],
+            'cudnn_deterministic': [True, False],
+            'autotune': [True, False],
+        })]))
 class TestDeconvolution2DFunction(unittest.TestCase):
 
     in_channels = 3
@@ -52,11 +70,12 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         kh, kw = _pair(self.ksize)
         sh, sw = _pair(self.stride)
         ph, pw = _pair(self.pad)
-        self.W = numpy.random.normal(
+
+        W = numpy.random.normal(
             0, numpy.sqrt(1. / (kh * kw * self.in_channels)),
             (self.in_channels, self.out_channels, kh, kw)
         ).astype(self.W_dtype)
-        self.b = None if self.nobias else numpy.random.uniform(
+        b = None if self.nobias else numpy.random.uniform(
             -1, 1, self.out_channels).astype(self.x_dtype)
 
         N = 2
@@ -64,17 +83,21 @@ class TestDeconvolution2DFunction(unittest.TestCase):
         outh = conv.get_deconv_outsize(inh, kh, sh, ph)
         outw = conv.get_deconv_outsize(inw, kw, sw, pw)
         self.outsize = (outh, outw) if self.test_outsize else None
-        self.x = numpy.random.uniform(
+        x = numpy.random.uniform(
             -1, 1, (N, self.in_channels, inh, inw)).astype(self.x_dtype)
-        self.gy = numpy.random.uniform(
+        gy = numpy.random.uniform(
             -1, 1, (N, self.out_channels, outh, outw)).astype(self.x_dtype)
 
-        self.ggx = numpy.random.uniform(-1, 1, self.x.shape).astype(
+        ggx = numpy.random.uniform(-1, 1, x.shape).astype(
             self.x_dtype)
-        self.ggW = numpy.random.uniform(-1, 1, self.W.shape).astype(
+        ggW = numpy.random.uniform(-1, 1, W.shape).astype(
             self.W_dtype)
-        self.ggb = None if self.nobias else numpy.random.uniform(
-            -1, 1, self.b.shape).astype(self.x_dtype)
+        ggb = None if self.nobias else numpy.random.uniform(
+            -1, 1, b.shape).astype(self.x_dtype)
+
+        self.inputs = [x, W, b]
+        self.grad_outputs = [gy]
+        self.grad_grad_inputs = [ggx, ggW, ggb]
 
         self.test_forward_options = {}
         self.check_backward_options = {'dtype': numpy.float64}
@@ -87,54 +110,67 @@ class TestDeconvolution2DFunction(unittest.TestCase):
             self.check_backward_options.update(atol=5e-4, rtol=5e-3)
             self.check_double_backward_options.update(atol=5e-3, rtol=5e-2)
 
-    @attr.gpu
-    def test_forward_consistency(self):
-        x_cpu = chainer.Variable(self.x)
-        W_cpu = chainer.Variable(self.W)
-        b_cpu = None if self.nobias else chainer.Variable(self.b)
-        with chainer.using_config('cudnn_deterministic',
-                                  self.cudnn_deterministic):
-            y_cpu = F.deconvolution_2d(
-                x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
+    def forward_cpu(self, inputs):
+        x, W, b = inputs
+        x_cpu = chainer.Variable(x)
+        W_cpu = chainer.Variable(W)
+        b_cpu = None if b is None else chainer.Variable(b)
+        y_cpu = F.deconvolution_2d(
+            x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
+            outsize=self.outsize)
+        return y_cpu,
+
+    def check_forward(self, inputs, backend_config):
+        y_expected, = self.forward_cpu(inputs)
+
+        if backend_config.use_cuda:
+            inputs = cuda.to_gpu(inputs)
+
+        x, W, b = inputs
+        x = chainer.Variable(x)
+        W = chainer.Variable(W)
+        b = None if b is None else chainer.Variable(b)
+
+        with backend_config:
+            y_actual = F.deconvolution_2d(
+                x, W, b, stride=self.stride, pad=self.pad,
                 outsize=self.outsize)
 
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        W_gpu = chainer.Variable(cuda.to_gpu(self.W))
-        b_gpu = None if self.nobias else chainer.Variable(
-            cuda.to_gpu(self.b))
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            with chainer.using_config('cudnn_deterministic',
-                                      self.cudnn_deterministic):
-                with chainer.using_config('autotune', self.autotune):
-                    y_gpu = F.deconvolution_2d(
-                        x_gpu, W_gpu, b_gpu, stride=self.stride, pad=self.pad,
-                        outsize=self.outsize)
-
-        self.assertEqual(y_cpu.data.dtype, self.x_dtype)
-        self.assertEqual(y_gpu.data.dtype, self.x_dtype)
+        assert y_expected.data.dtype == self.x_dtype
+        assert y_actual.data.dtype == self.x_dtype
         testing.assert_allclose(
-            y_cpu.data, y_gpu.data.get(), **self.test_forward_options)
+            y_expected.data, y_actual.data.get(), **self.test_forward_options)
 
     @attr.gpu
-    def test_forward_consistency_im2col(self):
-        self.use_cudnn = 'never'
-        self.test_forward_consistency()
+    def test_forward(self, backend_config):
+        # Forward test does not currently target CPU backend.
+        # It only tests for consistency between GPU and CPU computation.
+        if not backend_config.use_cuda:
+            return
+        self.check_forward(self.inputs, backend_config)
 
-    def check_backward(self, x_data, W_data, b_data, y_grad):
-        xp = cuda.get_array_module(x_data)
+    def check_backward(self, inputs, grad_outputs, backend_config):
+
+        xp = backend_config.xp
+        if backend_config.use_cuda:
+            inputs = cuda.to_gpu(inputs)
+            grad_outputs = cuda.to_gpu(grad_outputs)
+
+        x_data, W_data, b_data = inputs
+        y_grad, = grad_outputs
 
         if not self.c_contiguous:
             x_data = xp.asfortranarray(x_data)
             W_data = xp.asfortranarray(W_data)
             y_grad = xp.asfortranarray(y_grad)
-            self.assertFalse(x_data.flags.c_contiguous)
-            self.assertFalse(W_data.flags.c_contiguous)
-            self.assertFalse(y_grad.flags.c_contiguous)
+            assert not x_data.flags.c_contiguous
+            assert not W_data.flags.c_contiguous
+            assert not y_grad.flags.c_contiguous
             if b_data is not None:
-                b = xp.empty((len(b_data) * 2,), dtype=self.b.dtype)
+                b = xp.empty((len(b_data) * 2,), dtype=b_data.dtype)
                 b[::2] = b_data
                 b_data = b[::2]
-                self.assertFalse(b_data.flags.c_contiguous)
+                assert not b_data.flags.c_contiguous
 
         args = (x_data, W_data)
         if b_data is not None:
@@ -144,27 +180,26 @@ class TestDeconvolution2DFunction(unittest.TestCase):
             return F.deconvolution_2d(
                 *args, stride=self.stride, pad=self.pad, outsize=self.outsize)
 
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            with chainer.using_config('cudnn_deterministic',
-                                      self.cudnn_deterministic):
-                with chainer.using_config('autotune', self.autotune):
-                    gradient_check.check_backward(
-                        f, args, y_grad, **self.check_backward_options)
+        with backend_config:
+            gradient_check.check_backward(
+                f, args, y_grad, **self.check_backward_options)
 
     @condition.retry(10)
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.W, self.b, self.gy)
+    def test_backward(self, backend_config):
+        self.check_backward(self.inputs, self.grad_outputs, backend_config)
 
-    @attr.gpu
-    @condition.retry(10)
-    def test_backward_gpu(self):
-        b = None if self.b is None else cuda.to_gpu(self.b)
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.W),
-                            b, cuda.to_gpu(self.gy))
+    def check_double_backward(
+            self, inputs, grad_outputs, grad_grad_inputs, backend_config):
+        xp = backend_config.xp
 
-    def check_double_backward(self, x_data, W_data, b_data, y_grad,
-                              x_grad_grad, W_grad_grad, b_grad_grad):
-        xp = cuda.get_array_module(x_data)
+        if backend_config.use_cuda:
+            inputs = cuda.to_gpu(inputs)
+            grad_outputs = cuda.to_gpu(grad_outputs)
+            grad_grad_inputs = cuda.to_gpu(grad_grad_inputs)
+
+        x_data, W_data, b_data = inputs
+        y_grad, = grad_outputs
+        x_grad_grad, W_grad_grad, b_grad_grad = grad_grad_inputs
 
         if not self.c_contiguous:
             x_data = xp.asfortranarray(x_data)
@@ -172,21 +207,21 @@ class TestDeconvolution2DFunction(unittest.TestCase):
             y_grad = xp.asfortranarray(y_grad)
             x_grad_grad = xp.asfortranarray(x_grad_grad)
             W_grad_grad = xp.asfortranarray(W_grad_grad)
-            self.assertFalse(x_data.flags.c_contiguous)
-            self.assertFalse(W_data.flags.c_contiguous)
-            self.assertFalse(y_grad.flags.c_contiguous)
-            self.assertFalse(x_grad_grad.flags.c_contiguous)
-            self.assertFalse(W_grad_grad.flags.c_contiguous)
+            assert not x_data.flags.c_contiguous
+            assert not W_data.flags.c_contiguous
+            assert not y_grad.flags.c_contiguous
+            assert not x_grad_grad.flags.c_contiguous
+            assert not W_grad_grad.flags.c_contiguous
             if b_data is not None:
-                b = xp.empty((len(b_data) * 2,), dtype=self.b.dtype)
+                b = xp.empty((len(b_data) * 2,), dtype=b_data.dtype)
                 b[::2] = b_data
                 b_data = b[::2]
-                self.assertFalse(b_data.flags.c_contiguous)
+                assert not b_data.flags.c_contiguous
 
-                ggb = xp.empty((len(b_data) * 2,), dtype=self.b.dtype)
+                ggb = xp.empty((len(b_data) * 2,), dtype=b_grad_grad.dtype)
                 ggb[::2] = b_grad_grad
                 b_grad_grad = ggb[::2]
-                self.assertFalse(b_grad_grad.flags.c_contiguous)
+                assert not b_grad_grad.flags.c_contiguous
 
         args = (x_data, W_data)
         grad_grads = (x_grad_grad, W_grad_grad)
@@ -199,26 +234,16 @@ class TestDeconvolution2DFunction(unittest.TestCase):
                 *args, stride=self.stride, pad=self.pad, outsize=self.outsize)
             return y * y  # make the function nonlinear
 
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            with chainer.using_config('cudnn_deterministic',
-                                      self.cudnn_deterministic):
-                gradient_check.check_double_backward(
-                    f, args, y_grad, grad_grads,
-                    **self.check_double_backward_options)
+        with backend_config:
+            gradient_check.check_double_backward(
+                f, args, y_grad, grad_grads,
+                **self.check_double_backward_options)
 
     @condition.retry(10)
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.W, self.b, self.gy,
-                                   self.ggx, self.ggW, self.ggb)
-
-    @attr.gpu
-    @condition.retry(10)
-    def test_double_backward_gpu(self):
+    def test_double_backward(self, backend_config):
         self.check_double_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.W),
-            None if self.b is None else cuda.to_gpu(self.b),
-            cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx), cuda.to_gpu(self.ggW),
-            None if self.ggb is None else cuda.to_gpu(self.ggb))
+            self.inputs, self.grad_outputs, self.grad_grad_inputs,
+            backend_config)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
This PR depends on ~#3850~.

Currently in unit tests of functions, various data parameters (`x_dtype`, `stride`, `nobias`, etc.) and backend parameters (`use_cudnn`, `autotune`, etc.) are mixed. There are some problems regarding this scheme:
* It's exponentially difficult to add new backends.
* Some tests are duplicated. For example, CPU tests are performed for every combination of `use_cudnn`, `cudnn_deterministic`, `autotune`, etc.

This PR solves this problem by separating data and backend configuration.
To do this,
* `testing.backend.inject_backend_tests` has been introduced. A test writer can apply this decorator to a test case, so that specified test fixtures (e.g. `test_backward`) will be duplicated to as many as backend configuration combinations (specified by the test writer). Each of duplicated fixtures will accept a new argument of type `testing.backend.BackendConfig`. `BackendConfig` has the information of one instance of backend configuration combination. `with` construct can be used against this object to to apply backend configuration (`chainer.use_config` is called accordingly).
* `testing.product` has been extended to support hierarchical structure.
* Applied to `chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py`.