### PR TITLE
Serialize t of UpdateRule

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -274,6 +274,7 @@ class UpdateRule(object):
             serializer (~chainer.AbstractSerializer): Serializer object.
 
         """
+        self.t = serializer('t', self.t)
         if self.state is None:
             if isinstance(serializer, serializer_module.Deserializer):
                 # try to initialize the state to retrieve state entries

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -512,10 +512,13 @@ class TestGroupHierachy(unittest.TestCase):
         self.assertSetEqual(set(npzfile.keys()), {prefix + x for x in keys})
 
     def _check_optimizer_group(self, npzfile, state, prefix=''):
-        keys = ('child/linear/W/msg',
+        keys = ('child/linear/W/t',
+                'child/linear/W/msg',
                 'child/linear/W/msdx',
+                'child/linear/b/t',
                 'child/linear/b/msg',
                 'child/linear/b/msdx',
+                'child/Wc/t',
                 'child/Wc/msg',
                 'child/Wc/msdx') + state
         self.assertEqual(set(npzfile.keys()),
@@ -536,7 +539,7 @@ class TestGroupHierachy(unittest.TestCase):
 
         with numpy.load(self.file) as npzfile:
             self._check_optimizer_group(
-                npzfile, ('Wp/msg', 'Wp/msdx', 'epoch', 't'), 'test/')
+                npzfile, ('Wp/t', 'Wp/msg', 'Wp/msdx', 'epoch', 't'), 'test/')
 
     def test_save_chain2(self):
         self._save_npz(self.file, self.parent, self.compress)
@@ -547,7 +550,7 @@ class TestGroupHierachy(unittest.TestCase):
         self._save_npz(self.file, self.optimizer, self.compress)
         with numpy.load(self.file) as npzfile:
             self._check_optimizer_group(
-                npzfile, ('Wp/msg', 'Wp/msdx', 'epoch', 't'))
+                npzfile, ('Wp/t', 'Wp/msg', 'Wp/msdx', 'epoch', 't'))
 
     def test_load_optimizer_with_strict(self):
         for param in self.parent.params():


### PR DESCRIPTION
`t` of `UpdateRule` should be serialized since `UpdateRule.update` may depend on `t` (e.g. `AdamRule` does).

As well as `Optimizer.t` is a state, `UpdateRule.t` is a state in the sense of the document of `Trainer`:
> The serialization does not recover everything of the training loop. It only recovers the states which change over the training

The PR breaks the compatibility if an update rule already has`'t'` in `self.state`.

Resolves #4013.