### PR TITLE
fix trainer tutorial evaluate example code

### DIFF
--- a/docs/source/tutorial/trainer.rst
+++ b/docs/source/tutorial/trainer.rst
@@ -322,9 +322,9 @@ Evaluation using the snapshot of a model is as easy as what explained in the :do
     plt.show()
     print('label:', t)
 
-    y = model(x)
+    y = model(x[None, ...])
 
-    print('predicted_label:', y.argmax(axis=1)[0])
+    print('predicted_label:', y.data.argmax(axis=1)[0])
 
 .. image:: ../../image/trainer/mnist_output.png
 


### PR DESCRIPTION
Example code in https://docs.chainer.org/en/stable/tutorial/trainer.html#evaluate-a-pre-trained-model is broken.

`y = model(x)` raises `IndexError` because `x` is just one data, not a minibatch of length 1. (I have no idea about chaier's interface yet, but maybe it works at some previous version?)

And because the resulting `y` is not `np.array` anymore, we should access `y.data` instead. (or `y.array` ? which is better?)