### PR TITLE
New style ConvolutionND/DeconvolutionND

### DIFF
--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -5,7 +5,8 @@ from six import moves
 import chainer
 from chainer.backends import cuda
 from chainer import configuration
-from chainer import function
+from chainer import function_node
+import chainer.functions
 from chainer.functions.connection import convolution_2d
 from chainer.utils import conv
 from chainer.utils import conv_nd
@@ -23,7 +24,7 @@ if cuda.cudnn_enabled:
         libcudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT
 
 
-class ConvolutionND(function.Function):
+class ConvolutionND(function_node.FunctionNode):
 
     def __init__(self, ndim, stride=1, pad=0, cover_all=False):
         self.ndim = ndim
@@ -66,15 +67,15 @@ class ConvolutionND(function.Function):
 
         # Make patch array.
         if xp is numpy:
-            self.col = conv_nd.im2col_nd_cpu(
+            col = conv_nd.im2col_nd_cpu(
                 x, ksize, stride, pad, cover_all=self.cover_all)
         else:
-            self.col = conv_nd.im2col_nd_gpu(
+            col = conv_nd.im2col_nd_gpu(
                 x, ksize, stride, pad, cover_all=self.cover_all)
 
         # Compute correlation.
         axes = tuple(moves.range(1, ndim + 2))  # (1, 2, ..., N+1)
-        y = xp.tensordot(self.col, W, (axes, axes)).astype(x.dtype, copy=False)
+        y = xp.tensordot(col, W, (axes, axes)).astype(x.dtype, copy=False)
 
         # Apply bias if given.
         if b is not None:
@@ -152,6 +153,7 @@ class ConvolutionND(function.Function):
         return y,
 
     def forward(self, inputs):
+        self.retain_inputs((0, 1))  # retain only x and W
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
@@ -173,17 +175,64 @@ class ConvolutionND(function.Function):
         else:
             return self._forward_cudnn(x, W, b)
 
-    def _backward_xp(self, x, W, b, gy, xp):
-        dims = x.shape[2:]     # (n, c_I, d_1, d_2, ..., d_N)
-        stride = self.stride
-        pad = self.pad
-        ndim = self.ndim
+    def backward(self, indexes, grad_outputs):
+        x, W = self.get_retained_inputs()
+        gy, = grad_outputs
 
+        ret = []
+        if 0 in indexes:
+            x_shape = x.shape[2:]
+            gx = chainer.functions.deconvolution_nd(
+                gy, W, stride=self.stride, pad=self.pad, outsize=x_shape)
+            ret.append(gx)
+        if 1 in indexes:
+            gW, = ConvolutionNDGradW(self).apply((x, gy))
+            ret.append(gW)
+        if 2 in indexes:
+            axis = (0,) + tuple(moves.range(2, gy.ndim))
+            gb = chainer.functions.sum(gy, axis=axis)
+            ret.append(gb)
+
+        return ret
+
+
+class ConvolutionNDGradW(function_node.FunctionNode):
+
+    def __init__(self, convnd):
+        W_node = convnd.inputs[1]
+        self.ndim = convnd.ndim
+        self.ksize = W_node.shape[2:]
+        self.stride = convnd.stride
+        self.pad = convnd.pad
+        self.cover_all = convnd.cover_all
+        self.W_dtype = W_node.dtype
+
+    def _use_cudnn(self, x, gy):
+        return (
+            chainer.should_use_cudnn('>=auto')
+            and not self.cover_all
+            and x.dtype == self.W_dtype
+            and gy.dtype == self.W_dtype
+            and self.ndim > 1)
+
+    def forward(self, inputs):
+        self.retain_inputs((0, 1))
+        x, gy = inputs
+
+        xp = cuda.get_array_module(*inputs)
+        if xp is numpy:
+            return self._forward_xp(x, gy, numpy)
+        elif not self._use_cudnn(x, gy):
+            return self._forward_xp(x, gy, cuda.cupy)
+        else:
+            return self._forward_cudnn(x, gy)
+
+    def _forward_xp(self, x, gy, xp):
         # Compute filter weight gradient.
         # (n, _, out_1, out_2, ..., out_N)
-        out_axes = (0,) + tuple(moves.range(2, ndim + 2))
+        out_axes = (0,) + tuple(moves.range(2, self.ndim + 2))
         # (n, _, _, ..., _, out_1, out_2, ..., out_N)
-        col_axes = (0,) + tuple(moves.range(ndim + 2, ndim * 2 + 2))
+        col_axes = (0,) + tuple(moves.range(self.ndim + 2, self.ndim * 2 + 2))
 
         # NumPy raises an error when the array is not contiguous.
         # See: https://github.com/chainer/chainer/issues/2744
@@ -193,100 +242,82 @@ class ConvolutionND(function.Function):
                 1 in gy.shape):
             gy = numpy.ascontiguousarray(gy)
 
-        gW = xp.tensordot(gy, self.col, (out_axes, col_axes)).astype(
-            W.dtype, copy=False)
-
-        # Compute patch array gradient.
-        gcol = xp.tensordot(W, gy, (0, 1)).astype(x.dtype, copy=False)
-        gcol = xp.rollaxis(gcol, ndim + 1)
-
-        # Compute input gradient.
         if xp is numpy:
-            gx = conv_nd.col2im_nd_cpu(gcol, stride, pad, dims)
+            col = conv_nd.im2col_nd_cpu(
+                x, self.ksize, self.stride, self.pad, cover_all=self.cover_all)
         else:
-            gx = conv_nd.col2im_nd_gpu(gcol, stride, pad, dims)
+            col = conv_nd.im2col_nd_gpu(
+                x, self.ksize, self.stride, self.pad, cover_all=self.cover_all)
+        gW = xp.tensordot(gy, col, (out_axes, col_axes)).astype(
+            self.W_dtype, copy=False)
+        return gW,
 
-        # Compute bias gradient if given and return gradients.
-        if b is None:
-            return gx, gW
-        else:
-            # (n, _, out_1, out_2, ..., out_N)
-            axis = (0,) + tuple(moves.range(2, ndim + 2))
-            gb = gy.sum(axis=axis)
-            return gx, gW, gb
-
-    def _backward_cudnn(self, x, W, b, gy):
+    def _forward_cudnn(self, x, gy):
         # Convert to C-contiguous arrays.
         x = cuda.cupy.ascontiguousarray(x)
-        W = cuda.cupy.ascontiguousarray(W)
         gy = cuda.cupy.ascontiguousarray(gy)
 
         # Make empty arrays for result.
-        gx = cuda.cupy.empty_like(x)
-        gW = cuda.cupy.empty_like(W)
+        out_c = gy.shape[1]
+        in_c = x.shape[1]
+        gW = cuda.cupy.empty(
+            (out_c, in_c) + self.ksize, dtype=self.W_dtype)
 
         # Get cuDNN handler and descriptors.
+        use_tensor_core = chainer.should_use_cudnn_tensor_core(x.dtype)
+
         handle = cudnn.get_handle()
         x_desc = cudnn.create_tensor_descriptor(x)
         gy_desc = cudnn.create_tensor_descriptor(gy)
+
+        filter_desc = cudnn.create_filter_descriptor(gW)
+        conv_param = (self.pad, self.stride, self.W_dtype)
+        conv_desc = cudnn.create_convolution_descriptor(
+            *conv_param, use_tensor_core=use_tensor_core)
 
         # Compute gradients.
         oz_dtype = 'd' if x.dtype == 'd' else 'f'
         one = numpy.array(1, dtype=oz_dtype).ctypes
         zero = numpy.array(0, dtype=oz_dtype).ctypes
+
         workspace_size = cuda.get_max_workspace_size()
         workspace = cuda.cupy.empty((workspace_size,), dtype='b')
 
         # Compute filter weight gradient.
         if configuration.config.autotune and _cudnn_version_ >= 5000:
             algo = convolution_2d._get_algorithm_bwd_filter(
-                x, gy, gW, self.conv_param, handle, x_desc, gy_desc,
-                self.conv_desc, self.filter_desc, workspace)
+                x, gy, gW, conv_param, handle, x_desc, gy_desc,
+                conv_desc, filter_desc, workspace)
         else:
             algo = libcudnn.getConvolutionBackwardFilterAlgorithm(
-                handle, x_desc.value, gy_desc.value, self.conv_desc.value,
-                self.filter_desc.value, _bwd_filter_pref, workspace_size)
+                handle, x_desc.value, gy_desc.value, conv_desc.value,
+                filter_desc.value, _bwd_filter_pref, workspace_size)
 
         libcudnn.convolutionBackwardFilter_v3(
             handle, one.data, x_desc.value, x.data.ptr,
-            gy_desc.value, gy.data.ptr, self.conv_desc.value,
+            gy_desc.value, gy.data.ptr, conv_desc.value,
             algo, workspace.data.ptr, workspace_size,
-            zero.data, self.filter_desc.value, gW.data.ptr)
+            zero.data, filter_desc.value, gW.data.ptr)
 
