### PR TITLE
Deprecate array util

### DIFF
--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -3,7 +3,6 @@ import numpy
 import chainer
 from chainer.backends import cuda
 from chainer import function_node
-from chainer.utils import array
 from chainer.utils import type_check
 
 

--- a/chainer/functions/math/batch_l2_norm_squared.py
+++ b/chainer/functions/math/batch_l2_norm_squared.py
@@ -5,7 +5,6 @@ import chainer
 from chainer.backends import cuda
 from chainer import function_node
 from chainer.functions.math import sum as _sum
-from chainer.utils import array
 from chainer.utils import type_check
 
 
@@ -22,12 +21,12 @@ class BatchL2NormSquared(function_node.FunctionNode):
 
     def forward_cpu(self, inputs):
         self.retain_inputs((0,))
-        x = array.as_mat(inputs[0])
+        x = inputs[0].reshape(len(inputs[0]), -1)
         return (x * x).sum(axis=1),
 
     def forward_gpu(self, inputs):
         self.retain_inputs((0,))
-        x = array.as_mat(inputs[0])
+        x = inputs[0].reshape(len(inputs[0]), -1)
         l2normsquared_kernel = cuda.cupy.ReductionKernel(
             'T x', 'T y', 'x * x', 'a + b', 'y = a', '0', 'l2normsquared'
         )

--- a/chainer/utils/array.py
+++ b/chainer/utils/array.py
@@ -1,21 +1,36 @@
+import warnings
+
 import numpy
 
 from chainer.backends import cuda
 
 
 def as_vec(x):
+    warnings.warn(
+        'chainer.utils.array.as_vec is deprecated. Please refer to '
+        'numpy.ravel or other array backend functions to flatten ndarrays.',
+        DeprecationWarning)
     if x.ndim == 1:
         return x
     return x.ravel()
 
 
 def as_mat(x):
+    warnings.warn(
+        'chainer.utils.array.as_mat is deprecated. Please refer to '
+        'numpy.reshape or other array backend functions to reshape ndarrays.',
+        DeprecationWarning)
     if x.ndim == 2:
         return x
     return x.reshape(len(x), -1)
 
 
 def empty_like(x):
+    warnings.warn(
+        'chainer.utils.array.empty_like is deprecated. Please refer to '
+        'numpy.empty_like or other array backend functions to initialize '
+        'empty arrays.',
+        DeprecationWarning)
     if cuda.available and isinstance(x, cuda.ndarray):
         return cuda.cupy.empty_like(x)
     else:

--- a/tests/chainer_tests/links_tests/connection_tests/test_bilinear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_bilinear.py
@@ -9,7 +9,6 @@ from chainer import links
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
-from chainer.utils import array
 
 
 def _check_forward(e1, e2, f, y_expect):
@@ -34,6 +33,12 @@ def _batch_to_gpu(*xs):
 
 def _uniform(*shape):
     return numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+
+
+def _as_mat(x):
+    if x.ndim == 2:
+        return x
+    return x.reshape(len(x), -1)
 
 
 class TestBilinear(unittest.TestCase):
@@ -100,8 +105,8 @@ class TestBilinear2(TestBilinear):
         self.e2 = _uniform(self.batch_size, self.in_shape[1] // 2, 2)
         self.gy = _uniform(self.batch_size, self.out_size)
 
-        e1 = array.as_mat(self.e1)
-        e2 = array.as_mat(self.e2)
+        e1 = _as_mat(self.e1)
+        e2 = _as_mat(self.e2)
 
         self.y = (
             numpy.einsum('ij,ik,jkl->il', e1, e2, self.W) +
@@ -185,8 +190,8 @@ class TestBilinearWOBias2(TestBilinearWOBias):
         self.e2 = _uniform(self.batch_size, 2, self.in_shape[1] // 2)
         self.gy = _uniform(self.batch_size, self.out_size)
 
-        e1 = array.as_mat(self.e1)
-        e2 = array.as_mat(self.e2)
+        e1 = _as_mat(self.e1)
+        e2 = _as_mat(self.e2)
 
         self.y = numpy.einsum('ij,ik,jkl->il', e1, e2, self.W)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_bilinear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_bilinear.py
@@ -36,8 +36,6 @@ def _uniform(*shape):
 
 
 def _as_mat(x):
-    if x.ndim == 2:
-        return x
     return x.reshape(len(x), -1)
 
 
@@ -190,10 +188,8 @@ class TestBilinearWOBias2(TestBilinearWOBias):
         self.e2 = _uniform(self.batch_size, 2, self.in_shape[1] // 2)
         self.gy = _uniform(self.batch_size, self.out_size)
 
-        e1 = _as_mat(self.e1)
-        e2 = _as_mat(self.e2)
-
-        self.y = numpy.einsum('ij,ik,jkl->il', e1, e2, self.W)
+        self.y = numpy.einsum(
+            'ij,ik,jkl->il', _as_mat(self.e1), _as_mat(self.e2), self.W)
 
 
 class TestBilinearWOBias3(TestBilinearWOBias):


### PR DESCRIPTION
Raise deprecation warning on usage of `chainer.utils.array` since the functions included in the utility are all very primitive (and could in the future be removed).

May require discussion. Please refer to https://github.com/chainer/chainer/pull/3932.