### PR TITLE
[WIP] Introduce sticky option to Link.to_gpu to support transfer between GPU devices

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -358,9 +358,9 @@ Assign a Parameter object directly to an attribute within a \
         Args:
             device: Target device specifier. If omitted, the current device is
                 used.
-            sticky (bool): If ``True``, the link will be transferred to the
+            sticky (bool): If ``False``, the link will be transferred to the
                 specified GPU device even if the Link is already on another
-                GPU. If ``False``, ``to_gpu`` does nothing if the Link is
+                GPU. If ``True``, ``to_gpu`` does nothing if the Link is
                 already on GPU. If omitted, ``True`` is used as the default
                 in Chainer v4. Note that the default is planned to be changed
                 to ``False`` in the future release (possibly in Chainer v5).
@@ -389,11 +389,12 @@ if the Link is already on GPU, `to_gpu` does nothing.
 
 In Chainer v4, `sticky` option has been introduced to `Link.to_gpu` to \
 control this behavior.
-You can specify `sticky=True` option to `to_gpu` to perform inter-GPU transfer.
-If you don't want to perform inter-GPU transfer, explicitly specify
-`sticky=False` so that you can disable this warning.
+You can specify `sticky=False` option to `to_gpu` to perform inter-GPU \
+transfer.
+If you don't want to perform inter-GPU transfer, explicitly specify \
+`sticky=True` so that you can disable this warning.
 
-The default behavior is planned to be changed to "non-sticky" in the future \
+The default behavior is planned to be changed to `sticky=False` in the future \
 release (possibly in Chainer v5).
 '''.format(dst=device_id, src=self._device_id), FutureWarning)
                     return

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -780,12 +780,11 @@ Assign a Link object directly to an attribute within a \
             d[name].to_cpu()
         return self
 
-    def to_gpu(self, device=None):
-        with cuda._get_device(device):
-            super(Chain, self).to_gpu()
-            d = self.__dict__
-            for name in self._children:
-                d[name].to_gpu()
+    def to_gpu(self, device=None, sticky=None):
+        super(Chain, self).to_gpu(device, sticky)
+        d = self.__dict__
+        for name in self._children:
+            d[name].to_gpu(device, sticky)
         return self
 
     def to_intel64(self):
@@ -946,11 +945,10 @@ class ChainList(Link):
             link.to_cpu()
         return self
 
-    def to_gpu(self, device=None):
-        with cuda._get_device(device):
-            super(ChainList, self).to_gpu()
-            for link in self._children:
-                link.to_gpu()
+    def to_gpu(self, device=None, sticky=None):
+        super(ChainList, self).to_gpu(device, sticky)
+        for link in self._children:
+            link.to_gpu(device, sticky)
         return self
 
     def to_intel64(self):

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -363,8 +363,6 @@ Assign a Parameter object directly to an attribute within a \
 
         """
         cuda.check_cuda_available()
-        if not self._cpu:
-            return self
         d = self.__dict__
         with cuda._get_device(device):
             for name in self._params:
@@ -373,7 +371,7 @@ Assign a Parameter object directly to an attribute within a \
                 value = d[name]
                 if isinstance(value, intel64.mdarray):
                     value = numpy.array(value)
-                if isinstance(value, numpy.ndarray):
+                if isinstance(value, (numpy.ndarray, cuda.ndarray)):
                     d[name] = cuda.to_gpu(value)
             self._device_id = cuda.cupy.cuda.get_device_id()
         self._cpu = False

--- a/chainer/training/updaters/standard_updater.py
+++ b/chainer/training/updaters/standard_updater.py
@@ -64,7 +64,10 @@ class StandardUpdater(_updater.Updater):
 
         if device is not None and device >= 0:
             for optimizer in six.itervalues(self._optimizers):
-                optimizer.target.to_gpu(device)
+                # Use sticky mode; if the target is manually transferred to
+                # the GPU by user (e.g., model-parallel use-case), we should
+                # not reloacte it.
+                optimizer.target.to_gpu(device, sticky=True)
 
         self.converter = converter
         self.loss_func = loss_func

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -292,7 +292,22 @@ class TestLink(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_to_gpu_between_devices(self):
         self.link.to_gpu(0)
-        self.link.to_gpu(1)
+
+        # sticky = default (True in Chainer v4)
+        with testing.assert_warns(FutureWarning):
+            self.link.to_gpu(1)
+        self.assertEqual(self.link._device_id, 0)
+        self.assertEqual(self.link.x.data.device.id, 0)
+        self.assertEqual(self.link.y.data.device.id, 0)
+
+        # sticky = True
+        self.link.to_gpu(1, sticky=True)
+        self.assertEqual(self.link._device_id, 0)
+        self.assertEqual(self.link.x.data.device.id, 0)
+        self.assertEqual(self.link.y.data.device.id, 0)
+
+        # sticky = False
+        self.link.to_gpu(1, sticky=False)
         self.assertEqual(self.link._device_id, 1)
         self.assertEqual(self.link.x.data.device.id, 1)
         self.assertEqual(self.link.y.data.device.id, 1)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -289,6 +289,14 @@ class TestLink(unittest.TestCase):
         self.link.to_gpu()
         self.assertEqual(self.link._device_id, 1)
 
+    @attr.multi_gpu(2)
+    def test_to_gpu_between_devices(self):
+        self.link.to_gpu(0)
+        self.link.to_gpu(1)
+        self.assertEqual(self.link._device_id, 1)
+        self.assertEqual(self.link.x.data.device.id, 1)
+        self.assertEqual(self.link.y.data.device.id, 1)
+
     def test_params(self):
         params = list(self.link.params())
         self.assertEqual({id(p) for p in params},


### PR DESCRIPTION
Fixes #4129.

TODOs:
- [ ] Support `sticky` option in `Variable.to_gpu`
- [ ] Fix all Links that overrides `to_gpu`

e.g., https://github.com/chainer/chainer/blob/v5.0.0b2/chainer/links/connection/peephole.py#L73-L78