### PR TITLE
Avoid mixing cupy.ndarray and numpy.ndarray in n_step_xxx links

### DIFF
--- a/chainer/links/connection/n_step_gru.py
+++ b/chainer/links/connection/n_step_gru.py
@@ -109,13 +109,15 @@ class NStepGRUBase(link.ChainList):
         argument.assert_kwargs_empty(kwargs)
 
         assert isinstance(xs, (list, tuple))
+        xp = cuda.get_array_module(hx, *xs)
         indices = argsort_list_descent(xs)
+        indices_array = xp.array(indices)
 
         xs = permutate_list(xs, indices, inv=False)
         if hx is None:
             hx = self.init_hx(xs)
         else:
-            hx = permutate.permutate(hx, indices, axis=1, inv=False)
+            hx = permutate.permutate(hx, indices_array, axis=1, inv=False)
 
         trans_x = transpose_sequence.transpose_sequence(xs)
 
@@ -125,7 +127,7 @@ class NStepGRUBase(link.ChainList):
         hy, trans_y = self.rnn(
             self.n_layers, self.dropout, hx, ws, bs, trans_x)
 
-        hy = permutate.permutate(hy, indices, axis=1, inv=True)
+        hy = permutate.permutate(hy, indices_array, axis=1, inv=True)
         ys = transpose_sequence.transpose_sequence(trans_y)
         ys = permutate_list(ys, indices, inv=True)
 

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -111,18 +111,20 @@ class NStepLSTMBase(link.ChainList):
         argument.assert_kwargs_empty(kwargs)
 
         assert isinstance(xs, (list, tuple))
+        xp = cuda.get_array_module(hx, *xs)
         indices = n_step_rnn.argsort_list_descent(xs)
+        indices_array = xp.array(indices)
 
         xs = n_step_rnn.permutate_list(xs, indices, inv=False)
         if hx is None:
             hx = self.init_hx(xs)
         else:
-            hx = permutate.permutate(hx, indices, axis=1, inv=False)
+            hx = permutate.permutate(hx, indices_array, axis=1, inv=False)
 
         if cx is None:
             cx = self.init_hx(xs)
         else:
-            cx = permutate.permutate(cx, indices, axis=1, inv=False)
+            cx = permutate.permutate(cx, indices_array, axis=1, inv=False)
 
         trans_x = transpose_sequence.transpose_sequence(xs)
 
@@ -132,8 +134,8 @@ class NStepLSTMBase(link.ChainList):
         hy, cy, trans_y = self.rnn(
             self.n_layers, self.dropout, hx, cx, ws, bs, trans_x)
 
-        hy = permutate.permutate(hy, indices, axis=1, inv=True)
-        cy = permutate.permutate(cy, indices, axis=1, inv=True)
+        hy = permutate.permutate(hy, indices_array, axis=1, inv=True)
+        cy = permutate.permutate(cy, indices_array, axis=1, inv=True)
         ys = transpose_sequence.transpose_sequence(trans_y)
         ys = n_step_rnn.permutate_list(ys, indices, inv=True)
 

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -127,13 +127,15 @@ class NStepRNNBase(link.ChainList):
         argument.assert_kwargs_empty(kwargs)
 
         assert isinstance(xs, (list, tuple))
+        xp = cuda.get_array_module(hx, *xs)
         indices = argsort_list_descent(xs)
+        indices_array = xp.array(indices)
 
         xs = permutate_list(xs, indices, inv=False)
         if hx is None:
             hx = self.init_hx(xs)
         else:
-            hx = permutate.permutate(hx, indices, axis=1, inv=False)
+            hx = permutate.permutate(hx, indices_array, axis=1, inv=False)
 
         trans_x = transpose_sequence.transpose_sequence(xs)
 
@@ -144,7 +146,7 @@ class NStepRNNBase(link.ChainList):
             self.n_layers, self.dropout, hx, ws, bs, trans_x,
             activation=self.activation)
 
-        hy = permutate.permutate(hy, indices, axis=1, inv=True)
+        hy = permutate.permutate(hy, indices_array, axis=1, inv=True)
         ys = transpose_sequence.transpose_sequence(trans_y)
         ys = permutate_list(ys, indices, inv=True)
 


### PR DESCRIPTION
`indices` is always `numpy.ndarray`, leading to mixture of numpy/cupy ndarrays.

This fix can be tested with #4029, but I separated the PRs because #4029 might be unsafe to backport.