### PR TITLE
optimize rsqrt function with CuPy

### DIFF
--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -56,7 +56,7 @@ class Rsqrt(function_node.FunctionNode):
     def backward(self, indexes, grad_outputs):
         x, = self.get_retained_inputs()
         gy, = grad_outputs
-        return - gy * (x ** -1.5) / 2.0,
+        return gy * (x ** -1.5) * -0.5,
 
 
 def sqrt(x):

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -56,7 +56,7 @@ class Rsqrt(function_node.FunctionNode):
     def backward(self, indexes, grad_outputs):
         x, = self.get_retained_inputs()
         gy, = grad_outputs
-        return - gy / (2.0 * (x ** 1.5)),
+        return - gy * (x ** -1.5) / 2.0,
 
 
 def sqrt(x):

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -50,7 +50,7 @@ class Rsqrt(function_node.FunctionNode):
             out = xp.reciprocal(xp.sqrt(x, dtype=dtype), dtype=dtype)
         else:
             # CuPy provides `rsqrt` which is faster than `1.0 / sqrt(x)`.
-            out = xp.ext.rsqrt(x, dtype=dtype)
+            out = cuda.cupyx.rsqrt(x, dtype=dtype)
         return utils.force_array(out),
 
     def backward(self, indexes, grad_outputs):

--- a/chainer/functions/math/sqrt.py
+++ b/chainer/functions/math/sqrt.py
@@ -1,3 +1,5 @@
+import numpy
+
 from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
@@ -25,6 +27,36 @@ class Sqrt(function_node.FunctionNode):
         gx = self.get_retained_outputs()[0]
         gy = grad_outputs[0]
         return gy / (gx * 2.0),
+
+
+class Rsqrt(function_node.FunctionNode):
+
+    @property
+    def label(self):
+        return 'rsqrt'
+
+    def check_type_forward(self, in_types):
+        type_check.expect(
+            in_types.size() == 1,
+            in_types[0].dtype.kind == 'f',
+        )
+
+    def forward(self, inputs):
+        self.retain_inputs((0,))
+        x, = inputs
+        xp = cuda.get_array_module(x)
+        dtype = x.dtype
+        if xp is numpy:
+            out = xp.reciprocal(xp.sqrt(x, dtype=dtype), dtype=dtype)
+        else:
+            # CuPy provides `rsqrt` which is faster than `1.0 / sqrt(x)`.
+            out = xp.ext.rsqrt(x, dtype=dtype)
+        return utils.force_array(out),
+
+    def backward(self, indexes, grad_outputs):
+        x, = self.get_retained_inputs()
+        gy, = grad_outputs
+        return - gy / (2.0 * (x ** 1.5)),
 
 
 def sqrt(x):
@@ -59,4 +91,4 @@ def rsqrt(x):
 
     .. seealso:: :func:`~chainer.functions.sqrt`
     """
-    return 1.0 / sqrt(x)
+    return Rsqrt().apply((x,))[0]

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -35,7 +35,7 @@ def rsqrt(x, dtype):
     F.rsqrt,
     func_expected=rsqrt,
     make_data=make_data,
-    forward_options={'atol': 1e-3},
+    forward_options={'atol': 1e-2},
     backward_options={'eps': 1e-2, 'atol': 1e-2, 'rtol': 1e-2},
     double_backward_options={'eps': 1e-2, 'atol': 1e-1, 'rtol': 1e-1},
 )

--- a/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sqrt.py
@@ -27,15 +27,20 @@ class TestSqrt(unittest.TestCase):
 
 # rsqrt
 
-def rsqrt(x):
-    return numpy.reciprocal(numpy.sqrt(x))
+def rsqrt(x, dtype):
+    return numpy.reciprocal(numpy.sqrt(x, dtype=dtype), dtype=dtype)
 
 
+@testing.unary_math_function_unittest(
+    F.rsqrt,
+    func_expected=rsqrt,
+    make_data=make_data,
+    forward_options={'atol': 1e-3},
+    backward_options={'eps': 1e-2, 'atol': 1e-2, 'rtol': 1e-2},
+    double_backward_options={'eps': 1e-2, 'atol': 1e-1, 'rtol': 1e-1},
+)
 class TestRsqrt(unittest.TestCase):
-
-    def test_rsqrt(self):
-        x = numpy.random.uniform(0.1, 5, (3, 2)).astype(numpy.float32)
-        testing.assert_allclose(F.rsqrt(x).data, rsqrt(x))
+    pass
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR optimizes `F.rsqrt` with `cupy.ext.rsqrt`.
Fixes #4092. Depends on https://github.com/cupy/cupy/pull/846.

Tests (backward / double_backward) are confirmed to pass 10,000 repeats.