### PR TITLE
Fix initialization of random vectors in the test for RNNs

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -33,6 +33,10 @@ def _to_gpu(x):
         return cuda.to_gpu(x)
 
 
+def _shaped_random(shape, dtype='f'):
+    return numpy.random.uniform(-1, 1, shape).astype(dtype)
+
+
 def _wrap_variable(x):
     if isinstance(x, list):
         return [_wrap_variable(xi) for xi in x]
@@ -53,10 +57,9 @@ class TestNStepRNN(unittest.TestCase):
     dropout = 0.0
 
     def setUp(self):
-        self.xs = [numpy.random.uniform(-1, 1, (b, self.in_size)).astype('f')
-                   for b in self.batches]
+        self.xs = [_shaped_random((b, self.in_size)) for b in self.batches]
         h_shape = (self.n_layers, self.batches[0], self.out_size)
-        self.hx = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        self.hx = _shaped_random(h_shape)
 
         self.ws = []
         self.bs = []
@@ -69,16 +72,13 @@ class TestNStepRNN(unittest.TestCase):
                 else:
                     w_in = self.out_size
 
-                weights.append(numpy.random.uniform(
-                    -1, 1, (self.out_size, w_in)).astype('f'))
-                biases.append(numpy.random.uniform(
-                    -1, 1, (self.out_size,)).astype('f'))
+                weights.append(_shaped_random((self.out_size, w_in)))
+                biases.append(_shaped_random(self.out_size))
             self.ws.append(weights)
             self.bs.append(biases)
 
-        self.dys = [numpy.random.uniform(-1, 1, (b, self.out_size)).astype('f')
-                    for b in self.batches]
-        self.dhy = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        self.dys = [_shaped_random((b, self.out_size)) for b in self.batches]
+        self.dhy = _shaped_random(h_shape)
 
     def check_forward(
             self, h_data, xs_data, ws_data, bs_data):
@@ -240,10 +240,9 @@ class TestNStepBiRNN(unittest.TestCase):
     dropout = 0.0
 
     def setUp(self):
-        self.xs = [numpy.random.uniform(-1, 1, (b, self.in_size)).astype('f')
-                   for b in self.batches]
+        self.xs = [_shaped_random((b, self.in_size)) for b in self.batches]
         h_shape = (self.n_layers * 2, self.batches[0], self.out_size)
-        self.hx = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        self.hx = _shaped_random(h_shape)
 
         self.ws = []
         self.bs = []
@@ -259,17 +258,14 @@ class TestNStepBiRNN(unittest.TestCase):
                     else:
                         w_in = self.out_size
 
-                    weights.append(numpy.random.uniform(
-                        -1, 1, (self.out_size, w_in)).astype('f'))
-                    biases.append(numpy.random.uniform(
-                        -1, 1, (self.out_size,)).astype('f'))
+                    weights.append(_shaped_random((self.out_size, w_in)))
+                    biases.append(_shaped_random(self.out_size))
                 self.ws.append(weights)
                 self.bs.append(biases)
 
-        self.dys = [numpy.random.uniform(-1, 1,
-                                         (b, self.out_size * 2)).astype('f')
+        self.dys = [_shaped_random((b, self.out_size * 2))
                     for b in self.batches]
-        self.dhy = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        self.dhy = _shaped_random(h_shape)
 
     def check_forward(
             self, h_data, xs_data, ws_data, bs_data):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -65,7 +65,7 @@ class TestNStepRNN(unittest.TestCase):
         self.hx = _shaped_random(h_shape)
 
         o = self.out_size
-        i = self.in_size 
+        i = self.in_size
         self.ws = []
         self.bs = []
         # The first layer has the different shape


### PR DESCRIPTION
I simplified initialization of random vectors in the NStepRNN's test.
merge #4047 first
related to #4045 