### PR TITLE
[backport] Avoid zero division error in linear init call

### DIFF
--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -1,3 +1,6 @@
+import functools
+import operator
+
 from chainer.functions.connection import linear
 from chainer import initializers
 from chainer import link
@@ -120,5 +123,6 @@ class Linear(link.Link):
 
         """
         if self.W.data is None:
-            self._initialize_params(x.size // x.shape[0])
+            in_size = functools.reduce(operator.mul, x.shape[1:], 1)
+            self._initialize_params(in_size)
         return linear.linear(x, self.W, self.b)

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -1,3 +1,6 @@
+import functools
+import operator
+
 import numpy
 import six
 
@@ -298,7 +301,7 @@ class LSTM(LSTMBase):
         """
         if self.upward.W.data is None:
             with cuda.get_device_from_id(self._device_id):
-                in_size = x.size // x.shape[0]
+                in_size = functools.reduce(operator.mul, x.shape[1:], 1)
                 self.upward._initialize_params(in_size)
                 self._initialize_params()
 

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -1,3 +1,6 @@
+import functools
+import operator
+
 from chainer.functions.normalization import layer_normalization
 from chainer import link
 from chainer import utils
@@ -78,7 +81,8 @@ class LayerNormalization(link.Link):
 
         """
         if self.gamma.data is None:
-            self._initialize_params(x.size // x.shape[0])
+            in_size = functools.reduce(operator.mul, x.shape[1:], 1)
+            self._initialize_params(in_size)
 
         return layer_normalization.layer_normalization(
             x, self.gamma, self.beta, self.eps)

--- a/tests/chainer_tests/links_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_linear.py
@@ -154,6 +154,17 @@ class TestLinearParameterShapePlaceholder(unittest.TestCase):
         self.assertEqual((w1 == w2).all(), True)
 
 
+class TestEmptyBatchInitialize(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.Linear(4)
+        self.x = numpy.random.uniform(-1, 1, (0, 3)).astype(numpy.float32)
+
+    def test_empty_batch_dim(self):
+        y = self.link(chainer.Variable(self.x))
+        assert y.shape == (0, 4)
+
+
 class TestInvalidLinear(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -248,6 +248,17 @@ class TestLSTMInitialize(unittest.TestCase):
             numpy.array([0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0]))
 
 
+class TestLSTMEmptyBatchInitialize(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.LSTM(4)
+        self.x = numpy.random.uniform(-1, 1, (0, 3)).astype(numpy.float32)
+
+    def test_empty_batch_dim(self):
+        y = self.link(chainer.Variable(self.x))
+        assert y.shape == (0, 4)
+
+
 @testing.parameterize(*testing.product_dict(
     [
         {'in_size': 10, 'out_size': 10},

--- a/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_layer_normalization.py
@@ -153,6 +153,18 @@ class TestDefaultInitializer(unittest.TestCase):
             numpy.zeros(self.size), self.link.beta.data)
 
 
+class TestEmptyBatchInitialize(unittest.TestCase):
+
+    def setUp(self):
+        self.link = _create_ln()
+        self.shape = (0, 3)
+        self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+
+    def test_empty_batch_dim(self):
+        y = self.link(chainer.Variable(self.x))
+        assert y.shape == self.shape
+
+
 @testing.parameterize(*testing.product({
     'shape': [(2, 4, 3), (2, 5, 3, 4)],
 }))


### PR DESCRIPTION
Backport of #3871