### PR TITLE
Fix test failure with cuDNN v6

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -348,7 +348,9 @@ class Convolution2DGradW(function_node.FunctionNode):
 
         if (not self.cover_all and chainer.should_use_cudnn('>=auto') and
                 x.dtype == self.W_dtype and
-                ((self.dy == 1 and self.dx == 1) or _cudnn_version >= 6000) and
+                ((self.dy == 1 and self.dx == 1)
+                     or (_cudnn_version >= 6000
+                         and not configuration.config.cudnn_deterministic)) and
                 _gc_use_cudnn):
 
             # cuDNN implementation

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -348,9 +348,9 @@ class Convolution2DGradW(function_node.FunctionNode):
 
         if (not self.cover_all and chainer.should_use_cudnn('>=auto') and
                 x.dtype == self.W_dtype and
-                ((self.dy == 1 and self.dx == 1)
-                     or (_cudnn_version >= 6000
-                         and not configuration.config.cudnn_deterministic)) and
+                ((self.dy == 1 and self.dx == 1) or
+                    (_cudnn_version >= 6000
+                     and not configuration.config.cudnn_deterministic)) and
                 _gc_use_cudnn):
 
             # cuDNN implementation

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -33,7 +33,7 @@ from chainer.testing import condition
 }) + testing.product({
     'c_contiguous': [False],
     'cover_all': [False],
-    'cudnn_deterministic': [False],
+    'cudnn_deterministic': [True, False],
     'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'dilate': [2],


### PR DESCRIPTION
It seems that cuDNN v6 does not support backward computation of dilated convolution when deterministic algorithm (`CUDNN_CONVOLUTION_BWD_DATA_ALGO_1`) is selected.