### PR TITLE
Add expm1 to the document.

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -179,6 +179,7 @@ Mathematical functions
    chainer.functions.cosh
    chainer.functions.cumsum
    chainer.functions.exp
+   chainer.functions.expm1
    chainer.functions.fix
    chainer.functions.fmod
    chainer.functions.floor


### PR DESCRIPTION
`expm1` seems to be missing in the document.