### PR TITLE
Optimize CTC backward

### DIFF
--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -143,11 +143,12 @@ class ConnectionistTemporalClassification(function.Function):
                 'T prob, I path, I path_length, I max_path_length',
                 'raw T cum_prob',
                 '''
-                int n_batch = cum_prob.shape()[1];
-                I s = i / (max_path_length * n_batch);
-                I b = (i - s * (max_path_length * n_batch)) / max_path_length;
                 I t = i % max_path_length;
                 if (t < path_length) {
+                  int n_batch = cum_prob.shape()[1];
+                  I s = i / (max_path_length * n_batch);
+                  I b = (i - s * (max_path_length * n_batch))
+                      / max_path_length;
                   int ind[] = {s, b, path};
                   atomicAdd(&cum_prob[ind], prob);
                 }

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -152,7 +152,7 @@ class ConnectionistTemporalClassification(function.Function):
                   int ind[] = {s, b, path};
                   atomicAdd(&cum_prob[ind], prob);
                 }
-                ''', 'ctc_label_logsumexp'
+                ''', 'ctc_label_prob_sum'
             )(multiply_seq, path, path_length[:, None], path.shape[1], ret)
         return ret
 


### PR DESCRIPTION
In CTC backward process, it accumulates probabilities. That is not in the log world. So we can just use `sum` instead of `logsumexp`. And, replaced the for loop with `atomicAdd` to accumulate the same label probabilities.

related to #4248 