### PR TITLE
Moveaxis array operation proposal

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -64,7 +64,6 @@ from chainer.functions.array.hstack import hstack  # NOQA
 from chainer.functions.array.im2col import im2col  # NOQA
 from chainer.functions.array.im2col import Im2Col  # NOQA
 from chainer.functions.array.moveaxis import moveaxis  # NOQA
-from chainer.functions.array.moveaxis import Moveaxis  # NOQA
 from chainer.functions.array.pad import pad  # NOQA
 from chainer.functions.array.pad import Pad  # NOQA
 from chainer.functions.array.pad_sequence import pad_sequence  # NOQA

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -63,6 +63,8 @@ from chainer.functions.array.get_item import GetItem  # NOQA
 from chainer.functions.array.hstack import hstack  # NOQA
 from chainer.functions.array.im2col import im2col  # NOQA
 from chainer.functions.array.im2col import Im2Col  # NOQA
+from chainer.functions.array.moveaxis import moveaxis  # NOQA
+from chainer.functions.array.moveaxis import Moveaxis  # NOQA
 from chainer.functions.array.pad import pad  # NOQA
 from chainer.functions.array.pad import Pad  # NOQA
 from chainer.functions.array.pad_sequence import pad_sequence  # NOQA

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -18,6 +18,9 @@ def _normalize_axis_tuple(axis, ndim, xp):
 def _moveaxis(a, source, destination, xp):
     if hasattr(xp, 'moveaxis'):
         return xp.moveaxis(a, source, destination)
+    if len(source) != len(destination):
+        raise ValueError('Length of source and destination are '
+                         'different.')
     source = _normalize_axis_tuple(source, a.ndim, xp)
     destination = _normalize_axis_tuple(destination, a.ndim, xp)
     order = [n for n in six.moves.range(a.ndim) if n not in source]
@@ -47,9 +50,6 @@ class Moveaxis(function_node.FunctionNode):
                                  'different.')
             if not all(isinstance(a, int) for a in destination):
                 raise ValueError('int or tuple of int are required.')
-            if len(source) != len(destination):
-                raise ValueError('Length of source and destination are '
-                                 'different.')
             if len(set(source)) != len(source):
                 raise ValueError('duplicate value in source axis: ({})'.format(
                     ', '.join(map(str, source))))

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -18,31 +18,24 @@ def _normalize_axis_tuple(axis, ndim, xp):
 def _moveaxis(a, source, destination, xp):
     if hasattr(xp, 'moveaxis'):
         return xp.moveaxis(a, source, destination)
-    if isinstance(source, int):
-        if not isinstance(destination, int):
-            raise ValueError('Types of source and destination are '
-                             'different.')
-    elif isinstance(source, tuple) and all(isinstance(a, int)
-                                           for a in source):
-        if not isinstance(destination, tuple):
-            raise ValueError('Types of source and destination are '
-                             'different.')
-        if len(source) != len(destination):
-            raise ValueError('Length of source and destination are '
-                             'different.')
-        if not all(isinstance(a, int) for a in destination):
-            raise TypeError('int or tuple of int are required.')
-        if len(set(source)) != len(source):
-            raise ValueError('duplicate value in source axis: ({})'.format(
-                ', '.join(map(str, source))))
-        if len(set(destination)) != len(destination):
-            raise ValueError('duplicate value in destination axis: ({})'
-                             .format(', '.join(map(str, destination))))
-    else:
+    if all(isinstance(a, int) for a in source):
         raise TypeError('int or tuple of int are required.')
+    if not all(isinstance(a, int) for a in destination):
+        raise TypeError('int or tuple of int are required.')
+    if len(source) != len(destination):
+        raise ValueError('Length of source and destination are '
+                         'different.')
 
     source = _normalize_axis_tuple(source, a.ndim, xp)
     destination = _normalize_axis_tuple(destination, a.ndim, xp)
