### PR TITLE
Fix document: chainer.backends.cuda

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -2,19 +2,19 @@
 
 Chainer uses `CuPy <https://cupy.chainer.org/>`_ (with very thin wrapper)
 to exploit the speed of GPU computation. Following modules and classes defined
-in CuPy are imported to :mod:`chainer.cuda` module for convenience (refer to
-this table when reading chainer's source codes).
+in CuPy are imported to :mod:`chainer.backends.cuda` module for convenience
+(refer to this table when reading chainer's source codes).
 
-============================ =================================
- imported name                original name
-============================ =================================
- ``chainer.cuda.cupy``        :mod:`cupy`
- ``chainer.cuda.ndarray``     :class:`cupy.ndarray`
- ``chainer.cuda.cupy.cuda``   :mod:`cupy.cuda`
- ``chainer.cuda.Device``      :class:`cupy.cuda.Device`
- ``chainer.cuda.Event``       :class:`cupy.cuda.Event`
- ``chainer.cuda.Stream``      :class:`cupy.cuda.Stream`
-============================ =================================
+====================================== =================================
+ imported name                          original name
+====================================== =================================
+ ``chainer.backends.cuda.cupy``        :mod:`cupy`
+ ``chainer.backends.cuda.ndarray``     :class:`cupy.ndarray`
+ ``chainer.backends.cuda.cupy.cuda``   :mod:`cupy.cuda`
+ ``chainer.backends.cuda.Device``      :class:`cupy.cuda.Device`
+ ``chainer.backends.cuda.Event``       :class:`cupy.cuda.Event`
+ ``chainer.backends.cuda.Stream``      :class:`cupy.cuda.Stream`
+====================================== =================================
 
 Chainer replaces the default allocator of CuPy by its memory pool
 implementation. It enables us to reuse the device memory over multiple


### PR DESCRIPTION
`chainer.cuda` is available for backward compatibility.
Use `chainer.backends.cuda` (#3974) in documents.