### PR TITLE
[RFC] Require "scalar" variables to be 0-dim

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -859,8 +859,8 @@ Actual: {0}'''.format(type(data))
         where further backprop does not take place at such inputs.
 
         This method uses :data:`grad` as the initial error array. User can
-        manually set a gradient array before calling this method. If
-        :data:`data` contains only one element (i.e., it is scalar) and
+        manually set a gradient array before calling this method.
+        If the shape of :data:`data` is ``()`` (i.e., it is scalar) and
         :data:`grad` is ``None``, then this method automatically complements
         1.0 as the initial error. This is useful on starting backprop from
         some scalar loss value.
@@ -919,7 +919,15 @@ Actual: {0}'''.format(type(data))
 
         # Initialize error by 1, if this is a loss variable
         if self.data.size == 1 and self._grad_var is None:
-            assert self.data.ndim == 0
+            if self.data.ndim != 0:
+                warnings.warn(
+                    'Treating as a scalar a variable with only one element'
+                    ' in Variable.backward is deprecated. A scalar variable'
+                    ' must be a 0-dimensional array. Apply'
+                    ' chainer.functions.squeeze to obtain a scalar variable.'
+                    ' If the size of this variable accidentally becomes one,'
+                    ' set zero to grad.',
+                    DeprecationWarning)
             with cuda.get_device_from_array(self.data) as device:
                 if device is cuda.DummyDevice:
                     self.grad = numpy.ones_like(self.data)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -919,6 +919,7 @@ Actual: {0}'''.format(type(data))
 
         # Initialize error by 1, if this is a loss variable
         if self.data.size == 1 and self._grad_var is None:
+            assert self.data.ndim == 0
             with cuda.get_device_from_array(self.data) as device:
                 if device is cuda.DummyDevice:
                     self.grad = numpy.ones_like(self.data)

--- a/tests/chainer_tests/test_function.py
+++ b/tests/chainer_tests/test_function.py
@@ -356,7 +356,7 @@ class TestFunctionForwardDebug(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'return_value': (numpy.array([float('nan')], numpy.float32),),
+    {'return_value': (numpy.array(float('nan'), numpy.float32),),
      'valid': False},
     {'return_value': (None,), 'valid': True},
 )
@@ -365,7 +365,7 @@ class TestFunctionBackwardDebug(unittest.TestCase):
     def setUp(self):
         self.original_debug = chainer.is_debug()
         chainer.set_debug(True)
-        self.one = numpy.array([1], numpy.float32)
+        self.one = numpy.array(1, numpy.float32)
         self.f = chainer.Function()
 
     def tearDown(self):

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -337,7 +337,7 @@ class TestFunctionNodeForwardDebug(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'return_data': (numpy.array([float('nan')], numpy.float32),),
+    {'return_data': (numpy.array(float('nan'), numpy.float32),),
      'valid': False},
     {'return_data': (None,), 'valid': True},
 )
@@ -346,7 +346,7 @@ class TestFunctionNodeBackwardDebug(unittest.TestCase):
     def setUp(self):
         self.original_debug = chainer.is_debug()
         chainer.set_debug(True)
-        self.one = numpy.array([1], numpy.float32)
+        self.one = numpy.array(1, numpy.float32)
         self.f = chainer.FunctionNode()
         self.return_value = tuple(None if x is None else chainer.Variable(x)
                                   for x in self.return_data)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1527,7 +1527,7 @@ class IdentityFunction(chainer.Function):
 class TestVariableDoubleBackward(unittest.TestCase):
 
     def test_default_backward(self):
-        x = chainer.Variable(np.empty(1, np.float32))
+        x = chainer.Variable(np.empty((), np.float32))
         y = F.identity(x)
         y.backward()
         self.assertIsNone(x.grad_var.creator)
@@ -1535,14 +1535,14 @@ class TestVariableDoubleBackward(unittest.TestCase):
         self.assertIsNone(y.grad_var.grad_var)
 
     def test_raise_double_backprop(self):
-        x = chainer.Variable(np.empty(1, np.float32))
+        x = chainer.Variable(np.empty((), np.float32))
         y = IdentityFunction()(x)
         y.backward(enable_double_backprop=True)
         with self.assertRaises(RuntimeError):
             x.grad_var.backward()
 
     def test_raise_double_backprop_2(self):
-        x = chainer.Variable(np.empty(1, np.float32))
+        x = chainer.Variable(np.empty((), np.float32))
         z = F.identity(x)  # new style
         y = IdentityFunction()(z)  # old style
         y.backward(enable_double_backprop=True)


### PR DESCRIPTION
The current definition in `Variable.backward` of a "scalar" variable is an array containing 1 element.  This may cause unexpected behavior that only occurs when `batch_size=1`.  The PR proposes to fix the definition to being a 0-dimensional array.