### PR TITLE
Keyword-only link argument in GradientMethod

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -8,6 +8,7 @@ import six
 from chainer import cuda
 from chainer import link as link_module
 from chainer import serializer as serializer_module
+from chainer.utils import argument
 from chainer import variable
 
 
@@ -53,6 +54,8 @@ class Hyperparameter(object):
 
     """
 
+    _parent = None
+
     def __init__(self, parent=None):
         self._parent = parent
 
@@ -60,6 +63,19 @@ class Hyperparameter(object):
         if '_parent' not in self.__dict__:
             raise AttributeError('_parent is not set up yet')
         return getattr(self._parent, name)
+
+    def __setattr__(self, name, value):
+        # If the attribute is not defined as the class attribute of
+        # `Hyperparameter`, it's assumed to be a hyperparameter.
+        if not hasattr(Hyperparameter, name):
+            if not (isinstance(value, (numpy.ndarray, cuda.ndarray))
+                    or (not isinstance(value, (str, bytes))
+                        and numpy.isscalar(value))):
+                raise TypeError(
+                    'Hyperparameter must be a scalar or an array '
+                    '(name=\'{}\').\n'
+                    'Actual: {}'.format(name, type(value)))
+        super(Hyperparameter, self).__setattr__(name, value)
 
     def __repr__(self):
         d = self.get_dict()
@@ -523,12 +539,21 @@ class GradientMethod(Optimizer):
 
     """
 
-    def __init__(self, link=None):
+    _use_fp32_update = False
+
+    def __init__(self, **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
-        if isinstance(link, link_module.Link):
+
+        if link is None:
+            pass
+        elif isinstance(link, link_module.Link):
             self.setup(link)
-        self._use_fp32_update = False
+        else:
+            raise TypeError(
+                'link argument must be an instance of chainer.Link.\n'
+                'Actual: {}'.format(type(link)))
 
     def setup(self, link):
         super(GradientMethod, self).setup(link)

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -2,6 +2,7 @@ import numpy
 
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -84,8 +85,9 @@ class AdaDelta(optimizer.GradientMethod):
     """
 
     def __init__(self, rho=_default_hyperparam.rho,
-                 eps=_default_hyperparam.eps, model=None):
-        super(AdaDelta, self).__init__(model)
+                 eps=_default_hyperparam.eps, **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(AdaDelta, self).__init__(link=link)
         self.hyperparam.rho = rho
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -2,6 +2,7 @@ import numpy
 
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -75,8 +76,9 @@ class AdaGrad(optimizer.GradientMethod):
     """
 
     def __init__(self, lr=_default_hyperparam.lr,
-                 eps=_default_hyperparam.eps, model=None):
-        super(AdaGrad, self).__init__(model)
+                 eps=_default_hyperparam.eps, **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(AdaGrad, self).__init__(link=link)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -4,6 +4,7 @@ import numpy
 
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -111,8 +112,9 @@ class Adam(optimizer.GradientMethod):
                  beta1=_default_hyperparam.beta1,
                  beta2=_default_hyperparam.beta2,
                  eps=_default_hyperparam.eps,
-                 model=None):
-        super(Adam, self).__init__(model)
+                 **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(Adam, self).__init__(link=link)
         self.hyperparam.alpha = alpha
         self.hyperparam.beta1 = beta1
         self.hyperparam.beta2 = beta2

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -1,5 +1,6 @@
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -69,8 +70,9 @@ class MomentumSGD(optimizer.GradientMethod):
     """
 
     def __init__(self, lr=_default_hyperparam.lr,
-                 momentum=_default_hyperparam.momentum, model=None):
-        super(MomentumSGD, self).__init__(model)
+                 momentum=_default_hyperparam.momentum, **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(MomentumSGD, self).__init__(link=link)
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -1,5 +1,6 @@
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -76,8 +77,9 @@ class NesterovAG(optimizer.GradientMethod):
     """
 
     def __init__(self, lr=_default_hyperparam.lr,
-                 momentum=_default_hyperparam.momentum, model=None):
-        super(NesterovAG, self).__init__(model)
+                 momentum=_default_hyperparam.momentum, **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(NesterovAG, self).__init__(link=link)
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -2,6 +2,7 @@ import numpy
 
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -92,8 +93,9 @@ class RMSprop(optimizer.GradientMethod):
 
     def __init__(self, lr=_default_hyperparam.lr,
                  alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps,
-                 model=None):
-        super(RMSprop, self).__init__(model)
+                 **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(RMSprop, self).__init__(link=link)
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.eps = eps

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -2,6 +2,7 @@ import numpy
 
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -103,8 +104,9 @@ class RMSpropGraves(optimizer.GradientMethod):
                  alpha=_default_hyperparam.alpha,
                  momentum=_default_hyperparam.momentum,
                  eps=_default_hyperparam.eps,