-        # Compute input gradient.
-        algo = libcudnn.getConvolutionBackwardDataAlgorithm(
-            handle, self.filter_desc.value, gy_desc.value,
-            self.conv_desc.value, x_desc.value, _bwd_data_pref,
-            workspace_size)
-        libcudnn.convolutionBackwardData_v3(
-            handle, one.data, self.filter_desc.value, W.data.ptr,
-            gy_desc.value, gy.data.ptr, self.conv_desc.value,
-            algo, workspace.data.ptr, workspace_size,
-            zero.data, x_desc.value, gx.data.ptr)
+        return gW,
 
-        # Compute bias gradient if given and return gradients.
-        if b is None:
-            return gx, gW
-        else:
-            gb = cuda.cupy.empty_like(b)
-            libcudnn.convolutionBackwardBias(
-                handle, one.data, gy_desc.value, gy.data.ptr,
-                zero.data, self.bias_desc.value, gb.data.ptr)
-            return gx, gW, gb
+    def backward(self, indexes, grad_outputs):
+        x, gy = self.get_retained_inputs()
+        ggW, = grad_outputs
 
-    def backward(self, inputs, grad_outputs):
-        x, W = inputs[:2]
-        b = inputs[2] if len(inputs) == 3 else None
+        ret = []
+        if 0 in indexes:
+            x_shape = x.shape[2:]
+            gx = chainer.functions.deconvolution_nd(
+                gy, ggW, stride=self.stride, pad=self.pad, outsize=x_shape)
+            ret.append(gx)
+        if 1 in indexes:
+            ggy = convolution_nd(
+                x, ggW, stride=self.stride, pad=self.pad,
+                cover_all=self.cover_all)
+            ret.append(ggy)
 
