### PR TITLE
fix macOS test in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,15 +36,16 @@ matrix:
       if: (branch = master OR branch = v3) AND (NOT type in (pull_request))
 
 before_install:
+  # Remove oclint as it conflicts with GCC (indirect dependency of hdf5)
   - if [[ $TRAVIS_OS_NAME = "osx" ]]; then
       brew update >/dev/null;
       brew outdated pyenv || brew upgrade --quiet pyenv;
-      brew install homebrew/boneyard/pyenv-pip-rehash;
 
       PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION;
       pyenv global $PYTHON_VERSION;
       python --version;
 
+      brew cask uninstall oclint;
       brew install homebrew/science/hdf5;
     fi
 


### PR DESCRIPTION
As [Travis updated their macOS image to Xcode 8.3](https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce), macOS tests are currently failling.
This PR fixes the issue.

* Remove `pyenv-pip-rehash` installation, because it causes error and is no longer needed.
  https://github.com/pyenv/pyenv-pip-rehash
* Remove `oclint` package, that conflicts with GCC installed via `hdf5`.
  Some other projects are doing the same thing: https://github.com/search?utf8=%E2%9C%93&q=%22os%3A+osx%22+%22brew+cask+uninstall+oclint%22&type=Code

I confirmed that this work in my master branch. (as currently macOS tests are not enabled for PRs)

https://travis-ci.org/kmaehashi/chainer/builds/308838386