### PR TITLE
fix Link tutorial’s linear layer document math

### DIFF
--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -165,7 +165,7 @@ The most fundamental ones are links that behave like regular functions while rep
 We will introduce higher level links, but here think of links as simply functions with parameters.
 
 One of the most frequently used links is the :class:`~functions.Linear` link (a.k.a. *fully-connected layer* or *affine transformation*).
-It represents a mathematical function :math:`f(x) = Wx + b`, where the matrix :math:`W` and the vector :math:`b` are parameters.
+It represents a mathematical function :math:`f(x) = xW^\top + b`, where the matrix :math:`W` and the vector :math:`b` are parameters.
 This link corresponds to its pure counterpart :func:`~functions.linear`, which accepts :math:`x, W, b` as arguments.
 A linear link from three-dimensional space to two-dimensional space is defined by the following line:
 


### PR DESCRIPTION
fix linear layer math document in [Official tutorial's Links section](https://docs.chainer.org/en/stable/tutorial/basic.html#links).

Currently it says "f(x) = Wx + b", but chainer's linear layer actually calculate "f(x) = xW^\top + b".  `Links.Lenear` calls https://github.com/chainer/chainer/blob/master/chainer/functions/connection/linear.py#L78, which self-documents to calculate Y = xW^\\top + b and actually this function [transposes](https://github.com/chainer/chainer/blob/master/chainer/functions/connection/linear.py#L47) the matrix $W$.