-        gy = grad_outputs[0]    # (n, c_O, out_1, out_2, ..., out_N)
-
-        xp = cuda.get_array_module(*inputs)
-        if xp is numpy:
-            return self._backward_xp(x, W, b, gy, numpy)
-        elif not self._use_cudnn(x, W):
-            return self._backward_xp(x, W, b, gy, cuda.cupy)
-        else:
-            return self._backward_cudnn(x, W, b, gy)
+        return ret
 
 
 def convolution_nd(x, W, b=None, stride=1, pad=0, cover_all=False):
@@ -416,8 +447,7 @@ def convolution_nd(x, W, b=None, stride=1, pad=0, cover_all=False):
 
     """
     ndim = len(x.shape[2:])
-    func = ConvolutionND(ndim, stride, pad, cover_all)
-    if b is None:
-        return func(x, W)
-    else:
-        return func(x, W, b)
+    fnode = ConvolutionND(ndim, stride, pad, cover_all)
+    args = (x, W) if b is None else (x, W, b)
+    y, = fnode.apply(args)
+    return y

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -6,7 +6,6 @@ import chainer
 from chainer.backends import cuda
 from chainer import configuration
 from chainer import function_node
-import chainer.functions
 from chainer.functions.connection import convolution_2d
 from chainer.utils import conv
 from chainer.utils import conv_nd

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -4,7 +4,8 @@ import six
 import chainer
 from chainer.backends import cuda
 from chainer import configuration
-from chainer import function
+from chainer import function_node
+from chainer.functions.connection import convolution_nd
 from chainer.functions.connection import deconvolution_2d
 from chainer.utils import conv
 from chainer.utils import conv_nd
@@ -22,7 +23,9 @@ if cuda.cudnn_enabled:
         libcudnn.CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT
 
 
-class DeconvolutionND(function.Function):
+class DeconvolutionND(function_node.FunctionNode):
+
+    cover_all = None
 
     def __init__(self, ndim, stride=1, pad=0, outsize=None):
         self.ndim = ndim
@@ -48,10 +51,13 @@ class DeconvolutionND(function.Function):
         if self.outs is not None:
             for i, (out, s, p) in enumerate(zip(
                     self.outs, self.stride, self.pad)):
+                lower_bound = conv.get_conv_outsize(
+                    out, w_type.shape[i + 2], s, p)
+                upper_bound = conv.get_conv_outsize(
+                    out, w_type.shape[i + 2], s, p, cover_all=True)
                 type_check.expect(
-                    x_type.shape[i + 2] ==
-                    conv.get_conv_outsize(out, w_type.shape[i + 2], s, p)
-                )
+                    lower_bound <= x_type.shape[i + 2],
+                    x_type.shape[i + 2] <= upper_bound)
 
         if type_check.eval(n_in) == 3:
             b_type = in_types[2]
@@ -62,13 +68,14 @@ class DeconvolutionND(function.Function):
             )
 
     def _use_cudnn(self, x, W):
-        return (chainer.should_use_cudnn('>=auto') and
-                self.ndim > 1 and x.dtype == W.dtype)
+        return (
+            chainer.should_use_cudnn('>=auto')
+            and not self.cover_all
+            and self.ndim > 1
+            and x.dtype == W.dtype)
 
     def _forward_xp(self, x, W, b, xp):
         ndim = self.ndim
-        ksize = W.shape[2:]     # W: C_I, C_O, k_1, k_2, ..., k_N
-        dims = x.shape[2:]      # x: n, C_I, d_1, d_2, ..., d_N
         stride = self.stride
         pad = self.pad
 
@@ -77,12 +84,6 @@ class DeconvolutionND(function.Function):
         # Roll n, which is batch size, before the first.
         gcol = xp.rollaxis(gcol, ndim + 1)
 
-        if self.outs is None:
-            self.outs = tuple(
-                conv.get_deconv_outsize(d, k, s, p)
-                for d, k, s, p in zip(dims, ksize, stride, pad))
-            assert all(out > 0 for out in self.outs), \
-                'Output sizes should be positive.'
         # y: n, C_O, d_1, d_2, ..., d_N
         if xp is numpy:
             y = conv_nd.col2im_nd_cpu(gcol, stride, pad, self.outs)
@@ -96,19 +97,11 @@ class DeconvolutionND(function.Function):
 
     def _forward_cudnn(self, x, W, b):
         c = W.shape[1]          # W: C_I, C_O, k_1, k_2, ..., k_N
-        ksize = W.shape[2:]
         n, in_c = x.shape[:2]   # x: n, C_I, d_1, d_2, ..., d_N
-        dims = x.shape[2:]
         ndim = self.ndim
         colon = slice(None)
 
         # Make empty array for output.
-        if self.outs is None:
-            self.outs = tuple(
-                conv.get_deconv_outsize(d, k, s, p)
-                for d, k, s, p in zip(dims, ksize, self.stride, self.pad))
-            assert all(out > 0 for out in self.outs), \
-                'Output sizes should be positive.'
         y_shape = (n, c) + self.outs  # (n, c_O, out_1, out_2, ..., out_N)
         y = cuda.cupy.empty(y_shape, dtype=x.dtype)
 
@@ -162,6 +155,7 @@ class DeconvolutionND(function.Function):
         return y,
 
     def forward(self, inputs):
+        self.retain_inputs((0, 1))  # only retain x and W
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
@@ -174,6 +168,16 @@ class DeconvolutionND(function.Function):
                 raise ValueError('numpy and cupy must not be used together\n'
                                  'type(W): {0}, type(x): {1}'
                                  .format(type(W), type(x)))
+
+        if self.outs is None:
+            dims = x.shape[2:]
+            ksize = W.shape[2:]
+            self.outs = tuple(
+                conv.get_deconv_outsize(d, k, s, p)
+                for d, k, s, p in zip(dims, ksize, self.stride, self.pad))
+            assert all(out > 0 for out in self.outs), \
+                'Output sizes should be positive.'
+        self._set_cover_all(x, W)
 
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:
@@ -272,19 +276,33 @@ class DeconvolutionND(function.Function):
         else:
             return gx, gW, gb
 
-    def backward(self, inputs, grad_outputs):
-        x, W = inputs[:2]
-        b = inputs[2] if len(inputs) == 3 else None
+    def backward(self, indexes, grad_outputs):
+        x, W = self.get_retained_inputs()
+        gy, = grad_outputs
 
-        gy = grad_outputs[0]
+        ret = []
+        if 0 in indexes:
+            gx = chainer.functions.convolution_nd(
+                gy, W, stride=self.stride, pad=self.pad,
+                cover_all=self.cover_all)
+            ret.append(gx)
+        if 1 in indexes:
+            gW, = convolution_nd.ConvolutionNDGradW(self).apply((gy, x))
+            ret.append(gW)
+        if 2 in indexes:
+            axis = (0,) + tuple(six.moves.range(2, gy.ndim))
+            gb = chainer.functions.sum(gy, axis=axis)
+            ret.append(gb)
 
-        xp = cuda.get_array_module(*inputs)
-        if xp is numpy:
-            return self._backward_xp(x, W, b, gy, numpy)
-        elif self._use_cudnn(x, W):
-            return self._backward_cudnn(x, W, b, gy)
-        else:
-            return self._backward_xp(x, W, b, gy, cuda.cupy)
+        return ret
+
+    def _set_cover_all(self, x, W):
+        x_shape = x.shape[2:]
+        k_shape = W.shape[2:]
+        self.cover_all = any(
+            ix != conv.get_conv_outsize(oy, k, s, p)
+            for (ix, oy, k, s, p)
+            in zip(x_shape, self.outs, k_shape, self.stride, self.pad))
 
 
 def deconvolution_nd(x, W, b=None, stride=1, pad=0, outsize=None):
@@ -431,7 +449,6 @@ pad=(p1, p2, p3), outsize=(l1, l2, l3))
     """
     ndim = len(x.shape[2:])
     func = DeconvolutionND(ndim, stride, pad, outsize)
