### PR TITLE
Infer input size in batchnorm

### DIFF
--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -82,11 +82,6 @@ class BatchNormalization(link.Link):
         self._axis = (axis,) if isinstance(axis, int) else tuple(axis)
         self._dtype = dtype
 
-        self.avg_mean = numpy.zeros(self._size, dtype=self._dtype)
-        self.register_persistent('avg_mean')
-        self.avg_var = numpy.zeros(self._size, dtype=self._dtype)
-        self.register_persistent('avg_var')
-
         with self.init_scope():
             if use_gamma:
                 if initial_gamma is None:
@@ -102,12 +97,11 @@ class BatchNormalization(link.Link):
                 beta_initializer.dtype = self._dtype
                 self.beta = variable.Parameter(beta_initializer)
 
-        if self._size is not None:
-            self._initialize_params(self._size)
-
     def _initialize_params(self, shape):
         self.avg_mean = numpy.zeros(shape, dtype=self._dtype)
+        self.register_persistent('avg_mean')
         self.avg_var = numpy.zeros(shape, dtype=self._dtype)
+        self.register_persistent('avg_var')
         if hasattr(self, 'gamma'):
             self.gamma.initialize(shape)
         if hasattr(self, 'beta'):
@@ -137,7 +131,7 @@ class BatchNormalization(link.Link):
                 statistics.
 
         """
-        if not self.avg_mean.shape:
+        if self.gamma.data is None:
             if self._size is not None:
                 self._initialize_params(self._size)
             else:

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -97,6 +97,9 @@ class BatchNormalization(link.Link):
                 beta_initializer.dtype = self._dtype
                 self.beta = variable.Parameter(beta_initializer)
 
+        if self._size is not None:
+            self._initialize_params(self._size)
+
     def _initialize_params(self, shape):
         self.avg_mean = numpy.zeros(shape, dtype=self._dtype)
         self.register_persistent('avg_mean')
@@ -131,12 +134,9 @@ class BatchNormalization(link.Link):
                 statistics.
 
         """
