### PR TITLE
[backport] Show original traceback in `testing.parameterized`

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -51,7 +51,11 @@ def _gen_case(base, module, i, param):
                     s.write('  {}: {}\n'.format(k, v))
                 s.write('\n')
                 s.write('{}: {}\n'.format(type(e).__name__, e))
-                raise AssertionError(s.getvalue())
+                e_new = AssertionError(s.getvalue())
+                if sys.version_info < (3,):
+                    six.reraise(AssertionError, e_new, sys.exc_info()[2])
+                else:
+                    six.raise_from(e_new.with_traceback(e.__traceback__), None)
         return wrap
 
     # ismethod for Python 2 and isfunction for Python 3


### PR DESCRIPTION
Backport of #3954