### PR TITLE
Fix document about links in chainer.functions

### DIFF
--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -10,7 +10,7 @@ functions, which users should use.
 .. note::
    As of v1.5, the concept of parameterized functions are gone, and they are
    replaced by corresponding :class:`~chainer.Link` implementations. They are
-   put in the :mod:`~chainer.links` namespace.
+   found in the :mod:`~chainer.links` namespace.
 
 ..
    For contributors that want to update these lists:

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -10,8 +10,7 @@ functions, which users should use.
 .. note::
    As of v1.5, the concept of parameterized functions are gone, and they are
    replaced by corresponding :class:`~chainer.Link` implementations. They are
-   no longer in the :mod:`~chainer.functions` namespace. Use them via the
-   :mod:`chainer.links` package.
+   put in the :mod:`~chainer.links` namespace.
 
 ..
    For contributors that want to update these lists:

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -10,8 +10,7 @@ functions, which users should use.
 .. note::
    As of v1.5, the concept of parameterized functions are gone, and they are
    replaced by corresponding :class:`~chainer.Link` implementations. They are
-   still put in the :mod:`~chainer.functions` namespace for backward
-   compatibility, though it is strongly recommended to use them via the
+   no longer in the :mod:`~chainer.functions` namespace. Use them via the
    :mod:`chainer.links` package.
 
 ..


### PR DESCRIPTION
Links are not in `chainer.functions`.  (From v2?)