### PR TITLE
Fix unused argument(--out) of seq2seq example

### DIFF
--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -262,7 +262,7 @@ def main():
     train_iter = chainer.iterators.SerialIterator(train_data, args.batchsize)
     updater = training.updaters.StandardUpdater(
         train_iter, optimizer, converter=convert, device=args.gpu)
-    trainer = training.Trainer(updater, (args.epoch, 'epoch'))
+    trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
     trainer.extend(extensions.LogReport(
         trigger=(args.log_interval, 'iteration')))
     trainer.extend(extensions.PrintReport(


### PR DESCRIPTION
Seq2seq example does not use the argument of "--out".
I fixed it to work the argument correctly.