### PR TITLE
Fix Dockerfile to be able to train mnist with GPU

### DIFF
--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -1,9 +1,11 @@
-FROM nvidia/cuda:7.5-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn6-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     python-dev \
-    python-pip && \
+    python-pip \
+    python-wheel \
+    python-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN pip install cupy==4.0.0b2 chainer==4.0.0b2

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,9 +1,11 @@
-FROM nvidia/cuda:7.5-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn6-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     python3-dev \
-    python3-pip && \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN pip3 install cupy==4.0.0b2 chainer==4.0.0b2


### PR DESCRIPTION
From this PR: https://github.com/chainer/chainer/pull/3898. I have found a proper method to install python wheel as it is a dependency according to this error:
```
  ----------------------------------------
  Failed building wheel for cupy
  Running setup.py clean for cupy
  Running setup.py bdist_wheel for chainer: started
  Running setup.py bdist_wheel for chainer: finished with status 'error'
  Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-y_acju7c/chainer/setup.py';exec(co
mpile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpc8g4swgupip-wheel- --
python-tag cp35:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'

  ----------------------------------------
```