-    if b is None:
-        return func(x, W)
-    else:
-        return func(x, W, b)
+    args = (x, W) if b is None else (x, W, b)
+    y, = func.apply(args)
+    return y

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -7,8 +7,7 @@ from operator import mul
 
 import chainer
 from chainer import cuda
-from chainer import functions
-from chainer.functions.connection import convolution_nd
+import chainer.functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
@@ -61,11 +60,18 @@ class TestConvolutionND(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 2 ** -4, 'rtol': 2 ** -4}
 
+        self.ggx = numpy.random.uniform(-1, 1, self.x.shape).astype(
+            self.x_dtype)
+        self.ggW = numpy.random.uniform(-1, 1, self.W.shape).astype(
+            self.W_dtype)
+        self.ggb = numpy.random.uniform(-1, 1, self.b.shape).astype(
+            self.x_dtype)
+
     def check_forward_consistency(self, nobias=False, use_cudnn='never'):
         x_cpu = chainer.Variable(self.x)
         W_cpu = chainer.Variable(self.W)
         b_cpu = None if nobias else chainer.Variable(self.b)
-        y_cpu = functions.convolution_nd(
+        y_cpu = F.convolution_nd(
             x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
             cover_all=self.cover_all)
 
@@ -74,7 +80,7 @@ class TestConvolutionND(unittest.TestCase):
         b_gpu = None if nobias else chainer.Variable(cuda.to_gpu(self.b))
         with chainer.using_config('use_cudnn', use_cudnn):
             with chainer.using_config('autotune', self.autotune):
-                y_gpu = functions.convolution_nd(
+                y_gpu = F.convolution_nd(
                     x_gpu, W_gpu, b_gpu, stride=self.stride, pad=self.pad,
                     cover_all=self.cover_all)
 
@@ -103,10 +109,10 @@ class TestConvolutionND(unittest.TestCase):
         b = None if nobias else chainer.Variable(self.b)
 
         with chainer.using_config('use_cudnn', 'never'):
-            y_nd = functions.convolution_nd(
+            y_nd = F.convolution_nd(
                 x, W, b, stride=self.stride, pad=self.pad,
                 cover_all=self.cover_all)
-            y_2d = functions.convolution_2d(
+            y_2d = F.convolution_2d(
                 x, W, b, stride=self.stride, pad=self.pad,
                 cover_all=self.cover_all)
 
@@ -143,13 +149,15 @@ class TestConvolutionND(unittest.TestCase):
         if b_data is not None:
             args = args + (b_data,)
 
-        ndim = len(self.dims)
+        def f(*args):
+            return F.convolution_nd(
+                *args, stride=self.stride, pad=self.pad,
+                cover_all=self.cover_all)
+
         with chainer.using_config('use_cudnn', use_cudnn):
             with chainer.using_config('autotune', self.autotune):
                 gradient_check.check_backward(
-                    convolution_nd.ConvolutionND(
-                        ndim, self.stride, self.pad, self.cover_all),
-                    args, y_grad, **self.check_backward_options)
+                    f, args, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -187,6 +195,91 @@ class TestConvolutionND(unittest.TestCase):
                             None, cuda.to_gpu(self.gy),
                             use_cudnn='never')
 
+    def check_double_backward(self, x_data, W_data, b_data, y_grad,
+                              x_grad_grad, W_grad_grad, b_grad_grad,
+                              use_cudnn='always'):
+        xp = cuda.get_array_module(x_data)
+
+        if not self.c_contiguous:
+            x_data = xp.asfortranarray(x_data)
+            W_data = xp.asfortranarray(W_data)
+            y_grad = xp.asfortranarray(y_grad)
+            x_grad_grad = xp.asfortranarray(x_grad_grad)
+            W_grad_grad = xp.asfortranarray(W_grad_grad)
+            self.assertFalse(x_data.flags.c_contiguous)
+            self.assertFalse(W_data.flags.c_contiguous)
+            self.assertFalse(y_grad.flags.c_contiguous)
+            self.assertFalse(x_grad_grad.flags.c_contiguous)
+            self.assertFalse(W_grad_grad.flags.c_contiguous)
+            if b_data is not None:
+                b = xp.empty((len(b_data) * 2,), dtype=self.b.dtype)
+                b[::2] = b_data
+                b_data = b[::2]
+                self.assertFalse(b_data.flags.c_contiguous)
+
+                ggb = xp.empty((len(b_data) * 2,), dtype=self.b.dtype)
+                ggb[::2] = b_grad_grad
+                b_grad_grad = ggb[::2]
+                self.assertFalse(b_grad_grad.flags.c_contiguous)
+
+        args = (x_data, W_data)
+        grad_grads = (x_grad_grad, W_grad_grad)
+        if b_data is not None:
+            args = args + (b_data,)
+            grad_grads = grad_grads + (b_grad_grad,)
+
+        def f(*args):
+            y = F.convolution_nd(*args, stride=self.stride, pad=self.pad,
+                                 cover_all=self.cover_all)
+            return y * y  # make the function nonlinear
+
+        with chainer.using_config('use_cudnn', use_cudnn):
+            with chainer.using_config('autotune', self.autotune):
+                gradient_check.check_double_backward(
+                    f, args, y_grad, grad_grads,
+                    dtype='d', atol=5e-3, rtol=5e-2)
+
+    @condition.retry(3)
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.W, self.b, self.gy,
+                                   self.ggx, self.ggW, self.ggb,
+                                   use_cudnn='always')
+
+    @condition.retry(3)
+    def test_double_backward_cpu_nobias(self):
+        self.check_double_backward(self.x, self.W, None, self.gy,
+                                   self.ggx, self.ggW, None,
+                                   use_cudnn='always')
+
+    def check_double_backward_gpu(self, bias=True, im2col=False):
+        use_cudnn = 'never' if im2col else 'always'
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.W),
+            cuda.to_gpu(self.b) if bias else None,
+            cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx), cuda.to_gpu(self.ggW),
+            cuda.to_gpu(self.ggb) if bias else None,
+            use_cudnn=use_cudnn)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu(self):
+        self.check_double_backward_gpu()
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu_nobias(self):
+        self.check_double_backward_gpu(bias=False)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu_im2col(self):
+        self.check_double_backward_gpu(im2col=True)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu_im2col_nobias(self):
+        self.check_double_backward_gpu(bias=False, im2col=True)
+
 
 @testing.parameterize(*testing.product({
     'dims': [(10,), (10, 8), (10, 8, 6)],
@@ -219,7 +312,7 @@ class TestConvolutionNDCudnnCall(unittest.TestCase):
     def forward(self):
         x = chainer.Variable(cuda.to_gpu(self.x))
         W = chainer.Variable(cuda.to_gpu(self.W))
-        return functions.convolution_nd(
+        return F.convolution_nd(
             x, W, None, stride=self.stride, pad=self.pad)
 
     def test_call_cudnn_forward(self):
@@ -253,12 +346,12 @@ class TestConvolutionNDarraySupplied(unittest.TestCase):
         self.b_data = numpy.random.uniform(-1, 1, out_channels).astype(dtype)
 
     def check_array_supplied(self, x_ary, W_ary, b_ary):
-        y_ary = functions.convolution_nd(x_ary, W_ary, b_ary)
+        y_ary = F.convolution_nd(x_ary, W_ary, b_ary)
 
         x_var = chainer.Variable(x_ary)
         W_var = chainer.Variable(W_ary)
         b_var = chainer.Variable(b_ary)
-        y_var = functions.convolution_nd(x_var, W_var, b_var)
+        y_var = F.convolution_nd(x_var, W_var, b_var)
 
         testing.assert_allclose(y_ary.data, y_var.data)
 
@@ -288,8 +381,8 @@ class TestConvolutionNDBackwardNoncontiguousGradOutputs(unittest.TestCase):
         w_shape = (out_channels, in_channels, 3)
         x = numpy.ones(x_shape, numpy.float32)
         w = numpy.ones(w_shape, numpy.float32)
-        y = functions.convolution_nd(chainer.Variable(x), w)
-        z = functions.sum(y)
+        y = F.convolution_nd(chainer.Variable(x), w)
+        z = F.sum(y)
         z.backward()
 
     def test_2(self):
@@ -300,8 +393,8 @@ class TestConvolutionNDBackwardNoncontiguousGradOutputs(unittest.TestCase):
         w_shape = (out_channels, in_channels, 3)
         x = numpy.ones(x_shape, numpy.float32)
         w = numpy.ones(w_shape, numpy.float32)
-        y = functions.convolution_nd(x, chainer.Variable(w))
-        z = functions.sum(y)
+        y = F.convolution_nd(x, chainer.Variable(w))
+        z = F.sum(y)
         z.backward()
 
 

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -147,7 +147,7 @@ class TestConvolutionND(unittest.TestCase):
 
         args = (x_data, W_data)
         if b_data is not None:
-            args = args + (b_data,)
+            args += (b_data,)
 
         def f(*args):
             return F.convolution_nd(
@@ -225,8 +225,8 @@ class TestConvolutionND(unittest.TestCase):
         args = (x_data, W_data)
         grad_grads = (x_grad_grad, W_grad_grad)
         if b_data is not None:
-            args = args + (b_data,)
-            grad_grads = grad_grads + (b_grad_grad,)
+            args += (b_data,)
+            grad_grads += (b_grad_grad,)
 
         def f(*args):
             y = F.convolution_nd(*args, stride=self.stride, pad=self.pad,

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -169,7 +169,7 @@ class TestDeconvolutionND(unittest.TestCase):
 
         args = (x_data, W_data)
         if b_data is not None:
-            args = args + (b_data,)
+            args += (b_data,)
 
         def f(*args):
             return F.deconvolution_nd(*args, stride=self.stride, pad=self.pad,
@@ -232,8 +232,8 @@ class TestDeconvolutionND(unittest.TestCase):
         args = (x_data, W_data)
         grad_grads = (x_grad_grad, W_grad_grad)
         if b_data is not None:
-            args = args + (b_data,)
-            grad_grads = grad_grads + (b_grad_grad,)
+            args += (b_data,)
+            grad_grads += (b_grad_grad,)
 
         def f(*args):
             y = F.deconvolution_nd(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -8,7 +8,6 @@ from operator import mul
 import chainer
 from chainer import cuda
 import chainer.functions as F
-from chainer.functions.connection import deconvolution_nd
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
@@ -57,6 +56,7 @@ class TestDeconvolutionND(unittest.TestCase):
         W_shape = (in_channels, out_channels) + ksize
         self.W = numpy.random.normal(0, W_scale, W_shape).astype(self.W_dtype)
         self.b = numpy.random.uniform(-1, 1, out_channels).astype(self.x_dtype)
+        self.check_double_backward_options = {'dtype': numpy.float64}
 
         outs = tuple(
             conv.get_deconv_outsize(d, k, s, p)
@@ -66,6 +66,13 @@ class TestDeconvolutionND(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.x_dtype)
         gy_shape = (2, out_channels) + outs
         self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.x_dtype)
+
+        self.ggx = numpy.random.uniform(
+            -1, 1, self.x.shape).astype(self.x.dtype)
+        self.ggW = numpy.random.uniform(
+            -1, 1, self.W.shape).astype(self.W.dtype)
+        self.ggb = numpy.random.uniform(
+            -1, 1, self.b.shape).astype(self.x.dtype)
 
         self.test_forward_options = {}
         self.check_backward_options = {
@@ -160,17 +167,18 @@ class TestDeconvolutionND(unittest.TestCase):
                 b_data = b[::2]
                 self.assertFalse(b_data.flags.c_contiguous)
 
-        inputs = (x_data, W_data)
+        args = (x_data, W_data)
         if b_data is not None:
-            inputs = inputs + (b_data,)
+            args = args + (b_data,)
 
-        ndim = len(self.dims)
+        def f(*args):
+            return F.deconvolution_nd(*args, stride=self.stride, pad=self.pad,
+                                      outsize=self.outsize)
+
         with chainer.using_config('use_cudnn', use_cudnn):
             with chainer.using_config('autotune', self.autotune):
                 gradient_check.check_backward(
-                    deconvolution_nd.DeconvolutionND(
-                        ndim, self.stride, self.pad, self.outsize),
-                    inputs, y_grad, **self.check_backward_options)
+                    f, args, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -191,6 +199,80 @@ class TestDeconvolutionND(unittest.TestCase):
         self.check_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.W), b,
             cuda.to_gpu(self.gy), use_cudnn='never')
+
+    def check_double_backward(
+            self, inputs, grad_outputs, grad_grad_inputs, use_cudnn='always'):
+        x_data, W_data, b_data = inputs
+        y_grad, = grad_outputs
+        x_grad_grad, W_grad_grad, b_grad_grad = grad_grad_inputs
+
+        if not self.c_contiguous:
+            xp = cuda.get_array_module(x_data)
+            x_data = xp.asfortranarray(x_data)
+            W_data = xp.asfortranarray(W_data)
+            y_grad = xp.asfortranarray(y_grad)
+            x_grad_grad = xp.asfortranarray(x_grad_grad)
+            W_grad_grad = xp.asfortranarray(W_grad_grad)
+            assert not x_data.flags.c_contiguous
+            assert not W_data.flags.c_contiguous
+            assert not y_grad.flags.c_contiguous
+            assert not x_grad_grad.flags.c_contiguous
+            assert not W_grad_grad.flags.c_contiguous
+            if b_data is not None:
+                b = xp.empty((len(b_data) * 2,), dtype=b_data.dtype)
+                b[::2] = b_data
+                b_data = b[::2]
+                assert not b_data.flags.c_contiguous
+
+                ggb = xp.empty((len(b_data) * 2,), dtype=b_grad_grad.dtype)
+                ggb[::2] = b_grad_grad
+                b_grad_grad = ggb[::2]
+                assert not b_grad_grad.flags.c_contiguous
+
+        args = (x_data, W_data)
+        grad_grads = (x_grad_grad, W_grad_grad)
+        if b_data is not None:
+            args = args + (b_data,)
+            grad_grads = grad_grads + (b_grad_grad,)
+
+        def f(*args):
+            y = F.deconvolution_nd(
+                *args, stride=self.stride, pad=self.pad, outsize=self.outsize)
+            return y * y  # make the function nonlinear
+
+        with chainer.using_config('use_cudnn', use_cudnn):
+            with chainer.using_config('autotune', self.autotune):
+                gradient_check.check_double_backward(
+                    f, args, y_grad, grad_grads,
+                    **self.check_double_backward_options)
+
+    @condition.retry(10)
+    def test_double_backward_cpu(self):
+        inputs = [self.x, self.W, self.b]
+        grad_outputs = [self.gy]
+        grad_grad_inputs = [self.ggx, self.ggW, self.ggb]
+        self.check_double_backward(
+            inputs, grad_outputs, grad_grad_inputs)
+
+    @attr.cudnn
+    @condition.retry(10)
+    def test_double_backward_cudnn(self):
+        b = None if self.b is None else cuda.to_gpu(self.b)
+        inputs = [cuda.to_gpu(self.x), cuda.to_gpu(self.W), b]
+        grad_outputs = cuda.to_gpu([self.gy])
+        grad_grad_inputs = cuda.to_gpu([self.ggx, self.ggW, self.ggb])
+        self.check_double_backward(
+            inputs, grad_outputs, grad_grad_inputs, use_cudnn='always')
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu(self):
+        b = None if self.b is None else cuda.to_gpu(self.b)
+        inputs = [cuda.to_gpu(self.x), cuda.to_gpu(self.W), b]
+        grad_outputs = cuda.to_gpu([self.gy])
+        grad_grad_inputs = cuda.to_gpu([self.ggx, self.ggW, self.ggb])
+        self.check_double_backward(
+            inputs, grad_outputs, grad_grad_inputs, use_cudnn='never')
 
 
 @testing.parameterize(*testing.product({
@@ -284,14 +366,15 @@ class TestDeconvolutionNDTypeCheck(unittest.TestCase):
         # Too few inputs
         x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
         with self.assertRaises(type_check.InvalidType):
-            F.connection.deconvolution_nd.DeconvolutionND(1)(x)
+            F.connection.deconvolution_nd.DeconvolutionND(1).apply((x,))
 
         # Too much inputs
         x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(numpy.float32)
         W = numpy.random.uniform(-1, 1, (3, 2, 2)).astype(numpy.float32)
         b = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
         with self.assertRaises(type_check.InvalidType):
-            F.connection.deconvolution_nd.DeconvolutionND(1)(x, W, b, x)
+            F.connection.deconvolution_nd.DeconvolutionND(1).apply(
+                (x, W, b, x))
 
     def test_data_and_weight(self):
         # dtype of data


### PR DESCRIPTION
Related to #2745. This challenging PR aims to update ConvolutionND/DeconvolutionND functions to support double back propagations.
(I finally want to integrate `Convolution2D` and `ConvolutionND`, and derive `Convolution2D` as a special case of `ConvolutionND`, however, in the first stage this PR aims to rewrite `ConvolutionND` with reference to `Convolution2D`, and support double back propagations.)