### PR TITLE
New style AveragePoolingND/MaxPoolingND/UnpoolingND

### DIFF
--- a/chainer/functions/pooling/average_pooling_nd.py
+++ b/chainer/functions/pooling/average_pooling_nd.py
@@ -6,6 +6,7 @@ import six
 
 import chainer
 from chainer.backends import cuda
+from chainer import function_node
 from chainer.functions.pooling import average_pooling_nd_kernel
 from chainer.functions.pooling import pooling_nd
 from chainer import utils
@@ -33,7 +34,6 @@ class AveragePoolingND(pooling_nd._PoolingND):
             ndim, ksize, stride=stride, pad=pad, cover_all=cover_all)
 
     def forward_cpu(self, x):
-        self.retain_inputs(())
         self._in_shape = x[0].shape
         self._in_dtype = x[0].dtype
 
@@ -49,9 +49,9 @@ class AveragePoolingND(pooling_nd._PoolingND):
         if chainer.should_use_cudnn('>=auto') and 2 <= self.ndim <= 3:
             # With cuDNN v3 or greater, use cuDNN implementation for inputs
             # with spatial dimensions of two or more.
+            self.retain_inputs((0,))
             return super(AveragePoolingND, self).forward_gpu(x)
 
-        self.retain_inputs(())
         self._in_shape = x[0].shape
         self._in_dtype = x[0].dtype
 
@@ -75,7 +75,30 @@ class AveragePoolingND(pooling_nd._PoolingND):
 
         return y,
 
