### PR TITLE
Fix cuda import path

### DIFF
--- a/chainer/testing/backend.py
+++ b/chainer/testing/backend.py
@@ -4,7 +4,7 @@ import unittest
 import numpy
 
 import chainer
-from chainer import cuda
+from chainer.backends import cuda
 from chainer.testing import attr
 
 


### PR DESCRIPTION
Fixed cuda import path to go via the new `chainer.backends` submodule.