### PR TITLE
Minor change to enable using Chainer with PyPy

### DIFF
--- a/chainer/datasets/svhn.py
+++ b/chainer/datasets/svhn.py
@@ -4,7 +4,7 @@ import numpy
 try:
     from scipy import io
     _scipy_available = True
-except ImportError:
+except:
     _scipy_available = False
 
 from chainer.dataset import download


### PR DESCRIPTION
Using PyPy, the following code (chainer/datasets/svhn.py", line 5) raises an AttributeError exception, which is not handled properly.

try:
    from scipy import io
    _scipy_available = True
except ImportError:
    _scipy_available = False

It seems reasonable that *any* exception raised when importing scipy.io would make SciPy be considered unavailable.

The following is the full traceback:

Traceback (most recent call last):
  File "/usr/local/bin/agglplanner2", line 67, in <module>
    from dnnpredictor import *
  File "/usr/local/share/agm/dnnpredictor.py", line 12, in <module>
    from chainer import Variable
  File "/usr/local/lib/pypy2.7/dist-packages/chainer-4.0.0a1-py2.7.egg/chainer/__init__.py", line 11, in <module>
    from chainer import datasets  # NOQA
  File "/usr/local/lib/pypy2.7/dist-packages/chainer-4.0.0a1-py2.7.egg/chainer/datasets/__init__.py", line 7, in <module>
    from chainer.datasets import svhn  # NOQA
  File "/usr/local/lib/pypy2.7/dist-packages/chainer-4.0.0a1-py2.7.egg/chainer/datasets/svhn.py", line 5, in <module>
    from scipy import io
  File "/usr/local/lib/pypy2.7/dist-packages/scipy/io/__init__.py", line 97, in <module>
    from .matlab import loadmat, savemat, whosmat, byteordercodes
  File "/usr/local/lib/pypy2.7/dist-packages/scipy/io/matlab/__init__.py", line 13, in <module>
    from .mio import loadmat, savemat, whosmat
  File "/usr/local/lib/pypy2.7/dist-packages/scipy/io/matlab/mio.py", line 14, in <module>
    from .mio5 import MatFile5Reader, MatFile5Writer
  File "/usr/local/lib/pypy2.7/dist-packages/scipy/io/matlab/mio5.py", line 98, in <module>
    from .mio5_utils import VarReader5
  File "scipy/io/matlab/streams.pxd", line 3, in init scipy.io.matlab.mio5_utils (scipy/io/matlab/mio5_utils.c:14798)
AttributeError: 'module' object has no attribute 'cStringIO_CAPI'
