### PR TITLE
Fix description of built-in batch converters

### DIFF
--- a/docs/source/reference/core/dataset.rst
+++ b/docs/source/reference/core/dataset.rst
@@ -9,7 +9,11 @@ Chainer has a support of common interface of training and validation datasets. T
 
 **Iterator** iterates over the dataset, and at each iteration, it yields a mini batch of examples as a list. Iterators should support the :class:`Iterator` interface, which includes the standard iterator protocol of Python. Iterators manage where to read next, which means they are `stateful`.
 
-**Batch conversion function** converts the mini batch into arrays to feed to the neural nets. They are also responsible to send each array to an appropriate device. Chainer currently provides :func:`concat_examples` as the only example of batch conversion functions.
+**Batch conversion function** converts the mini batch into arrays to feed to the neural nets. They are also responsible to send each array to an appropriate device.
+Chainer currently provides two implementations:
+
+- :func:`concat_examples` is a plain implementation which is used as the default choice.
+- :class:`ConcatWithAsyncTransfer` is a variant which is basically same as :func:`concat_examples` except that it overlaps other GPU computations and data transfer for the next iteration.
 
 These components are all customizable, and designed to have a minimum interface to restrict the types of datasets and ways to handle them. In most cases, though, implementations provided by Chainer itself are enough to cover the usages.
 


### PR DESCRIPTION
Now we have two batch conversion functions. I fixed the documentation.