### PR TITLE
Support Caffe global pooling functions

### DIFF
--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -328,7 +328,14 @@ class CaffeFunction(link.Chain):
         else:
             raise RuntimeError('Stochastic pooling is not supported')
 
-        fw = _SingleArgumentFunction(func, ksize, stride=stride, pad=pad)
+        if param.global_pooling and not ksize:
+            # if global_pooling is set but no kernel size, the kernel size
+            # is computed dynamically to cover the whole input feature map
+            def _func(x, stride, pad):
+                return func(x, x.shape[2:], stride=stride, pad=pad)
+            fw = _SingleArgumentFunction(_func, stride=stride, pad=pad)
+        else:
+            fw = _SingleArgumentFunction(func, ksize, stride=stride, pad=pad)
         self.forwards[layer.name] = fw
         self._add_layer(layer)
 

--- a/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
+++ b/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
@@ -471,6 +471,35 @@ class TestAveragePooling(TestCaffeFunctionBaseMock):
             self.inputs[0], 2, stride=4, pad=6)
 
 
+class TestGlobalPooling(TestCaffeFunctionBaseMock):
+
+    func_name = 'chainer.functions.max_pooling_2d'
+    in_shapes = [(3, 2, 3, 4)]
+    out_shapes = [(3, 2, 3, 4)]
+
+    data = {
+        'layer': [
+            {
+                'name': 'l1',
+                'type': 'Pooling',
+                'bottom': ['x'],
+                'top': ['y'],
+                'pooling_param': {
+                    'pool': 0,  # MAX
+                    'global_pooling': True,
+                }
+            }
+        ]
+    }
+
+    def test_global_pooling(self):
+        self.init_func()
+        self.assertEqual(len(self.func.layers), 1)
+        self.call(['x'], ['y'])
+        self.mock.assert_called_once_with(
+            self.inputs[0], (3, 4), stride=1, pad=0)
+
+
 class TestStochasticPooling(TestCaffeFunctionBase):
 
     data = {


### PR DESCRIPTION
Fixes https://github.com/chainer/chainer/issues/3098

Wrapped the Chainer pooling functions so that the kernel sizes can be computed dynamically to cover the whole input. 

Caffe reference https://github.com/BVLC/caffe/blob/master/src/caffe/proto/caffe.proto#L921