### PR TITLE
fix sphinx build option assignment in Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,10 +2,10 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build -W
-PAPER         =
-BUILDDIR      = build
+SPHINXOPTS   ?= -W
+SPHINXBUILD  ?= sphinx-build
+PAPER        ?=
+BUILDDIR     ?= build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(word 1, $(SPHINXBUILD)) >/dev/null 2>&1; echo $$?), 1)


### PR DESCRIPTION
Sometimes I want to confirm all warnings raised by Sphinx, but currently we can only confirm one warning at a time, because `-W` is specified.
This PR allows `SPHINXOPTS` to be overridden by environment variable, so we can:

```
SPHINXOPTS= make html
```

to disable `-W`.