### PR TITLE
Fix a doctest error

### DIFF
--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -94,7 +94,7 @@ The resulting ``y`` is also a :class:`Variable` object, whose value can be extra
 .. doctest::
 
    >>> y.data
-   array([ 16.], dtype=float32)
+   array([ 16. ], dtype=float32)
 
 What ``y`` holds is not only the result value.
 It also holds the history of computation (i.e., computational graph), which enables to compute its differentiation.


### PR DESCRIPTION
Currently doctest fails due to this error:

```
17:32:59 Warning, treated as error:
17:32:59 WARNING: **********************************************************************
17:32:59 File "tutorial/basic.rst", line 95, in default
17:32:59 Failed example:
17:32:59     y.data
17:32:59 Expected:
17:32:59     array([ 16.], dtype=float32)
17:32:59 Got:
17:32:59     array([16.], dtype=float32)
```

This PR fixes it.