### PR TITLE
Add image captioning example using MSCOCO

### DIFF
--- a/examples/image_captioning/README.md
+++ b/examples/image_captioning/README.md
@@ -44,7 +44,7 @@ Once `download.py` finishes, you can start training the model.
 $ python train.py --rnn nsteplstm --max-caption-length 30 --snapshot-iter 1000 --max-iters 50000 --batch-size 128 --gpu 0
 ```
 
-The above example start the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model each every 1000 iteration. By default, the first model snapshot is saved as `result/model_1000`.
+The above example start the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model every 1000 iteration. By default, the first model snapshot is saved as `result/model_1000`.
 
 If you have specified a download directory for MSCOCO when preparing the dataset, add the `--mscoco-root` option followed by the path to that directory.
 

--- a/examples/image_captioning/README.md
+++ b/examples/image_captioning/README.md
@@ -6,11 +6,11 @@ Given an image, this model generates a sentence that describes it.
 
 ## Requirements
 
-This example requires
+This example requires the following packages.
 
+- PIL
 - [pycocotools](https://github.com/cocodataset/cocoapi/tree/master/PythonAPI)
 
-to work with the dataset.
 To install pycocotools, clone the repository and run `pip install -e .` from `cocoapi/PythonAPI` where `setup.py` is located.
 
 ## Model Overview
@@ -24,6 +24,7 @@ During training, the loss is the softmax cross entropy of predicting the next wo
 The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers.
 However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former.
 This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions.
+When training with LSTM, you may want to specify the maximum caption length `--max-caption-length` to which all captions will be capped.
 
 ## Dataset
 
@@ -42,7 +43,13 @@ Notice that this may take a while and that it requires approximately 20 GB of di
 Once `download.py` finishes, you can start training the model.
 
 ```bash
-$ python train.py --rnn nsteplstm --max-caption-length 30 --snapshot-iter 1000 --max-iters 50000 --batch-size 128 --gpu 0
+$ python train.py --rnn nsteplstm --snapshot-iter 1000 --max-iters 50000 --batch-size 128 --gpu 0
+```
+
+If you run this script on Linux, setting the environmental variable `MPLBACKEND` to `Agg` may be required to use `matplotlib`. For example,
+
+```
+MPLBACKEND=Agg python train.py ...
 ```
 
 The above example starts the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model every 1000 iteration.
@@ -61,3 +68,4 @@ $ python predict.py --img cat.jpg --model result/model_20000 --rnn nsteplstm --m
 
 It will print out the generated captions to std out.
 If you want to generate captions to all images in a directory, replace `--img` with `--img-dir` followed by the directory.
+Note that `--rnn` needs to given the correct value corresponding to the model.

--- a/examples/image_captioning/README.md
+++ b/examples/image_captioning/README.md
@@ -1,23 +1,33 @@
 # Image Captioning with Convolutional Neural Networks
 
-This is an example of a generative image captioning model using a neural networks with convolutional and recurrent layers. Given an image, this model generates a sentence that describe it.
+This is an example of a generative image captioning model using a neural network with convolutional and recurrent layers. Given an image, this model generates a sentence that describe it.
 
 
 ## Requirements
 
-This example requires:
+This example requires
 
 - [pycocotools](https://github.com/cocodataset/cocoapi/tree/master/PythonAPI)
 
-To install pycocotools, clone the repository and run `pip install -e .` from the directory where `setup.py` is located.
+to work with the dataset. To install pycocotools, clone the repository and run `pip install -e .` from the directory where `setup.py` is located.
 
 ## Model Overview
 
-The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features. These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a predetermined maximum caption length. The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers. However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) through the language model which runs faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you do if using the former. During training, the loss is the softmax cross entropy of correctly predicting the next word in the caption given the current word averaged over the minibatch. This example includes both LSTM and NStepLSTM implementations.
+### 1. Extract features from an image
+
+The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features.
+
+### 2. Generating a caption from extracted features
+
+These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a predetermined maximum caption length. The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers. However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former. This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions.
+
+### 3. Objective function
+
+During training, the loss is the softmax cross entropy of correctly predicting the next word in the caption given the current word averaged over the minibatch.
 
 ## Dataset
 
-You need to download the MSCOCO captioning dataset in order to train the model. Run it wthe following command to download and extract the necessary files.
+You need to download the MSCOCO captioning dataset in order to train the model. Run the following command to download and extract the necessary files.
 
 
 ```bash
@@ -31,19 +41,19 @@ This downloads and extracts the training and validation images, as well as neces
 Once `download.py` finishes, you can start training the model.
 
 ```bash
-$ python train.py --rnn nsteplstm --max-caption-length 30 --snapshot-iter 1000 --max-iters 50000 --gpu 0
+$ python train.py --rnn nsteplstm --max-caption-length 30 --snapshot-iter 1000 --max-iters 50000 --batch-size 128 --gpu 0
 ```
 
-The above example command start the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model each 1000 iteration. By default, the first model snapshot is saved under `result/model_1000`.
+The above example start the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model each every 1000 iteration. By default, the first model snapshot is saved as `result/model_1000`.
 
-If you have specified a download directory for the MSCOCO dataset when preparing the dataset, add the `--mscoco-root` option followed by the path to that directory.
+If you have specified a download directory for MSCOCO when preparing the dataset, add the `--mscoco-root` option followed by the path to that directory.
 
 ## Testing
 
-To generate captions for new images, you need to have trained a snapshot of a trained model. Assuming we are using the model snapshots from the training example after 20000 iterations, we can generate new captions as follows.
+To generate captions for new images, you need to have a snapshot of a trained model. Assuming we are using the model snapshots from the training example after 20000 iterations, we can generate new captions as follows.
 
 ```bash
 $ python predict.py --img cat.jpg --model result/model_20000 --rnn nsteplstm --max-caption-length 30 --gpu 0
 ```
 
-This will print out the generated captions to std out. If you want to generate captions to all images in a directory, replace `--img` with `--img-dir` followed by the directory.
+It will print out the generated captions to std out. If you want to generate captions to all images in a directory, replace `--img` with `--img-dir` followed by the directory.

--- a/examples/image_captioning/README.md
+++ b/examples/image_captioning/README.md
@@ -1,6 +1,6 @@
 # Image Captioning with Convolutional Neural Networks
 
