### PR TITLE
Have RandomState instances unique to each batch index, can be used by e.g. random augmentation

### DIFF
--- a/chainer/iterators/__init__.py
+++ b/chainer/iterators/__init__.py
@@ -7,3 +7,5 @@ from chainer.iterators import serial_iterator  # NOQA
 from chainer.iterators.multiprocess_iterator import MultiprocessIterator  # NOQA
 from chainer.iterators.multithread_iterator import MultithreadIterator  # NOQA
 from chainer.iterators.serial_iterator import SerialIterator  # NOQA
+
+from chainer.iterators.random_state import get_random_state  # NOQA

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -14,7 +14,6 @@ from chainer.dataset import iterator
 
 
 _response_time = 1.
-_short_time = 0.001
 _PrefetchState = namedtuple('_PrefetchState', (
     'current_position', 'epoch', 'is_new_epoch',
     'previous_epoch_detail', 'order'))

--- a/chainer/iterators/random_state.py
+++ b/chainer/iterators/random_state.py
@@ -1,0 +1,68 @@
+import contextlib
+import threading
+
+import numpy
+
+
+_random_state = threading.local()
+_random_state.value = None
+
+
+def get_random_state():
+    """Get a :class:`~numpy.random.RandomState` during iteration.
+
+    The instance obtained is unique to each index on a batch.  You can
+    employ the state, for example, to perform random data augmentation.
+    No manual initialization is required even if you are using
+    :class:`~chainer.iterators.MultiprocessIterator` or
+    :class:`~chainer.iterators.MultithreadIterator`.
+
+    The state is deterministically determined by the initial state of
+    ``numpy.random``. Therefore you can reproduce the same result
+    if you set the same seed by :func:`numpy.random.seed` at the program
+    startup.
+
+    Returns:
+        The :class:`numpy.random.RandomState` instance bound to the batch
+        index, if a :class:`~chainer.dataset.Iterator` instance is fetching
+        data; otherwise ``None``.
+
+    """
+    state = _random_state.value
+    if not isinstance(state, numpy.random.RandomState):
+        state = state()
+    return state
+
+
+def derive_random_state():
+    """Derive a new PRNG state from the global one.
+
+    The global state will be put one step forward.
+
+    It is likely that the derived state and the global one are far distant on
+    the PRNG state-transition sequence.  We need to rely on this empirical way,
+    as numpy doesn't implement `random.jumpahead` like functionality, which
+    allows making a jump on the state-transition sequence with arbitrary
+    length.
+
+    To support 32-bit platform and numpy < 1.11, the value is taken in
+    a verbose manner.
+
+    Returns:
+        A :class:`numpy.random.RandomState` instance.
+
+    """
+    seed = numpy.asscalar(
+        numpy.random.randint(-(1 << 31), 1 << 31, 1).astype('uint32'))
+    return numpy.random.RandomState(seed)
+
+
+def create_random_states(num):
+    return [derive_random_state() for _ in range(num)]
+
+
+@contextlib.contextmanager
+def set_random_state(random_state):
+    _random_state.value = random_state
+    yield
+    _random_state.value = None

--- a/chainer/iterators/random_state.py
+++ b/chainer/iterators/random_state.py
@@ -22,6 +22,9 @@ def get_random_state():
     if you set the same seed by :func:`numpy.random.seed` at the program
     startup.
 
+    The states remain unchanged when an iterator is reset. Internal states
+    during prefetch are silently discarded.
+
     Returns:
         The :class:`numpy.random.RandomState` instance bound to the batch
         index, if a :class:`~chainer.dataset.Iterator` instance is fetching

--- a/docs/source/reference/iterators.rst
+++ b/docs/source/reference/iterators.rst
@@ -17,3 +17,13 @@ Chainer provides some iterators that implement typical strategies to create mini
    chainer.iterators.SerialIterator
    chainer.iterators.MultiprocessIterator
    chainer.iterators.MultithreadIterator
+
+
+Chainer also provides a handy way to use properly initialized :class:`numpy.random.RandomState` instances at iteration.
+
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.iterators.get_random_state

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -408,6 +408,162 @@ class TestMultiprocessIteratorConcurrency(unittest.TestCase):
         self.assertFalse(deadlock)
 
 
