### PR TITLE
Test of RNN in the case when some gradients are None

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -161,6 +161,13 @@ class TestNStepRNN(unittest.TestCase):
         self.check_backward(self.hx, self.xs, self.ws, self.bs,
                             self.dhy, self.dys)
 
+    @condition.retry(3)
+    def test_backward_partially_none_cpu(self):
+        dys = self.dys.copy()
+        dys[1] = None
+        self.check_backward(self.hx, self.xs, self.ws, self.bs,
+                            None, dys)
+
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
@@ -172,6 +179,20 @@ class TestNStepRNN(unittest.TestCase):
                 _to_gpu(self.bs),
                 _to_gpu(self.dhy),
                 _to_gpu(self.dys))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_partially_none_gpu(self):
+        dys = self.dys.copy()
+        dys[1] = None
+        with chainer.using_config('use_cudnn', 'always'):
+            self.check_backward(
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                None,
+                _to_gpu(dys))
 
     def call_forward(self, train):
         hx = _wrap_variable(_to_gpu(self.hx))
@@ -370,6 +391,13 @@ class TestNStepBiRNN(unittest.TestCase):
         self.check_backward(self.hx, self.xs, self.ws, self.bs,
                             self.dhy, self.dys)
 
+    @condition.retry(3)
+    def test_backward_partially_none_cpu(self):
+        dys = self.dys.copy()
+        dys[1] = None
+        self.check_backward(self.hx, self.xs, self.ws, self.bs,
+                            None, dys)
+
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
@@ -381,6 +409,20 @@ class TestNStepBiRNN(unittest.TestCase):
                 _to_gpu(self.bs),
                 _to_gpu(self.dhy),
                 _to_gpu(self.dys))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_partially_none_gpu(self):
+        dys = self.dys.copy()
+        dys[1] = None
+        with chainer.using_config('use_cudnn', 'always'):
+            self.check_backward(
+                _to_gpu(self.hx),
+                _to_gpu(self.xs),
+                _to_gpu(self.ws),
+                _to_gpu(self.bs),
+                None,
+                _to_gpu(dys))
 
     def call_forward(self, train):
         hx = _wrap_variable(_to_gpu(self.hx))

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -163,10 +163,9 @@ class TestNStepRNN(unittest.TestCase):
 
     @condition.retry(3)
     def test_backward_partially_none_cpu(self):
-        dys = self.dys.copy()
-        dys[1] = None
+        self.dys[1] = None
         self.check_backward(self.hx, self.xs, self.ws, self.bs,
-                            None, dys)
+                            None, self.dys)
 
     @attr.gpu
     @condition.retry(3)
@@ -183,8 +182,7 @@ class TestNStepRNN(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_partially_none_gpu(self):
-        dys = self.dys.copy()
-        dys[1] = None
+        self.dys[1] = None
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
                 _to_gpu(self.hx),
@@ -192,7 +190,7 @@ class TestNStepRNN(unittest.TestCase):
                 _to_gpu(self.ws),
                 _to_gpu(self.bs),
                 None,
-                _to_gpu(dys))
+                _to_gpu(self.dys))
 
     def call_forward(self, train):
         hx = _wrap_variable(_to_gpu(self.hx))
@@ -393,10 +391,9 @@ class TestNStepBiRNN(unittest.TestCase):
 
     @condition.retry(3)
     def test_backward_partially_none_cpu(self):
-        dys = self.dys.copy()
-        dys[1] = None
+        self.dys[1] = None
         self.check_backward(self.hx, self.xs, self.ws, self.bs,
-                            None, dys)
+                            None, self.dys)
 
     @attr.gpu
     @condition.retry(3)
@@ -413,8 +410,7 @@ class TestNStepBiRNN(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_backward_partially_none_gpu(self):
-        dys = self.dys.copy()
-        dys[1] = None
+        self.dys[1] = None
         with chainer.using_config('use_cudnn', 'always'):
             self.check_backward(
                 _to_gpu(self.hx),
@@ -422,7 +418,7 @@ class TestNStepBiRNN(unittest.TestCase):
                 _to_gpu(self.ws),
                 _to_gpu(self.bs),
                 None,
-                _to_gpu(dys))
+                _to_gpu(self.dys))
 
     def call_forward(self, train):
         hx = _wrap_variable(_to_gpu(self.hx))


### PR DESCRIPTION
I added a test case which checks RNN behavior when some gradients are None.
This fix includes the test case that checks #3042 
merge #4048 first
related to #4045, #3042 