-This is an example of a generative image captioning model using a neural network with convolutional and recurrent layers. Given an image, this model generates a sentence that describe it.
+This is an example implementation of Show and Tell: A Neural Image Caption Generator (https://arxiv.org/abs/1411.4555) a generative image captioning model using a neural network with convolutional and recurrent layers. Given an image, this model generates a sentence that describe it.
 
 
 ## Requirements
@@ -13,17 +13,7 @@ to work with the dataset. To install pycocotools, clone the repository and run `
 
 ## Model Overview
 
-### 1. Extract features from an image
-
-The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features.
-
-### 2. Generating a caption from extracted features
-
-These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a predetermined maximum caption length. The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers. However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former. This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions.
-
-### 3. Objective function
-
-During training, the loss is the softmax cross entropy of correctly predicting the next word in the caption given the current word averaged over the minibatch.
+The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features. These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a predetermined maximum caption length. The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers. However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former. This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions. During training, the loss is the softmax cross entropy of correctly predicting the next word in the caption given the current word averaged over the minibatch.
 
 ## Dataset
 

--- a/examples/image_captioning/README.md
+++ b/examples/image_captioning/README.md
@@ -1,6 +1,7 @@
 # Image Captioning with Convolutional Neural Networks
 
-This is an example implementation of Show and Tell: A Neural Image Caption Generator (https://arxiv.org/abs/1411.4555) a generative image captioning model using a neural network with convolutional and recurrent layers. Given an image, this model generates a sentence that describes it.
+This is an example implementation of Show and Tell: A Neural Image Caption Generator (https://arxiv.org/abs/1411.4555) a generative image captioning model using a neural network with convolutional and recurrent layers.
+Given an image, this model generates a sentence that describes it.
 
 
 ## Requirements
@@ -9,15 +10,20 @@ This example requires
 
 - [pycocotools](https://github.com/cocodataset/cocoapi/tree/master/PythonAPI)
 
-to work with the dataset. To install pycocotools, clone the repository and run `pip install -e .` from `cocoapi/PythonAPI` where `setup.py` is located.
+to work with the dataset.
+To install pycocotools, clone the repository and run `pip install -e .` from `cocoapi/PythonAPI` where `setup.py` is located.
 
 ## Model Overview
 
-The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features. These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a maximum length. During training, the loss is the softmax cross entropy of predicting the next word given the preceding words in the caption.
+The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features.
+These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a maximum length.
+During training, the loss is the softmax cross entropy of predicting the next word given the preceding words in the caption.
 
 ### More About the Language Model
 
-The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers. However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former. This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions.
+The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers.
+However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former.
+This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions.
 
 ## Dataset
 
@@ -27,7 +33,9 @@ Run the following command to download the MSCOCO captioning dataset for training
 $ python download.py
 ```
 
-This downloads and extracts the training and validation images, as well as necessary meta data including captions to a `data` directory under the current folder. You can change the output directory by appeding `--out` followed by the target directory. Notice that this may take a while and that it requires approximately 20 GB of disk space.
+This downloads and extracts the training and validation images, as well as necessary meta data including captions to a `data` directory under the current folder.
+You can change the output directory by appeding `--out` followed by the target directory.
+Notice that this may take a while and that it requires approximately 20 GB of disk space.
 
 ## Training
 
@@ -37,16 +45,19 @@ Once `download.py` finishes, you can start training the model.
 $ python train.py --rnn nsteplstm --max-caption-length 30 --snapshot-iter 1000 --max-iters 50000 --batch-size 128 --gpu 0
 ```
 
-The above example starts the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model every 1000 iteration. By default, the first model snapshot is saved as `result/model_1000`.
+The above example starts the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model every 1000 iteration.
+By default, the first model snapshot is saved as `result/model_1000`.
 
 If you have specified a download directory for MSCOCO when preparing the dataset, add the `--mscoco-root` option followed by the path to that directory.
 
 ## Testing
 
-To generate captions for new images, you need to have a snapshot of a trained model. Assuming we are using the model snapshots from the training example after 20000 iterations, we can generate new captions as follows.
+To generate captions for new images, you need to have a snapshot of a trained model.
+Assuming we are using the model snapshots from the training example after 20000 iterations, we can generate new captions as follows.
 
 ```bash
 $ python predict.py --img cat.jpg --model result/model_20000 --rnn nsteplstm --max-caption-length 30 --gpu 0
 ```
 
-It will print out the generated captions to std out. If you want to generate captions to all images in a directory, replace `--img` with `--img-dir` followed by the directory.
+It will print out the generated captions to std out.
+If you want to generate captions to all images in a directory, replace `--img` with `--img-dir` followed by the directory.

--- a/examples/image_captioning/README.md
+++ b/examples/image_captioning/README.md
@@ -23,7 +23,7 @@ During training, the loss is the softmax cross entropy of predicting the next wo
 
 The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers.
 However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former.
-This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions.
+This example uses NStepLSTM by default, but also includes the equivalent code implmenented using standard LSTM as a reference.
 When training with LSTM, you may want to specify the maximum caption length `--max-caption-length` to which all captions will be capped.
 
 ## Dataset

--- a/examples/image_captioning/README.md
+++ b/examples/image_captioning/README.md
@@ -1,6 +1,6 @@
 # Image Captioning with Convolutional Neural Networks
 
-This is an example implementation of Show and Tell: A Neural Image Caption Generator (https://arxiv.org/abs/1411.4555) a generative image captioning model using a neural network with convolutional and recurrent layers. Given an image, this model generates a sentence that describe it.
+This is an example implementation of Show and Tell: A Neural Image Caption Generator (https://arxiv.org/abs/1411.4555) a generative image captioning model using a neural network with convolutional and recurrent layers. Given an image, this model generates a sentence that describes it.
 
 
 ## Requirements
@@ -9,16 +9,19 @@ This example requires
 
 - [pycocotools](https://github.com/cocodataset/cocoapi/tree/master/PythonAPI)
 
-to work with the dataset. To install pycocotools, clone the repository and run `pip install -e .` from the directory where `setup.py` is located.
+to work with the dataset. To install pycocotools, clone the repository and run `pip install -e .` from `cocoapi/PythonAPI` where `setup.py` is located.
 
 ## Model Overview
 
-The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features. These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a predetermined maximum caption length. The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers. However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former. This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions. During training, the loss is the softmax cross entropy of correctly predicting the next word in the caption given the current word averaged over the minibatch.
+The model takes an image as input which is fed through a pretrained VGG16 model in order to extract features. These features are then passed to a language model, a recurrent neural network that generates a caption word-by-word until the `EOS` (end-of-sentence) token is encountered or the caption reaches a maximum length. During training, the loss is the softmax cross entropy of predicting the next word given the preceding words in the caption.
+
+### More About the Language Model
+
+The internals of the language models is a neural network with [LSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.LSTM.html) layers. However, Chainer also has a [NStepLSTM](http://docs.chainer.org/en/stable/reference/generated/chainer.links.NStepLSTM.html) layer which does not require sequential passes (for-loops in the code) which is faster. Using the latter, you do not have to align the caption lengths in the training data neither, which you usually do if using the former. This example includes both LSTM and NStepLSTM implementations and preprocessing of the captions.
 
 ## Dataset
 
-You need to download the MSCOCO captioning dataset in order to train the model. Run the following command to download and extract the necessary files.
-
+Run the following command to download the MSCOCO captioning dataset for training this model.
 
 ```bash
 $ python download.py
@@ -34,7 +37,7 @@ Once `download.py` finishes, you can start training the model.
 $ python train.py --rnn nsteplstm --max-caption-length 30 --snapshot-iter 1000 --max-iters 50000 --batch-size 128 --gpu 0
 ```
 
-The above example start the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model every 1000 iteration. By default, the first model snapshot is saved as `result/model_1000`.
+The above example starts the training with the NStepLSTM layers in the language model and saves a snapshot of the trained model every 1000 iteration. By default, the first model snapshot is saved as `result/model_1000`.
 
 If you have specified a download directory for MSCOCO when preparing the dataset, add the `--mscoco-root` option followed by the path to that directory.
 

--- a/examples/image_captioning/datasets.py
+++ b/examples/image_captioning/datasets.py
@@ -97,6 +97,9 @@ def get_mscoco(
         for w in split(c):
             word_counts[w] += 1
 
+    # This vocabulary is needed in order to convert the words in the captions
+    # to integer tokens. When generating captions during testing, these tokens
+    # are mapped back to their corresponding words.
     vocab = {'<bos>': _bos, '<eos>': _eos, '<unk>': _unk}
     for w, count in six.iteritems(word_counts):
         if w not in vocab and count >= unk_threshold:

--- a/examples/image_captioning/datasets.py
+++ b/examples/image_captioning/datasets.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import os
-import six
 
 import numpy as np
 from PIL import Image
@@ -11,7 +10,7 @@ from chainer.dataset.convert import to_device
 
 
 # Vocabulary tokens of BOS (beginning of sentence), EOS (end of sentence),
-# UNK (unknown word) and token labels to be ignore in the loss computation by
+# UNK (unknown word) and token labels to be ignored in the loss computation by
 # the LSTM layers
 _bos = 0
 _eos = 1
@@ -86,10 +85,9 @@ def get_mscoco(
     train = MsCocoDataset(root_dir, train_dir, train_anno)
     val = MsCocoDataset(root_dir, val_dir, val_anno)
 
-    # Create a vocabulary based on the captions from both the training and the
-    # validation datasets
-    anns = train.anns + val.anns
-    captions = [ann['caption'] for ann in anns]
+    # Create a vocabulary based on the captions from the training set only
+    # (excluding the validation sets). This is common practice.
+    captions = [ann['caption'] for ann in train.anns]
 
     # Filter out rare words as UNK
     word_counts = defaultdict(int)
@@ -99,9 +97,10 @@ def get_mscoco(
 
     # This vocabulary is needed in order to convert the words in the captions
     # to integer tokens. When generating captions during testing, these tokens
-    # are mapped back to their corresponding words.
+    # are mapped back to their corresponding words. Note that this vocabulary
+    # sorted alphanumerically.
     vocab = {'<bos>': _bos, '<eos>': _eos, '<unk>': _unk}
-    for w, count in six.iteritems(word_counts):
+    for w, count in sorted(word_counts.items()):
         if w not in vocab and count >= unk_threshold:
             vocab[w] = len(vocab)
 

--- a/examples/image_captioning/datasets.py
+++ b/examples/image_captioning/datasets.py
@@ -43,7 +43,7 @@ class MsCocoDataset(dataset.DatasetMixin):
     def get_example(self, i):
         """Called by the iterator to fetch a data sample.
 
-        A data sample from MSCOCO consists of an image its corresponding
+        A data sample from MSCOCO consists of an image and its corresponding
         caption.
         """
         ann = self.anns[i]
@@ -80,7 +80,7 @@ def get_mscoco(
 
     The datasets can be used by the iterator during training.
 
-    A vocabulary is dynamically created based on all caption and and is
+    A vocabulary is dynamically created based on all captions and is
     returned as members of the training and validation dataset objects.
     """
     train = MsCocoDataset(root_dir, train_dir, train_anno)
@@ -91,6 +91,7 @@ def get_mscoco(
     anns = train.anns + val.anns
     captions = [ann['caption'] for ann in anns]
 
+    # Filter out rare words as UNK
     word_counts = defaultdict(int)
     for c in captions:
         for w in split(c):

--- a/examples/image_captioning/datasets.py
+++ b/examples/image_captioning/datasets.py
@@ -1,0 +1,135 @@
+from collections import defaultdict
+import os
+import six
+
+import numpy as np
+from PIL import Image
+from pycocotools.coco import COCO
+
+from chainer import dataset
+from chainer.dataset.convert import to_device
+
+
+# Vocabulary tokens of BOS (beginning of sentence), EOS (end of sentence),
+# UNK (unknown word) and token labels to be ignore in the loss computation by
+# the LSTM layers
+_bos = 0
+_eos = 1
+_unk = 2
+_ignore = -1
+
+
+def split(sentence):
+    return sentence.lower().replace('.', ' .').replace(',', ' ,').split()
+
+
+class MsCocoDataset(dataset.DatasetMixin):
+
+    """Wraps the MSCOCO datasets and is used by the iterator to fetch data."""
+
+    def __init__(self, root_dir, data_dir, anno_file):
+        coco = COCO(os.path.join(root_dir, anno_file))
+        anns = coco.loadAnns(coco.getAnnIds())
+
+        self.coco = coco
+        self.anns = anns
+        self.vocab = None  # Later set from outside
+        self.coco_root = root_dir
+        self.coco_data = data_dir
+
+    def __len__(self):
+        return len(self.anns)
+
+    def get_example(self, i):
+        """Called by the iterator to fetch a data sample.
+
+        A data sample from MSCOCO consists of an image its corresponding
+        caption.
+        """
+        ann = self.anns[i]
+
+        # Load the image
+        img_id = ann['image_id']
+        img_file_name = self.coco.loadImgs([img_id])[0]['file_name']
+        img = Image.open(
+            os.path.join(self.coco_root, self.coco_data, img_file_name))
+        if img.mode == 'RGB':
+            img = np.asarray(img, np.float32).transpose(2, 0, 1)
+        elif img.mode == 'L':
+            img = np.asarray(img, np.float32)
+            img = np.broadcast_to(img, (3,) + img.shape)
+        else:
+            raise ValueError('Invalid image mode {}'.format(img.mode))
+
+        # Load the caption, i.e. sequence of tokens
+        tokens = [self.vocab.get(w, _unk) for w in
+                  ['<bos>'] + split(ann['caption']) + ['<eos>']]
+        tokens = np.array(tokens, np.int32)
+
+        return img, tokens
+
+
+def get_mscoco(
+        root_dir,
+        train_dir='train2014',
+        train_anno='annotations/captions_train2014.json',
+        val_dir='val2014',
+        val_anno='annotations/captions_val2014.json',
+        unk_threshold=5):
+    """Return the training and validation datasets for MSCOCO.
+
+    The datasets can be used by the iterator during training.
+
+    A vocabulary is dynamically created based on all caption and and is
+    returned as members of the training and validation dataset objects.
+    """
+    train = MsCocoDataset(root_dir, train_dir, train_anno)
+    val = MsCocoDataset(root_dir, val_dir, val_anno)
+
+    # Create a vocabulary based on the captions from both the training and the
+    # validation datasets
+    anns = train.anns + val.anns
+    captions = [ann['caption'] for ann in anns]
+
+    word_counts = defaultdict(int)
+    for c in captions:
+        for w in split(c):
+            word_counts[w] += 1
+
+    vocab = {'<bos>': _bos, '<eos>': _eos, '<unk>': _unk}
+    for w, count in six.iteritems(word_counts):
+        if w not in vocab and count >= unk_threshold:
+            vocab[w] = len(vocab)
+
+    train.vocab = vocab
+    val.vocab = vocab
+
+    return train, val
+
+
+def converter(batch, device, max_caption_length=None):
+    """Optional preprocessing of the batch before forward pass."""
+    pad = max_caption_length is not None
+
+    imgs = []
+    captions = []
+    for img, caption in batch:
+        # Preproess the caption by either fixing the length by padding (LSTM)
+        # or by simply wrapping each caption in an ndarray (NStepLSTM)
+        if pad:
+            arr = np.full(max_caption_length, _ignore, dtype=np.int32)
+
+            # Clip to max length if necessary
+            arr[:len(caption)] = caption[:max_caption_length]
+            caption = arr
+        else:
+            caption = to_device(device, np.asarray(caption, dtype=np.int32))
+
+        imgs.append(img)
+        captions.append(caption)
+
+    if pad:
+        captions = to_device(device, np.stack(captions))
+    imgs = to_device(device, np.stack(imgs))
+
+    return imgs, captions

--- a/examples/image_captioning/datasets.py
+++ b/examples/image_captioning/datasets.py
@@ -44,6 +44,8 @@ class MsCocoDataset(dataset.DatasetMixin):
 
         A data sample from MSCOCO consists of an image and its corresponding
         caption.
+
+        The returned image has the shape (channel, height, width).
         """
         ann = self.anns[i]
 

--- a/examples/image_captioning/download.py
+++ b/examples/image_captioning/download.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import os
 from six.moves.urllib import request
@@ -16,7 +17,8 @@ urls = [
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--out', type=str, default='data')
+    parser.add_argument('--out', type=str, default='data',
+                        help='Target MSOCO dataset root directory')
     args = parser.parse_args()
 
     try:

--- a/examples/image_captioning/download.py
+++ b/examples/image_captioning/download.py
@@ -1,0 +1,44 @@
+import argparse
+import os
+from six.moves.urllib import request
+import zipfile
+
+
+"""Download the MSCOCO dataset (images and captions)."""
+
+
+urls = [
+    'http://images.cocodataset.org/zips/train2014.zip',
+    'http://images.cocodataset.org/zips/val2014.zip',
+    'http://images.cocodataset.org/annotations/annotations_trainval2014.zip'
+]
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--out', type=str, default='data')
+    args = parser.parse_args()
+
+    try:
+        os.makedirs(args.out)
+    except FileExistsError:
+        raise FileExistsError(
+            "'{}' already exists, delete it and try again".format(args.out))
+
+    for url in urls:
+        print('Downloading {}...'.format(url))
+
+        # Download the zip file
+        file_name = os.path.basename(url)
+        dst_file_path = os.path.join(args.out, file_name)
+        request.urlretrieve(url, dst_file_path)
+
+        # Unzip the file
+        zf = zipfile.ZipFile(dst_file_path)
+        for name in zf.namelist():
+            dirname, filename = os.path.split(name)
+            if not filename == '':
+                zf.extract(name, args.out)
+
+        # Remove the zip file since it has been extracted
+        os.remove(dst_file_path)

--- a/examples/image_captioning/download.py
+++ b/examples/image_captioning/download.py
@@ -21,8 +21,8 @@ if __name__ == '__main__':
 
     try:
         os.makedirs(args.out)
-    except FileExistsError:
-        raise FileExistsError(
+    except OSError:
+        raise OSError(
             "'{}' already exists, delete it and try again".format(args.out))
 
     for url in urls:

--- a/examples/image_captioning/model.py
+++ b/examples/image_captioning/model.py
@@ -79,7 +79,12 @@ class VGG16FeatureExtractor(chainer.Chain):
         self.cnn_layer_name = 'fc7'
 
     def prepare(self, img):
-        """Single image to resized and normalized image."""
+        """Single image to resized and normalized image.
+
+        The inputs image should have the shape (channel, height, width) where
+        channels are aligned RGB. The returned image has the same shape but
+        channels in BGR order.
+        """
         return L.model.vision.vgg.prepare(img)
 
     def __call__(self, imgs):

--- a/examples/image_captioning/model.py
+++ b/examples/image_captioning/model.py
@@ -243,6 +243,7 @@ class NStepLSTMLanguageModel(chainer.Chain):
 
     def reset(self, img_feats):
         """Batch of image features to LSTM states and hidden representations.
+
         """
         h = self.embed_img(img_feats)
         h = F.split_axis(h, h.shape[0], axis=0)

--- a/examples/image_captioning/model.py
+++ b/examples/image_captioning/model.py
@@ -1,0 +1,264 @@
+import numpy as np
+
+import chainer
+from chainer import functions as F
+from chainer import initializers
+from chainer import links as L
+from chainer import reporter
+from chainer import Variable
+
+
+class ImageCaptionModel(chainer.Chain):
+
+    """Image captioning model."""
+
+    def __init__(self, vocab_size, hidden_size=512, rnn='lstm',
+                 dropout_ratio=0.5, finetune_feat_extractor=False,
+                 ignore_label=-1):
+        super(ImageCaptionModel, self).__init__()
+
+        if rnn == 'lstm':
+            LanguageModel = LSTMLanguageModel
+        elif rnn == 'nsteplstm':
+            LanguageModel = NStepLSTMLanguageModel
+        else:
+            raise ValueError('Invalid RNN type.')
+
+        with self.init_scope():
+            self.feat_extractor = VGG16FeatureExtractor()
+            self.lang_model = LanguageModel(
+                vocab_size, hidden_size, dropout_ratio=dropout_ratio,
+                ignore_label=ignore_label)
+
+        self.finetune_feat_extractor = finetune_feat_extractor
+
+    def prepare(self, img):
+        """Single image to resized and normalized image."""
+        return self.feat_extractor.prepare(img)
+
+    def __call__(self, imgs, captions):
+        """Batch of images to a single loss."""
+        imgs = Variable(imgs)
+        if self.finetune_feat_extractor:
+            img_feats = self.feat_extractor(imgs)
+        else:
+            # Extract features without building a computational chain
+            with chainer.no_backprop_mode():
+                img_feats = self.feat_extractor(imgs)
+
+        loss = self.lang_model(img_feats, captions)
+
+        # Report the loss so that it can be printed, logged and plotted by
+        # other trainer extensions
+        reporter.report({'loss': loss}, self)
+
+        return loss
+
+    def predict(self, imgs, bos, eos, max_caption_length):
+        """Batch of images to captions."""
+        imgs = Variable(imgs)
+        img_feats = self.feat_extractor(imgs)
+        captions = self.lang_model.predict(
+            img_feats, bos=bos, eos=eos, max_caption_length=max_caption_length)
+        return captions
+
+
+class VGG16FeatureExtractor(chainer.Chain):
+
+    """VGG16 image feature extractor."""
+
+    def __init__(self):
+        super(VGG16FeatureExtractor, self).__init__()
+        with self.init_scope():
+            self.cnn = L.VGG16Layers()
+        self.cnn_layer_name = 'fc7'
+
+    def prepare(self, img):
+        """Single image to resized and normalized image."""
+        return L.model.vision.vgg.prepare(img)
+
+    def __call__(self, imgs):
+        """Batch of images to image features."""
+        h = self.cnn(imgs, [self.cnn_layer_name])[self.cnn_layer_name]
+        img_feat = F.dropout(F.relu(h), ratio=0.5)
+        return img_feat
+
+
+class LSTMLanguageModel(chainer.Chain):
+
+    """Recurrent LSTM language model.
+
+    Generate captions given features extracted from images.
+    """
+
+    def __init__(self, vocab_size, hidden_size, dropout_ratio, ignore_label):
+        super(LSTMLanguageModel, self).__init__()
+        with self.init_scope():
+            self.embed_word = L.EmbedID(
+                vocab_size,
+                hidden_size,
+                initialW=initializers.Normal(1.0),
+                ignore_label=ignore_label
+            )
+            self.embed_img = L.Linear(
+                hidden_size,
+                initialW=initializers.Normal(0.01),
+                initial_bias=initializers.Zero()
+            )
+            self.lstm = L.LSTM(hidden_size, hidden_size)
+            self.out_word = L.Linear(
+                hidden_size,
+                vocab_size,
+                initialW=initializers.Normal(0.01),
+                initial_bias=initializers.Zero()
+            )
+
+        self.dropout_ratio = dropout_ratio
+
+    def __call__(self, img_feats, captions):
+        """Batch of image features and image captions to a singe loss.
+
+        Compute the softmax cross-entropy captioning loss.
+        """
+        self.reset(img_feats)
+
+        loss = 0
+        size = 0
+        caption_length = captions.shape[1]
+        for i in range(caption_length - 1):
+            # Compute the loss based on the prediction of the next token in the
+            # sequence
+            x = Variable(self.xp.asarray(captions[:, i]))
+            t = Variable(self.xp.asarray(captions[:, i + 1]))
+            if (t.data == self.embed_word.ignore_label).all():
+                # The next tokens in the sequence should not be accounted for
+                # in the loss, e.g. the targets are paddings that were used to
+                # align the lengths of all captions within the same batch
+                break
+            y = self.step(x)
+            loss += F.softmax_cross_entropy(
+                y, t, ignore_label=self.embed_word.ignore_label)
+            size += 1
+        return loss / max(size, 1)
+
+    def predict(self, img_feats, bos, eos, max_caption_length):
+        """Batch of image features to captions."""
+        self.reset(img_feats)
+
+        captions = self.xp.full((img_feats.shape[0], 1), bos, dtype=np.int32)
+        for _ in range(max_caption_length):
+            x = Variable(captions[:, -1])  # Previous word token as input
+            y = self.step(x)
+            pred = y.data.argmax(axis=1).astype(np.int32)
+            captions = self.xp.hstack((captions, pred[:, None]))
+            if (pred == eos).all():
+                break
+        return captions
+
+    def reset(self, img_feats):
+        """Batch of image features to hidden representations.
+
+        Also, reset and then update the internal state of the LSTM.
+        """
+        self.lstm.reset_state()
+        h = self.embed_img(img_feats)
+        h = self.lstm(F.dropout(h, ratio=self.dropout_ratio))
+        return h
+
+    def step(self, x):
+        """Batch of word tokens to word tokens.
+
+        Predict the next set of tokens given previous tokens.
+        """
+        h = self.embed_word(x)
+        h = self.lstm(F.dropout(h, ratio=self.dropout_ratio))
+        h = self.out_word(F.dropout(h, ratio=self.dropout_ratio))
+        return h
+
+
+class NStepLSTMLanguageModel(chainer.Chain):
+    """Recurrent NStepLSTM language model.
+
+    Generate captions given features extracted from images.
+    """
+
+    def __init__(self, vocab_size, hidden_size, dropout_ratio, ignore_label):
+        super(NStepLSTMLanguageModel, self).__init__()
+        with self.init_scope():
+            self.embed_word = L.EmbedID(
+                vocab_size,
+                hidden_size,
+                initialW=initializers.Normal(1.0),
+                ignore_label=ignore_label
+            )
+            self.embed_img = L.Linear(
+                hidden_size,
+                initialW=initializers.Normal(0.01),
+                initial_bias=initializers.Zero()
+            )
+            self.lstm = L.NStepLSTM(1, hidden_size, hidden_size, dropout_ratio)
+            self.decode_caption = L.Linear(
+                hidden_size,
+                vocab_size,
+                initialW=initializers.Normal(0.01),
+                initial_bias=initializers.Zero()
+            )
+
+        self.dropout_ratio = dropout_ratio
+
+    def __call__(self, img_feats, captions):
+        """Batch of image features and image captions to a singe loss.
+
+        Compute the softmax cross-entropy captioning loss in a single pass
+        without iterating over the sequences.
+        """
+        hx, cx, _ = self.reset(img_feats)
+
+        xs = [c[:-1] for c in captions]
+        ts = [c[1:] for c in captions]
+
+        # Concatenate all input captions and pass them through the model
+        caption_lens = [len(x) for x in xs]
+        caption_sections = np.cumsum(caption_lens[:-1])
+        xs = F.concat(xs, axis=0)
+        _, _, ys = self.step(hx, cx, xs, sections=caption_sections)
+
+        ts = F.concat(ts, axis=0)
+        loss = F.softmax_cross_entropy(ys, ts)
+        return loss
+
+    def predict(self, img_feats, bos, eos, max_caption_length):
+        """Batch of image features to captions."""
+        hx, cx, _ = self.reset(img_feats)
+
+        captions = self.xp.full((img_feats.shape[0], 1), bos, dtype=np.int32)
+        for i in range(max_caption_length):
+            xs = Variable(captions[:, -1])
+            hx, cx, ys = self.step(hx, cx, xs, sections=xs.shape[0])
+            pred = ys.data.argmax(axis=1).astype(np.int32)
+            captions = self.xp.hstack((captions, pred[:, None]))
+            if (pred == eos).all():
+                break
+        return captions
+
+    def reset(self, img_feats):
+        """Batch of image features to LSTM states and hidden representations.
+        """
+        h = self.embed_img(img_feats)
+        h = F.split_axis(h, h.shape[0], axis=0)
+        hx, cx, ys = self.lstm(None, None, h)
+        return hx, cx, ys
+
+    def step(self, hx, cx, xs, sections=None):
+        """Batch of word tokens to word tokens and hidden LSTM states.
+
+        Predict the next set of tokens given previous tokens.
+        """
+        xs = self.embed_word(xs)
+        xs = F.split_axis(xs, sections, axis=0)
+        hx, cx, ys = self.lstm(hx, cx, xs)
+
+        ys = F.concat(ys, axis=0)
+        ys = F.dropout(ys, self.dropout_ratio)
+        ys = self.decode_caption(ys)
+        return hx, cx, ys

--- a/examples/image_captioning/model.py
+++ b/examples/image_captioning/model.py
@@ -214,10 +214,12 @@ class NStepLSTMLanguageModel(chainer.Chain):
         """
         hx, cx, _ = self.reset(img_feats)
 
+        # Extract all inputs and targets for all captions in the batch
         xs = [c[:-1] for c in captions]
         ts = [c[1:] for c in captions]
 
-        # Concatenate all input captions and pass them through the model
+        # Concatenate all input captions and pass them through the model in a
+        # single pass
         caption_lens = [len(x) for x in xs]
         caption_sections = np.cumsum(caption_lens[:-1])
         xs = F.concat(xs, axis=0)

--- a/examples/image_captioning/model.py
+++ b/examples/image_captioning/model.py
@@ -102,15 +102,13 @@ class LSTMLanguageModel(chainer.Chain):
             )
             self.embed_img = L.Linear(
                 hidden_size,
-                initialW=initializers.Normal(0.01),
-                initial_bias=initializers.Zero()
+                initialW=initializers.Normal(0.01)
             )
             self.lstm = L.LSTM(hidden_size, hidden_size)
             self.out_word = L.Linear(
                 hidden_size,
                 vocab_size,
-                initialW=initializers.Normal(0.01),
-                initial_bias=initializers.Zero()
+                initialW=initializers.Normal(0.01)
             )
 
         self.dropout_ratio = dropout_ratio
@@ -193,15 +191,13 @@ class NStepLSTMLanguageModel(chainer.Chain):
             )
             self.embed_img = L.Linear(
                 hidden_size,
-                initialW=initializers.Normal(0.01),
-                initial_bias=initializers.Zero()
+                initialW=initializers.Normal(0.01)
             )
             self.lstm = L.NStepLSTM(1, hidden_size, hidden_size, dropout_ratio)
             self.decode_caption = L.Linear(
                 hidden_size,
                 vocab_size,
-                initialW=initializers.Normal(0.01),
-                initial_bias=initializers.Zero()
+                initialW=initializers.Normal(0.01)
             )
 
         self.dropout_ratio = dropout_ratio

--- a/examples/image_captioning/predict.py
+++ b/examples/image_captioning/predict.py
@@ -18,8 +18,8 @@ def main():
     parser.add_argument('--img-dir', type=str)
     parser.add_argument('--model', type=str, default='result/model_1000')
     parser.add_argument('--mscoco-root', type=str, default='data')
-    parser.add_argument('--rnn', type=str, default='lstm',
-                        choices=['lstm', 'nsteplstm'])
+    parser.add_argument('--rnn', type=str, default='nsteplstm',
+                        choices=['nsteplstm', 'lstm'])
     parser.add_argument('--gpu', type=int, default=0)
     parser.add_argument('--max-caption-length', type=int, default=30)
     args = parser.parse_args()

--- a/examples/image_captioning/predict.py
+++ b/examples/image_captioning/predict.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import glob
 import os
@@ -14,14 +15,21 @@ from model import ImageCaptionModel
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--img', type=str)
-    parser.add_argument('--img-dir', type=str)
-    parser.add_argument('--model', type=str, default='result/model_1000')
-    parser.add_argument('--mscoco-root', type=str, default='data')
+    parser.add_argument('--img', type=str,
+                        help='Image path')
+    parser.add_argument('--img-dir', type=str,
+                        help='Image directory path, instead of a single image')
+    parser.add_argument('--model', type=str, default='result/model_1000',
+                        help='Trained model path')
+    parser.add_argument('--mscoco-root', type=str, default='data',
+                        help='MSOCO dataset root directory')
     parser.add_argument('--rnn', type=str, default='nsteplstm',
-                        choices=['nsteplstm', 'lstm'])
-    parser.add_argument('--gpu', type=int, default=0)
-    parser.add_argument('--max-caption-length', type=int, default=30)
+                        choices=['nsteplstm', 'lstm'],
+                        help='Language model layer type')
+    parser.add_argument('--gpu', type=int, default=0,
+                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--max-caption-length', type=int, default=30,
+                        help='Maximum caption length generated')
     args = parser.parse_args()
 
     # Load the dataset to obtain the vocabulary, which is needed to convert

--- a/examples/image_captioning/predict.py
+++ b/examples/image_captioning/predict.py
@@ -1,0 +1,74 @@
+import argparse
+import glob
+import os
+
+import numpy as np
+from PIL import Image
+
+import chainer
+from chainer import serializers
+
+import datasets
+from model import ImageCaptionModel
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--img', type=str)
+    parser.add_argument('--img-dir', type=str)
+    parser.add_argument('--model', type=str, default='result/model_1000')
+    parser.add_argument('--mscoco-root', type=str, default='data')
+    parser.add_argument('--rnn', type=str, default='lstm',
+                        choices=['lstm', 'nsteplstm'])
+    parser.add_argument('--gpu', type=int, default=0)
+    parser.add_argument('--max-caption-length', type=int, default=30)
+    args = parser.parse_args()
+
+    # Load the dataset to obtain the vocabulary, which is needed to convert
+    # predicted tokens into actual words
+    train, _ = datasets.get_mscoco(args.mscoco_root)
+    vocab = train.vocab
+    ivocab = {v: k for k, v in vocab.items()}
+
+    model = ImageCaptionModel(len(train.vocab), rnn=args.rnn)
+    serializers.load_npz(args.model, model)
+
+    if args.img_dir:  # Read all images in directory
+        img_paths = [
+            i for i in glob.glob(os.path.join(args.img_dir, '*')) if
+            i.endswith(('png', 'jpg'))]
+        img_paths = sorted(img_paths)
+    else:  # Load a single image
+        img_paths = [args.img]
+
+    imgs = []
+    for img_path in img_paths:
+        img = Image.open(img_path)
+        img = model.prepare(img)
+        imgs.append(img)
+    imgs = np.asarray(imgs)
+
+    if args.gpu >= 0:
+        chainer.cuda.get_device_from_id(args.gpu).use()
+        model.to_gpu()
+        imgs = chainer.cuda.to_gpu(imgs)
+
+    bos = vocab['<bos>']
+    eos = vocab['<eos>']
+    with chainer.using_config('train', False), \
+            chainer.no_backprop_mode():
+        captions = model.predict(
+            imgs, bos=bos, eos=eos, max_caption_length=args.max_caption_length)
+    captions = chainer.cuda.to_cpu(captions)
+
+    # Print the predicted captions
+    file_names = [os.path.basename(path) for path in img_paths]
+    max_length = max(len(name) for name in file_names)
+    for file_name, caption in zip(file_names, captions):
+        caption = ' '.join(ivocab[token] for token in caption)
+        caption = caption.replace('<bos>', '').replace('<eos>', '').strip()
+        print(('{0:' + str(max_length) + '} {1}').format(file_name, caption))
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/image_captioning/predict.py
+++ b/examples/image_captioning/predict.py
@@ -41,6 +41,9 @@ def main():
     else:  # Load a single image
         img_paths = [args.img]
 
+    if not img_paths:
+        raise IOError('No images found for the given path')
+
     imgs = []
     for img_path in img_paths:
         img = Image.open(img_path)

--- a/examples/image_captioning/train.py
+++ b/examples/image_captioning/train.py
@@ -75,9 +75,10 @@ def main():
     train = TransformDataset(train, transform)
     val = TransformDataset(val, transform)
 
-    train_iter = iterators.SerialIterator(train, args.batch_size)
-    val_iter = chainer.iterators.SerialIterator(
-        val, args.batch_size, repeat=False, shuffle=False)
+    train_iter = iterators.MultiprocessIterator(
+        train, args.batch_size, shared_mem=700000)
+    val_iter = chainer.iterators.MultiprocessIterator(
+        val, args.batch_size, repeat=False, shuffle=False, shared_mem=700000)
 
     optimizer = optimizers.Adam()
     optimizer.setup(model)

--- a/examples/image_captioning/train.py
+++ b/examples/image_captioning/train.py
@@ -32,7 +32,7 @@ def main():
     parser.add_argument('--val-n-imgs', type=int, default=1000)
     parser.add_argument('--val-iter', type=int, default=100)
     parser.add_argument('--log-iter', type=int, default=1)
-    parser.add_argument('--snapshot-iter', type=int, default=100)
+    parser.add_argument('--snapshot-iter', type=int, default=1000)
     parser.add_argument('--rnn', type=str, default='lstm',
                         choices=['lstm', 'nsteplstm'])
     parser.add_argument('--gpu', type=int, default=0)

--- a/examples/image_captioning/train.py
+++ b/examples/image_captioning/train.py
@@ -1,11 +1,11 @@
 import argparse
 
 import chainer
-from chainer import optimizers
+from chainer.datasets import TransformDataset
 from chainer import iterators
+from chainer import optimizers
 from chainer import training
 from chainer.training import extensions
-from chainer.datasets import TransformDataset
 
 import datasets
 from model import ImageCaptionModel

--- a/examples/image_captioning/train.py
+++ b/examples/image_captioning/train.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 
 import chainer
@@ -13,19 +14,31 @@ from model import ImageCaptionModel
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--out', type=str, default='result')
-    parser.add_argument('--mscoco-root', type=str, default='data')
-    parser.add_argument('--max-iters', type=int, default=50000)
-    parser.add_argument('--batch-size', type=int, default=128)
-    parser.add_argument('--dropout-ratio', type=float, default=0.5)
-    parser.add_argument('--val-keep-quantity', type=int, default=100)
-    parser.add_argument('--val-iter', type=int, default=100)
-    parser.add_argument('--log-iter', type=int, default=1)
-    parser.add_argument('--snapshot-iter', type=int, default=1000)
+    parser.add_argument('--out', type=str, default='result',
+                        help='Output directory')
+    parser.add_argument('--mscoco-root', type=str, default='data',
+                        help='MSOCO dataset root directory')
+    parser.add_argument('--max-iters', type=int, default=50000,
+                        help='Maximum number of iterations to train')
+    parser.add_argument('--batch-size', type=int, default=128,
+                        help='Minibatch size')
+    parser.add_argument('--dropout-ratio', type=float, default=0.5,
+                        help='Language model dropout ratio')
+    parser.add_argument('--val-keep-quantity', type=int, default=100,
+                        help='Keep every N-th validation image')
+    parser.add_argument('--val-iter', type=int, default=100,
+                        help='Run validation every N-th iteration')
+    parser.add_argument('--log-iter', type=int, default=1,
+                        help='Log every N-th iteration')
+    parser.add_argument('--snapshot-iter', type=int, default=1000,
+                        help='Model snapshot every N-th iteration')
     parser.add_argument('--rnn', type=str, default='nsteplstm',
-                        choices=['nsteplstm', 'lstm'])
-    parser.add_argument('--gpu', type=int, default=0)
-    parser.add_argument('--max-caption-length', type=int, default=30)
+                        choices=['nsteplstm', 'lstm'],
+                        help='Language model layer type')
+    parser.add_argument('--gpu', type=int, default=0,
+                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--max-caption-length', type=int, default=30,
+                        help='Maxium caption length when using LSTM layer')
     args = parser.parse_args()
 
     # Load the MSCOCO dataset. Assumes that the dataset has been downloaded
@@ -57,9 +70,8 @@ def main():
         img = model.prepare(img)
         return img, caption
 
-    # Usually not required but we need to preprocess the images since their
-    # sizes may vary (and the model requires that they have the exact same
-    # fixed size)
+    # We need to preprocess the images since their sizes may vary (and the
+    # model requires that they have the exact same fixed size)
     train = TransformDataset(train, transform)
     val = TransformDataset(val, transform)
 

--- a/examples/image_captioning/train.py
+++ b/examples/image_captioning/train.py
@@ -33,8 +33,8 @@ def main():
     parser.add_argument('--val-iter', type=int, default=100)
     parser.add_argument('--log-iter', type=int, default=1)
     parser.add_argument('--snapshot-iter', type=int, default=1000)
-    parser.add_argument('--rnn', type=str, default='lstm',
-                        choices=['lstm', 'nsteplstm'])
+    parser.add_argument('--rnn', type=str, default='nsteplstm',
+                        choices=['nsteplstm', 'lstm'])
     parser.add_argument('--gpu', type=int, default=0)
     parser.add_argument('--max-caption-length', type=int, default=30)
     args = parser.parse_args()

--- a/examples/image_captioning/train.py
+++ b/examples/image_captioning/train.py
@@ -1,0 +1,141 @@
+import argparse
+
+import chainer
+from chainer import optimizers
+from chainer import iterators
+from chainer import training
+from chainer.training import extensions
+from chainer.datasets import TransformDataset
+
+import datasets
+from model import ImageCaptionModel
+
+
+class TestModeEvaluator(extensions.Evaluator):
+
+    """Evaluates the model on the validation dataset."""
+
+    def evaluate(self):
+        with chainer.using_config('train', False), \
+                chainer.no_backprop_mode():
+            ret = super(TestModeEvaluator, self).evaluate()
+        return ret
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--out', type=str, default='result')
+    parser.add_argument('--mscoco-root', type=str, default='data')
+    parser.add_argument('--max-iters', type=int, default=50000)
+    parser.add_argument('--batch-size', type=int, default=128)
+    parser.add_argument('--dropout-ratio', type=float, default=0.5)
+    parser.add_argument('--val-n-imgs', type=int, default=1000)
+    parser.add_argument('--val-iter', type=int, default=100)
+    parser.add_argument('--log-iter', type=int, default=1)
+    parser.add_argument('--snapshot-iter', type=int, default=100)
+    parser.add_argument('--rnn', type=str, default='lstm',
+                        choices=['lstm', 'nsteplstm'])
+    parser.add_argument('--gpu', type=int, default=0)
+    parser.add_argument('--max-caption-length', type=int, default=30)
+    args = parser.parse_args()
+
+    # Load the MSCOCO dataset. Assumes that the dataset has been downloaded
+    # already using e.g. the `download.py` script
+    train, val = datasets.get_mscoco(args.mscoco_root)
+
+    # Use any number of samples from the validation set for validation, using
+    # all of them is usually quite slow since the number of validation images
+    # are many
+    val = val[:args.val_n_imgs]
+
+    # Number of unique words that are found in the dataset
+    vocab_size = len(train.vocab)
+
+    # Instantiate the model to be trained either with LSTM layers or with
+    # NStepLSTM layers
+    model = ImageCaptionModel(
+        vocab_size, dropout_ratio=args.dropout_ratio, rnn=args.rnn)
+
+    if args.gpu >= 0:
+        chainer.cuda.get_device_from_id(args.gpu).use()
+        model.to_gpu()
+
+    def transform(in_data):
+        # Called for each sample and applies necessary preprocessing to the
+        # image such as resizing and normalizing
+        img, caption = in_data
+        img = model.prepare(img)
+        return img, caption
+
+    # Usually not required but we need to preprocess the images since their
+    # sizes may vary (and the model requires that they have the exact same
+    # fixed size)
+    train = TransformDataset(train, transform)
+    val = TransformDataset(val, transform)
+
+    train_iter = iterators.SerialIterator(train, args.batch_size)
+    val_iter = chainer.iterators.SerialIterator(
+        val, args.batch_size, repeat=False, shuffle=False)
+
+    optimizer = optimizers.Adam()
+    optimizer.setup(model)
+
+    def converter(batch, device):
+        # The converted receives a batch of input samples any may modify it if
+        # necessary. In our case, we need to align the captions depending on if
+        # we are using LSTM layers of NStepLSTM layers in the model.
+        if args.rnn == 'lstm':
+            max_caption_length = args.max_caption_length
+        elif args.rnn == 'nsteplstm':
+            max_caption_length = None
+        else:
+            raise ValueError('Invalid RNN type.')
+        return datasets.converter(
+            batch, device, max_caption_length=max_caption_length)
+
+    updater = training.updater.StandardUpdater(
+        train_iter, optimizer=optimizer, device=args.gpu, converter=converter)
+
+    trainer = training.Trainer(
+        updater, out=args.out, stop_trigger=(args.max_iters, 'iteration'))
+    trainer.extend(
+        TestModeEvaluator(
+            val_iter, model,
+            eval_func=model,
+            converter=converter,
+            device=args.gpu
+        ),
+        trigger=(args.val_iter, 'iteration')
+    )
+    trainer.extend(
+        extensions.LogReport(
+            ['main/loss', 'validation/main/loss'],
+            trigger=(args.log_iter, 'iteration')
+        )
+    )
+    trainer.extend(
+        extensions.PlotReport(
+            ['main/loss', 'validation/main/loss'],
+            trigger=(args.log_iter, 'iteration')
+        )
+    )
+    trainer.extend(
+        extensions.PrintReport(
+            ['elapsed_time', 'epoch', 'iteration', 'main/loss',
+             'validation/main/loss']
+        ),
+        trigger=(args.log_iter, 'iteration')
+    )
+
+    # Save model snapshots so that later on, we can load them and generate new
+    # captions for any image. This can be done in the `predict.py` script
+    trainer.extend(
+        extensions.snapshot_object(model, 'model_{.updater.iteration}'),
+        trigger=(args.snapshot_iter, 'iteration')
+    )
+    trainer.extend(extensions.ProgressBar())
+    trainer.run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds an image captioning example with MSCOCO downloader/wrapper.

This implementation includes two variations of the model, one using traditional `LSTM` layers and another one using `NStepLSTM` layers.

Please feel free to comment.

~- [ ] Add beam search.~ (See in #4089 )
- [x] Fix docs and clean up the code.
- [x] Add README.