### PR TITLE
Skip unnecessary backward computation in matmul

### DIFF
--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -113,7 +113,7 @@ class MatMul(function_node.FunctionNode):
         else:
             y = _matmul(a, b, self.transa, self.transb, self.transc)
         if self.dtype is not None and y.dtype != self.dtype:
-            y = y.astype(self.dtype, copy=False)
+            y = y.astype(self.dtype)
         return utils.force_array(y),
 
     def backward(self, indexes, grad_outputs):

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -121,13 +121,15 @@ class MatMul(function_node.FunctionNode):
         if 0 in indexes:
             ga, = MatMul(self.transc, not self.transb,
                          self.transa).apply((gy, b))
-            ga.data = ga.data.astype(a.dtype)
+            if ga.dtype != a.dtype:
+                ga.array = ga.array.astype(a.dtype)
 
         gb = None
         if 1 in indexes:
             gb, = MatMul(not self.transa, self.transc,
                          self.transb).apply((a, gy))
-            gb.data = gb.data.astype(b.dtype)
+            if gb.dtype != b.dtype:
+                gb.array = gb.array.astype(b.dtype)
 
         return ga, gb
 


### PR DESCRIPTION
This PR is to reduce unnecessary computation in `MatMul`.

When you specify one of inputs to matmul as `required_grad=False` like below, there is no need to compute the gradient of that input, but it is computed with current master. This PR reduces that unnecessary computation.

    a = Variable(a)
    b = Variable(b, required_grad=False)
    c = F.matmul(a, b)

I also noticed that `MatMulGrad` is not necessary if you add small fix to `MatMul`. Thus there is no `MatMulGrad` in this branch.

BTW, I found this issue when I was looking at Chainer chemistry.