-    def backward_cpu(self, x, gy):
+    def backward(self, indexes, gy):
+        return AveragePoolingNDGrad(self).apply(gy)
+
+    def create_pool_desc(self):
+        return cuda.cudnn.create_pooling_descriptor(
+            self.ksize, self.stride, self.pad,
+            cuda.cuda.cudnn.CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
+
+
+class AveragePoolingNDGrad(function_node.FunctionNode):
+
+    def __init__(self, apoolnd):
+        self.ndim = apoolnd.ndim
+        self.ksize = apoolnd.ksize
+        self.stride = apoolnd.stride
+        self.pad = apoolnd.pad
+        self.cover_all = apoolnd.cover_all
+        self._used_cudnn = apoolnd._used_cudnn
+        if not self._used_cudnn:
+            self._in_shape = apoolnd._in_shape
+            self._in_dtype = apoolnd._in_dtype
+        self.apoolnd = apoolnd
+
+    def forward_cpu(self, gy):
         dims = self._in_shape[2:]
         outs = gy[0].shape[2:]
         colon = slice(None, None, None)
@@ -86,9 +109,10 @@ class AveragePoolingND(pooling_nd._PoolingND):
         gx /= functools.reduce(operator.mul, self.ksize)
         return gx,
 
-    def backward_gpu(self, x, gy):
+    def forward_gpu(self, gy):
         if self._used_cudnn:
-            return super(AveragePoolingND, self).backward_gpu(x, gy)
+            x, = self.apoolnd.get_retained_inputs()
+            return self.apoolnd.backward_gpu((x.data,), gy)
 
         n, c = self._in_shape[:2]
         dims = self._in_shape[2:]
@@ -105,10 +129,10 @@ class AveragePoolingND(pooling_nd._PoolingND):
 
         return gx,
 
-    def create_pool_desc(self):
-        return cuda.cudnn.create_pooling_descriptor(
-            self.ksize, self.stride, self.pad,
-            cuda.cuda.cudnn.CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING)
+    def backward(self, indexes, grad_outputs):
+        return AveragePoolingND(
+            self.ndim, self.ksize, self.stride, self.pad,
+            cover_all=False).apply(grad_outputs)
 
 
 def average_pooling_nd(x, ksize, stride=None, pad=0):
@@ -145,4 +169,4 @@ def average_pooling_nd(x, ksize, stride=None, pad=0):
 
     """
     ndim = len(x.shape[2:])
-    return AveragePoolingND(ndim, ksize, stride=stride, pad=pad)(x)
+    return AveragePoolingND(ndim, ksize, stride=stride, pad=pad).apply((x,))[0]

--- a/chainer/functions/pooling/max_pooling_nd.py
+++ b/chainer/functions/pooling/max_pooling_nd.py
@@ -6,6 +6,7 @@ import six
 
 import chainer
 from chainer.backends import cuda
+from chainer import function_node
 from chainer.functions.pooling import max_pooling_nd_kernel
 from chainer.functions.pooling import pooling_nd
 from chainer import utils
@@ -28,7 +29,6 @@ class MaxPoolingND(pooling_nd._PoolingND):
             ndim, ksize, stride=stride, pad=pad, cover_all=cover_all)
 
     def forward_cpu(self, x):
-        self.retain_inputs(())
         self._in_shape = x[0].shape
         self._in_dtype = x[0].dtype
 
@@ -53,9 +53,9 @@ class MaxPoolingND(pooling_nd._PoolingND):
         if chainer.should_use_cudnn('>=auto') and 2 <= self.ndim <= 3:
             # With cuDNN v3 or greater, use cuDNN implementation for inputs
             # with spatial dimensions of two or more.
+            self.retain_inputs((0,))
             return super(MaxPoolingND, self).forward_gpu(x)
 
-        self.retain_inputs(())
         self._in_shape = x[0].shape
         self._in_dtype = x[0].dtype
 
@@ -78,7 +78,31 @@ class MaxPoolingND(pooling_nd._PoolingND):
 
         return y,
 
-    def backward_cpu(self, x, gy):
+    def backward(self, indexes, gy):
+        return MaxPoolingNDGrad(self).apply(gy)
+
+    def create_pool_desc(self):
+        return cuda.cudnn.create_pooling_descriptor(
+            self.ksize, self.stride, self.pad,
+            cuda.cuda.cudnn.CUDNN_POOLING_MAX)
+
+
+class MaxPoolingNDGrad(function_node.FunctionNode):
+
+    def __init__(self, mpoolnd):
+        self.ndim = mpoolnd.ndim
+        self.ksize = mpoolnd.ksize
+        self.stride = mpoolnd.stride
+        self.pad = mpoolnd.pad
+        self.cover_all = mpoolnd.cover_all
+        self._used_cudnn = mpoolnd._used_cudnn
+        if not self._used_cudnn:
+            self.indexes = mpoolnd.indexes
+            self._in_shape = mpoolnd._in_shape
+            self._in_dtype = mpoolnd._in_dtype
+        self.mpoolnd = mpoolnd
+
+    def forward_cpu(self, gy):
         ndim = self.ndim
         n, c = gy[0].shape[:2]
         outs = gy[0].shape[2:]
@@ -101,9 +125,10 @@ class MaxPoolingND(pooling_nd._PoolingND):
         gx = conv_nd.col2im_nd_cpu(gcol, self.stride, self.pad, dims)
         return gx,
 
-    def backward_gpu(self, x, gy):
+    def forward_gpu(self, gy):
         if self._used_cudnn:
-            return super(MaxPoolingND, self).backward_gpu(x, gy)
+            x, = self.mpoolnd.get_retained_inputs()
+            return self.mpoolnd.backward_gpu((x.data,), gy)
 
         n, c = self._in_shape[:2]
         dims = self._in_shape[2:]
@@ -118,10 +143,72 @@ class MaxPoolingND(pooling_nd._PoolingND):
             *(dims + ys + self.ksize + self.stride + self.pad + (gx,)))
         return gx,
 
-    def create_pool_desc(self):
-        return cuda.cudnn.create_pooling_descriptor(
-            self.ksize, self.stride, self.pad,
-            cuda.cuda.cudnn.CUDNN_POOLING_MAX)
+    def backward(self, indexes, ggx):
+        return MaxPoolingNDWithIndexes(self.mpoolnd).apply(ggx)
+
+
+# XXX: WIP
+class MaxPoolingNDWithIndexes(function_node.FunctionNode):
+
+    def __init__(self, mpoolnd):
+        self.ndim = mpoolnd.ndim
+        self.ksize = mpoolnd.ksize
+        self.stride = mpoolnd.stride
+        self.pad = mpoolnd.pad
+        self.cover_all = mpoolnd.cover_all
+        self._used_cudnn = mpoolnd._used_cudnn
+        if not self._used_cudnn:
+            self.indexes = mpoolnd.indexes
+        else:
+            self.mpoolnd = mpoolnd
+
+    def forward_cpu(self, x):
+        col = conv_nd.im2col_nd_cpu(
+            x[0], self.ksize, self.stride, self.pad, pval=-float('inf'),
+            cover_all=self.cover_all)
+        n, c = col.shape[:2]
+        mid = (len(col.shape) - 2) // 2 + 2
+        ksize = col.shape[2:mid]
+        outs = col.shape[mid:]
+        # (n, c, k_1 * k_2 * ... * k_N, out_1, out_2, ..., out_N)
+        ksize_total = functools.reduce(mul, ksize)
+        col_shape = (n, c) + (ksize_total,) + outs
+        col = col.reshape(col_shape)
+        # (n, c, out_1, ..., out_N, k_1 * .. * k_N)
+        col_indexes = (0, 1) + tuple(six.moves.range(3, 3 + self.ndim)) + (2,)
+        col = col.transpose(col_indexes)
+        col = col.reshape(-1, ksize_total)
+
+        indexes = self.indexes.ravel()
+        col = col[numpy.arange(len(indexes)), indexes]
+        return col.reshape((n, c) + outs),
+
+    def forward_gpu(self, inputs):
+        if self._used_cudnn:
+            x, = self.mpoolnd.get_retained_inputs()
+            return self._forward_gpu_compute_indexes_again((x.data, inputs[0]))
+        x, = inputs
+
+        self._in_shape = x.shape
+        self._in_dtype = x.dtype
+
+        n, c = x.shape[:2]
+        dims = x.shape[2:]
+
+        ys = tuple(conv_nd.get_conv_outsize(d, k, s, p, self.cover_all)
+                   for (d, k, s, p) in six.moves.zip(
+                       dims, self.ksize, self.stride, self.pad))
+        # (n, c, y_1, y_2, ..., y_N)
+        y_shape = (n, c) + ys
+        y = cuda.cupy.empty(y_shape, dtype=x.dtype)
+        self.indexes = cuda.cupy.empty(y_shape, dtype=numpy.int32)
+
+        in_params, out_params, operation, name = \
+            max_pooling_nd_kernel.MaxPoolingNDKernelForward.generate(self.ndim)
+        cuda.elementwise(in_params, out_params, operation, name)(
+            x.reduced_view(),
+            *(dims + ys + self.ksize + self.stride + self.pad +
+              (y, self.indexes)))
 
 
 def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True):
@@ -155,4 +242,4 @@ def max_pooling_nd(x, ksize, stride=None, pad=0, cover_all=True):
 
     """
     ndim = len(x.shape[2:])
-    return MaxPoolingND(ndim, ksize, stride, pad, cover_all)(x)
+    return MaxPoolingND(ndim, ksize, stride, pad, cover_all).apply((x,))[0]

--- a/chainer/functions/pooling/max_pooling_nd_kernel.py
+++ b/chainer/functions/pooling/max_pooling_nd_kernel.py
@@ -90,3 +90,117 @@ class MaxPoolingNDKernelBackward(pooling_nd_kernel.PoolingNDKernelBackward):
 
     def after(self, xs):
         return 'gx = val;'
+
+
+class MaxPoolingNDKernelForwardWithIndexes(
+        pooling_nd_kernel.PoolingNDKernelForward):
+
+    def name(self):
+        # max_index_pool_{N}d_fwd
+        return 'max_index'
+
+    def in_params(self):
+        # 2D: raw T in, int32 d_0, int32 d_1, int32 out_0, int32 out_1,
+        #     int32 k_0, int32 k_1, int32 s_0, int32 s_1, int32 p_0, int32 p_1,
+        #     raw S indexes
+        return ['raw S indexes']
+
+    def out_params(self):
+        # T out
+        return []
+
+    def _compile_max_x(self):
+        def aux(max_val, out_val, stride_val, pad_val, ksize_vals):
+            head = ksize_vals[0]
+            tail = ksize_vals[1:]
+            if tail:
+                command = 'int {} = max(0, {} * {} - {} + index / ({}) % {});'
+                return command.format(
+                    max_val, out_val, stride_val, pad_val,
+                    conv_nd_kernel.mulexp(tail), head)
+            else:
+                return 'int {} = max(0, {} * {} - {} + index % {});'.format(
+                    max_val, out_val, stride_val, pad_val, head)
+
+        max_vals = conv_nd_kernel.vars('max', self.ndim)
+        out_vals = conv_nd_kernel.vars('out_x', self.ndim)
+        stride_vals = conv_nd_kernel.vars('s', self.ndim)
+        pad_vals = conv_nd_kernel.vars('p', self.ndim)
+        ksize_vals = conv_nd_kernel.vars('k', self.ndim)
+
+        offset_ks_decls = conv_nd_kernel.map_(
+            aux, max_vals, out_vals, stride_vals, pad_vals,
+            conv_nd_kernel.succ_sublists(ksize_vals))
+        return offset_ks_decls
+
+    def _compile_out(self):
+        def aux(offset, d_val, max_val, offset1):
+            return 'int {} = {} * ({} + {});'.format(
+                offset, d_val, max_val, offset1)
+
+        d_vals = conv_nd_kernel.vars('d', self.ndim)[1:] + [1]
+        max_vals = conv_nd_kernel.vars('max', self.ndim)
+        offsets = conv_nd_kernel.vars('offset', self.ndim)
+        offsets1 = ['d_0 * c0'] + offsets[:-1]
+        offset_strs = conv_nd_kernel.map_(
+            aux, offsets, d_vals, max_vals, offsets1)
+        offset_strs.append('out = in[offset_{}];'.format(self.ndim - 1))
+        return offset_strs
+
+    def _operation(self):
+        # In the case of 2D, the kernel is the following:
+        #
+        # // result by self._compile_c0()
+        # int c0 = i / (out_0 * out_1);
+        #
+        # // result by self._compile_max_x()
+        # int out_x_0 = i / (out_1) % out_0;
+        # int out_x_1 = i % out_1;
+        # int index = indexes[i];
+        #
+        # // result by self._compile_out()
+        # int max_0 = max(0, out_x_0 * s_0 - p_0 + index / (k_1) % k_0);
+        # int max_1 = max(0, out_x_1 * s_1 - p_1 + index % k_1);
+        # int offset_0 = d_1 * (max_0 + d_0 * c0);
+        # int offset_1 = 1 * (max_1 + offset_0);
+        # out = in[offset_1];
+        c0 = self._compile_c0()
+        out_x, out_xs = self._compile_out_x()
+        max_x = self._compile_max_x()
+        index = ['int index = indexes[i];']
+        out = self._compile_out()
+        return '\n'.join(c0 + out_x + index + max_x + out)
+
+
+class MaxPoolingNDKernelForwardWithIndexes1(MaxPoolingNDKernelForward):
+
+    def name(self):
+        # max_index1_pool_{N}d_fwd
+        return 'max_index1'
+
+    def in_params(self):
+        # 2D: raw T gy, raw S indexes, int32 d_0, int32 d_1, int32 out_0,
+        #     int32 out_1, int32 k_0, int32 k_1, int32 s_0, int32 s_1,
+        #     int32 p_0, int32 p_1
+        return ['raw T ggx']
+
+    def out_params(self):
+        # T out
+        return []
+
+    def after(self, out_xs):
+        # 2D: int offset_0 = d_1 * (argmax_0 + d_0 * c0);
+        #     int offset_1 = 1 * (argmax_1 + offset_0);
+        #     out = ggx[offset_1];
+        def aux(offset, d_val, max_val, offset1):
+            return 'int {} = {} * ({} + {});'.format(
+                offset, d_val, max_val, offset1)
+
+        d_vals = conv_nd_kernel.vars('d', self.ndim)[1:] + [1]
+        max_vals = conv_nd_kernel.vars('argmax', self.ndim)
+        offsets = conv_nd_kernel.vars('offset', self.ndim)
+        offsets1 = ['d_0 * c0'] + offsets[:-1]
+        offset_strs = conv_nd_kernel.map_(
+            aux, offsets, d_vals, max_vals, offsets1)
+        offset_strs.append('out = ggx[offset_{}];'.format(self.ndim - 1))
+        return '\n'.join(offset_strs)

--- a/chainer/functions/pooling/pooling_nd.py
+++ b/chainer/functions/pooling/pooling_nd.py
@@ -2,7 +2,7 @@ import numpy
 import six
 
 from chainer.backends import cuda
-from chainer import function
+from chainer import function_node
 from chainer.utils import conv
 from chainer.utils import conv_nd
 from chainer.utils import type_check
@@ -13,7 +13,7 @@ if cuda.cudnn_enabled:
     libcudnn = cuda.cuda.cudnn
 
 
-class _PoolingND(function.Function):
+class _PoolingND(function_node.FunctionNode):
 
     """Base class of pooling function over a set of N-dimensional planes."""
 

--- a/chainer/functions/pooling/unpooling_nd.py
+++ b/chainer/functions/pooling/unpooling_nd.py
@@ -3,8 +3,8 @@ import six
 
 from chainer.backends import cuda
 from chainer import function_node
-from chainer import utils
 from chainer.functions.pooling import pooling_nd
+from chainer import utils
 from chainer.utils import conv
 from chainer.utils import conv_nd
 from chainer.utils import type_check

--- a/chainer/functions/pooling/unpooling_nd.py
+++ b/chainer/functions/pooling/unpooling_nd.py
@@ -2,14 +2,15 @@ import numpy
 import six
 
 from chainer.backends import cuda
-from chainer import function
+from chainer import function_node
 from chainer import utils
+from chainer.functions.pooling import pooling_nd
 from chainer.utils import conv
 from chainer.utils import conv_nd
 from chainer.utils import type_check
 
 
-class UnpoolingND(function.Function):
+class UnpoolingND(pooling_nd._PoolingND):
     """Unpooling over a set of N-dimensional planes.
 
     .. warning::
@@ -20,16 +21,9 @@ class UnpoolingND(function.Function):
 
     def __init__(self, ndim, ksize, stride=None, pad=0, outsize=None,
                  cover_all=True):
+        super(UnpoolingND, self).__init__(ndim, ksize, stride, pad, cover_all)
+        self.outs = None if outsize is None else outsize
         utils.experimental('chainer.functions.pooling.UnpoolingND')
-        if stride is None:
-            stride = ksize
-
-        self.ndim = ndim
-        self.ksize = conv_nd.as_tuple(ksize, ndim)
-        self.stride = conv_nd.as_tuple(stride, ndim)
-        self.pad = conv_nd.as_tuple(pad, ndim)
-        self.outs = outsize
-        self.cover_all = cover_all
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -77,17 +71,36 @@ class UnpoolingND(function.Function):
 
         return y,
 
-    def backward(self, x, gy):
+    def backward(self, indexes, grad_outputs):
+        return UnpoolingNDGrad(self).apply(grad_outputs)
+
+
+class UnpoolingNDGrad(function_node.FunctionNode):
+
+    def __init__(self, unpoolingnd):
+        self.ndim = unpoolingnd.ndim
+        self.ksize = unpoolingnd.ksize
+        self.stride = unpoolingnd.stride
+        self.pad = unpoolingnd.pad
+        self.outs = unpoolingnd.outs
+        self.cover_all = unpoolingnd.cover_all
+
+    def forward(self, gy):
         xp = cuda.get_array_module(*gy)
         if xp is numpy:
             im2col_nd = conv_nd.im2col_nd_cpu
         else:
             im2col_nd = conv_nd.im2col_nd_gpu
-        gcol = im2col_nd(gy[0], self.ksize, self.stride, self.pad,
-                         cover_all=self.cover_all)
+        gcol = im2col_nd(
+            gy[0], self.ksize, self.stride, self.pad, cover_all=self.cover_all)
         gcol_axis = tuple(six.moves.range(2, 2 + self.ndim))
         gx = gcol.sum(axis=gcol_axis)
         return gx,
+
+    def backward(self, indexes, ggx):
+        return UnpoolingND(
+            self.ndim, self.ksize, self.stride, self.pad, self.outs,
+            self.cover_all).apply(ggx)
 
 
 def unpooling_nd(x, ksize, stride=None, pad=0, outsize=None, cover_all=True):
@@ -125,4 +138,5 @@ def unpooling_nd(x, ksize, stride=None, pad=0, outsize=None, cover_all=True):
 
     """
     ndim = len(x.shape[2:])
-    return UnpoolingND(ndim, ksize, stride, pad, outsize, cover_all)(x)
+    return UnpoolingND(
+        ndim, ksize, stride, pad, outsize, cover_all).apply((x,))[0]

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
@@ -12,6 +12,7 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
+from chainer.testing import condition
 from chainer.utils import conv
 from chainer_tests.functions_tests.pooling_tests import pooling_nd_helper
 
@@ -36,6 +37,7 @@ class TestAveragePoolingND(unittest.TestCase):
                          self.dims, self.ksize, self.stride, self.pad))
         gy_shape = (2, 3) + outs
         self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
