### PR TITLE
Check cuDNN convolution algorithm

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -259,7 +259,9 @@ class Convolution2DFunction(function_node.FunctionNode):
                 conv_desc.value, y_desc.value, _fwd_pref, workspace_size)
 
         if use_tensor_core:
-            algo = self._tensor_core_adjust_algo()
+            cudnn.check_convolution_forward_algorithm(
+                algo, handle, x_desc, filter_desc, conv_desc, y_desc,
+                workspace_size)
 
         oz_dtype = 'd' if x.dtype == 'd' else 'f'
         one = numpy.array(1, dtype=oz_dtype).ctypes
@@ -277,11 +279,6 @@ class Convolution2DFunction(function_node.FunctionNode):
                 one.data, y_desc.value, y.data.ptr)
 
         return y,
-
-    def _tensor_core_adjust_algo(self):
-        # Only CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
-        # supports Tensor-Core in cuDNN7.
-        return libcudnn.CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
 
     def backward(self, indexes, grad_outputs):
         x, W = self.get_retained_inputs()
@@ -459,7 +456,9 @@ class Convolution2DGradW(function_node.FunctionNode):
                 filter_desc.value, _bwd_filter_pref, workspace_size)
 
         if use_tensor_core:
-            algo = self._tensor_core_adjust_algo()
+            cudnn.check_convolution_backward_filter_algorithm(
+                algo, handle, x_desc, gy_desc, conv_desc, filter_desc,
+                workspace_size)
 
         libcudnn.convolutionBackwardFilter_v3(
             handle, one.data, x_desc.value, x.data.ptr, gy_desc.value,
@@ -467,11 +466,6 @@ class Convolution2DGradW(function_node.FunctionNode):
             workspace_size, zero.data, filter_desc.value, gW.data.ptr)
 
         return gW,
-
-    def _tensor_core_adjust_algo(self):
-        # Only CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1 supports
-        # Tensor-Core in cuDNN7.
-        return libcudnn.CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1
 
     def backward(self, indexes, grad_outputs):
         x, gy = self.get_retained_inputs()

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -287,7 +287,9 @@ class Deconvolution2DFunction(function_node.FunctionNode):
                 y_desc.value, _bwd_data_pref, workspace_size)
 
         if use_tensor_core:
-            algo = self._tensor_core_adjust_algo()
+            cudnn.check_convolution_backward_data_algorithm(
+                algo, handle, filter_desc, x_desc, conv_desc, y_desc,
+                workspace_size)
 
         libcudnn.convolutionBackwardData_v3(
             handle, one.data, filter_desc.value, W.data.ptr,
@@ -301,11 +303,6 @@ class Deconvolution2DFunction(function_node.FunctionNode):
                 one.data, y_desc.value, y.data.ptr)
 
         return y,
-
-    def _tensor_core_adjust_algo(self):
-        # Only CUDNN_CONVOLUTION_BWD_DATA_ALGO_1 supports
-        # Tensor-Core in cuDNN7
-        return libcudnn.CUDNN_CONVOLUTION_BWD_DATA_ALGO_1
 
     def backward(self, indexes, grad_outputs):
         x, W = self.get_retained_inputs()

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -311,8 +311,7 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
 
     def test_call_cudnn_forward(self):
         name = 'cupy.cuda.cudnn.convolutionForward'
-        name2 = 'chainer.functions.connection.convolution_2d' \
-            '.Convolution2DFunction._tensor_core_adjust_algo'
+        name2 = 'cupy.cudnn.check_convolution_forward_algorithm'
         with chainer.using_config('use_cudnn', self.use_cudnn):
             with chainer.using_config('cudnn_deterministic',
                                       self.cudnn_deterministic):
@@ -320,16 +319,15 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
                     name
                 ) as func, mock.patch(
                     name2
-                ) as tensor_core_adjust_algo:
+                ) as tensor_core_check_algo:
                     self.forward()
                     self.assertEqual(func.called, self.should_call_cudnn)
                     if not self.can_use_tensor_core:
-                        self.assertEqual(tensor_core_adjust_algo.called, False)
+                        self.assertEqual(tensor_core_check_algo.called, False)
 
     def test_call_cudnn_backward(self):
         name = 'cupy.cuda.cudnn.convolutionBackwardData_v3'
-        name2 = 'chainer.functions.connection.convolution_2d' \
-            '.Convolution2DGradW._tensor_core_adjust_algo'
+        name2 = 'cupy.cudnn.check_convolution_backward_data_algorithm'
         with chainer.using_config('use_cudnn', self.use_cudnn):
             with chainer.using_config('cudnn_deterministic',
                                       self.cudnn_deterministic):
@@ -339,11 +337,11 @@ class TestConvolution2DCudnnCall(unittest.TestCase):
                     name
                 ) as func, mock.patch(
                     name2
-                ) as tensor_core_adjust_algo:
+                ) as tensor_core_check_algo:
                     y.backward()
                     self.assertEqual(func.called, self.should_call_cudnn)
                     if not self.can_use_tensor_core:
-                        self.assertEqual(tensor_core_adjust_algo.called, False)
+                        self.assertEqual(tensor_core_check_algo.called, False)
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
This PR adds methods to check whether Tensor Core enabled algorithm is selected or not when Tensor Core is available. If not, it shows warning messages like below, so that users can see which layer does not use Tensor Core.

    /*/chainer/functions/connection/deconvolution_2d.py:292: RuntimeWarning: Tensor Core mode is set but the selected convolution backward data algorithm(0) is not Tensor Core enabled algo. (xN,xC,xH,xW)=(128,512,28,28), (kH,kW)=(1,1), (yN,yC,yH,yW)=(128,1024,14,14). 

Please note that this PR is related to https://github.com/cupy/cupy/pull/890, and you should apply it first. Also this is related to https://github.com/chainer/chainer/pull/3972 that was closed.