+@testing.parameterize(*testing.product({
+    'n_prefetch': [1, 2],
+    'shared_mem': [None, 1000000],
+}))
+class TestMultiprocessIteratorRandomState(unittest.TestCase):
+
+    def setUp(self):
+        self.n_processes = 2
+        self.options = {'shuffle': False,
+                        'n_processes': self.n_processes,
+                        'n_prefetch': self.n_prefetch,
+                        'shared_mem': self.shared_mem}
+        self._seed = 3141592653
+        self._random_bak = numpy.random.get_state()
+
+    def tearDown(self):
+        numpy.random.set_state(self._random_bak)
+
+    class RandomDataset(object):
+        def __init__(self, interleave=False, twice=False):
+            self.interleave = interleave
+            self.twice = twice
+
+        def __len__(self):
+            return 64
+
+        def __getitem__(self, i):
+            if self.interleave and i // 4 % 2 == 1:
+                return 0
+            else:
+                random = iterators.get_random_state()
+                if self.twice:
+                    return random.uniform(), random.uniform()
+                else:
+                    return random.uniform()
+
+    def test_random_state_different_numbers(self):
+        dataset = self.RandomDataset()
+        it = iterators.MultiprocessIterator(dataset, 4, **self.options)
+
+        batch1 = it.next()
+        batch2 = it.next()
+        batch3 = it.next()
+        batch4 = it.next()
+
+        data = numpy.concatenate([batch1, batch2, batch3, batch4])
+        # To prevent accidental failure, we allow two elements to be same.
+        self.assertGreaterEqual(numpy.unique(data).size, 15)
+
+    def test_random_state_different_numbers_interleaved(self):
+        dataset = self.RandomDataset(interleave=True)
+        it = iterators.MultiprocessIterator(dataset, 4, **self.options)
+
+        batch1 = it.next()
+        it.next()
+        batch2 = it.next()
+        it.next()
+        batch3 = it.next()
+        it.next()
+        batch4 = it.next()
+        it.next()
+
+        data = numpy.concatenate([batch1, batch2, batch3, batch4])
+        # To prevent accidental failure, we allow two elements to be same.
+        self.assertGreaterEqual(numpy.unique(data).size, 15)
+
+    def test_random_state_same_seed(self):
+        dataset1 = self.RandomDataset()
+        numpy.random.seed(self._seed)
+        it1 = iterators.MultiprocessIterator(dataset1, 4, **self.options)
+
+        dataset2 = self.RandomDataset(interleave=True)
+        numpy.random.seed(self._seed)
+        it2 = iterators.MultiprocessIterator(dataset2, 4, **self.options)
+
+        for _ in range(4):
+            batch1 = it1.next()
+            batch2 = it2.next()
+            it2.next()
+            self.assertEqual(batch1, batch2)
+
+    def test_random_state_keep_sequence_for_each_batch_idx(self):
+        dataset1 = self.RandomDataset()
+        numpy.random.seed(self._seed)
+        it1 = iterators.MultiprocessIterator(dataset1, 4, **self.options)
+
+        dataset2 = self.RandomDataset(twice=True)
+        numpy.random.seed(self._seed)
+        it2 = iterators.MultiprocessIterator(dataset2, 4, **self.options)
+
+        for _ in range(4):
+            batch1 = list(zip(it1.next(), it1.next()))
+            batch2 = it2.next()
+            self.assertEqual(batch1, batch2)
+
+    def test_random_state_reset(self):
+        dataset = self.RandomDataset()
+
+        numpy.random.seed(self._seed)
+        it1 = iterators.MultiprocessIterator(dataset, 4, **self.options)
+        it1.next()
+        batch_a = it1.next()
+        it1.next()
+        it1.next()
+        batch_b = it1.next()
+
+        numpy.random.seed(self._seed)
+        it2 = iterators.MultiprocessIterator(dataset, 4, **self.options)
+        it2.next()
+        time.sleep(0.2)
+
+        it2.reset()
+        assert batch_a == it2.next()
+
+        it2.next()
+        it2.next()
+        time.sleep(0.2)
+
+        it2.reset()
+        assert batch_b == it2.next()
+
+    def test_random_state_serialize(self):
+        dataset = self.RandomDataset()
+
+        numpy.random.seed(self._seed)
+        it1 = iterators.MultiprocessIterator(dataset, 4, **self.options)
+        it1.next()
+        batch_a = it1.next()
+        it1.next()
+        it1.next()
+        batch_b = it1.next()
+
+        numpy.random.seed(self._seed)
+        it2 = iterators.MultiprocessIterator(dataset, 4, **self.options)
+        it2.next()
+        time.sleep(0.2)
+
+        target = dict()
+        it2.serialize(DummySerializer(target))
+        assert batch_a == it2.next()
+        it2 = iterators.MultiprocessIterator(dataset, 4, **self.options)
+        it2.serialize(DummyDeserializer(target))
+        assert batch_a == it2.next()
+
+        it2.next()
+        it2.next()
+        time.sleep(0.2)
+
+        target = dict()
+        it2.serialize(DummySerializer(target))
+        assert batch_b == it2.next()
+        it2 = iterators.MultiprocessIterator(dataset, 4, **self.options)
+        it2.serialize(DummyDeserializer(target))
+        assert batch_b == it2.next()
+
+
 class TestMultiprocessIteratorDeterminancy(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
@@ -44,6 +44,25 @@ class DummyDeserializer(serializer.Deserializer):
         return value
 
 
+class RandomDataset(object):
+    def __init__(self, interleave=False, twice=False):
+        self.interleave = interleave
+        self.twice = twice
+
+    def __len__(self):
+        return 64
+
+    def __getitem__(self, i):
+        if self.interleave and i // 4 % 2 == 1:
+            return 0
+        else:
+            random = iterators.get_random_state()
+            if self.twice:
+                return random.uniform(), random.uniform()
+            else:
+                return random.uniform()
+
+
 @testing.parameterize(*testing.product({
     'n_threads': [1, 2],
 }))
@@ -342,26 +361,8 @@ class TestMultithreadIteratorRandomState(unittest.TestCase):
     def tearDown(self):
         numpy.random.set_state(self._random_bak)
 
-    class RandomDataset(object):
-        def __init__(self, interleave=False, twice=False):
-            self.interleave = interleave
-            self.twice = twice
-
-        def __len__(self):
-            return 64
-
-        def __getitem__(self, i):
-            if self.interleave and i // 4 % 2 == 1:
-                return 0
-            else:
-                random = iterators.get_random_state()
-                if self.twice:
-                    return random.uniform(), random.uniform()
-                else:
-                    return random.uniform()
-
     def test_random_state_different_numbers(self):
-        dataset = self.RandomDataset()
+        dataset = RandomDataset()
         it = iterators.MultithreadIterator(dataset, 4, **self.options)
 
         batch1 = it.next()
@@ -374,7 +375,7 @@ class TestMultithreadIteratorRandomState(unittest.TestCase):
         self.assertGreaterEqual(numpy.unique(data).size, 15)
 
     def test_random_state_different_numbers_interleaved(self):
-        dataset = self.RandomDataset(interleave=True)
+        dataset = RandomDataset(interleave=True)
         it = iterators.MultithreadIterator(dataset, 4, **self.options)
 
         batch1 = it.next()
@@ -391,11 +392,11 @@ class TestMultithreadIteratorRandomState(unittest.TestCase):
         self.assertGreaterEqual(numpy.unique(data).size, 15)
 
     def test_random_state_same_seed(self):
-        dataset1 = self.RandomDataset()
+        dataset1 = RandomDataset()
         numpy.random.seed(self._seed)
         it1 = iterators.MultithreadIterator(dataset1, 4, **self.options)
 
-        dataset2 = self.RandomDataset(interleave=True)
+        dataset2 = RandomDataset(interleave=True)
         numpy.random.seed(self._seed)
         it2 = iterators.MultithreadIterator(dataset2, 4, **self.options)
 
@@ -406,11 +407,11 @@ class TestMultithreadIteratorRandomState(unittest.TestCase):
             self.assertEqual(batch1, batch2)
 
     def test_random_state_keep_sequence_for_each_batch_idx(self):
-        dataset1 = self.RandomDataset()
+        dataset1 = RandomDataset()
         numpy.random.seed(self._seed)
         it1 = iterators.MultithreadIterator(dataset1, 4, **self.options)
 
-        dataset2 = self.RandomDataset(twice=True)
+        dataset2 = RandomDataset(twice=True)
         numpy.random.seed(self._seed)
         it2 = iterators.MultithreadIterator(dataset2, 4, **self.options)
 
@@ -420,7 +421,7 @@ class TestMultithreadIteratorRandomState(unittest.TestCase):
             self.assertEqual(batch1, batch2)
 
     def test_random_state_reset(self):
-        dataset = self.RandomDataset()
+        dataset = RandomDataset()
 
         numpy.random.seed(self._seed)
         it1 = iterators.MultithreadIterator(dataset, 4, **self.options)
@@ -446,7 +447,7 @@ class TestMultithreadIteratorRandomState(unittest.TestCase):
         assert batch_b == it2.next()
 
     def test_random_state_serialize(self):
-        dataset = self.RandomDataset()
+        dataset = RandomDataset()
 
         numpy.random.seed(self._seed)
         it1 = iterators.MultithreadIterator(dataset, 4, **self.options)

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -42,6 +42,25 @@ class DummyDeserializer(serializer.Deserializer):
         return value
 
 
+class RandomDataset(object):
+    def __init__(self, interleave=False, twice=False):
+        self.interleave = interleave
+        self.twice = twice
+
+    def __len__(self):
+        return 64
+
+    def __getitem__(self, i):
+        if self.interleave and i // 4 % 2 == 1:
+            return 0
+        else:
+            random = iterators.get_random_state()
+            if self.twice:
+                return random.uniform(), random.uniform()
+            else:
+                return random.uniform()
+
+
 class TestSerialIterator(unittest.TestCase):
 
     def test_iterator_repeat(self):
@@ -319,26 +338,8 @@ class TestSerialIteratorRandomState(unittest.TestCase):
     def tearDown(self):
         numpy.random.set_state(self._random_bak)
 
-    class RandomDataset(object):
-        def __init__(self, interleave=False, twice=False):
-            self.interleave = interleave
-            self.twice = twice
-
-        def __len__(self):
-            return 64
-
-        def __getitem__(self, i):
-            if self.interleave and i // 4 % 2 == 1:
-                return 0
-            else:
-                random = iterators.get_random_state()
-                if self.twice:
-                    return random.uniform(), random.uniform()
-                else:
-                    return random.uniform()
-
     def test_random_state_different_numbers(self):
-        dataset = self.RandomDataset()
+        dataset = RandomDataset()
         it = iterators.SerialIterator(dataset, 4, **self.options)
 
         batch1 = it.next()
@@ -351,7 +352,7 @@ class TestSerialIteratorRandomState(unittest.TestCase):
         self.assertGreaterEqual(numpy.unique(data).size, 15)
 
     def test_random_state_different_numbers_interleaved(self):
-        dataset = self.RandomDataset(interleave=True)
+        dataset = RandomDataset(interleave=True)
         it = iterators.SerialIterator(dataset, 4, **self.options)
 
         batch1 = it.next()
@@ -368,11 +369,11 @@ class TestSerialIteratorRandomState(unittest.TestCase):
         self.assertGreaterEqual(numpy.unique(data).size, 15)
 
     def test_random_state_same_seed(self):
-        dataset1 = self.RandomDataset()
+        dataset1 = RandomDataset()
         numpy.random.seed(self._seed)
         it1 = iterators.SerialIterator(dataset1, 4, **self.options)
 
-        dataset2 = self.RandomDataset(interleave=True)
+        dataset2 = RandomDataset(interleave=True)
         numpy.random.seed(self._seed)
         it2 = iterators.SerialIterator(dataset2, 4, **self.options)
 
@@ -383,11 +384,11 @@ class TestSerialIteratorRandomState(unittest.TestCase):
             self.assertEqual(batch1, batch2)
 
     def test_random_state_keep_sequence_for_each_batch_idx(self):
-        dataset1 = self.RandomDataset()
+        dataset1 = RandomDataset()
         numpy.random.seed(self._seed)
         it1 = iterators.SerialIterator(dataset1, 4, **self.options)
 
-        dataset2 = self.RandomDataset(twice=True)
+        dataset2 = RandomDataset(twice=True)
         numpy.random.seed(self._seed)
         it2 = iterators.SerialIterator(dataset2, 4, **self.options)
 
@@ -397,7 +398,7 @@ class TestSerialIteratorRandomState(unittest.TestCase):
             self.assertEqual(batch1, batch2)
 
     def test_random_state_reset(self):
-        dataset = self.RandomDataset()
+        dataset = RandomDataset()
 
         numpy.random.seed(self._seed)
         it1 = iterators.SerialIterator(dataset, 4, **self.options)
@@ -423,7 +424,7 @@ class TestSerialIteratorRandomState(unittest.TestCase):
         assert batch_b == it2.next()
 
     def test_random_state_serialize(self):
-        dataset = self.RandomDataset()
+        dataset = RandomDataset()
 
         numpy.random.seed(self._seed)
         it1 = iterators.SerialIterator(dataset, 4, **self.options)

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -1,4 +1,5 @@
 from __future__ import division
+import time
 import unittest
 
 import numpy
@@ -306,6 +307,154 @@ class TestSerialIteratorSerialize(unittest.TestCase):
         self.assertEqual(sorted(batch1 + batch2 + batch3), dataset)
         self.assertAlmostEqual(it.epoch_detail, 6 / 6)
         self.assertAlmostEqual(it.previous_epoch_detail, 4 / 6)
+
+
+class TestSerialIteratorRandomState(unittest.TestCase):
+
+    def setUp(self):
+        self.options = {'shuffle': False}
+        self._seed = 3141592653
+        self._random_bak = numpy.random.get_state()
+
+    def tearDown(self):
+        numpy.random.set_state(self._random_bak)
+
+    class RandomDataset(object):
+        def __init__(self, interleave=False, twice=False):
+            self.interleave = interleave
+            self.twice = twice
+
+        def __len__(self):
+            return 64
+
+        def __getitem__(self, i):
+            if self.interleave and i // 4 % 2 == 1:
+                return 0
+            else:
+                random = iterators.get_random_state()
+                if self.twice:
+                    return random.uniform(), random.uniform()
+                else:
+                    return random.uniform()
+
+    def test_random_state_different_numbers(self):
+        dataset = self.RandomDataset()
+        it = iterators.SerialIterator(dataset, 4, **self.options)
+
+        batch1 = it.next()
+        batch2 = it.next()
+        batch3 = it.next()
+        batch4 = it.next()
+
+        data = numpy.concatenate([batch1, batch2, batch3, batch4])
+        # To prevent accidental failure, we allow two elements to be same.
+        self.assertGreaterEqual(numpy.unique(data).size, 15)
+
+    def test_random_state_different_numbers_interleaved(self):
+        dataset = self.RandomDataset(interleave=True)
+        it = iterators.SerialIterator(dataset, 4, **self.options)
+
+        batch1 = it.next()
+        it.next()
+        batch2 = it.next()
+        it.next()
+        batch3 = it.next()
+        it.next()
+        batch4 = it.next()
+        it.next()
+
+        data = numpy.concatenate([batch1, batch2, batch3, batch4])
+        # To prevent accidental failure, we allow two elements to be same.
+        self.assertGreaterEqual(numpy.unique(data).size, 15)
+
+    def test_random_state_same_seed(self):
+        dataset1 = self.RandomDataset()
+        numpy.random.seed(self._seed)
+        it1 = iterators.SerialIterator(dataset1, 4, **self.options)
+
+        dataset2 = self.RandomDataset(interleave=True)
+        numpy.random.seed(self._seed)
+        it2 = iterators.SerialIterator(dataset2, 4, **self.options)
+
+        for _ in range(4):
+            batch1 = it1.next()
+            batch2 = it2.next()
+            it2.next()
+            self.assertEqual(batch1, batch2)
+
+    def test_random_state_keep_sequence_for_each_batch_idx(self):
+        dataset1 = self.RandomDataset()
+        numpy.random.seed(self._seed)
+        it1 = iterators.SerialIterator(dataset1, 4, **self.options)
+
+        dataset2 = self.RandomDataset(twice=True)
+        numpy.random.seed(self._seed)
+        it2 = iterators.SerialIterator(dataset2, 4, **self.options)
+
+        for _ in range(4):
+            batch1 = list(zip(it1.next(), it1.next()))
+            batch2 = it2.next()
+            self.assertEqual(batch1, batch2)
+
+    def test_random_state_reset(self):
+        dataset = self.RandomDataset()
+
+        numpy.random.seed(self._seed)
+        it1 = iterators.SerialIterator(dataset, 4, **self.options)
+        it1.next()
+        batch_a = it1.next()
+        it1.next()
+        it1.next()
+        batch_b = it1.next()
+
+        numpy.random.seed(self._seed)
+        it2 = iterators.SerialIterator(dataset, 4, **self.options)
+        it2.next()
+        time.sleep(0.2)
+
+        it2.reset()
+        assert batch_a == it2.next()
+
+        it2.next()
+        it2.next()
+        time.sleep(0.2)
+
+        it2.reset()
+        assert batch_b == it2.next()
+
+    def test_random_state_serialize(self):
+        dataset = self.RandomDataset()
+
+        numpy.random.seed(self._seed)
+        it1 = iterators.SerialIterator(dataset, 4, **self.options)
+        it1.next()
+        batch_a = it1.next()
+        it1.next()
+        it1.next()
+        batch_b = it1.next()
+
+        numpy.random.seed(self._seed)
+        it2 = iterators.SerialIterator(dataset, 4, **self.options)
+        it2.next()
+        time.sleep(0.2)
+
+        target = dict()
+        it2.serialize(DummySerializer(target))
+        assert batch_a == it2.next()
+        it2 = iterators.SerialIterator(dataset, 4, **self.options)
+        it2.serialize(DummyDeserializer(target))
+        assert batch_a == it2.next()
+
+        it2.next()
+        it2.next()
+        time.sleep(0.2)
+
+        target = dict()
+        it2.serialize(DummySerializer(target))
+        assert batch_b == it2.next()
+        it2 = iterators.SerialIterator(dataset, 4, **self.options)
+        it2.serialize(DummyDeserializer(target))
+        assert batch_b == it2.next()
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
I've made iterators store `numpy.random.RandomState` instances those are bound to batch indices. They can be retrieved by `chainer.iteartors.get_random_state()`.

The implementation is trivial for `SerialIterator`. For `MultithreadIterator`, a set of the backup states (implemented as tuples) is required to support `reset` and `serialize` correctly. For `MultiprocessIterator`, shared memory is necessary.

This feature is very useful when you use `MultiprocessIterator`. To perform random augmentation correctly with this iterator class, you need to set the random seed at the fetch of first batch, as the global random state remains the same on every forked processes.

Making the random seed deterministic is rather hard, because for each part of a batch to be fetched, assignment of a process that does fetch is completely non-deterministic. You may mitigate the situation by reseeding the random state at every fetch, but it hurts the long periodicity of Mersenne Twistter.

## overhead
If `chainer.iteartors.get_random_state()` is not called, there is almost no overhead. If called, overhead for `RandomState.get_state()` and/or `RandomState.set_state()` are incurred; but a benchmark suggests it's still negligible.

I performed the benchmark bellow on my Linux desktop machine, with i5-3550 (4 cores) processor. It just iterates over MNIST dataset with random flip augmentation. The size of batches is very small compared to most real workload, so the overhead of iteration is rate-limiting. Even on such a extreme setting, the measured performance impact is less than 10%.

```python
import time

from chainer.datasets import get_mnist, TransformDataset
from chainer.iterators import (get_random_state,
                               SerialIterator,
                               MultiprocessIterator,
                               MultithreadIterator)
import numpy


def random_flip_local(img):
    random = get_random_state()
    if random.uniform() >= 0.5:
        img = numpy.fliplr(img)
    return img


def random_flip_global(img):
    random = numpy.random
    if random.uniform() >= 0.5:
        img = numpy.fliplr(img)
    return img


N_PROC = 4
COUNT = 10000


def main():
    for it_cls in (SerialIterator, MultithreadIterator, MultiprocessIterator):
        for aug_meth in (random_flip_local, random_flip_global):
            dataset, _ = get_mnist(withlabel=False, ndim=2)
            dataset = TransformDataset(dataset, aug_meth)
            options = {}
            t1 = time.perf_counter()
            if it_cls == MultithreadIterator:
                options['n_threads'] = N_PROC
            if it_cls == MultiprocessIterator:
                options['n_processes'] = N_PROC
            it = it_cls(dataset, N_PROC, **options)
            for _ in range(COUNT):
                it.next()
            t2 = time.perf_counter()
            print("{:20} {:18} {:6.2f}us".format(it_cls.__name__, aug_meth.__name__,
                                            (t2 - t1) / COUNT * 1000 * 1000))


if __name__ == '__main__':
    main()
```

The result is:

```
SerialIterator       random_flip_local   52.33us
SerialIterator       random_flip_global  50.77us
MultithreadIterator  random_flip_local  315.76us
MultithreadIterator  random_flip_global 284.20us
MultiprocessIterator random_flip_local  527.36us
MultiprocessIterator random_flip_global 504.12us
```

As I've thought this issue is more important, so I made it prior to #3754.