### PR TITLE
[RFC]Fix progress bar

### DIFF
--- a/chainer/training/extensions/progress_bar.py
+++ b/chainer/training/extensions/progress_bar.py
@@ -63,6 +63,9 @@ class ProgressBar(extension.Extension):
         # print the progress bar
         if iteration % self._update_interval == 0:
             epoch = trainer.updater.epoch_detail
+            one_iteration_epoch = epoch / iteration
+            if length % one_iteration_epoch:
+                length += one_iteration_epoch - length % one_iteration_epoch
             recent_timing = self._recent_timing
             now = time.time()
 

--- a/chainer/training/extensions/progress_bar.py
+++ b/chainer/training/extensions/progress_bar.py
@@ -63,9 +63,6 @@ class ProgressBar(extension.Extension):
         # print the progress bar
         if iteration % self._update_interval == 0:
             epoch = trainer.updater.epoch_detail
-            one_iteration_epoch = epoch / iteration
-            if length % one_iteration_epoch:
-                length += one_iteration_epoch - length % one_iteration_epoch
             recent_timing = self._recent_timing
             now = time.time()
 
@@ -80,6 +77,7 @@ class ProgressBar(extension.Extension):
                 rate = iteration / length
             else:
                 rate = epoch / length
+            rate = min(rate, 1.0)
 
             bar_length = self._bar_length
             marks = '#' * int(rate * bar_length)
@@ -107,6 +105,7 @@ class ProgressBar(extension.Extension):
                 estimated_time = (length - iteration) / speed_t
             else:
                 estimated_time = (length - epoch) / speed_e
+            estimated_time = max(estimated_time, 0.0)
             out.write('{:10.5g} iters/sec. Estimated time to finish: {}.\n'
                       .format(speed_t,
                               datetime.timedelta(seconds=estimated_time)))


### PR DESCRIPTION
Fixes #3969
Recalculate epoch_length not to exceed 100%
before:
<pre>
[gen@localhost chainer]$ python3 examples/ptb/train_ptb.py --test
#vocab = 10000
     total [#####################################################] 107.69%
this epoch [..................................................]  0.00%
         6 iter, 42 epoch / 39 epochs
   0.10037 iters/sec. Estimated time to finish: -1 day, 23:59:55.730007.
</pre>
after:
<pre>
[gen@localhost chainer]$ python3 examples/ptb/train_ptb.py --test
#vocab = 10000
     total [##################################################] 100.00%
this epoch [..................................................]  0.00%
         6 iter, 42 epoch / 39 epochs
  0.099782 iters/sec. Estimated time to finish: 0:00:00.
</pre>
