### PR TITLE
fix CuPy requirment version

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -38,7 +38,7 @@ Chainer can be installed without them, in which case the corresponding features 
 
 * CUDA/cuDNN support
 
-  * `cupy <https://cupy.chainer.org/>`__ 3.0+
+  * `cupy <https://cupy.chainer.org/>`__ 4.0+
 
 * Caffe model support
 


### PR DESCRIPTION
Chainer v4.0 will require CuPy v4.0.