### PR TITLE
support using cupy wheels as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,11 +104,11 @@ def find_any_distribution(pkgs):
 # Currently cupy provides source package (cupy) and binary wheel packages
 # (cupy-cudaXX). Chainer can use any one of these packages.
 cupy_pkg = find_any_distribution([
-    'cupy',
-    'cupy-cuda70',
-    'cupy-cuda75',
-    'cupy-cuda80',
     'cupy-cuda90',
+    'cupy-cuda80',
+    'cupy-cuda75',
+    'cupy-cuda70',
+    'cupy',
 ])
 if cupy_pkg is not None:
     req = cupy_requirement(cupy_pkg.project_name)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,10 @@ set CHAINER_PYTHON_350_FORCE environment variable to 1."""
         sys.exit(1)
 
 
+def cupy_requirement(pkg):
+    return '{}==4.0.0b4'.format(pkg)
+
+
 requirements = {
     'install': [
         'filelock',
@@ -28,7 +32,7 @@ requirements = {
         'six>=1.9.0',
     ],
     'cuda': [
-        'cupy==4.0.0b4',
+        cupy_requirement('cupy'),
     ],
     'stylecheck': [
         'hacking',
@@ -87,15 +91,29 @@ extras_require = {k: v for k, v in requirements.items() if k != 'install'}
 setup_requires = []
 install_requires = requirements['install']
 
-cupy_pkg = None
-try:
-    cupy_pkg = pkg_resources.get_distribution('cupy')
-except pkg_resources.DistributionNotFound:
-    pass
 
+def find_any_distribution(pkgs):
+    for pkg in pkgs:
+        try:
+            return pkg_resources.get_distribution(pkg)
+        except pkg_resources.DistributionNotFound:
+            pass
+    return None
+
+
+cupy_pkg = find_any_distribution([
+    'cupy',
+    'cupy-cuda70',
+    'cupy-cuda75',
+    'cupy-cuda80',
+    'cupy-cuda90',
+])
 if cupy_pkg is not None:
-    install_requires.append(requirements['cuda'])
-    print('Use %s' % requirements['cuda'])
+    req = cupy_requirement(cupy_pkg.project_name)
+    install_requires.append(req)
+    print('Use %s' % req)
+else:
+    print('No CuPy installation detected')
 
 here = os.path.abspath(os.path.dirname(__file__))
 __version__ = imp.load_source(

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ def find_any_distribution(pkgs):
     return None
 
 
+# Currently cupy provides source package (cupy) and binary wheel packages
+# (cupy-cudaXX). Chainer can use any one of these packages.
 cupy_pkg = find_any_distribution([
     'cupy',
     'cupy-cuda70',

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,6 @@ def find_any_distribution(pkgs):
 cupy_pkg = find_any_distribution([
     'cupy-cuda90',
     'cupy-cuda80',
-    'cupy-cuda75',
-    'cupy-cuda70',
     'cupy',
 ])
 if cupy_pkg is not None:


### PR DESCRIPTION
This PR depends on https://github.com/cupy/cupy/pull/899.

Support CuPy wheels as a dependency.