+
+    if len(set(source)) != len(source):
+        raise ValueError('duplicate value in source axis: ({})'.format(
+            ', '.join(map(str, source))))
+    if len(set(destination)) != len(destination):
+        raise ValueError('duplicate value in destination axis: ({})'
+                         .format(', '.join(map(str, destination))))
+
     order = [n for n in six.moves.range(a.ndim) if n not in source]
 
     for dest, src in sorted(six.moves.zip(destination, source)):

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -1,0 +1,113 @@
+import six
+
+from chainer import cuda
+from chainer import function_node
+from chainer.utils import type_check
+
+
+def _normalize_axis_tuple(axis, ndim, xp):
+    if xp.isscalar(axis):
+        axis = (axis,)
+
+    ret = []
+    for ax in axis:
+        ret.append(ax % ndim)
+    return ret
+
+
+def _moveaxis(a, source, destination, xp):
+    if hasattr(xp, 'moveaxis'):
+        return xp.moveaxis(a, source, destination)
+    source = _normalize_axis_tuple(source, a.ndim, xp)
+    destination = _normalize_axis_tuple(destination, a.ndim, xp)
+    order = [n for n in six.moves.range(a.ndim) if n not in source]
+
+    for dest, src in sorted(six.moves.zip(destination, source)):
+        order.insert(dest, src)
+
+    result = a.transpose(order)
+    return result
+
+
+class Moveaxis(function_node.FunctionNode):
+
+    """Move axis of an array."""
+
+    def __init__(self, source, destination):
+        if isinstance(source, int):
+            if not isinstance(destination, int):
+                raise ValueError('Types of source and destination are '
+                                 'different.')
+            self.source = (source,)
+            self.destination = (destination,)
+        elif isinstance(source, tuple) and all(isinstance(a, int)
+                                               for a in source):
+            if not isinstance(destination, tuple):
+                raise ValueError('Types of source and destination are '
+                                 'different.')
+            if len(source) != len(destination):
+                raise ValueError('Length of source and destination are '
+                                 'different.')
+            if len(set(source)) != len(source):
+                raise ValueError('duplicate value in source axis: ({})'.format(
+                    ', '.join(map(str, source))))
+            if len(set(destination)) != len(destination):
+                raise ValueError('duplicate value in destination axis: ({})'
+                    .format(', '.join(map(str, destination))))
+            self.source = source
+            self.destination = destination
+        else:
+            raise ValueError('int or tuple of int are required')
+
+    def check_type_forward(self, in_types):
+        type_check.expect(
+            in_types.size() == 1,
+            in_types[0].dtype.kind == 'f',
+        )
+
+        if self.source is not None:
+            for axis in self.source:
+                if axis >= 0:
+                    type_check.expect(
+                        axis < in_types[0].ndim,
+                    )
+                else:
+                    type_check.expect(
+                        -axis - 1 < in_types[0].ndim,
+                    )
+        if self.destination is not None:
+            for axis in self.destination:
+                if axis >= 0:
+                    type_check.expect(
+                        axis < in_types[0].ndim,
+                    )
+                else:
+                    type_check.expect(
+                        -axis - 1 < in_types[0].ndim,
+                    )
+
+    def forward(self, inputs):
+        self.retain_inputs(())
+        self._in_ndim = inputs[0].ndim
+        xp = cuda.get_array_module(*inputs)
+        return _moveaxis(inputs[0], self.source, self.destination, xp),
+
+    def backward(self, indexes, gy):
+        return Moveaxis(self.destination, self.source).apply(gy)
+
+
+def moveaxis(x, source, destination):
+    """Move the source axis to the destination.
+
+    Args:
+        x (~chainer.Variable): Input variable.
+        source (int or tuple of int):
+            Original positions of the axes to move. These must be unique.
+        destination (int or tuple of int):
+            Destination positions for each of the original axes.
+            These must also be unique.
+
+    Returns:
+        ~chainer.Variable: Variable whose axis is moved.
+    """
+    return Moveaxis(source, destination).apply((x,))[0]

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -59,9 +59,12 @@ class Moveaxis(function_node.FunctionNode):
     def __init__(self, source, destination):
         if isinstance(source, int):
             self.source = (source,)
-            self.destination = (destination,)
         else:
             self.source = source
+
+        if isinstance(destination, int):
+            self.destination = (destination,)
+        else:
             self.destination = destination
 
     def check_type_forward(self, in_types):

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -5,10 +5,7 @@ from chainer import function_node
 from chainer.utils import type_check
 
 
-def _normalize_axis_tuple(axis, ndim, xp):
-    if xp.isscalar(axis):
-        axis = (axis,)
-
+def _normalize_axis_tuple(axis, ndim):
     ret = []
     for ax in axis:
         ret.append(ax % ndim)
@@ -26,8 +23,8 @@ def _moveaxis(a, source, destination, xp):
         raise ValueError('Length of source and destination are '
                          'different.')
 
