### PR TITLE
Fix a corner-case bug in gradient_check

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -650,16 +650,17 @@ class _GradientSetter(FunctionNode):
         self.grad = grad
 
     def forward(self, inputs):
+        xp = cuda.get_array_module(inputs[0])
+
         if self.grad is None:
             y0, = inputs
-            xp = cuda.get_array_module(y0)
-            gy0 = xp.ones_like(inputs[0])
+            gy0 = xp.ones_like(y0)
             assert gy0.size == 1
 
             self.grad = (gy0,)
 
         # output a 0-sized 1-dim array like inputs
-        return inputs[0].flatten()[:0],
+        return xp.empty((0,), dtype=inputs[0].dtype),
 
     def backward(self, inputs, grad_outputs):
         grad = self.grad

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -604,6 +604,45 @@ class TestCheckBackward(unittest.TestCase):
                                       no_grads=[False, True], dtype=self.dtype)
 
 
+class IdentNoneIsZero(chainer.Function):
+    """Identity function but following None-grad convention for RNNs"""
+
+    def forward(self, inputs):
+        return inputs
+
+    def backward(self, inputs, grads):
+        return tuple(
+            numpy.zeros_like(x) if g is None else g
+            for x, g in zip(inputs, grads)
+        )
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [None, numpy.float32, numpy.float64],
+    'size': [3, 1]
+}))
+class TestCheckBackwardNoneConvention(unittest.TestCase):
+    dtype = numpy.float64
+
+    def test_multiple_output(self):
+        size = self.size
+        x1 = numpy.arange(size).astype('f')
+        x2 = numpy.arange(size).astype('f')
+        g1 = numpy.ones(size, dtype='f')
+        g2 = numpy.ones(size, dtype='f')
+
+        def f(x, y):
+            s, t = IdentNoneIsZero()(x, y)
+            return s, t
+
+        gradient_check.check_backward(
+            f, (x1, x2), (g1, g2), dtype=self.dtype, atol=1e-4, rtol=1e-3)
+        gradient_check.check_backward(
+            f, (x1, x2), (g1, None), dtype=self.dtype, atol=1e-4, rtol=1e-3)
+        gradient_check.check_backward(
+            f, (x1, x2), (None, g2), dtype=self.dtype, atol=1e-4, rtol=1e-3)
+
+
 class TestCheckBackwardFailure(unittest.TestCase):
 
     def _broken_func_1(self):


### PR DESCRIPTION
The current code of  `gradient_check` uses a hack that appends `identity` function in order to compute `backward` for all the variables. But doing `y[0].backward()` is not perfect since its behavior depends on the size of y[0].

It seems it is allowed to `backward` a `None` gradient as a `zeros` gradient (of unused output Variable), e.g. in `LSTM` function. `gradient_check` overwrites such `None` by `ones` if `y[0].size == 1`.

Resolves #4010