### PR TITLE
Simplify to_gpu in RNN tests

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_gru.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_gru.py
@@ -19,6 +19,15 @@ def _split(inputs, pos):
     return inputs[:pos], inputs[pos:]
 
 
+def _to_gpu(x):
+    if x is None:
+        return None
+    elif isinstance(x, list):
+        return [_to_gpu(xi) for xi in x]
+    else:
+        return cuda.to_gpu(x)
+
+
 class TestNStepGRU(unittest.TestCase):
 
     batches = [3, 2, 1]
@@ -97,10 +106,10 @@ class TestNStepGRU(unittest.TestCase):
     def check_forward_gpu(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn):
             self.check_forward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs))
 
     @attr.gpu
     def test_forward_gpu_cudnn_always(self):
@@ -146,12 +155,12 @@ class TestNStepGRU(unittest.TestCase):
     def test_backward_gpu(self):
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs],
-                cuda.to_gpu(self.dhy),
-                [cuda.to_gpu(dy) for dy in self.dys])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                _to_gpu(self.dhy),
+                _to_gpu(self.dys))
 
 
 class TestNStepBiGRU(unittest.TestCase):
@@ -262,10 +271,10 @@ class TestNStepBiGRU(unittest.TestCase):
     def check_forward_gpu(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn):
             self.check_forward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs))
 
     @attr.gpu
     def test_forward_gpu_cudnn_always(self):
@@ -311,12 +320,12 @@ class TestNStepBiGRU(unittest.TestCase):
     def test_backward_gpu(self):
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs],
-                cuda.to_gpu(self.dhy),
-                [cuda.to_gpu(dy) for dy in self.dys])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                _to_gpu(self.dhy),
+                _to_gpu(self.dys))
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -20,6 +20,15 @@ def _split(inputs, pos):
     return inputs[:pos], inputs[pos:]
 
 
+def _to_gpu(x):
+    if x is None:
+        return None
+    elif isinstance(x, list):
+        return [_to_gpu(xi) for xi in x]
+    else:
+        return cuda.to_gpu(x)
+
+
 class TestNStepLSTM(unittest.TestCase):
 
     batches = [3, 2, 1]
@@ -105,11 +114,11 @@ class TestNStepLSTM(unittest.TestCase):
     def check_forward_gpu(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn):
             self.check_forward(
-                cuda.to_gpu(self.hx),
-                cuda.to_gpu(self.cx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs])
+                _to_gpu(self.hx),
+                _to_gpu(self.cx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs))
 
     @attr.gpu
     def test_forward_gpu_cudnn_always(self):
@@ -155,14 +164,14 @@ class TestNStepLSTM(unittest.TestCase):
     def test_backward_gpu(self):
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
-                cuda.to_gpu(self.hx),
-                cuda.to_gpu(self.cx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs],
-                cuda.to_gpu(self.dhy),
-                cuda.to_gpu(self.dcy),
-                [cuda.to_gpu(dy) for dy in self.dys])
+                _to_gpu(self.hx),
+                _to_gpu(self.cx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                _to_gpu(self.dhy),
+                _to_gpu(self.dcy),
+                _to_gpu(self.dys))
 
 
 class TestNStepBiLSTM(unittest.TestCase):
@@ -285,11 +294,11 @@ class TestNStepBiLSTM(unittest.TestCase):
     def check_forward_gpu(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn):
             self.check_forward(
-                cuda.to_gpu(self.hx),
-                cuda.to_gpu(self.cx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs])
+                _to_gpu(self.hx),
+                _to_gpu(self.cx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs))
 
     @attr.gpu
     def test_forward_gpu_cudnn_always(self):
@@ -335,14 +344,14 @@ class TestNStepBiLSTM(unittest.TestCase):
     def check_backward_gpu(self):
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
-                cuda.to_gpu(self.hx),
-                cuda.to_gpu(self.cx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs],
-                cuda.to_gpu(self.dhy),
-                cuda.to_gpu(self.dcy),
-                [cuda.to_gpu(dy) for dy in self.dys])
+                _to_gpu(self.hx),
+                _to_gpu(self.cx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                _to_gpu(self.dhy),
+                _to_gpu(self.dcy),
+                _to_gpu(self.dys))
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -24,6 +24,15 @@ def _relu(x):
     return expected
 
 
+def _to_gpu(x):
+    if x is None:
+        return None
+    elif isinstance(x, list):
+        return [_to_gpu(xi) for xi in x]
+    else:
+        return cuda.to_gpu(x)
+
+
 @testing.parameterize(*testing.product({
     'activation': ['tanh', 'relu']
 }))
@@ -106,10 +115,10 @@ class TestNStepRNN(unittest.TestCase):
     def check_forward_gpu(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn):
             self.check_forward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs))
 
     @attr.gpu
     def test_forward_gpu_cudnn_always(self):
@@ -154,12 +163,12 @@ class TestNStepRNN(unittest.TestCase):
     def test_backward_gpu(self):
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs],
-                cuda.to_gpu(self.dhy),
-                [cuda.to_gpu(dy) for dy in self.dys])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                _to_gpu(self.dhy),
+                _to_gpu(self.dys))
 
 
 @testing.parameterize(*testing.product({
@@ -275,10 +284,10 @@ class TestNStepBiRNN(unittest.TestCase):
     def check_forward_gpu(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn):
             self.check_forward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs))
 
     @attr.gpu
     def test_forward_gpu_cudnn_always(self):
@@ -323,12 +332,12 @@ class TestNStepBiRNN(unittest.TestCase):
     def test_backward_gpu(self):
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
-                cuda.to_gpu(self.hx),
-                [cuda.to_gpu(x) for x in self.xs],
-                [[cuda.to_gpu(w) for w in ws] for ws in self.ws],
-                [[cuda.to_gpu(b) for b in bs] for bs in self.bs],
-                cuda.to_gpu(self.dhy),
-                [cuda.to_gpu(dy) for dy in self.dys])
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                _to_gpu(self.dhy),
+                _to_gpu(self.dys))
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
I replaced to_gpu in RNN tests.
related to #4045 