### PR TITLE
Finalize iterator in evaluator (in trainer)

### DIFF
--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -193,3 +193,8 @@ class Evaluator(extension.Extension):
             summary.add(observation)
 
         return summary.compute_mean()
+
+    def finalize(self):
+        for _, iterator in self._iterators.items():
+            if hasattr(iterator, 'finalize'):
+                iterator.finalize()

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -195,6 +195,12 @@ class Evaluator(extension.Extension):
         return summary.compute_mean()
 
     def finalize(self):
-        for _, iterator in self._iterators.items():
-            if hasattr(iterator, 'finalize'):
-                iterator.finalize()
+        """Finalizes the updater object.
+
+        This method calls the `finalize` method of each iterator that
+        this updater has.
+        It is called at the end of training loops.
+
+        """
+        for iterator in six.itervalues(self._iterators):
+            iterator.finalize()

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -195,11 +195,10 @@ class Evaluator(extension.Extension):
         return summary.compute_mean()
 
     def finalize(self):
-        """Finalizes the updater object.
+        """Finalizes the iterator objects.
 
-        This method calls the `finalize` method of each iterator that
-        this updater has.
-        It is called at the end of training loops.
+        This method calls the `finalize` method of each iterator.
+        They are called at the end of training loops.
 
         """
         for iterator in six.itervalues(self._iterators):

--- a/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
@@ -44,6 +44,7 @@ class DummyIterator(dataset.Iterator):
     def finalize(self):
         self.finalized = True
 
+
 class DummyConverter(object):
 
     def __init__(self, return_values):

--- a/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
@@ -36,10 +36,13 @@ class DummyIterator(dataset.Iterator):
 
     def __init__(self, return_values):
         self.iterator = iter(return_values)
+        self.finalized = False
 
     def __next__(self):
         return next(self.iterator)
 
+    def finalize(self):
+        self.finalized = True
 
 class DummyConverter(object):
 
@@ -92,6 +95,9 @@ class TestEvaluator(unittest.TestCase):
                 self.target.args[i], self.batches[i])
 
         self.assertAlmostEqual(mean['target/loss'], self.expect_mean, places=4)
+
+        self.evaluator.finalize()
+        self.assertTrue(self.iterator.finalized)
 
     def test_call(self):
         mean = self.evaluator()


### PR DESCRIPTION
This addresses an unreported deadlock bug found during ChainerMN testing.

`MultiProcessIterator` has a bug, when its finalization code runs during program finishing garbage collection it may cause a deadlock in one process, main thread running `__del__()` waits for `self._thread.join()` and never returns. Thus after all main Python path finished the process just hangs with [weird stacktrace](https://gist.github.com/kuenishi/029684b3e6ae3f4bc71510fd47e5cd8e#file-backtrace).

I reproduced with a [simple patching to an evaluate method](https://gist.github.com/kuenishi/029684b3e6ae3f4bc71510fd47e5cd8e#file-diff) which is close to [ChainerMN's new Evaluator usage](https://github.com/chainer/chainermn/pull/160), at current master. As of ChainerMN, this happens with most popular Chainer versions, such as 3.1, 3.2 and 4.0.0b2. Thus I request this patch to be backported to 3.2.

Simplest way to work around this issue is to call iterator's `finalize()` method directly from user code, after all training finished and _before the program exits_, or just use other iterators.

I also suggest removing `__del__()` method from Evaluator and add `__enter__()` and `__exit__()` methods instead, to use with `with` clause.

Note: it looks like [this line](https://github.com/chainer/chainer/blob/master/chainer/iterators/multiprocess_iterator.py#L321) creates cycle reference and may cause re-entrance on `MultiProcessIterator.__del__()` .