### PR TITLE
Check for mixed use of ndarrays

### DIFF
--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import six
 
 import chainer
 from chainer import cuda

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -57,15 +57,13 @@ class TestEmbedID(unittest.TestCase):
     @attr.gpu
     def test_forward_mixed_cpu_gpu_1(self):
         # self.link is not sent to gpu
-        with six.assertRaisesRegex(self, ValueError, "numpy and cupy must not \
-be used together.*"):
+        with self.assertRaises(ValueError):
             self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
     def test_forward_mixed_cpu_gpu_2(self):
         self.link.to_gpu()
-        with six.assertRaisesRegex(self, ValueError, "numpy and cupy must not \
-be used together.*"):
+        with self.assertRaises(ValueError):
             # self.x is not sent to gpu
             self.check_forward(self.x)
 


### PR DESCRIPTION
Checks input/output array types of forward operations.

This PR may be unsafe to backport, because existing functions may be mixing cupy and numpy arrays.
Also, some builtin functions will fail to pass this check. They need to be fixed before this PR.