### PR TITLE
Remove empty retain

### DIFF
--- a/chainer/functions/math/identity.py
+++ b/chainer/functions/math/identity.py
@@ -6,7 +6,6 @@ class Identity(function_node.FunctionNode):
     """Identity function."""
 
     def forward(self, xs):
-        self.retain_inputs(())
         return xs
 
     def backward(self, indexes, gys):


### PR DESCRIPTION
Remove unneeded empty retain (it is by default empty in `FunctionNode`s).