+        self.ggx = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
 
         self.check_forward_options = {}
         self.check_backward_options = {'eps': 1e-2}
@@ -111,11 +113,12 @@ class TestAveragePoolingND(unittest.TestCase):
         self.check_forward_consistency_regression(cuda.to_gpu(self.x), 'never')
 
     def check_backward(self, x_data, y_grad, use_cudnn='always'):
+        def f(x):
+            return functions.average_pooling_nd(
+                x, self.ksize, stride=self.stride, pad=self.pad)
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
-                functions.AveragePoolingND(
-                    self.ndim, self.ksize, self.stride, self.pad),
-                x_data, y_grad, dtype=numpy.float64,
+                f, x_data, y_grad, dtype=numpy.float64,
                 **self.check_backward_options)
 
     def test_backward_cpu(self):
@@ -152,7 +155,7 @@ class TestAveragePoolingND(unittest.TestCase):
         with chainer.using_config('use_cudnn', use_cudnn):
             func_nd = functions.AveragePoolingND(self.ndim, ksize,
                                                  stride=stride, pad=pad)
-        y_nd = func_nd(x_nd)
+        y_nd = func_nd.apply((x_nd,))[0]
         y_nd.grad = gy_data
         y_nd.backward()
 
@@ -180,6 +183,41 @@ class TestAveragePoolingND(unittest.TestCase):
     def test_backward_consistency_regression_no_cudnn(self):
         self.check_backward_consistency_regression(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), use_cudnn='never')
