### PR TITLE
Provide a cleaner way to collect threads and processes in MultiprocessIterator

### DIFF
--- a/chainer/dataset/iterator.py
+++ b/chainer/dataset/iterator.py
@@ -61,6 +61,24 @@ class Iterator(object):
         """
         pass
 
+    def __enter__(self):
+        """With statement context manager method
+
+        This method does nothing by default. Implementation may override it to
+        better handle the internal resources by with statement.
+
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """With statement context manager method
+
+        This method does nothing by default. Implementation may override it to
+        better handle the internal resources by with statement.
+
+        """
+        return None
+
     def serialize(self, serializer):
         """Serializes the internal state of the iterator.
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -116,6 +116,12 @@ class MultiprocessIterator(iterator.Iterator):
 
     finalize = __del__
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.finalize()
+
     def __copy__(self):
         other = MultiprocessIterator(
             self.dataset, self.batch_size, self.repeat, self.shuffle,

--- a/chainer/iterators/multithread_iterator.py
+++ b/chainer/iterators/multithread_iterator.py
@@ -61,7 +61,10 @@ class MultithreadIterator(iterator.Iterator):
         self._next = None
         self._previous_epoch_detail = None
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
         self.finalize()
 
     def finalize(self):

--- a/examples/mnist/train_mnist_custom_loop.py
+++ b/examples/mnist/train_mnist_custom_loop.py
@@ -11,6 +11,7 @@ import argparse
 
 import chainer
 from chainer.dataset import convert
+from chainer.iterators import MultiprocessIterator
 import chainer.links as L
 from chainer import serializers
 
@@ -62,48 +63,48 @@ def main():
     train_count = len(train)
     test_count = len(test)
 
-    train_iter = chainer.iterators.SerialIterator(train, args.batchsize)
-    test_iter = chainer.iterators.SerialIterator(test, args.batchsize,
-                                                 repeat=False, shuffle=False)
+    with MultiprocessIterator(train, args.batchsize) as train_iter, \
+        MultiprocessIterator(test, args.batchsize,
+                             repeat=False, shuffle=False) as test_iter:
 
-    sum_accuracy = 0
-    sum_loss = 0
+        sum_accuracy = 0
+        sum_loss = 0
 
-    while train_iter.epoch < args.epoch:
-        batch = train_iter.next()
-        x_array, t_array = convert.concat_examples(batch, args.gpu)
-        x = chainer.Variable(x_array)
-        t = chainer.Variable(t_array)
-        optimizer.update(model, x, t)
-        sum_loss += float(model.loss.data) * len(t.data)
-        sum_accuracy += float(model.accuracy.data) * len(t.data)
+        while train_iter.epoch < args.epoch:
+            batch = train_iter.next()
+            x_array, t_array = convert.concat_examples(batch, args.gpu)
+            x = chainer.Variable(x_array)
+            t = chainer.Variable(t_array)
+            optimizer.update(model, x, t)
+            sum_loss += float(model.loss.data) * len(t.data)
+            sum_accuracy += float(model.accuracy.data) * len(t.data)
 
-        if train_iter.is_new_epoch:
-            print('epoch: {}'.format(train_iter.epoch))
-            print('train mean loss: {}, accuracy: {}'.format(
-                sum_loss / train_count, sum_accuracy / train_count))
-            # evaluation
-            sum_accuracy = 0
-            sum_loss = 0
-            for batch in test_iter:
-                x_array, t_array = convert.concat_examples(batch, args.gpu)
-                x = chainer.Variable(x_array)
-                t = chainer.Variable(t_array)
-                loss = model(x, t)
-                sum_loss += float(loss.data) * len(t.data)
-                sum_accuracy += float(model.accuracy.data) * len(t.data)
+            if train_iter.is_new_epoch:
+                print('epoch: {}'.format(train_iter.epoch))
+                print('train mean loss: {}, accuracy: {}'.format(
+                    sum_loss / train_count, sum_accuracy / train_count))
+                # evaluation
+                sum_accuracy = 0
+                sum_loss = 0
+                for batch in test_iter:
+                    x_array, t_array = convert.concat_examples(batch, args.gpu)
+                    x = chainer.Variable(x_array)
+                    t = chainer.Variable(t_array)
+                    loss = model(x, t)
+                    sum_loss += float(loss.data) * len(t.data)
+                    sum_accuracy += float(model.accuracy.data) * len(t.data)
 
-            test_iter.reset()
-            print('test mean  loss: {}, accuracy: {}'.format(
-                sum_loss / test_count, sum_accuracy / test_count))
-            sum_accuracy = 0
-            sum_loss = 0
+                test_iter.reset()
+                print('test mean  loss: {}, accuracy: {}'.format(
+                    sum_loss / test_count, sum_accuracy / test_count))
+                sum_accuracy = 0
+                sum_loss = 0
 
-    # Save the model and the optimizer
-    print('save the model')
-    serializers.save_npz('{}/mlp.model'.format(args.out), model)
-    print('save the optimizer')
-    serializers.save_npz('{}/mlp.state'.format(args.out), optimizer)
+        # Save the model and the optimizer
+        print('save the model')
+        serializers.save_npz('{}/mlp.model'.format(args.out), model)
+        print('save the optimizer')
+        serializers.save_npz('{}/mlp.state'.format(args.out), optimizer)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is rather a request for comment than a change request - `__del__` is often harmful because the timing and order of  objects of `__del__` is unpredictable especially when those objects have cyclic references. This commit tries to remove `__del__` and to make iterators as context manager, available in [`with` statement](https://www.python.org/dev/peps/pep-0343/). Pros and cons in my thought follows on this:

Pros
- Good for users those don't use Trainer which does explicitly finalize iterators: #4145 and #4148 are not sufficient
- Removes unpredictable behavior around garbage collection of MultiprocessIterator and related object included in object reference graph, especially when it includes cyclic reference.
- Provides a good interface to collect external resources such as files or sockets, for custom iterators

Cons
- Changes the usage of iterators; may or may not affect existing codes that do important finalization in `__del__`. See 'Side effects' below for further discussions.
- Possibly one more indentation needed to custom loop training codes, like `train_mnist_custom_loop.py`  like this:

```python
    with MultiprocessIterator(train, args.batchsize) as train_iter, \
        MultiprocessIterator(test, args.batchsize,
                             repeat=False, shuffle=False) as test_iter:

        sum_accuracy = 0
        sum_loss = 0

        while train_iter.epoch < args.epoch:
            batch = train_iter.next()
            ...
```

Side effects of removing `__del__`:
- As far as I grepped the whole Chainer master branch there are no usage of `__del__` method other than MultiprocessIterator.
- I tried to see effect of *not* calling `finalize()` in garbage collection (via `__del__` ), with MNist example, so far I cannot find any unexpected behavior such as remaining shared memory or child processes but saw things cleanly removed by operating system.
- MultiprocessIterator's `bulk_mem` is shared (ctypes memory) buffer, which may possibly remain after parent process termination, but as far as I tested with Python 3.6.3 it was tied to a temporary file and was removed right after memory allocation succeeded. See `strace` result of running `sharedctypes.RawArray('b', 1024 * 1024)` below:

```
openat(AT_FDCWD, "/tmp/pymp-p30fkagk/pym-9895-4bozg6h7", O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC, 0600) = 3
unlink("/tmp/pymp-p30fkagk/pym-9895-4bozg6h7") = 0
getpid()                                = 9895
fstat(3, {st_mode=S_IFREG|0600, st_size=0, ...}) = 0
ioctl(3, TCGETS, 0x7ffe0072ac40)        = -1 ENOTTY (Inappropriate ioctl for device)
lseek(3, 0, SEEK_CUR)                   = 0
mmap(NULL, 1052672, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f9c0216e000
write(3, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 1048576) = 1048576
munmap(0x7f9c0216e000, 1052672)         = 0
lseek(3, 0, SEEK_CUR)                   = 1048576
fstat(3, {st_mode=S_IFREG|0600, st_size=1048576, ...}) = 0
fcntl(3, F_DUPFD_CLOEXEC, 0)            = 4
mmap(NULL, 1048576, PROT_READ|PROT_WRITE, MAP_SHARED, 3, 0) = 0x7f9c0216f000
```

- Also, process pool owned by MultiprocessIterator seemed to gracefully terminate after last task finished, even when I killed it forcibly with `SIGKILL`.
