### PR TITLE
Fix CUDNN_STATUS_EXECUTION_FAILED when NStepBiLSTM is using CuPy

### DIFF
--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -12,7 +12,7 @@ from chainer import variable
 
 
 def argsort_list_descent(lst):
-    return numpy.argsort([-len(x.data) for x in lst]).astype('i')
+    return numpy.argsort([-len(x) for x in lst]).astype('i')
 
 
 def permutate_list(lst, indices, inv):


### PR DESCRIPTION
# Fix CUDNN_STATUS_EXECUTION_FAILED
## Issue description
Model definition:
```
# ...
self.lstm = L.NStepBiLSTM(n_layers=3, in_size=96, out_size=128, dropout=0.3)
# ...
```

In [n_step_rnn.py](https://github.com/chainer/chainer/blob/5d4673bcc3589ee07d0185571629675581740a31/chainer/links/connection/n_step_rnn.py#L15) 
Line 15:
```
    return numpy.argsort([-len(x.data) for x in lst]).astype('i')
```
When using CuPy, the type of `x.data` is `cupy.cuda.MemoryPointer`, which doesn't have `__len__()`
However, the problem will not appear when using CPU only, because the type of `x.data` is `numpy.ndarray`, which could be passed to `len()` by invoking `__len__()`.

## Fixing

While the type of `x` is `chainer.Variable`, and has `__len__()`, so it should be changed to `len(x)` to cover both CPU and GPU.