-    source = _normalize_axis_tuple(source, a.ndim, xp)
-    destination = _normalize_axis_tuple(destination, a.ndim, xp)
+    source = _normalize_axis_tuple(source, a.ndim)
+    destination = _normalize_axis_tuple(destination, a.ndim)
 
     if len(set(source)) != len(source):
         raise ValueError('duplicate value in source axis: ({})'.format(

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -53,7 +53,7 @@ class Moveaxis(function_node.FunctionNode):
                     ', '.join(map(str, source))))
             if len(set(destination)) != len(destination):
                 raise ValueError('duplicate value in destination axis: ({})'
-                    .format(', '.join(map(str, destination))))
+                                 .format(', '.join(map(str, destination))))
             self.source = source
             self.destination = destination
         else:

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -18,7 +18,7 @@ def _normalize_axis_tuple(axis, ndim, xp):
 def _moveaxis(a, source, destination, xp):
     if hasattr(xp, 'moveaxis'):
         return xp.moveaxis(a, source, destination)
-    if all(isinstance(a, int) for a in source):
+    if not all(isinstance(a, int) for a in source):
         raise TypeError('int or tuple of int are required.')
     if not all(isinstance(a, int) for a in destination):
         raise TypeError('int or tuple of int are required.')

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -45,6 +45,8 @@ class Moveaxis(function_node.FunctionNode):
             if not isinstance(destination, tuple):
                 raise ValueError('Types of source and destination are '
                                  'different.')
+            if not all(isinstance(a, int) for a in destination):
+                raise ValueError('int or tuple of int are required.')
             if len(source) != len(destination):
                 raise ValueError('Length of source and destination are '
                                  'different.')
@@ -57,7 +59,7 @@ class Moveaxis(function_node.FunctionNode):
             self.source = source
             self.destination = destination
         else:
-            raise ValueError('int or tuple of int are required')
+            raise ValueError('int or tuple of int are required.')
 
     def check_type_forward(self, in_types):
         type_check.expect(

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -79,6 +79,7 @@ Array manipulations
    chainer.functions.get_item
    chainer.functions.hstack
    chainer.functions.im2col
+   chainer.functions.moveaxis
    chainer.functions.pad
    chainer.functions.pad_sequence
    chainer.functions.permutate

--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -1,0 +1,121 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+from chainer.utils import type_check
+
+
+@testing.parameterize(
+    {'source': 0, 'destination': 2, 'out_shape': (3, 4, 2)},
+    {'source': -1, 'destination': 1, 'out_shape': (2, 4, 3)},
+    {'source': (0, 2), 'destination': (1, 0), 'out_shape': (4, 2, 3)},
+    {'source': (0, -1), 'destination': (-1, 1), 'out_shape': (3, 4, 2)},
+)
+class TestMoveaxis(unittest.TestCase):
+
+    dtype = numpy.float32
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
+        self.g = numpy.random.uniform(-1, 1, self.out_shape).astype(self.dtype)
+        self.gg = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
+        self.check_backward_options = {}
+        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+
+    def check_forward(self, x_data):
+        x = chainer.Variable(x_data)
+        y = functions.moveaxis(x, self.source, self.destination)
+
+        expect = numpy.moveaxis(self.x, self.source, self.destination)
+        testing.assert_allclose(y.data, expect)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x_data, g_data):
+        def f(x):
+            return functions.moveaxis(x, self.source, self.destination)
+
+        gradient_check.check_backward(
+            f, x_data, g_data, dtype='d', **self.check_backward_options)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.g)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g))
+
+    def check_double_backward(self, x_data, g_data, gg_data):
+        def f(x):
+            y = functions.moveaxis(x, self.source, self.destination)
+            return y * y
+
+        gradient_check.check_double_backward(
+            f, x_data, g_data, gg_data, dtype='d',
+            **self.check_double_backward_options)
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.g, self.gg)
+
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g),
+                                   cuda.to_gpu(self.gg))
+
+
+@testing.parameterize(
+    {'source': 4, 'destination': 0},
+    {'source': 0, 'destination': -4},
+)
+class TestMoveaxisInvalidType(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f')
+
+    def check_type_error(self, x):
+        with self.assertRaises(type_check.InvalidType):
+            functions.moveaxis(x, self.source, self.destination)
+
+    def test_type_error_cpu(self):
+        self.check_type_error(self.x)
+
+    @attr.gpu
+    def test_type_error_gpu(self):
+        self.check_type_error(cuda.to_gpu(self.x))
+
+
+@testing.parameterize(
+    {'source': 0, 'destination': (2,)},
+    {'source': (1, 2), 'destination': (1, 2, 0)},
+    {'source': (0, 0), 'destination': (1, 2)},
+    {'source': (0, 1), 'destination': (2, 2)},
+)
+class TestMoveaxisInvalidValue(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f')
+
+    def check_type_error(self, x):
+        with self.assertRaises(ValueError):
+            functions.moveaxis(x, self.source, self.destination)
+
+    def test_type_error_cpu(self):
+        self.check_type_error(self.x)
+
+    @attr.gpu
+    def test_type_error_gpu(self):
+        self.check_type_error(cuda.to_gpu(self.x))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -157,6 +157,9 @@ class TestMoveaxisTypeError(unittest.TestCase):
         with self.assertRaises(TypeError):
             functions.moveaxis(x, self.source, self.destination)
 
+    # For escaping numpy==1.11 bug.
+    # numpy 1.11 arrows float axis input.
+    @testing.with_requires('numpy!=1.11.*')
     def test_type_error_cpu(self):
         self.check_type_error(self.x)
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -123,21 +123,40 @@ class TestMoveaxisInvalidType(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'source': 0, 'destination': (2,)},
-    {'source': (2,), 'destination': 0},
     {'source': (1, 2), 'destination': (1, 2, 0)},
     {'source': (0, 0), 'destination': (1, 2)},
     {'source': (0, 1), 'destination': (2, 2)},
-    {'source': (1, 2.0), 'destination': (1, 2)},
-    {'source': (1, 2), 'destination': (1, 2.0)},
 )
-class TestMoveaxisInvalidValue(unittest.TestCase):
+class TestMoveaxisValueError(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f')
 
     def check_type_error(self, x):
         with self.assertRaises(ValueError):
+            functions.moveaxis(x, self.source, self.destination)
+
+    def test_type_error_cpu(self):
+        self.check_type_error(self.x)
+
+    @attr.gpu
+    def test_type_error_gpu(self):
+        self.check_type_error(cuda.to_gpu(self.x))
+
+
+@testing.parameterize(
+    {'source': (2,), 'destination': 0},
+    {'source': 0, 'destination': (2,)},
+    {'source': (1, 2), 'destination': (1, 2.0)},
+    {'source': (1, 2.0), 'destination': (1, 2)},
+)
+class TestMoveaxisTypeError(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype('f')
+
+    def check_type_error(self, x):
+        with self.assertRaises(TypeError):
             functions.moveaxis(x, self.source, self.destination)
 
     def test_type_error_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -145,8 +145,6 @@ class TestMoveaxisValueError(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'source': (2,), 'destination': 0},
-    {'source': 0, 'destination': (2,)},
     {'source': (1, 2), 'destination': (1, 2.0)},
     {'source': (1, 2.0), 'destination': (1, 2)},
 )

--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -12,7 +12,7 @@ from chainer.utils import type_check
 
 
 @testing.parameterize(
-    {'source': 0, 'destination': 2, 'out_shape': (3, 4, 2)},
+    {'source': 0, 'destination': -1, 'out_shape': (3, 4, 2)},
     {'source': -1, 'destination': 1, 'out_shape': (2, 4, 3)},
     {'source': (0, 2), 'destination': (1, 0), 'out_shape': (4, 2, 3)},
     {'source': (0, -1), 'destination': (-1, 1), 'out_shape': (3, 4, 2)},
@@ -76,7 +76,9 @@ class TestMoveaxis(unittest.TestCase):
 
 @testing.parameterize(
     {'source': 4, 'destination': 0},
+    {'source': 0, 'destination': 4},
     {'source': 0, 'destination': -4},
+    {'source': -4, 'destination': 0},
 )
 class TestMoveaxisInvalidType(unittest.TestCase):
 
@@ -97,9 +99,12 @@ class TestMoveaxisInvalidType(unittest.TestCase):
 
 @testing.parameterize(
     {'source': 0, 'destination': (2,)},
+    {'source': (2,), 'destination': 0},
     {'source': (1, 2), 'destination': (1, 2, 0)},
     {'source': (0, 0), 'destination': (1, 2)},
     {'source': (0, 1), 'destination': (2, 2)},
+    {'source': (1, 2.0), 'destination': (1, 2)},
+    {'source': (1, 2), 'destination': (1, 2.0)},
 )
 class TestMoveaxisInvalidValue(unittest.TestCase):
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -158,7 +158,7 @@ class TestMoveaxisTypeError(unittest.TestCase):
             functions.moveaxis(x, self.source, self.destination)
 
     # For escaping numpy==1.11 bug.
-    # numpy 1.11 arrows float axis input.
+    # numpy 1.11 allows float axis input.
     @testing.with_requires('numpy!=1.11.*')
     def test_type_error_cpu(self):
         self.check_type_error(self.x)


### PR DESCRIPTION
numpy 1.13 supports moveaxis and it is more useful than existing array manipulation such as rollaxis or transpose in some cases.