-        if self.gamma.data is None:
-            if self._size is not None:
-                self._initialize_params(self._size)
-            else:
-                shape = tuple(x.shape[i] for i in self._axis)
-                self._initialize_params(shape)
+        if not hasattr(self, 'avg_mean'):
+            shape = tuple(x.shape[i] for i in self._axis)
+            self._initialize_params(shape)
 
         argument.check_unexpected_kwargs(
             kwargs, test='test argument is not supported anymore. '

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -91,7 +91,8 @@ class BatchNormalization(link.Link):
             if use_gamma:
                 if initial_gamma is None:
                     initial_gamma = 1
-                gamma_initializer = initializers._get_initializer(initial_gamma)
+                gamma_initializer = \
+                    initializers._get_initializer(initial_gamma)
                 gamma_initializer.dtype = self._dtype
                 self.gamma = variable.Parameter(gamma_initializer)
             if use_beta:

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -81,6 +81,11 @@ class BatchNormalization(link.Link):
         self._axis = (axis,) if isinstance(axis, int) else tuple(axis)
         self._dtype = dtype
 
+        self.avg_mean = numpy.zeros(self._size, dtype=self._dtype)
+        self.register_persistent('avg_mean')
+        self.avg_var = numpy.zeros(self._size, dtype=self._dtype)
+        self.register_persistent('avg_var')
+
         with self.init_scope():
             if use_gamma:
                 if initial_gamma is None:
@@ -95,11 +100,12 @@ class BatchNormalization(link.Link):
                 beta_initializer.dtype = self._dtype
                 self.beta = variable.Parameter(beta_initializer)
 
+        if self._size is not None:
+            self._initialize_params(self._size)
+
     def _initialize_params(self, shape):
         self.avg_mean = numpy.zeros(shape, dtype=self._dtype)
-        self.register_persistent('avg_mean')
         self.avg_var = numpy.zeros(shape, dtype=self._dtype)
-        self.register_persistent('avg_var')
         if hasattr(self, 'gamma'):
             self.gamma.initialize(shape)
         if hasattr(self, 'beta'):
@@ -129,7 +135,7 @@ class BatchNormalization(link.Link):
                 statistics.
 
         """
-        if self.gamma.data is None:
+        if not self.avg_mean.shape:
             if self._size is not None:
                 self._initialize_params(self._size)
             else:

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -46,7 +46,8 @@ class BatchNormalization(link.Link):
             unit(0) which makes no effect.
         axis (int or tuple of ints): Axis or axes of channel dimension(s). When
              ``size``` is ``None``, this value is used to determine parameter
-             sizes during the first forward pass.
+             sizes during the first forward pass. Otherwise, this value is
+             ignored.
 
     See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
           Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -100,8 +100,10 @@ class BatchNormalization(link.Link):
         self.register_persistent('avg_mean')
         self.avg_var = numpy.zeros(shape, dtype=self._dtype)
         self.register_persistent('avg_var')
-        self.gamma.initialize(shape)
-        self.beta.initialize(shape)
+        if hasattr(self, 'gamma'):
+            self.gamma.initialize(shape)
+        if hasattr(self, 'beta'):
+            self.beta.initialize(shape)
 
     def __call__(self, x, **kwargs):
         """__call__(self, x, finetune=False)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -388,8 +388,12 @@ class TestChannalSizeInference(unittest.TestCase):
         self.link = links.BatchNormalization(None)
         self.x = numpy.random.randn(1, 16).astype('f')
 
+    def test_initialization(self):
+        assert hasattr(self.link, 'avg_mean')
+        assert hasattr(self.link, 'avg_var')
+
     def test_inference(self):
-        self.link(self.x, test=True)
+        self.link(self.x)
         assert self.link.beta.shape == (16,)
         assert self.link.gamma.shape == (16,)
         assert self.link.avg_mean.shape == (16,)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -386,6 +386,8 @@ class TestChannalSizeInference(unittest.TestCase):
 
     def setUp(self):
         self.link = links.BatchNormalization(None)
+        self.link_no_gamma = links.BatchNormalization(None, use_gamma=False)
+        self.link_no_beta = links.BatchNormalization(None, use_beta=False)
         self.x = numpy.random.randn(1, 16).astype('f')
 
     def test_initialization(self):
@@ -398,6 +400,16 @@ class TestChannalSizeInference(unittest.TestCase):
         assert self.link.gamma.shape == (16,)
         assert self.link.avg_mean.shape == (16,)
         assert self.link.avg_mean.shape == (16,)
+
+    def test_no_gamma(self):
+        assert not hasattr(self.link_no_gamma, 'gamma')
+        self.link_no_gamma(self.x)
+        assert not hasattr(self.link_no_gamma, 'gamma')
+
+    def test_no_beta(self):
+        assert not hasattr(self.link_no_beta, 'beta')
+        self.link_no_beta(self.x)
+        assert not hasattr(self.link_no_beta, 'beta')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -389,7 +389,7 @@ class TestChannalSizeInference(unittest.TestCase):
         self.x = numpy.random.randn(1, 16).astype('f')
 
     def test_inference(self):
-        self.link(x, test=True)
+        self.link(self.x, test=True)
         assert self.link.beta.shape == (16,)
         assert self.link.gamma.shape == (16,)
         assert self.link.avg_mean.shape == (16,)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -400,7 +400,7 @@ class TestChannalSizeInference(unittest.TestCase):
         assert self.link.beta.shape == (16,)
         assert self.link.gamma.shape == (16,)
         assert self.link.avg_mean.shape == (16,)
-        assert self.link.avg_mean.shape == (16,)
+        assert self.link.avg_var.shape == (16,)
 
     def test_no_gamma(self):
         assert not hasattr(self.link_no_gamma, 'gamma')

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -390,12 +390,8 @@ class TestChannalSizeInference(unittest.TestCase):
         self.link_no_beta = links.BatchNormalization(None, use_beta=False)
         self.x = numpy.random.randn(1, 16).astype('f')
 
-    def test_initialization(self):
-        assert hasattr(self.link, 'avg_mean')
-        assert hasattr(self.link, 'avg_var')
-
     def test_inference(self):
-        self.link(self.x)
+        self.link(self.x, test=True)
         assert self.link.beta.shape == (16,)
         assert self.link.gamma.shape == (16,)
         assert self.link.avg_mean.shape == (16,)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -382,4 +382,18 @@ class TestInvalidArgument(unittest.TestCase):
             self.link(self.x, unknown_argument=1)
 
 
+class TestChannalSizeInference(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.BatchNormalization(None)
+        self.x = numpy.random.randn(1, 16).astype('f')
+
+    def test_inference(self):
+        self.link(x, test=True)
+        assert self.link.beta.shape == (16,)
+        assert self.link.gamma.shape == (16,)
+        assert self.link.avg_mean.shape == (16,)
+        assert self.link.avg_mean.shape == (16,)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -390,8 +390,13 @@ class TestChannalSizeInference(unittest.TestCase):
         self.link_no_beta = links.BatchNormalization(None, use_beta=False)
         self.x = numpy.random.randn(1, 16).astype('f')
 
+    def test_no_inference(self):
+        bn = links.BatchNormalization(16)
+        assert hasattr(bn, 'avg_mean')
+        assert hasattr(bn, 'avg_var')
+
     def test_inference(self):
-        self.link(self.x, test=True)
+        self.link(self.x)
         assert self.link.beta.shape == (16,)
         assert self.link.gamma.shape == (16,)
         assert self.link.avg_mean.shape == (16,)


### PR DESCRIPTION
This addresses #3221. If `size`  is None, BatchNormalization infers the channel size from the input array during the first call of `__call__()`. The axis or axes of channels will be determined by `axis` parameters, which default value is 1. To maintain the backward compatibility, the `axis` comes the last of the arguments.