### PR TITLE
Fix backward of NormalizeL2

### DIFF
--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -35,13 +35,15 @@ class NormalizeL2(function_node.FunctionNode):
         gy, = grad_outputs
         F = chainer.functions
 
-        norm = F.sqrt(F.sum(F.square(x), axis=self.axis)) + self.eps
+        norm_noeps = F.sqrt(F.sum(F.square(x), axis=self.axis))
+        norm = norm_noeps + self.eps
         norm = F.broadcast_to(F.expand_dims(norm, self.axis), gy.shape)
 
         x_gy_reduced = F.sum((x * gy), axis=self.axis)
+        x_gy_reduced /= norm_noeps
         x_gy_reduced = F.broadcast_to(
             F.expand_dims(x_gy_reduced, self.axis), gy.shape)
-        gx = gy * norm - x_gy_reduced * x / norm
+        gx = gy * norm - x_gy_reduced * x
         gx = gx / norm ** 2
 
         return gx,

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -12,13 +12,19 @@ from chainer import testing
 from chainer.testing import attr
 
 
-@testing.parameterize(
-    {'shape': (4, 15), 'axis': 1},
-    {'shape': (4, 3, 2, 5), 'axis': 0},
-    {'shape': (4, 3, 2, 5), 'axis': 1},
-    {'shape': (4, 3, 2, 5), 'axis': 2},
-    {'shape': (4, 3, 2, 5), 'axis': 3},
-)
+@testing.parameterize(*testing.product([
+    [
+        {'shape': (4, 15), 'axis': 1},
+        {'shape': (4, 3, 2, 5), 'axis': 0},
+        {'shape': (4, 3, 2, 5), 'axis': 1},
+        {'shape': (4, 3, 2, 5), 'axis': 2},
+        {'shape': (4, 3, 2, 5), 'axis': 3},
+    ],
+    [
+        {'eps': 1e-5},
+        {'eps': 1e-1},
+    ],
+]))
 class TestL2Normalization(unittest.TestCase):
 
     def setUp(self):
@@ -28,7 +34,7 @@ class TestL2Normalization(unittest.TestCase):
             -1, 1, self.shape).astype(numpy.float32)
 
     def check_forward(self, x_data, axis):
-        eps = 1e-5
+        eps = self.eps
         x = chainer.Variable(x_data)
 
         y = functions.normalize(x, eps=eps, axis=axis)
@@ -58,7 +64,7 @@ class TestL2Normalization(unittest.TestCase):
 
     def check_backward(self, x_data, axis, y_grad):
         def f(x):
-            return functions.normalize(x, eps=1e-6, axis=axis)
+            return functions.normalize(x, eps=self.eps, axis=axis)
 
         gradient_check.check_backward(
             f, x_data, y_grad, dtype='d', atol=1e-2, rtol=3e-2)
@@ -73,7 +79,7 @@ class TestL2Normalization(unittest.TestCase):
 
     def check_double_backward(self, x_data, axis, y_grad, x_grad_grad):
         def f(x):
-            return functions.normalize(x, eps=1e-6, axis=axis)
+            return functions.normalize(x, eps=self.eps, axis=axis)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype='d', atol=1e-2, rtol=3e-2)


### PR DESCRIPTION
The backward computation of `NormalizeL2` was wrong (for non-negligible `eps`).