### PR TITLE
catch all exceptions in parameterized test

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -41,7 +41,7 @@ def _gen_case(base, module, i, param):
         def wrap(*args, **kwargs):
             try:
                 return method(*args, **kwargs)
-            except AssertionError as e:
+            except Exception as e:
                 s = six.StringIO()
                 s.write('Parameterized test failed.\n\n')
                 s.write('Base test method: {}.{}\n'.format(


### PR DESCRIPTION
This PR fixes to show test parameter for exceptions other than AssertionFailure.
This is helpful to diagnose why exception occurred during writing tests.