### PR TITLE
Fix optimizer AttributeError with new optimizer setup

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -528,9 +528,9 @@ class GradientMethod(Optimizer):
     def __init__(self, link=None):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
+        self._use_fp32_update = False
         if isinstance(link, link_module.Link):
             self.setup(link)
-        self._use_fp32_update = False
 
     def setup(self, link):
         super(GradientMethod, self).setup(link)


### PR DESCRIPTION
Fix AttributeError caused by `_use_fp32_update ` not being set when initializing an optimizer with a model passed as a constructor argument.