+
+    def check_double_backward(self, x_data, y_grad, x_grad_grad,
+                              use_cudnn='always'):
+        def f(x):
+            y = functions.average_pooling_nd(
+                x, self.ksize, stride=self.stride, pad=self.pad)
+            return y * y
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_double_backward(
+                f, x_data, y_grad, x_grad_grad, **self.check_backward_options)
+
+    @condition.retry(10)
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.gy, self.ggx, 'never')
+
+    @attr.gpu
+    @condition.retry(10)
+    def test_double_backward_gpu(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
+
+    @attr.gpu
+    @condition.retry(10)
+    def test_double_backward_gpu_non_contiguous(self):
+        self.check_double_backward(
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
+
+    @attr.gpu
+    @condition.retry(10)
+    def test_double_backward_gpu_no_cudnn(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
+            'never')
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -43,11 +43,20 @@ class TestMaxPoolingND(unittest.TestCase):
                          self.dims, self.ksize, self.stride, self.pad))
         gy_shape = (2, 3) + outs
         self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
+        self.ggx = numpy.random.uniform(
+            -1, 1, x_shape).astype(self.dtype)
 
         self.check_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
-                'atol': 1e-03, 'rtol': 1e-03}
+                'atol': 1e-3, 'rtol': 1e-2}
+            self.check_double_backward_options = {
+                'atol': 1e-3, 'rtol': 1e-2}
+        else:
+            self.check_backward_options = {
+                'atol': 1e-4, 'rtol': 1e-3}
+            self.check_double_backward_options = {
+                'atol': 1e-4, 'rtol': 1e-3}
 
     def check_forward(self, x_data, use_cudnn='always'):
         dims = self.dims
