### PR TITLE
Fix incorrect use of single backslashes in docstrings

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -474,7 +474,7 @@ Use apply() method instead.\
             target_input_indexes (tuple of int): Indices of the input variables
                 w.r.t. which the gradients are required. It is guaranteed that
                 this tuple contains at least one element.
-            grad_outputs (tuple of :class:`~chainer.Variable`\ s): Gradients
+            grad_outputs (tuple of :class:`~chainer.Variable`\\ s): Gradients
                 w.r.t. the output variables.
                 If the gradient w.r.t. an output variable is not
                 given, the corresponding element is ``None``.

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -1,7 +1,7 @@
 """Collection of function implementations.
 
-Functions are either implemented as :class:`~chainer.Function`\s or
-:class:`~chainer.FunctionNode`\s.
+Functions are either implemented as :class:`~chainer.Function`\\ s or
+:class:`~chainer.FunctionNode`\\ s.
 """
 
 from chainer.functions.activation.clipped_relu import clipped_relu  # NOQA

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -105,8 +105,9 @@ def n_step_lstm(
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is the
             mini-batch size for time ``t``. The sequences must be transposed.
             :func:`~chainer.functions.transpose_sequence` can be used to
-            transpose a list of :class:`~chainer.Variable`\\ s each representing
-            a sequence. When sequences has different lengths, they must be
+            transpose a list of :class:`~chainer.Variable`\\ s each
+            representing a sequence.
+            When sequences has different lengths, they must be
             sorted in descending order of their lengths before transposing.
             So ``xs`` needs to satisfy
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.
@@ -271,8 +272,9 @@ def n_step_bilstm(
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is the
             mini-batch size for time ``t``. The sequences must be transposed.
             :func:`~chainer.functions.transpose_sequence` can be used to
-            transpose a list of :class:`~chainer.Variable`\\ s each representing
-            a sequence. When sequences has different lengths, they must be
+            transpose a list of :class:`~chainer.Variable`\\ s each
+            representing a sequence.
+            When sequences has different lengths, they must be
             sorted in descending order of their lengths before transposing.
             So ``xs`` needs to satisfy
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.
@@ -379,8 +381,9 @@ def n_step_lstm_base(
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is the
             mini-batch size for time ``t``. The sequences must be transposed.
             :func:`~chainer.functions.transpose_sequence` can be used to
-            transpose a list of :class:`~chainer.Variable`\\ s each representing
-            a sequence. When sequences has different lengths, they must be
+            transpose a list of :class:`~chainer.Variable`\\ s each
+            representing a sequence.
+            When sequences has different lengths, they must be
             sorted in descending order of their lengths before transposing.
             So ``xs`` needs to satisfy
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -105,7 +105,7 @@ def n_step_lstm(
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is the
             mini-batch size for time ``t``. The sequences must be transposed.
             :func:`~chainer.functions.transpose_sequence` can be used to
-            transpose a list of :class:`~chainer.Variable`\ s each representing
+            transpose a list of :class:`~chainer.Variable`\\ s each representing
             a sequence. When sequences has different lengths, they must be
             sorted in descending order of their lengths before transposing.
             So ``xs`` needs to satisfy
@@ -271,7 +271,7 @@ def n_step_bilstm(
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is the
             mini-batch size for time ``t``. The sequences must be transposed.
             :func:`~chainer.functions.transpose_sequence` can be used to
-            transpose a list of :class:`~chainer.Variable`\ s each representing
+            transpose a list of :class:`~chainer.Variable`\\ s each representing
             a sequence. When sequences has different lengths, they must be
             sorted in descending order of their lengths before transposing.
             So ``xs`` needs to satisfy
@@ -379,7 +379,7 @@ def n_step_lstm_base(
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is the
             mini-batch size for time ``t``. The sequences must be transposed.
             :func:`~chainer.functions.transpose_sequence` can be used to
-            transpose a list of :class:`~chainer.Variable`\ s each representing
+            transpose a list of :class:`~chainer.Variable`\\ s each representing
             a sequence. When sequences has different lengths, they must be
             sorted in descending order of their lengths before transposing.
             So ``xs`` needs to satisfy

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -63,7 +63,7 @@ def accuracy(y, t, ignore_label=None):
             Array whose (i, j, k, ...)-th element indicates the score of
             the class j at the (i, k, ...)-th sample.
             The prediction label :math:`\\hat t` is calculated by the formula
-            :math:`\\hat t(i, k, ...) = \operatorname{\mathrm{argmax}}_j \
+            :math:`\\hat t(i, k, ...) = \\operatorname{\\mathrm{argmax}}_j \
 y(i, j, k, ...)`.
         t (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray` of signed integer):

--- a/chainer/functions/loss/black_out.py
+++ b/chainer/functions/loss/black_out.py
@@ -20,7 +20,7 @@ def black_out(x, t, W, samples, reduce='mean'):
       -\\log(p(t)) - \\sum_{s \\in S} \\log(1 - p(s)),
 
     where :math:`t` is the correct label, :math:`S` is a set of negative
-    examples and :math:`p(\cdot)` is likelihood of a given label.
+    examples and :math:`p(\\cdot)` is likelihood of a given label.
     And, :math:`p` is defined as
 
     .. math::
@@ -38,7 +38,7 @@ def black_out(x, t, W, samples, reduce='mean'):
             Its shape should be :math:`(N, D)`.
         t (~chainer.Variable): Vector of ground truth labels.
             Its shape should be :math:`(N,)`. Each elements :math:`v`
-            should satisfy :math:`0 \geq v \geq V` or :math:`-1`
+            should satisfy :math:`0 \\geq v \\geq V` or :math:`-1`
             where :math:`V` is the number of label types.
         W (~chainer.Variable): Weight matrix.
             Its shape should be :math:`(V, D)`

--- a/chainer/functions/loss/hinge.py
+++ b/chainer/functions/loss/hinge.py
@@ -123,7 +123,7 @@ def hinge(x, t, norm='L1', reduce='mean'):
 
         .. math::
             \\delta \\{ {\\rm condition} \\} = \\left \\{ \\begin{array}{cc}
-            1 & {\\rm if~condition\ is\ true} \\\\
+            1 & {\\rm if~condition\\ is\\ true} \\\\
             -1 & {\\rm otherwise,}
             \\end{array} \\right.
 
@@ -139,7 +139,7 @@ def hinge(x, t, norm='L1', reduce='mean'):
         :math:`\\left[\\max(0, 1 - \\delta x) \\right]^p`.
         When :math:`x` and :math:`\\delta` have the same sign (meaning
         :math:`x` predicts the proper score for classification) and
-        :math:`|x| \geq 1`, the hinge loss :math:`l(x, \\delta) = 0`, but when
+        :math:`|x| \\geq 1`, the hinge loss :math:`l(x, \\delta) = 0`, but when
         they have opposite sign, :math:`l(x, \\delta)` increases linearly
         with :math:`x`.
 
@@ -155,7 +155,7 @@ def hinge(x, t, norm='L1', reduce='mean'):
         t (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray` of signed integer):
             The :math:`N`-dimensional label vector with values
-            :math:`t_n \in \{0, 1, 2, \dots, K-1\}`.
+            :math:`t_n \\in \\{0, 1, 2, \\dots, K-1\\}`.
             The shape of ``t`` should be (:math:`N`,).
         norm (string): Specifies norm type. Either ``'L1'`` or ``'L2'`` is
             acceptable.

--- a/chainer/functions/loss/triplet.py
+++ b/chainer/functions/loss/triplet.py
@@ -91,8 +91,8 @@ def triplet(anchor, positive, negative, margin=0.2, reduce='mean'):
     :math:`(N, K)`.
 
     .. math::
-        L(a, p, n) = \\frac{1}{N} \\left( \\sum_{i=1}^N \\max \{d(a_i, p_i)
-            - d(a_i, n_i) + {\\rm margin}, 0\} \\right)
+        L(a, p, n) = \\frac{1}{N} \\left( \\sum_{i=1}^N \\max \\{d(a_i, p_i)
+            - d(a_i, n_i) + {\\rm margin}, 0\\} \\right)
 
     where :math:`d(x_i, y_i) = \\| {\\bf x}_i - {\\bf y}_i \\|_2^2`.
 

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -59,7 +59,7 @@ def normalize(x, eps=1e-5, axis=1):
     vector :math:`y` by the following equation:
 
     .. math::
-       y_i = {x_i \\over \\| x_i \\|_2 + \epsilon}
+       y_i = {x_i \\over \\| x_i \\|_2 + \\epsilon}
 
     :obj:`eps` is used to avoid division by zero when norm of :math:`x` along
     the given axis is zero.

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -110,9 +110,9 @@ def forget(func, *xs):
 
         In case input argument variables are of class :class:`numpy.ndarray` or
         :class:`cupy.ndarray` objects, arguments will automatically be
-        converted to :class:`~chainer.Variable`\\ s. This conversion takes place
-        to ensure that this function is included in the computational graph to
-        enable backward computations.
+        converted to :class:`~chainer.Variable`\\ s.
+        This conversion takes place to ensure that this function is included
+        in the computational graph to enable backward computations.
 
     Args:
         func (callable): A function to call. It needs to be called with

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -110,7 +110,7 @@ def forget(func, *xs):
 
         In case input argument variables are of class :class:`numpy.ndarray` or
         :class:`cupy.ndarray` objects, arguments will automatically be
-        converted to :class:`~chainer.Variable`\ s. This conversion takes place
+        converted to :class:`~chainer.Variable`\\ s. This conversion takes place
         to ensure that this function is included in the computational graph to
         enable backward computations.
 

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -64,7 +64,7 @@ def forget(func, *xs):
     """Calls a function without storing intermediate results.
 
     On a forward propagation, Chainer normally stores all intermediate results
-    of :class:`~chainer.variable.VariableNode`\ s on a computational graph as
+    of :class:`~chainer.variable.VariableNode`\\ s on a computational graph as
     they are required on backward propagation.
     Sometimes these results consume too much memory.
     ``F.forget`` *forgets* such intermediate results on forward propagation,
@@ -86,7 +86,7 @@ def forget(func, *xs):
        >>> def f(a, b):
        ...   return a + b + a
 
-       and, ``x`` and ``y`` be :class:`~chainer.Variable`\ s:
+       and, ``x`` and ``y`` be :class:`~chainer.Variable`\\ s:
 
        >>> x = chainer.Variable(np.random.uniform(-1, 1, 5).astype('f'))
        >>> y = chainer.Variable(np.random.uniform(-1, 1, 5).astype('f'))

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -152,7 +152,7 @@ class Evaluator(extension.Extension):
 
             This method encloses :attr:`eval_func` calls with
             :func:`function.no_backprop_mode` context, so all calculations
-            using :class:`~chainer.FunctionNode`\s inside
+            using :class:`~chainer.FunctionNode`\\s inside
             :attr:`eval_func` do not make computational graphs. It is for
             reducing the memory consumption.
 

--- a/chainer/training/extensions/micro_average.py
+++ b/chainer/training/extensions/micro_average.py
@@ -7,8 +7,8 @@ class MicroAverage(extension.Extension):
 
     """Calculates micro-average ratio.
 
-    Give :math:`N` batches and values :math:`\\{n_1, \dots, n_N\\}` and
-    :math:`\\{d_1, \dots, d_N\\}`, this extension calculates micro-average of
+    Give :math:`N` batches and values :math:`\\{n_1, \\dots, n_N\\}` and
+    :math:`\\{d_1, \\dots, d_N\\}`, this extension calculates micro-average of
     these ratio defined as:
 
     .. math::


### PR DESCRIPTION
`tests/chainer_tests/test_init_docstring.py` fails due to these backslashes in Python 3.