### PR TITLE
Fix inconsistency on transferring copied link with uninitialized variables to GPU.

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -709,7 +709,7 @@ Actual: {0}'''.format(type(data))
         if self.data is None:
             self._initial_device = (cuda.Device().id
                                     if device is None else device)
-            self._data = [None]
+            self._data = [None]  # Renew placeholder to break sharing
         else:
             self._data = [cuda.to_gpu(self.data, device)]
             if self._grad_var is not None:

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -709,6 +709,7 @@ Actual: {0}'''.format(type(data))
         if self.data is None:
             self._initial_device = (cuda.Device().id
                                     if device is None else device)
+            self._data = [None]
         else:
             self._data = [cuda.to_gpu(self.data, device)]
             if self._grad_var is not None:

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -177,6 +177,24 @@ class TestLink(unittest.TestCase):
         self.assertIsNone(l0.u.data)
         self.assertIsInstance(l1.u.data, cupy.ndarray)
 
+    @attr.multi_gpu(2)
+    def test_copy_and_to_gpu_uninit_multi_gpu(self):
+        cupy = cuda.cupy
+        l0 = self.link
+        l1 = l0.copy()
+        l2 = l0.copy()
+        self.assertIsNone(l0.u.data)
+        self.assertIsNone(l1.u.data)
+        self.assertIsNone(l2.u.data)
+        l1.to_gpu()
+        l1.u.initialize((2, 3))
+        l2.to_gpu()
+        l2.u.initialize((2, 3))
+        self.assertIsNone(l0.u.data)
+        self.assertIsInstance(l1.u.data, cupy.ndarray)
+        self.assertIsInstance(l2.u.data, cupy.ndarray)
+        self.assertNotEqual(l1.u.data.data, l2.u.data.data)
+
     def _check_deepcopy(self, link):
         self.assertIsInstance(link._params, set)
         self.assertIsInstance(link._persistent, set)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -154,6 +154,27 @@ class TestLink(unittest.TestCase):
         self.assertIs(link.p, self.link.p)
         self.assertIs(link.name, None)
 
+    def test_copy_and_to_gpu_init(self):
+        cupy = cuda.cupy
+        l0 = self.link
+        l1 = l0.copy()
+        self.assertIs(l0.x.data, l1.x.data)
+        l1.to_gpu()
+        self.assertIsNot(l0.x.data, l1.x.data)
+        self.assertIsInstance(l0.x.data, numpy.ndarray)
+        self.assertIsInstance(l1.x.data, cupy.ndarray)
+
+    def test_copy_and_to_gpu_uninit(self):
+        cupy = cuda.cupy
+        l0 = self.link
+        l1 = l0.copy()
+        self.assertIsNone(l0.u.data)
+        self.assertIsNone(l1.u.data)
+        l1.to_gpu()
+        l1.u.initialize((2, 3))
+        self.assertIsNone(l0.u.data)
+        self.assertIsInstance(l1.u.data, cupy.ndarray)
+
     def _check_deepcopy(self, link):
         self.assertIsInstance(link._params, set)
         self.assertIsInstance(link._persistent, set)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -154,6 +154,7 @@ class TestLink(unittest.TestCase):
         self.assertIs(link.p, self.link.p)
         self.assertIs(link.name, None)
 
+    @attr.gpu
     def test_copy_and_to_gpu_init(self):
         cupy = cuda.cupy
         l0 = self.link
@@ -164,6 +165,7 @@ class TestLink(unittest.TestCase):
         self.assertIsInstance(l0.x.data, numpy.ndarray)
         self.assertIsInstance(l1.x.data, cupy.ndarray)
 
+    @attr.gpu
     def test_copy_and_to_gpu_uninit(self):
         cupy = cuda.cupy
         l0 = self.link


### PR DESCRIPTION
Fix #4068.

This PR fixes inconsistency when a link that has uninitialized variables is `link.copy()`ed, `link.to_gpu()`ed then initialized.