@@ -130,12 +139,13 @@ class TestMaxPoolingND(unittest.TestCase):
         self.check_forward_consistency_regression(cuda.to_gpu(self.x), 'never')
 
     def check_backward(self, x_data, y_grad, use_cudnn='always'):
+        def f(x):
+            return functions.max_pooling_nd(
+                x, self.ksize, stride=self.stride, pad=self.pad,
+                cover_all=self.cover_all)
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
-                functions.MaxPoolingND(
-                    self.ndim, self.ksize, stride=self.stride, pad=self.pad,
-                    cover_all=self.cover_all),
-                x_data, y_grad, dtype='d', **self.check_backward_options)
+                f, x_data, y_grad, dtype='d', **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -175,7 +185,7 @@ class TestMaxPoolingND(unittest.TestCase):
         with chainer.using_config('use_cudnn', use_cudnn):
             func_nd = functions.MaxPoolingND(self.ndim, ksize, stride=stride,
                                              pad=pad, cover_all=self.cover_all)
-        y_nd = func_nd(x_nd)
+        y_nd = func_nd.apply((x_nd,))[0]
         y_nd.grad = gy_data
         y_nd.backward()
 
@@ -211,9 +221,45 @@ class TestMaxPoolingND(unittest.TestCase):
         func = functions.MaxPoolingND(
             self.ndim, self.ksize, stride=self.stride, pad=self.pad,
             cover_all=self.cover_all)
