### PR TITLE
Avoid unnecessary `hasattr`

### DIFF
--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -28,7 +28,7 @@ class DotNode(object):
         self.id_ = id(node)
         self.attribute = {'label': node.label}
         if isinstance(node, variable.VariableNode):
-            if show_name and hasattr(node, 'name') and node.name is not None:
+            if show_name and node.name is not None:
                 self.attribute['label'] = '{}: {}'.format(
                     node.name, self.attribute['label'])
             self.attribute.update({'shape': 'oval'})

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -9,7 +9,6 @@ from chainer.utils import type_check
 class NegativeSamplingFunction(function.Function):
 
     ignore_label = -1
-    samples = None
 
     def __init__(self, sampler, sample_size, reduce='sum'):
         if reduce not in ('sum', 'no'):
@@ -22,7 +21,7 @@ class NegativeSamplingFunction(function.Function):
         self.reduce = reduce
 
     def _make_samples(self, t):
-        if self.samples is not None:
+        if hasattr(self, 'samples'):
             return self.samples  # for testing
 
         size = int(t.shape[0])

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -9,6 +9,7 @@ from chainer.utils import type_check
 class NegativeSamplingFunction(function.Function):
 
     ignore_label = -1
+    samples = None
 
     def __init__(self, sampler, sample_size, reduce='sum'):
         if reduce not in ('sum', 'no'):
@@ -21,7 +22,7 @@ class NegativeSamplingFunction(function.Function):
         self.reduce = reduce
 
     def _make_samples(self, t):
-        if hasattr(self, 'samples'):
+        if self.samples is not None:
             return self.samples  # for testing
 
         size = int(t.shape[0])

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -10,7 +10,7 @@ from chainer import variable
 
 
 def _broadcast_to(array, shape):
-    if hasattr(numpy, "broadcast_to"):
+    if hasattr(numpy, 'broadcast_to'):
         return numpy.broadcast_to(array, shape)
     dummy = numpy.empty(shape, array.dtype)
     return numpy.broadcast_arrays(array, dummy)[0]
@@ -53,6 +53,7 @@ class SoftmaxCrossEntropy(function.Function):
     """Softmax activation followed by a cross entropy loss."""
 
     normalize = True
+    y = None
 
     def __init__(self, normalize=True, cache_score=True, class_weight=None,
                  ignore_label=-1, reduce='mean'):
@@ -164,7 +165,7 @@ class SoftmaxCrossEntropy(function.Function):
         gloss = grad_outputs[0]
         if x.size == 0:
             return numpy.zeros(x.shape, dtype=x.dtype), None
-        if hasattr(self, 'y'):
+        if self.y is not None:
             y = self.y.copy()
         else:
             y = log_softmax._log_softmax(x)
@@ -207,7 +208,7 @@ class SoftmaxCrossEntropy(function.Function):
         x, t = inputs
         if x.size == 0:
             return cupy.zeros(x.shape, dtype=x.dtype), None
-        if hasattr(self, 'y'):
+        if self.y is not None:
             y = self.y
         else:
             y = log_softmax._log_softmax(x)

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -45,7 +45,7 @@ def _matmul(a, b, transa=False, transb=False, transout=False):
         b = b.swapaxes(-1, -2)
     xp = cuda.get_array_module(a)
 
-    if hasattr(xp, 'matmul'):
+    if hasattr(xp, 'matmul'):  # numpy.matmul is supported from version 1.10.0
         return xp.matmul(a, b)
     if a.ndim <= 2:
         return numpy.dot(a, b)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -12,6 +12,8 @@ class Dropout(function_node.FunctionNode):
 
     """Dropout regularization."""
 
+    mask = None
+
     def __init__(self, dropout_ratio):
         if not 0.0 <= dropout_ratio < 1.0:
             raise ValueError('dropout_ratio must be in the range [0, 1)')
@@ -22,7 +24,7 @@ class Dropout(function_node.FunctionNode):
         type_check.expect(in_types[0].dtype.kind == 'f')
 
     def forward(self, x):
-        if hasattr(self, 'mask'):
+        if self.mask is not None:
             y = x[0] * self.mask
         else:
             scale = x[0].dtype.type(1. / (1 - self.dropout_ratio))

--- a/chainer/links/loss/black_out.py
+++ b/chainer/links/loss/black_out.py
@@ -23,6 +23,8 @@ class BlackOut(link.Link):
 
     """
 
+    sample_data = None
+
     def __init__(self, in_size, counts, sample_size):
         super(BlackOut, self).__init__()
         vocab_size = len(counts)
@@ -55,7 +57,7 @@ class BlackOut(link.Link):
         """
 
         batch_size = x.shape[0]
