### PR TITLE
Very thin wrapper for `ideep`.

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -31,6 +31,7 @@ from chainer import variable  # NOQA
 # These functions from backends.cuda are kept for backward compatibility
 from chainer.backends.cuda import should_use_cudnn  # NOQA
 from chainer.backends.cuda import should_use_cudnn_tensor_core  # NOQA
+from chainer.backends.ia import should_use_ideep  # NOQA
 from chainer.configuration import config  # NOQA
 from chainer.configuration import global_config  # NOQA
 from chainer.configuration import using_config  # NOQA
@@ -66,6 +67,7 @@ from chainer.variable import Variable  # NOQA
 
 # Alias for backward compatibility
 from chainer import cuda  # NOQA
+from chainer import ia  # NOQA
 
 
 from chainer import _environment_check
@@ -98,6 +100,7 @@ global_config.train = True
 global_config.type_check = bool(int(os.environ.get('CHAINER_TYPE_CHECK', '1')))
 global_config.use_cudnn = os.environ.get('CHAINER_USE_CUDNN', 'auto')
 global_config.use_cudnn_tensor_core = 'auto'
+global_config.use_ideep = os.environ.get('CHAINER_USE_IDEEP', 'auto')
 global_config.autotune = False
 
 

--- a/chainer/backends/ia.py
+++ b/chainer/backends/ia.py
@@ -21,7 +21,6 @@ import os
 import numpy
 
 import chainer
-from chainer import variable
 from chainer.configuration import config
 
 
@@ -152,7 +151,7 @@ def all_ready(inputs, supported_ndim=(2, 4)):
     if not ideep_enabled:
         return False
 
