### PR TITLE
Show original traceback in `testing.parameterized`

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -51,7 +51,10 @@ def _gen_case(base, module, i, param):
                     s.write('  {}: {}\n'.format(k, v))
                 s.write('\n')
                 s.write('{}: {}\n'.format(type(e).__name__, e))
-                raise AssertionError(s.getvalue())
+                six.raise_from(
+                    AssertionError(
+                        s.getvalue()).with_traceback(e.__traceback__),
+                    None)
         return wrap
 
     # ismethod for Python 2 and isfunction for Python 3

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -51,10 +51,11 @@ def _gen_case(base, module, i, param):
                     s.write('  {}: {}\n'.format(k, v))
                 s.write('\n')
                 s.write('{}: {}\n'.format(type(e).__name__, e))
-                six.raise_from(
-                    AssertionError(
-                        s.getvalue()).with_traceback(e.__traceback__),
-                    None)
+                e_new = AssertionError(s.getvalue())
+                if sys.version_info < (3,):
+                    six.reraise(AssertionError, e_new, sys.exc_info()[2])
+                else:
+                    six.raise_from(e_new.with_traceback(e.__traceback__), None)
         return wrap
 
     # ismethod for Python 2 and isfunction for Python 3


### PR DESCRIPTION
If `AssertionError` is re-raised from `testing.parameterized`, its original traceback is not shown.

### Original error message from PyTest result
```
E   AssertionError:
E   Fail: 1, Success: 0
E
E   The first error message:
E   Traceback (most recent call last):
E     File "/data/work/w/repos/chainer/chainer/testing/parameterized.py", line 43, in wrap
E       return method(*args, **kwargs)
E     File "/data/work/w/repos/chainer/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py", line 93, in test_backward_cpu_gpu
E       y_g = self.link(xg, tg)
E   AttributeError: 'NegativeSamplingFunction' object has no attribute 'samples'
E
E   During handling of the above exception, another exception occurred:
E
E   Traceback (most recent call last):
E     File "/data/work/w/repos/chainer/chainer/testing/condition.py", line 60, in <lambda>
E       lambda: f(ins, *args[1:], **kwargs),
E     File "/data/work/w/repos/chainer/chainer/testing/parameterized.py", line 54, in wrap
E       raise AssertionError(s.getvalue())
E   AssertionError: Parameterized test failed.
E
E   Base test method: TestNegativeSampling.test_backward_cpu_gpu
E   Test parameters:
E     reduce: sum
E     t: [0, 2]
E
E   AttributeError: 'NegativeSamplingFunction' object has no attribute 'samples'
```

### This PR

```
E   AssertionError:
E   Fail: 1, Success: 0
E
E   The first error message:
E   Traceback (most recent call last):
E     File "/data/work/w/repos/chainer/chainer/testing/condition.py", line 60, in <lambda>
E       lambda: f(ins, *args[1:], **kwargs),
E     File "/data/work/w/repos/chainer/chainer/testing/parameterized.py", line 54, in wrap
E       six.raise_from(AssertionError(s.getvalue()).with_traceback(e.__traceback__), None)
E     File "<string>", line 3, in raise_from
E     File "/data/work/w/repos/chainer/chainer/testing/parameterized.py", line 43, in wrap
E       return method(*args, **kwargs)
E     File "/data/work/w/repos/chainer/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py", line 93, in test_backward_cpu_gpu
E       y_g = self.link(xg, tg)
E     File "/data/work/w/repos/chainer/chainer/links/loss/negative_sampling.py", line 68, in __call__
E       reduce=reduce)
E     File "/data/work/w/repos/chainer/chainer/functions/loss/negative_sampling.py", line 257, in negative_sampling
E       return NegativeSamplingFunction(sampler, sample_size, reduce)(x, t, W)
E     File "/data/work/w/repos/chainer/chainer/function.py", line 235, in __call__
E       ret = node.apply(inputs)
E     File "/data/work/w/repos/chainer/chainer/function_node.py", line 245, in apply
E       outputs = self.forward(in_data)
E     File "/data/work/w/repos/chainer/chainer/function.py", line 135, in forward
E       return self._function.forward(inputs)
E     File "/data/work/w/repos/chainer/chainer/function.py", line 342, in forward
E       return self.forward_gpu(inputs)
E     File "/data/work/w/repos/chainer/chainer/functions/loss/negative_sampling.py", line 70, in forward_gpu
E       self._make_samples(t)
E     File "/data/work/w/repos/chainer/chainer/functions/loss/negative_sampling.py", line 25, in _make_samples
E       if self.samples is not None:
E   AssertionError: Parameterized test failed.
E
E   Base test method: TestNegativeSampling.test_backward_cpu_gpu
E   Test parameters:
E     reduce: sum
E     t: [0, 2]
E
E   AttributeError: 'NegativeSamplingFunction' object has no attribute 'samples'
```