-        if hasattr(self, 'sample_data'):
+        if self.sample_data is not None:
             # for test
             sample_data = self.sample_data
         else:

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -124,6 +124,7 @@ class BatchNormalization(link.Link):
             with cuda.get_device_from_id(self._device_id):
                 gamma = variable.Variable(self.xp.ones(
                     self.avg_mean.shape, dtype=x.dtype))
+
         if hasattr(self, 'beta'):
             beta = self.beta
         else:

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -28,6 +28,9 @@ class BatchRenormalization(BatchNormalization):
 
     """
 
+    gamma = None
+    beta = None
+
     def __init__(self, size, rmax=1, dmax=0, decay=0.9, eps=2e-5,
                  dtype=numpy.float32, use_gamma=True, use_beta=True,
                  initial_gamma=None, initial_beta=None,
@@ -42,13 +45,14 @@ class BatchRenormalization(BatchNormalization):
         self.freeze_running_statistics = freeze_running_statistics
 
     def __call__(self, x, finetune=False):
-        if hasattr(self, 'gamma'):
+        if self.gamma is not None:
             gamma = self.gamma
         else:
             with cuda.get_device(self._device_id):
                 gamma = variable.Variable(self.xp.ones(
                     self.avg_mean.shape, dtype=x.dtype))
-        if hasattr(self, 'beta'):
+
+        if self.beta is not None:
             beta = self.beta
         else:
             with cuda.get_device(self._device_id):

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -325,6 +325,8 @@ class Optimizer(object):
 
     """
 
+    _hooks = None
+
     def setup(self, link):
         """Sets a target link and initializes the optimizer states.
 
@@ -403,7 +405,7 @@ class Optimizer(object):
         """
         if not callable(hook):
             raise TypeError('hook function is not callable')
-        if not hasattr(self, '_hooks'):
+        if self._hooks is None:
             raise RuntimeError('call `setup` method before `add_hook` method')
 
         if name is None:

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -71,6 +71,8 @@ class Evaluator(extension.Extension):
     default_name = 'validation'
     priority = extension.PRIORITY_WRITER
 
+    name = None
+
     def __init__(self, iterator, target, converter=convert.concat_examples,
                  device=None, eval_hook=None, eval_func=None):
         if isinstance(iterator, iterator_module.Iterator):
@@ -123,7 +125,7 @@ class Evaluator(extension.Extension):
         """
         # set up a reporter
         reporter = reporter_module.Reporter()
-        if hasattr(self, 'name'):
+        if self.name is not None:
             prefix = self.name + '/'
         else:
             prefix = ''

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -85,7 +85,7 @@ class TestSoftmaxCrossEntropy(unittest.TestCase):
         self.assertEqual(loss.data.shape, ())
         self.assertEqual(loss.data.dtype, self.dtype)
         if not self.enable_double_backprop:
-            self.assertEqual(hasattr(loss.creator, 'y'), self.cache_score)
+            assert (loss.creator.y is not None) == self.cache_score
         loss_value = float(cuda.to_cpu(loss.data))
 
         # Compute expected value
@@ -365,7 +365,7 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
         self.assertEqual(loss.shape, t_data.shape)
         self.assertEqual(loss.data.dtype, self.dtype)
         if not self.enable_double_backprop:
-            self.assertEqual(hasattr(loss.creator, 'y'), self.cache_score)
+            assert (loss.creator.y is not None) == self.cache_score
         loss_value = cuda.to_cpu(loss.data)
 
         x = numpy.rollaxis(self.x, 1, self.x.ndim).reshape(

--- a/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py
@@ -78,6 +78,10 @@ class TestNegativeSampling(unittest.TestCase):
 
     @attr.gpu
     def test_backward_cpu_gpu(self):
+        # TODO(niboshi):
+        # Fix this test. The code seems to fix the samples in order to avoid
+        # random behavior, but resulting grads are always zero-tensors, no
+        # matter what are sampled.
         x = chainer.Variable(self.x)
         t = chainer.Variable(self.t)
         y = self.link(x, t)


### PR DESCRIPTION
I replaced `hasattr` with normal attribute lookup.

IMO `hasattr` should be avoided, because

* It's slower. In my test, it's more than 3x times slower than `self.a is None`.
* Less readable. You cannot tell what attributes a class can have without reading the actual code.
* Look weird, especially to those from other programming languages.