-        func(self.x)
-        func.backward_cpu((self.x,), (self.gy,))
-        func.backward_cpu((self.x,), (self.gy,))
+        func.apply((self.x,))
+        func.backward((self.x,), (self.gy,))
+        func.backward((self.x,), (self.gy,))
+
+    def check_double_backward(self, x_data, y_grad, x_grad_grad,
+                              use_cudnn='always'):
+        def f(x):
+            y = functions.max_pooling_nd(
+                x, self.ksize, stride=self.stride, pad=self.pad,
+                cover_all=self.cover_all)
+            return y * y
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_double_backward(
+                f, x_data, y_grad, x_grad_grad,
+                dtype='d',
+                **self.check_double_backward_options)
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.x, self.gy, self.ggx, 'never')
+
+    """
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
+
+    @attr.gpu
+    def test_double_backward_gpu_non_contiguous(self):
+        self.check_double_backward(
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
+
+    @attr.gpu
+    def test_double_backward_gpu_no_cudnn(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
+            'never')
+    """
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -241,7 +241,6 @@ class TestMaxPoolingND(unittest.TestCase):
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx, 'never')
 
-    """
     @attr.gpu
     def test_double_backward_gpu(self):
         self.check_double_backward(
@@ -259,7 +258,6 @@ class TestMaxPoolingND(unittest.TestCase):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
             'never')
-    """
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_nd.py
@@ -79,9 +79,13 @@ class TestUnpoolingND(unittest.TestCase):
             self.check_forward_options = {'atol': 2 ** -4, 'rtol': 2 ** -4}
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+            self.check_double_backward_options = {}
         else:
             self.check_forward_options = {}
             self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_double_backward_options = {'atol': 3e-3, 'rtol': 3e-2}
