### PR TITLE
Add direct convolution to depthwise_convolution_2d

### DIFF
--- a/chainer/links/connection/depthwise_convolution_2d.py
+++ b/chainer/links/connection/depthwise_convolution_2d.py
@@ -32,6 +32,9 @@ class DepthwiseConvolution2D(link.Link):
         initial_bias (:ref:`initializer <initializer>`): Initializer to
             initialize the bias. If ``None``, the bias will be initialized to
             zero. When it is :class:`numpy.ndarray`, its ``ndim`` should be 1.
+        direct (bool): If ``True`` and gpu enabled, this link use direct
+            implementation of convolution instead of im2col.
+            This is efficient when the channel size is large.
 
     .. seealso::
        See :func:`chainer.functions.depthwise_convolution_2d`.
@@ -43,13 +46,14 @@ class DepthwiseConvolution2D(link.Link):
     """
 
     def __init__(self, in_channels, channel_multiplier, ksize, stride=1, pad=0,
-                 nobias=False, initialW=None, initial_bias=None):
+                 nobias=False, initialW=None, initial_bias=None, direct=False):
         super(DepthwiseConvolution2D, self).__init__()
         self.ksize = ksize
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.channel_multiplier = channel_multiplier
         self.nobias = nobias
+        self.direct = direct
 
         if initialW is None:
             initialW = initializers.HeNormal(1. / numpy.sqrt(2))
@@ -90,7 +94,7 @@ class DepthwiseConvolution2D(link.Link):
         if self.W.data is None:
             self._initialize_params(x.shape[1])
         return depthwise_convolution_2d.depthwise_convolution_2d(
-            x, self.W, self.b, self.stride, self.pad)
+            x, self.W, self.b, self.stride, self.pad, self.direct)
 
 
 def _pair(x):

--- a/tests/chainer_tests/links_tests/connection_tests/test_depthwise_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_depthwise_convolution_2d.py
@@ -15,6 +15,7 @@ from chainer.testing import condition
     'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'nobias': [True, False],
+    'direct': [True, False],
 }))
 class TestDepthwiseConvolution2D(unittest.TestCase):
 
@@ -22,7 +23,8 @@ class TestDepthwiseConvolution2D(unittest.TestCase):
         self.link = links.DepthwiseConvolution2D(
             3, 2, 3, stride=2, pad=1,
             initialW=chainer.initializers.Normal(1, self.W_dtype),
-            initial_bias=chainer.initializers.Normal(1, self.x_dtype))
+            initial_bias=chainer.initializers.Normal(1, self.x_dtype),
+            direct=self.direct)
         self.link.cleargrads()
 
         self.x = numpy.random.uniform(-1, 1,


### PR DESCRIPTION
This PR aims to add a direct convolution to depthwise_convolution_2d.
The direct implementation is efficient when the function has the large size of channels.
This also reduces memory consumption and helps to implement 
relatively large networks like MobileNets.

Here is benchmark.
```
direct
time:27.16, mem: 363, batch: 16, channel:128, kernel:  3, multiplier:  1, stride:  1
time:26.35, mem: 697, batch: 32, channel:128, kernel:  3, multiplier:  1, stride:  1
time:26.53, mem:1369, batch: 64, channel:128, kernel:  3, multiplier:  1, stride:  1
time:19.51, mem: 345, batch: 64, channel: 32, kernel:  3, multiplier:  1, stride:  1
time:19.69, mem: 673, batch:128, channel: 32, kernel:  3, multiplier:  1, stride:  1
time:21.92, mem: 681, batch: 64, channel: 64, kernel:  3, multiplier:  1, stride:  1
time:22.11, mem:1337, batch:128, channel: 64, kernel:  3, multiplier:  1, stride:  1
time:37.59, mem:1393, batch: 32, channel:256, kernel:  3, multiplier:  1, stride:  1
time:33.51, mem:1030, batch: 32, channel:128, kernel:  3, multiplier:  2, stride:  1
time:33.16, mem: 697, batch: 32, channel:128, kernel:  5, multiplier:  1, stride:  1
time: 4.36, mem: 107, batch: 32, channel:128, kernel:  3, multiplier:  1, stride:  2
im2col
time:34.52, mem:1205, batch: 16, channel:128, kernel:  3, multiplier:  1, stride:  1
time:33.25, mem:2417, batch: 32, channel:128, kernel:  3, multiplier:  1, stride:  1
time:33.55, mem:4826, batch: 64, channel:128, kernel:  3, multiplier:  1, stride:  1
time:10.24, mem:1213, batch: 64, channel: 32, kernel:  3, multiplier:  1, stride:  1
time: 9.97, mem:2418, batch:128, channel: 32, kernel:  3, multiplier:  1, stride:  1
time:17.60, mem:2417, batch: 64, channel: 64, kernel:  3, multiplier:  1, stride:  1
time:17.71, mem:4827, batch:128, channel: 64, kernel:  3, multiplier:  1, stride:  1
time:67.24, mem:4826, batch: 32, channel:256, kernel:  3, multiplier:  1, stride:  1
time:37.92, mem:2679, batch: 32, channel:128, kernel:  3, multiplier:  2, stride:  1
time:80.74, mem:5383, batch: 32, channel:128, kernel:  5, multiplier:  1, stride:  1
time: 5.83, mem: 226, batch: 32, channel:128, kernel:  3, multiplier:  1, stride:  2
```

[this is benchmark code](https://gist.github.com/yasuyuky/6b07c5d795a21ffc2f6b26217843cfd5)
