### PR TITLE
Update documentation and examples

### DIFF
--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -156,7 +156,7 @@ class ConcatWithAsyncTransfer(object):
 
         from chainer.dataset import convert
         ...
-        updater = chainer.training.StandardUpdater(
+        updater = chainer.training.updaters.StandardUpdater(
                        ...,
                        converter=convert.ConcatWithAsyncTransfer(),
                        ...)

--- a/docs/source/tutorial/convnet.rst
+++ b/docs/source/tutorial/convnet.rst
@@ -397,8 +397,8 @@ extractor. See the details of this model here:
 :class:`chainer.links.VGG16Layers`.
 
 In the case of ResNet models, there are three variations differing in the number
-of layers. We have :class:`chainer.links.ResNet50`,
-:class:`chainer.links.ResNet101`, and :class:`chainer.links.ResNet152` models
+of layers. We have :class:`chainer.links.ResNet50Layers`,
+:class:`chainer.links.ResNet101Layers`, and :class:`chainer.links.ResNet152Layers` models
 with easy parameter loading feature. ResNet's pre-trained parameters are not
 available for direct downloading, so you need to download the weight from the
 author's web page first, and then place it into the dir
@@ -412,7 +412,7 @@ the preparation is finished, the usage is the same as VGG16:
     model = ResNet152layers()
 
 Please see the details of usage and how to prepare the pre-trained weights for
-ResNet here: :class:`chainer.links.ResNet50`
+ResNet here: :class:`chainer.links.ResNet50Layers`
 
 References
 ..........

--- a/docs/source/tutorial/convnet.rst
+++ b/docs/source/tutorial/convnet.rst
@@ -295,15 +295,15 @@ In the other words, it's easy. One possible way to write ResNet-152 is:
     class ResNet152(chainer.Chain):
         def __init__(self, n_blocks=[3, 8, 36, 3]):
             w = chainer.initializers.HeNormal()
-            super(ResNet152, self).__init__(
-                conv1=L.Convolution2D(
-                    None, 64, 7, 2, 3, initialW=w, nobias=True),
-                bn1=L.BatchNormalization(64),
-                res2=ResBlock(n_blocks[0], 64, 64, 256, 1),
-                res3=ResBlock(n_blocks[1], 256, 128, 512),
-                res4=ResBlock(n_blocks[2], 512, 256, 1024),
-                res5=ResBlock(n_blocks[3], 1024, 512, 2048),
-                fc6=L.Linear(2048, 1000))
+            super(ResNet152, self).__init__()
+            with self.init_scope():
+                self.conv1 = L.Convolution2D(None, 64, 7, 2, 3, initialW=w, nobias=True)
+                self.bn1 = L.BatchNormalization(64)
+                self.res2 = ResBlock(n_blocks[0], 64, 64, 256, 1)
+                self.res3 = ResBlock(n_blocks[1], 256, 128, 512)
+                self.res4 = ResBlock(n_blocks[2], 512, 256, 1024)
+                self.res5 = ResBlock(n_blocks[3], 1024, 512, 2048)
+                self.fc6 = L.Linear(2048, 1000)
 
         def __call__(self, x):
             h = self.bn1(self.conv1(x))
@@ -321,7 +321,6 @@ In the other words, it's easy. One possible way to write ResNet-152 is:
 
     class ResBlock(chainer.ChainList):
         def __init__(self, n_layers, n_in, n_mid, n_out, stride=2):
-            w = chainer.initializers.HeNormal()
             super(ResBlock, self).__init__()
             self.add_link(BottleNeck(n_in, n_mid, n_out, stride, True))
             for _ in range(n_layers - 1):

--- a/docs/source/tutorial/gpu.rst
+++ b/docs/source/tutorial/gpu.rst
@@ -320,11 +320,11 @@ First, define a model and optimizer instances:
 
 Recall that the ``MLP`` link implements the multi-layer perceptron, and the :class:`~chainer.links.Classifier` link wraps it to provide a classifier interface.
 We used :class:`~training.updaters.StandardUpdater` in the previous example.
-In order to enable data-parallel computation with multiple GPUs, we only have to replace it with :class:`~training.ParallelUpdater`.
+In order to enable data-parallel computation with multiple GPUs, we only have to replace it with :class:`~training.updaters.ParallelUpdater`.
 
 .. doctest::
 
-   updater = training.ParallelUpdater(train_iter, optimizer,
+   updater = training.updaters.ParallelUpdater(train_iter, optimizer,
                                       devices={'main': 0, 'second': 1})
 
 The ``devices`` option specifies which devices to use in data-parallel learning.
@@ -343,7 +343,7 @@ Data-parallel Computation on Multiple GPUs without Trainer
 We here introduce a way to write data-parallel computation without the help of :class:`~training.Trainer`.
 Most users can skip this section.
 If you are interested in how to write a data-parallel computation by yourself, this section should be informative.
-It is also helpful to, e.g., customize the :class:`~training.ParallelUpdater` class.
+It is also helpful to, e.g., customize the :class:`~training.updaters.ParallelUpdater` class.
 
 We again start from the MNIST example.
 At this time, we use a suffix like ``_0`` and ``_1`` to distinguish objects on each device.

--- a/docs/source/tutorial/gpu.rst
+++ b/docs/source/tutorial/gpu.rst
@@ -262,15 +262,15 @@ Let's write a link for the whole network.
 
    class ParallelMLP(Chain):
        def __init__(self):
-           super(ParallelMLP, self).__init__(
+           super(ParallelMLP, self).__init__()
+           with self.init_scope():
                # the input size, 784, is inferred
-               mlp1_gpu0=MLP(1000, 2000).to_gpu(0),
-               mlp1_gpu1=MLP(1000, 2000).to_gpu(1),
+               self.mlp1_gpu0 = MLP(1000, 2000).to_gpu(0)
+               self.mlp1_gpu1 = MLP(1000, 2000).to_gpu(1)
 
                # the input size, 2000, is inferred
-               mlp2_gpu0=MLP(1000, 10).to_gpu(0),
-               mlp2_gpu1=MLP(1000, 10).to_gpu(1),
-           )
+               self.mlp2_gpu0 = MLP(1000, 10).to_gpu(0)
+               self.mlp2_gpu1 = MLP(1000, 10).to_gpu(1)
 
        def __call__(self, x):
            # assume x is on GPU 0

--- a/docs/source/tutorial/ptb.rst
+++ b/docs/source/tutorial/ptb.rst
@@ -222,9 +222,9 @@ from different offsets equally spaced within the whole sequence.
 ^^^^^^^^^^^^^^^^^^^^^
 
 We use Backpropagation through time (BPTT) for optimize the RNNLM. BPTT can be implemented by
-overriding ``update_core()`` method of :class:`~chainer.training.StandardUpdater`. First,
+overriding ``update_core()`` method of :class:`~chainer.training.updaters.StandardUpdater`. First,
 in the constructor of the ``BPTTUpdater``, it takes ``bprop_len`` as an argument in addition
-to other arguments :class:`~chainer.training.StandardUpdater` needs. ``bprop_len`` defines the
+to other arguments :class:`~chainer.training.updaters.StandardUpdater` needs. ``bprop_len`` defines the
 length of sequence :math:`T` to calculate the loss:
 
 .. math::

--- a/docs/source/tutorial/recurrentnet.rst
+++ b/docs/source/tutorial/recurrentnet.rst
@@ -291,7 +291,7 @@ Backprop Through Time is implemented as follows.
 
 .. code-block:: python
 
-   class BPTTUpdater(training.StandardUpdater):
+   class BPTTUpdater(training.updaters.StandardUpdater):
 
        def __init__(self, train_iter, optimizer, bprop_len):
            super(BPTTUpdater, self).__init__(train_iter, optimizer)

--- a/docs/source/tutorial/trainer.rst
+++ b/docs/source/tutorial/trainer.rst
@@ -189,7 +189,7 @@ However, when you keep the whole :class:`~chainer.training.Trainer` object, in s
 ...............................................
 
 This method saves the structure of the computational graph of the model. The graph is saved in the
-`Graphviz <http://www.graphviz.org/>_`s dot format. The output location (directory) to save the graph is set by the :attr:`~chainer.training.Trainer.out` argument of :class:`~chainer.training.Trainer`.
+`Graphviz <http://www.graphviz.org/>`_'s dot format. The output location (directory) to save the graph is set by the :attr:`~chainer.training.Trainer.out` argument of :class:`~chainer.training.Trainer`.
 
 :class:`~chainer.training.extensions.Evaluator`
 ...............................................
@@ -208,7 +208,7 @@ It outputs the specified values to the standard output.
 
 ----
 
-Each :class:`~chainer.training.Extension` class has different options and some extensions are not mentioned here. And one of other important feature is, for instance, by using the :attr:`~chainer.training.Extension.trigger` option, you can set individual timings to fire the :class:`~chainer.training.Extension`. To know more details of all extensions, please take a look at the official document: `Trainer extensions <reference/extensions.html>_`.
+Each :class:`~chainer.training.Extension` class has different options and some extensions are not mentioned here. And one of other important feature is, for instance, by using the :attr:`~chainer.training.Extension.trigger` option, you can set individual timings to fire the :class:`~chainer.training.Extension`. To know more details of all extensions, please take a look at the official document: :ref:`extensions`.
 
 7. Start Training
 '''''''''''''''''

--- a/docs/source/tutorial/trainer.rst
+++ b/docs/source/tutorial/trainer.rst
@@ -105,7 +105,7 @@ Now let's create the :class:`~chainer.training.Updater` object !
     optimizer.setup(model)
 
     # Get an updater that uses the Iterator and Optimizer
-    updater = training.StandardUpdater(train_iter, optimizer, device=gpu_id)
+    updater = training.updaters.StandardUpdater(train_iter, optimizer, device=gpu_id)
 
 .. note::
 
@@ -118,7 +118,7 @@ Now let's create the :class:`~chainer.training.Updater` object !
     In :class:`~chainer.links.Classifier`, the :attr:`~chainer.links.Classifier.lossfun` is set to
     :meth:`~chainer.functions.softmax_cross_entropy` as default.
 
-    :class:`~chainer.training.StandardUpdater` is the simplest class among several updaters. There are also the :class:`~chainer.training.ParallelUpdater` and the :class:`~chainer.training.updaters.MultiprocessParallelUpdater` to utilize multiple GPUs. The :class:`~chainer.training.updaters.MultiprocessParallelUpdater` uses the NVIDIA NCCL library, so you need to install NCCL and re-install CuPy before using it.
+    :class:`~chainer.training.updaters.StandardUpdater` is the simplest class among several updaters. There are also the :class:`~chainer.training.updaters.ParallelUpdater` and the :class:`~chainer.training.updaters.MultiprocessParallelUpdater` to utilize multiple GPUs. The :class:`~chainer.training.updaters.MultiprocessParallelUpdater` uses the NVIDIA NCCL library, so you need to install NCCL and re-install CuPy before using it.
 
 5. Setup Trainer
 ''''''''''''''''

--- a/examples/mnist/train_mnist_data_parallel.py
+++ b/examples/mnist/train_mnist_data_parallel.py
@@ -51,7 +51,7 @@ def main():
     # ParallelUpdater implements the data-parallel gradient computation on
     # multiple GPUs. It accepts "devices" argument that specifies which GPU to
     # use.
-    updater = training.ParallelUpdater(
+    updater = training.updaters.ParallelUpdater(
         train_iter,
         optimizer,
         # The device of the name 'main' is used as a "master", while others are

--- a/examples/pos/postagging.py
+++ b/examples/pos/postagging.py
@@ -107,7 +107,7 @@ def main():
     train_iter = chainer.iterators.SerialIterator(train_data, args.batchsize)
     test_iter = chainer.iterators.SerialIterator(test_data, args.batchsize,
                                                  repeat=False, shuffle=False)
-    updater = training.StandardUpdater(
+    updater = training.updaters.StandardUpdater(
         train_iter, optimizer, converter=convert, device=args.gpu)
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
 

--- a/examples/pos/postagging.py
+++ b/examples/pos/postagging.py
@@ -17,10 +17,10 @@ from chainer.training import extensions
 class CRF(chainer.Chain):
 
     def __init__(self, n_vocab, n_pos):
-        super(CRF, self).__init__(
-            feature=L.EmbedID(n_vocab, n_pos),
-            crf=L.CRF1d(n_pos),
-        )
+        super(CRF, self).__init__()
+        with self.init_scope():
+            self.feature = L.EmbedID(n_vocab, n_pos)
+            self.crf = L.CRF1d(n_pos)
 
     def __call__(self, xs, ys):
         # Before making a transpose, you need to sort two lists in descending

--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -260,7 +260,7 @@ def main():
     optimizer.setup(model)
 
     train_iter = chainer.iterators.SerialIterator(train_data, args.batchsize)
-    updater = training.StandardUpdater(
+    updater = training.updaters.StandardUpdater(
         train_iter, optimizer, converter=convert, device=args.gpu)
     trainer = training.Trainer(updater, (args.epoch, 'epoch'))
     trainer.extend(extensions.LogReport(

--- a/examples/text_classification/nets.py
+++ b/examples/text_classification/nets.py
@@ -122,11 +122,12 @@ class RNNEncoder(chainer.Chain):
     """
 
     def __init__(self, n_layers, n_vocab, n_units, dropout=0.1):
-        super(RNNEncoder, self).__init__(
-            embed=L.EmbedID(n_vocab, n_units,
-                            initialW=embed_init),
-            encoder=L.NStepLSTM(n_layers, n_units, n_units, dropout),
-        )
+        super(RNNEncoder, self).__init__()
+        with self.init_scope():
+            self.embed = L.EmbedID(n_vocab, n_units,
+                                   initialW=embed_init)
+            self.encoder = L.NStepLSTM(n_layers, n_units, n_units, dropout)
+
         self.n_layers = n_layers
         self.out_units = n_units
         self.dropout = dropout
@@ -158,20 +159,21 @@ class CNNEncoder(chainer.Chain):
 
     def __init__(self, n_layers, n_vocab, n_units, dropout=0.1):
         out_units = n_units // 3
-        super(CNNEncoder, self).__init__(
-            embed=L.EmbedID(n_vocab, n_units, ignore_label=-1,
-                            initialW=embed_init),
-            cnn_w3=L.Convolution2D(
+        super(CNNEncoder, self).__init__()
+        with self.init_scope():
+            self.embed = L.EmbedID(n_vocab, n_units, ignore_label=-1,
+                                   initialW=embed_init)
+            self.cnn_w3 = L.Convolution2D(
                 n_units, out_units, ksize=(3, 1), stride=1, pad=(2, 0),
-                nobias=True),
-            cnn_w4=L.Convolution2D(
+                nobias=True)
+            self.cnn_w4 = L.Convolution2D(
                 n_units, out_units, ksize=(4, 1), stride=1, pad=(3, 0),
-                nobias=True),
-            cnn_w5=L.Convolution2D(
+                nobias=True)
+            self.cnn_w5 = L.Convolution2D(
                 n_units, out_units, ksize=(5, 1), stride=1, pad=(4, 0),
-                nobias=True),
-            mlp=MLP(n_layers, out_units * 3, dropout)
-        )
+                nobias=True)
+            self.mlp = MLP(n_layers, out_units * 3, dropout)
+
         self.out_units = out_units * 3
         self.dropout = dropout
 
@@ -227,10 +229,11 @@ class BOWEncoder(chainer.Chain):
     """
 
     def __init__(self, n_vocab, n_units, dropout=0.1):
-        super(BOWEncoder, self).__init__(
-            embed=L.EmbedID(n_vocab, n_units, ignore_label=-1,
-                            initialW=embed_init),
-        )
+        super(BOWEncoder, self).__init__()
+        with self.init_scope():
+            self.embed = L.EmbedID(n_vocab, n_units, ignore_label=-1,
+                                   initialW=embed_init)
+
         self.out_units = n_units
         self.dropout = dropout
 
@@ -258,10 +261,11 @@ class BOWMLPEncoder(chainer.Chain):
     """
 
     def __init__(self, n_layers, n_vocab, n_units, dropout=0.1):
-        super(BOWMLPEncoder, self).__init__(
-            bow_encoder=BOWEncoder(n_vocab, n_units, dropout),
-            mlp_encoder=MLP(n_layers, n_units, dropout)
-        )
+        super(BOWMLPEncoder, self).__init__()
+        with self.init_scope():
+            self.bow_encoder = BOWEncoder(n_vocab, n_units, dropout)
+            self.mlp_encoder = MLP(n_layers, n_units, dropout)
+
         self.out_units = n_units
 
     def __call__(self, xs):

--- a/examples/text_classification/train_text_classifier.py
+++ b/examples/text_classification/train_text_classifier.py
@@ -91,7 +91,7 @@ def main():
     optimizer.add_hook(chainer.optimizer.WeightDecay(1e-4))
 
     # Set up a trainer
-    updater = training.StandardUpdater(
+    updater = training.updaters.StandardUpdater(
         train_iter, optimizer,
         converter=convert_seq, device=args.gpu)
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)

--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -62,8 +62,9 @@ def main():
 
     # Set up an updater. StandardUpdater can explicitly specify a loss function
     # used in the training with 'loss_func' option
-    updater = training.updaters.StandardUpdater(train_iter, optimizer, device=args.gpu,
-                                       loss_func=model.get_loss_func())
+    updater = training.updaters.StandardUpdater(
+        train_iter, optimizer,
+        device=args.gpu, loss_func=model.get_loss_func())
 
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
     trainer.extend(extensions.Evaluator(test_iter, model, device=args.gpu,

--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -62,7 +62,7 @@ def main():
 
     # Set up an updater. StandardUpdater can explicitly specify a loss function
     # used in the training with 'loss_func' option
-    updater = training.StandardUpdater(train_iter, optimizer, device=args.gpu,
+    updater = training.updaters.StandardUpdater(train_iter, optimizer, device=args.gpu,
                                        loss_func=model.get_loss_func())
 
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)


### PR DESCRIPTION
In general, fix `init_scope()` and `StandardUpdater`, `ParallelUpdater` namespace problem in the documentation and examples, in addition to some wrong links in the document.