### PR TITLE
small fix for the example of seq2seq

### DIFF
--- a/examples/seq2seq/README.md
+++ b/examples/seq2seq/README.md
@@ -51,7 +51,7 @@ Then run the preprocess script `wmt_preprocess.py` to make sentence files and vo
 ```
 $ python wmt_preprocess.py giga-fren.release2.fixed.en giga-fren.preprocess.en \
   --vocab-file vocab.en
-$ python wmt_preprocess.py giga-fren.release2.fixed.en giga-fren.preprocess.fr \
+$ python wmt_preprocess.py giga-fren.release2.fixed.fr giga-fren.preprocess.fr \
   --vocab-file vocab.fr
 ```
 


### PR DESCRIPTION
README's cmd is incorrect.

 ```
 $ python wmt_preprocess.py giga-fren.release2.fixed.en giga-fren.preprocess.en \
   --vocab-file vocab.en
-$ python wmt_preprocess.py giga-fren.release2.fixed.en giga-fren.preprocess.fr \
+$ python wmt_preprocess.py giga-fren.release2.fixed.fr giga-fren.preprocess.fr \
   --vocab-file vocab.fr
 ```