+        self.ggx = numpy.random.uniform(
+            -1, 1, self.x.shape).astype(self.dtype)
 
     def check_forward(self, x_data):
         ksize = self.ksize
@@ -139,11 +143,12 @@ class TestUnpoolingND(unittest.TestCase):
         self.check_forward_consistency_regression(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, y_grad):
-        ndim = len(self.dims)
+        def f(x):
+            return functions.unpooling_nd(x, self.ksize, self.stride, self.pad,
+                                          cover_all=self.cover_all)
+
         gradient_check.check_backward(
-            functions.UnpoolingND(ndim, self.ksize, self.stride, self.pad,
-                                  cover_all=self.cover_all),
-            x_data, y_grad, **self.check_backward_options)
+            f, x_data, y_grad, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -170,7 +175,7 @@ class TestUnpoolingND(unittest.TestCase):
         x_nd = chainer.Variable(xp.array(x_data))
         func_nd = functions.UnpoolingND(ndim, ksize, stride=stride,
                                         pad=pad, cover_all=self.cover_all)
-        y_nd = func_nd(x_nd)
+        y_nd = func_nd.apply((x_nd,))[0]
         y_nd.grad = gy_data
         y_nd.backward()
 
@@ -196,6 +201,46 @@ class TestUnpoolingND(unittest.TestCase):
     def test_backward_consistency_regression_gpu(self):
         self.check_backward_consistency_regression(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    def check_double_backward(self, x_data, y_grad, x_grad_grad,
+                              use_cudnn='always'):
+        def f(x):
+            outs = self.gy.shape[2:]
+            y = functions.unpooling_nd(
+                x, self.ksize, stride=self.stride, pad=self.pad,
+                outsize=outs, cover_all=self.cover_all)
+            return y * y
+
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_double_backward(
+                f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+                **self.check_double_backward_options)
+
+    @condition.retry(3)
+    def test_double_backward_cpu(self):
+        self.check_double_backward(
+            self.x, self.gy, self.ggx, 'never')
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu_non_contiguous(self):
+        self.check_double_backward(
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_double_backward_gpu_no_cudnn(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
+            'never')
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Related to #2745. This PR aims to update `AveragePoolingND`, `MaxPoolingND`, and `UnpoolingND` to support double back propagations.
After merging this PR, I would like to integrate `Pooling2D` and `PoolingND` (it includes the support of `cover_all=True` in AveragePoolingND).

(This is a re-submission of #4131)