### PR TITLE
Use method chain at Optimizer.setup 

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -383,6 +383,7 @@ class Optimizer(object):
         self.t = 0
         self.epoch = 0
         self._hooks = collections.OrderedDict()
+        return self
 
     def update(self, lossfun=None, *args, **kwds):
         """Updates the parameters.

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -525,12 +525,10 @@ class GradientMethod(Optimizer):
 
     """
 
-    def __init__(self, link=None):
+    def __init__(self):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
         self._use_fp32_update = False
-        if isinstance(link, link_module.Link):
-            self.setup(link)
 
     def setup(self, link):
         super(GradientMethod, self).setup(link)

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -84,8 +84,8 @@ class AdaDelta(optimizer.GradientMethod):
     """
 
     def __init__(self, rho=_default_hyperparam.rho,
-                 eps=_default_hyperparam.eps, model=None):
-        super(AdaDelta, self).__init__(model)
+                 eps=_default_hyperparam.eps):
+        super(AdaDelta, self).__init__()
         self.hyperparam.rho = rho
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -74,9 +74,8 @@ class AdaGrad(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr,
-                 eps=_default_hyperparam.eps, model=None):
-        super(AdaGrad, self).__init__(model)
+    def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+        super(AdaGrad, self).__init__()
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -151,10 +151,8 @@ class Adam(optimizer.GradientMethod):
                  beta2=_default_hyperparam.beta2,
                  eps=_default_hyperparam.eps,
                  eta=_default_hyperparam.eta,
-                 weight_decay_rate=_default_hyperparam.weight_decay_rate,
-                 model=None):
-        super(Adam, self).__init__(model)
-
+                 weight_decay_rate=_default_hyperparam.weight_decay_rate):
+        super(Adam, self).__init__()
         self.hyperparam.alpha = alpha
         self.hyperparam.beta1 = beta1
         self.hyperparam.beta2 = beta2

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -69,8 +69,8 @@ class MomentumSGD(optimizer.GradientMethod):
     """
 
     def __init__(self, lr=_default_hyperparam.lr,
-                 momentum=_default_hyperparam.momentum, model=None):
-        super(MomentumSGD, self).__init__(model)
+                 momentum=_default_hyperparam.momentum):
+        super(MomentumSGD, self).__init__()
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -76,8 +76,8 @@ class NesterovAG(optimizer.GradientMethod):
     """
 
     def __init__(self, lr=_default_hyperparam.lr,
-                 momentum=_default_hyperparam.momentum, model=None):
-        super(NesterovAG, self).__init__(model)
+                 momentum=_default_hyperparam.momentum):
+        super(NesterovAG, self).__init__()
         self.hyperparam.lr = lr
         self.hyperparam.momentum = momentum
 

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -91,9 +91,8 @@ class RMSprop(optimizer.GradientMethod):
     """
 
     def __init__(self, lr=_default_hyperparam.lr,
-                 alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps,
-                 model=None):
-        super(RMSprop, self).__init__(model)
+                 alpha=_default_hyperparam.alpha, eps=_default_hyperparam.eps):
+        super(RMSprop, self).__init__()
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.eps = eps

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -102,9 +102,8 @@ class RMSpropGraves(optimizer.GradientMethod):
     def __init__(self, lr=_default_hyperparam.lr,
                  alpha=_default_hyperparam.alpha,
                  momentum=_default_hyperparam.momentum,
-                 eps=_default_hyperparam.eps,
-                 model=None):
-        super(RMSpropGraves, self).__init__(model)
+                 eps=_default_hyperparam.eps):
+        super(RMSpropGraves, self).__init__()
         self.hyperparam.lr = lr
         self.hyperparam.alpha = alpha
         self.hyperparam.momentum = momentum

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -50,8 +50,8 @@ class SGD(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr, model=None):
-        super(SGD, self).__init__(model)
+    def __init__(self, lr=_default_hyperparam.lr):
+        super(SGD, self).__init__()
         self.hyperparam.lr = lr
 
     lr = optimizer.HyperparameterProxy('lr')

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -87,9 +87,8 @@ class SMORMS3(optimizer.GradientMethod):
 
     """
 
-    def __init__(self, lr=_default_hyperparam.lr,
-                 eps=_default_hyperparam.eps, model=None):
-        super(SMORMS3, self).__init__(model)
+    def __init__(self, lr=_default_hyperparam.lr, eps=_default_hyperparam.eps):
+        super(SMORMS3, self).__init__()
         self.hyperparam.lr = lr
         self.hyperparam.eps = eps
 


### PR DESCRIPTION
#3488 allowed
```
optimizer = chainer.optimizers.SGD(link=model)
```
but it costs writing a new optimizer.

Instead I propose method-chain
```
optimizer = chainer.optimizers.SGD().setup(model)
```

This PR removes the feature (added to v4.0.0b2).
Nonetheless this PR is "more compatible to v3" solution to merge the two lines on an optimizer than #3488 is.