-    _inputs = [x.data if isinstance(x, variable.Variable)
+    _inputs = [x.data if isinstance(x, chainer.variable.Variable)
                else x for x in inputs]
 
     # Check with ideep4py supported dimension of input data

--- a/chainer/backends/ia.py
+++ b/chainer/backends/ia.py
@@ -15,10 +15,8 @@ when reading chainer's source cods).
 
 """
 
-
-import os
-import warnings
 import contextlib
+import os
 
 import numpy
 
@@ -33,26 +31,28 @@ ideep_enabled = False
 try:
     import ideep4py  # NOQA
     from ideep4py import mdarray  # NOQA
-    from ideep4py import intVector  # NOQA
     from ideep4py import mdarrayVector  # NOQA
+
+    from ideep4py import intVector  # NOQA
+
     from ideep4py import batchNormalization  # NOQA
-    from ideep4py import relu  # NOQA
-    from ideep4py import convolution2DParam  # NOQA
-    from ideep4py import convolution2D  # NOQA
-    from ideep4py import pooling2DParam  # NOQA
-    from ideep4py import pooling2D  # NOQA
     from ideep4py import concat  # NOQA
-    from ideep4py import linearParam  # NOQA
-    from ideep4py import linear  # NOQA
-    from ideep4py import localResponseNormalizationParam  # NOQA
-    from ideep4py import localResponseNormalization  # NOQA
+    from ideep4py import convolution2D  # NOQA
+    from ideep4py import convolution2DParam  # NOQA
     from ideep4py import dropout  # NOQA
+    from ideep4py import linear  # NOQA
+    from ideep4py import linearParam  # NOQA
+    from ideep4py import localResponseNormalization  # NOQA
+    from ideep4py import localResponseNormalizationParam  # NOQA
+    from ideep4py import pooling2D  # NOQA
+    from ideep4py import pooling2DParam  # NOQA
+    from ideep4py import relu  # NOQA
+
     from ideep4py import basic_acc_sum as acc_add  # NOQA
+
     from ideep4py import cosim  # NOQA
     available = True
 except Exception as ex:
-    # warnings.warn('IA acceleration is disabled: %s' % ex)
-
     class mdarray(object):
         pass
 

--- a/chainer/backends/ia.py
+++ b/chainer/backends/ia.py
@@ -1,0 +1,216 @@
+"""Context management on ideep.
+
+Very thin wrapper to exploit the speed of IA (Intel Architecture)
+computation. Following modules and classes defined in ideep are imported
+to :mod:`chainer.ia` module for convenience (refer to this table
+when reading chainer's source cods).
+
+============================ =================================
+ imported name                original name
+============================ =================================
+ ``chainer.ideep4py``         :mod:`ideep4py`
+ ``chainer.ia.mdarray``       :class:`ideep4py.mdarray`
+ ``chainer.ia.{operation}``   :class:`ideep4py.{opertaion}`
+============================ =================================
+
+"""
+
+
+import os
+import warnings
+import contextlib
+
+import numpy
+
+import chainer
+from chainer import variable
+from chainer.configuration import config
+
+
+available = False
+ideep_enabled = False
+
+try:
+    import ideep4py  # NOQA
+    from ideep4py import mdarray  # NOQA
+    from ideep4py import intVector  # NOQA
+    from ideep4py import mdarrayVector  # NOQA
+    from ideep4py import batchNormalization  # NOQA
+    from ideep4py import relu  # NOQA
+    from ideep4py import convolution2DParam  # NOQA
+    from ideep4py import convolution2D  # NOQA
+    from ideep4py import pooling2DParam  # NOQA
+    from ideep4py import pooling2D  # NOQA
+    from ideep4py import concat  # NOQA
+    from ideep4py import linearParam  # NOQA
+    from ideep4py import linear  # NOQA
+    from ideep4py import localResponseNormalizationParam  # NOQA
+    from ideep4py import localResponseNormalization  # NOQA
+    from ideep4py import dropout  # NOQA
+    from ideep4py import basic_acc_sum as acc_add  # NOQA
+    from ideep4py import cosim  # NOQA
+    available = True
+except Exception as ex:
+    # warnings.warn('IA acceleration is disabled: %s' % ex)
+
+    class mdarray(object):
+        pass
+
+if available:
+    _ideep_disabled_by_user = int(os.environ.get('CHAINER_IDEEP', '1')) == 0
+    ideep_enabled = not _ideep_disabled_by_user
+
+
+# ------------------------------------------------------------------------------
+# ideep configuration
+# ------------------------------------------------------------------------------
+_SHOULD_USE_IDEEP = {
+    '==always': {'always': True, 'auto': False, 'never': False},
+    '>=auto': {'always': True, 'auto': True, 'never': False},
+}
+
+
+_ideep_version = 0
+
+
+def should_use_ideep(level, lowest_version=0):
+    """Determines if we should use ideep.
+
+    This function checks ``chainer.config.use_ideep``,
+    ``chainer.ia.ideep_enabled``. Note that ``ideep_enabled``
+    flag is fixed at loading of :mod: `chainer` module.
+
+    Args:
+        level (str): ideep use level. It must be either ``'==always'`` or
+            ``'>=auto'``. ``'==always'`` indicates that the ``use_ideep``
+            config must be ``'always'`` to use ideep.
+        lowest_version (int): Required lowest ideep version. It must be
+            non-negative.
+
+    Returns:
+        bool: ``True`` if the caller should use ideep
+
+    """
+    if not ideep_enabled:
+        return False
+
+    if _ideep_version < lowest_version:
+        return False
+
+    if level not in _SHOULD_USE_IDEEP:
+        raise ValueError('invalid ideep use level: %s '
+                         '(must be either of "==always" or ">=auto")' %
+                         repr(level))
+    flags = _SHOULD_USE_IDEEP[level]
+
+    use_ideep = config.use_ideep
+    if use_ideep not in flags:
+        raise ValueError('invalid use_ideep configuration: %s '
+                         '(must be either of "always", "auto", or "never")' %
+                         repr(use_ideep))
+    return flags[use_ideep]
+
+
+def check_ideep_enabled():
+    """Check ``ideep_enabled``
+
+    """
+    return ideep_enabled
+
+
+@contextlib.contextmanager
+def disable():
+    """Disable ideep optimization at Chainer runtime.
+
+    """
+    global ideep_enabled
+    old = ideep_enabled
+    ideep_enabled = False
+    try:
+        yield
+    finally:
+        ideep_enabled = old
+
+
+def all_ready(inputs, supported_ndim=(2, 4)):
+    """Check inputs and configuration supported for ideep optimization.
+
+    The function checks :func:`chainer.ia.should_use_ideep`, ``inputs``
+        info and ``supported_ndim``.
+
+    Args:
+        inputs (numpy.ndarray, cupy.ndarray, ideep.mdarray):
+            ``inputs`` to be checked including array type, dimension
+            and data type.
+        supported_ndim: A tuple of ndim. ideep supports array dimension
+            in either 2 or 4 only.
+
+    Returns:
+        bool: ``True`` if all conditions meet.
+
+    """
+    if not ideep_enabled:
+        return False
+
+    _inputs = [x.data if isinstance(x, variable.Variable)
+               else x for x in inputs]
+
+    # Check with ideep4py supported dimension of input data
+    valid_ndim = False
+    for ndim in supported_ndim:
+        valid_ndim = valid_ndim or _inputs[0].ndim == ndim
+
+    if supported_ndim and not valid_ndim:
+        return False
+
+    if isinstance(_inputs[0], mdarray):
+        return True
+    elif isinstance(_inputs[0], numpy.ndarray):
+        # Check whether ideep4py configured and used correctly
+        _should_use_ideep = True
+
+        for x in _inputs:
+            _should_use_ideep = _should_use_ideep and \
+                x.dtype == numpy.dtype('float32')
+        if _should_use_ideep:
+            _should_use_ideep = _should_use_ideep and \
+                should_use_ideep('>=auto')
+        if not _should_use_ideep:
+            return False
+    else:
+        # cupy.ndarray
+        return False
+
+    return True
+
+
+# ------------------------------------------------------------------------------
+# ideep4py.mdarray allocation
+# ------------------------------------------------------------------------------
+data = 'd'  # data array
+weight = 'w'  # weight array
+
+
+def array(x, itype=data):
+    """Create a :class:`ideep4py.mdarray` object according to ``x``.
+
+    Args:
+        array (numpy.ndarray or ideep4py.mdarray):
+            if ``x`` is numpy.ndarray not in C contiguous, it will be
+            converted to C contiguous before ideep4py.mdarray created.
+        itype (=data): ideep4py.mdarray created is optimized according
+            ``itype`` flag.
+
+    Returns:
+        Instance of :class:`ideep4py.mdarray`.
+
+    """
+    if not check_ideep_enabled():
+        raise Exception("ideep4py is not installed correctly")
+    if isinstance(x, numpy.ndarray) and \
+            x.dtype == numpy.dtype('float32'):
+        if x.flags.contiguous is False:
+            x = numpy.ascontiguousarray(x)
+        return mdarray(x, itype)
+    else:
+        return x

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -386,10 +386,12 @@ Use apply() method instead.\
     def forward_ia(self, inputs):
         """Computes the output arrays from the input NumPy arrays or ideep arrays.
 
-        if function node does not implement forward_ia, then bridges to forward_cpu
+        if function node does not implement forward_ia, then
+        bridges to forward_cpu
 
         Args:
-            inputs: Tuple of input :class:`numpy.ndarray` or :class:`ideep4py.mdarray` objects.
+            inputs: Tuple of input :class:`numpy.ndarray` or
+                :class:`ideep4py.mdarray` objects.
 
         Returns:
             Tuple of output arrays. Each element can be ideep4py mdarray.

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -362,6 +362,8 @@ Use apply() method instead.\
         assert len(inputs) > 0
         if isinstance(inputs[0], cuda.ndarray):
             return self.forward_gpu(inputs)
+        elif chainer.ia.all_ready(inputs):
+            return self.forward_ia(inputs)
         return self.forward_cpu(inputs)
 
     def forward_cpu(self, inputs):
@@ -380,6 +382,28 @@ Use apply() method instead.\
 
         """
         raise NotImplementedError
+
+    def forward_ia(self, inputs):
+        """Computes the output arrays from the input NumPy arrays or ideep arrays.
+
+        if function node does not implement forward_ia, then bridges to forward_cpu
+
+        Args:
+            inputs: Tuple of input :class:`numpy.ndarray` or :class:`ideep4py.mdarray` objects.
+
+        Returns:
+            Tuple of output arrays. Each element can be ideep4py mdarray.
+
+        .. warning::
+
+            Implementation of :class:`FunctionNode` must take care that the
+            return value must be a tuple even if it returns only one array.
+
+        """
+        for i, x in enumerate(inputs):
+            if isinstance(x, chainer.ia.mdarray):
+                inputs[i] = numpy.array(x)
+        return self.forward_cpu(inputs)
 
     def forward_gpu(self, inputs):
         """Computes the output arrays from the input CuPy arrays.

--- a/chainer/ia.py
+++ b/chainer/ia.py
@@ -1,0 +1,6 @@
+import sys
+
+from chainer.backends import ia
+
+
+sys.modules[__name__] = ia


### PR DESCRIPTION
Very thin wrapper for `ideep` to exploit the speed of IA (Intel Architecture).

Two parts included,
1. A thin wrapper to import `ideep` interfaces and to manage related context.
2. `ideep` optimization entry in function node, :func:`function_node.forward_ia`.