### PR TITLE
Use input_num to remove array creation overhead

### DIFF
--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -251,29 +251,34 @@ def lstm_grad_grad(
 
     gc_bar = gh * sig_o * gtanh_c + gc
 
-    cuda.cupy.fusion.multiply(ggf * gc_bar, gsig_f, out=gc_prev)
-    cuda.cupy.fusion.multiply(
+    if isinstance(c_prev, numpy.ndarray):
+        xp = numpy
+    else:
+        xp = cuda.cupy.fusion
+
+    xp.multiply(ggf * gc_bar, gsig_f, out=gc_prev)
+    xp.multiply(
         (gga * sig_i * ggtanh_a + ggi * gtanh_a * gsig_i), gc_bar,
         out=ga)
-    cuda.cupy.fusion.multiply(
+    xp.multiply(
         (gga * gtanh_a * gsig_i + ggi * tanh_a * ggsig_i), gc_bar,
         out=gi)
-    cuda.cupy.fusion.add(
+    xp.add(
         ggc_prev * (gh * sig_o * gtanh_c + gc) * gsig_f,
         ggf * gc_bar * c_prev * ggsig_f, out=gf)
 
-    cuda.cupy.fusion.add(
+    xp.add(
         ggc_prev * sig_f +
         gga * sig_i * gtanh_a +
         ggi * tanh_a * gsig_i,
         ggf * c_prev * gsig_f, out=ggc)
 
     dgc_do = gh * gsig_o * gtanh_c
-    cuda.cupy.fusion.add(ggc * dgc_do, ggo * gh * tanh_c * ggsig_o, out=go)
+    xp.add(ggc * dgc_do, ggo * gh * tanh_c * ggsig_o, out=go)
     dgc_dc = gh * sig_o * ggtanh_c
-    cuda.cupy.fusion.add(
+    xp.add(
         ggc * dgc_dc, ggo * gh * gtanh_c * gsig_o, out=gc_next)
-    cuda.cupy.fusion.add(ggc * sig_o * gtanh_c, ggo * tanh_c * gsig_o, out=ggh)
+    xp.add(ggc * sig_o * gtanh_c, ggo * tanh_c * gsig_o, out=ggh)
     return gc_prev, ga, gi, gf, go, gc_next, ggc, ggh
 
 

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -229,7 +229,7 @@ def _cupy_sigmoid(x):
     return cuda.fusion.tanh(x * half) * half + half
 
 
-@cuda.fuse
+@cuda.fuse()
 def lstm_grad_grad(
         c_prev, a, i, f, o, c, gc, gh, ggc_prev, gga, ggi, ggf, ggo,
         gc_prev, ga, gi, gf, go, gc_next, ggc, ggh):

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -251,11 +251,6 @@ def lstm_grad_grad(
 
     gc_bar = gh * sig_o * gtanh_c + gc
 
-    if isinstance(c_prev, numpy.ndarray):
-        xp = numpy
-    else:
-        xp = cuda.cupy.fusion
-
     gc_prev[:] = ggf * gc_bar * gsig_f
     ga[:] = (gga * sig_i * ggtanh_a + ggi * gtanh_a * gsig_i) * gc_bar
     gi[:] = (gga * gtanh_a * gsig_i + ggi * tanh_a * ggsig_i) * gc_bar

--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -229,7 +229,7 @@ def _cupy_sigmoid(x):
     return cuda.fusion.tanh(x * half) * half + half
 
 
-@cuda.fuse(input_num=13)
+@cuda.fuse
 def lstm_grad_grad(
         c_prev, a, i, f, o, c, gc, gh, ggc_prev, gga, ggi, ggf, ggo,
         gc_prev, ga, gi, gf, go, gc_next, ggc, ggh):


### PR DESCRIPTION
To remove redundant array creation overhead, I used `input_num`. Merge https://github.com/cupy/cupy/pull/868 first.