-                 model=None):
-        super(RMSpropGraves, self).__init__(model)
+                 **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(RMSpropGraves, self).__init__(link=link)
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.momentum = momentum

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -1,5 +1,6 @@
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -50,8 +51,9 @@ class SGD(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr, model=None):
-        super(SGD, self).__init__(model)
+    def __init__(self, lr=_default_hyperparam.lr, **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(SGD, self).__init__(link=link)
         self.hyperparam.lr = lr
 
     lr = optimizer.HyperparameterProxy('lr')

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -2,6 +2,7 @@ import numpy
 
 from chainer import cuda
 from chainer import optimizer
+from chainer.utils import argument
 
 
 _default_hyperparam = optimizer.Hyperparameter()
@@ -88,8 +89,9 @@ class SMORMS3(optimizer.GradientMethod):
     """
 
     def __init__(self, lr=_default_hyperparam.lr,
-                 eps=_default_hyperparam.eps, model=None):
-        super(SMORMS3, self).__init__(model)
+                 eps=_default_hyperparam.eps, **kwargs):
+        link, = argument.parse_kwargs(kwargs, ('link', None))
+        super(SMORMS3, self).__init__(link=link)
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -53,6 +53,48 @@ class TestHyperparameter(unittest.TestCase):
         self.assertIs(child_copy.parent, parent_copy)
 
 
+@testing.parameterize(*testing.product(
+    {'value': [
+        1,
+        True,
+        2.1,
+        2.1j,
+        np.inf,
+        np.nan,
+        np.ones((1, 2), dtype=np.float32),
+        np.ones((1,), dtype=np.float32),
+        np.ones((0,), dtype=np.float32),
+        np.ones((), dtype=np.float32),
+    ]},
+))
+class TestHyperparameterValidType(unittest.TestCase):
+
+    def test_valid_value_type(self):
+        # Must not raise error
+        hp = optimizer.Hyperparameter()
+        hp.newparam = self.value
+
+
+@testing.parameterize(*testing.product(
+    {'value': [
+        None,
+        'str',
+        '1',
+        b'1',
+        object(),
+        chainer.Link(),
+        chainer.Variable(np.ones((), dtype=np.float32)),
+    ]},
+))
+class TestHyperparameterInvalidType(unittest.TestCase):
+
+    def test_invalid_value_type(self):
+        # Must raise error
+        hp = optimizer.Hyperparameter()
+        with self.assertRaises(TypeError):
+            hp.newparam = self.value
+
+
 class TestUpdateRule(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Improves #3488 by making `link` argument keyword-only.

```
optimizer = chainer.optimizers.SGD(model)  # does not work
```

In #3488, this code does not work and dangerous because `model` is treated as a hyperparameter.
In this PR, user must explicitly specify `link=` keyword.

```
optimizer = chainer.optimizers.SGD(link=model)
```

Also, type check on hyperparameter assignment is implemented, so the former code raises `TypeError`.

I wondered which is better keyword, `link` or `model`, but as `Optimizer.setup()` method has `link` argument, I chose `link`.