### PR TITLE
Child sum treelstm with less than 2 child

### DIFF
--- a/chainer/functions/activation/tree_lstm.py
+++ b/chainer/functions/activation/tree_lstm.py
@@ -65,7 +65,7 @@ class TreeLSTM(function.Function):
     """
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() >= 3)
+        type_check.expect(in_types.size() >= 2)
         c_types = in_types[:-1]
         x_type = in_types[-1]
         n_ary = len(c_types)

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -92,7 +92,7 @@ class ChildSumTreeLSTM(link.Chain):
             elif any(h is not None for h in hs):
                 base = [h for h in hs if h is not None][0]
             else:
-                raise ValueError('All inputs (x, cs, hs) are None.')
+                raise ValueError('All inputs (cs, hs, x) are None.')
             batchsize, dtype = base.shape[0], base.dtype
             x = self.xp.zeros(
                 (batchsize, self.in_size), dtype=dtype)
@@ -229,7 +229,7 @@ class NaryTreeLSTM(link.Chain):
             elif any(h is not None for h in hs):
                 base = [h for h in hs if h is not None][0]
             else:
-                raise ValueError('All inputs are None.')
+                raise ValueError('All inputs (cs, hs, x) are None.')
             batchsize, dtype = base.shape[0], base.dtype
             x = self.xp.zeros(
                 (batchsize, self.in_size), dtype=dtype)

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -107,21 +107,21 @@ class ChildSumTreeLSTM(link.Chain):
             c = sigmoid.sigmoid(i) * tanh.tanh(a)
             h = sigmoid.sigmoid(o) * tanh.tanh(c)
             return c, h
-        else:
-            hs = self._pad_zero_nodes(
-                hs, (x.shape[0], self.state_size), dtype=x.dtype)
-            cs = self._pad_zero_nodes(
-                cs, (x.shape[0], self.state_size), dtype=x.dtype)
 
-            aio_in = self.W_h_aio(sum(hs)) + W_x_aio_in
-            W_h_fs_in = concat.concat(split_axis.split_axis(
-                self.W_h_f(concat.concat(hs, axis=0)), len(hs), axis=0),
-                axis=1)
-            f_in = W_h_fs_in + \
-                concat.concat([W_x_f_in] * len(hs), axis=1)
-            tree_lstm_in = concat.concat([aio_in, f_in], axis=1)
+        hs = self._pad_zero_nodes(
+            hs, (x.shape[0], self.state_size), dtype=x.dtype)
+        cs = self._pad_zero_nodes(
+            cs, (x.shape[0], self.state_size), dtype=x.dtype)
 
-            return tree_lstm.tree_lstm(*(cs + (tree_lstm_in, )))
+        aio_in = self.W_h_aio(sum(hs)) + W_x_aio_in
+        W_h_fs_in = concat.concat(split_axis.split_axis(
+            self.W_h_f(concat.concat(hs, axis=0)), len(hs), axis=0),
+            axis=1)
+        f_in = W_h_fs_in + \
+            concat.concat([W_x_f_in] * len(hs), axis=1)
+        tree_lstm_in = concat.concat([aio_in, f_in], axis=1)
+
+        return tree_lstm.tree_lstm(*(cs + (tree_lstm_in, )))
 
     def _pad_zero_nodes(self, vs, shape, dtype='f'):
         if any(v is None for v in vs):

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -106,7 +106,7 @@ class ChildSumTreeLSTM(link.Chain):
             a, i, o = split_axis.split_axis(aio_in, 3, axis=1)
             c = sigmoid.sigmoid(i) * tanh.tanh(a)
             h = sigmoid.sigmoid(o) * tanh.tanh(c)
-            return (c, h)
+            return c, h
         else:
             hs = self._pad_zero_nodes(
                 hs, (x.shape[0], self.state_size), dtype=x.dtype)

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -115,7 +115,8 @@ class ChildSumTreeLSTM(link.Chain):
 
             aio_in = self.W_h_aio(sum(hs)) + W_x_aio_in
             W_h_fs_in = concat.concat(split_axis.split_axis(
-                self.W_h_f(concat.concat(hs, axis=0)), len(hs), axis=0), axis=1)
+                self.W_h_f(concat.concat(hs, axis=0)), len(hs), axis=0),
+                axis=1)
             f_in = W_h_fs_in + \
                 concat.concat([W_x_f_in] * len(hs), axis=1)
             tree_lstm_in = concat.concat([aio_in, f_in], axis=1)

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -1,3 +1,5 @@
+from chainer.functions.activation import sigmoid
+from chainer.functions.activation import tanh
 from chainer.functions.activation import tree_lstm
 from chainer.functions.array import concat
 from chainer.functions.array import split_axis
@@ -81,8 +83,7 @@ class ChildSumTreeLSTM(link.Chain):
         cs = cshsx[:len(cshsx) // 2]
         hs = cshsx[len(cshsx) // 2:-1]
         x = cshsx[-1]
-        assert(len(cs) >= 1)
-        assert(len(hs) >= 1)
+        assert(len(cshsx) % 2 == 1)
         assert(len(cs) == len(hs))
 
         if x is None:
@@ -91,7 +92,7 @@ class ChildSumTreeLSTM(link.Chain):
             elif any(h is not None for h in hs):
                 base = [h for h in hs if h is not None][0]
             else:
-                raise ValueError('All inputs are None.')
+                raise ValueError('All inputs (x, cs, hs) are None.')
             batchsize, dtype = base.shape[0], base.dtype
             x = self.xp.zeros(
                 (batchsize, self.in_size), dtype=dtype)
@@ -100,19 +101,26 @@ class ChildSumTreeLSTM(link.Chain):
         W_x_aio_in, W_x_f_in = split_axis.split_axis(
             W_x_in, [3 * self.state_size], axis=1)
 
-        hs = self._pad_zero_nodes(
-            hs, (x.shape[0], self.state_size), dtype=x.dtype)
-        cs = self._pad_zero_nodes(
-            cs, (x.shape[0], self.state_size), dtype=x.dtype)
+        if len(hs) == 0:
+            aio_in = W_x_aio_in
+            a, i, o = split_axis.split_axis(aio_in, 3, axis=1)
+            c = sigmoid.sigmoid(i) * tanh.tanh(a)
+            h = sigmoid.sigmoid(o) * tanh.tanh(c)
+            return (c, h)
+        else:
+            hs = self._pad_zero_nodes(
+                hs, (x.shape[0], self.state_size), dtype=x.dtype)
+            cs = self._pad_zero_nodes(
+                cs, (x.shape[0], self.state_size), dtype=x.dtype)
 
-        aio_in = self.W_h_aio(sum(hs)) + W_x_aio_in
-        W_h_fs_in = concat.concat(split_axis.split_axis(
-            self.W_h_f(concat.concat(hs, axis=0)), len(hs), axis=0), axis=1)
-        f_in = W_h_fs_in + \
-            concat.concat([W_x_f_in] * len(hs), axis=1)
-        tree_lstm_in = concat.concat([aio_in, f_in], axis=1)
+            aio_in = self.W_h_aio(sum(hs)) + W_x_aio_in
+            W_h_fs_in = concat.concat(split_axis.split_axis(
+                self.W_h_f(concat.concat(hs, axis=0)), len(hs), axis=0), axis=1)
+            f_in = W_h_fs_in + \
+                concat.concat([W_x_f_in] * len(hs), axis=1)
+            tree_lstm_in = concat.concat([aio_in, f_in], axis=1)
 
-        return tree_lstm.tree_lstm(*(cs + (tree_lstm_in, )))
+            return tree_lstm.tree_lstm(*(cs + (tree_lstm_in, )))
 
     def _pad_zero_nodes(self, vs, shape, dtype='f'):
         if any(v is None for v in vs):
@@ -179,7 +187,7 @@ class NaryTreeLSTM(link.Chain):
     """
 
     def __init__(self, in_size, out_size, n_ary=2):
-        assert(n_ary >= 2)
+        assert(n_ary >= 1)
         super(NaryTreeLSTM, self).__init__()
         with self.init_scope():
             self.W_x = linear.Linear(in_size, (3 + n_ary) * out_size)

--- a/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
@@ -118,7 +118,8 @@ class TestTreeLSTM(unittest.TestCase):
                 self.in_size, self.out_size)
         elif self.model_type == 'NaryTreeLSTM':
             if self.n_ary == 0:
-                self.n_ary = 1  # skip n_ary=1 test for NaryTreeLSTM
+                # n_ary=0 test should be skipped for NaryTreeLSTM
+                self.n_ary = 1
             self.link = links.NaryTreeLSTM(
                 self.in_size, self.out_size, n_ary=self.n_ary)
         else:

--- a/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
@@ -33,19 +33,29 @@ def _child_sum_tree_lstm(func, *inputs):
         W_ha, W_hi, W_ho = xp.split(W_h_aio, 3, 1)
         W_hf = W_h_f
 
-        sum_h = sum(hs)
-        a = x.dot(W_xa) + sum_h.dot(W_ha) + b_a
-        i = x.dot(W_xi) + sum_h.dot(W_hi) + b_i
-        o = x.dot(W_xo) + sum_h.dot(W_ho) + b_o
-        f_list = [x.dot(W_xf) + h.dot(W_hf) + b_f for h in hs]
+        if len(hs) >= 1:
+            sum_h = sum(hs)
+            a = x.dot(W_xa) + sum_h.dot(W_ha) + b_a
+            i = x.dot(W_xi) + sum_h.dot(W_hi) + b_i
+            o = x.dot(W_xo) + sum_h.dot(W_ho) + b_o
+            f_list = [x.dot(W_xf) + h.dot(W_hf) + b_f for h in hs]
 
-        a = xp.tanh(a)
-        i = _sigmoid(i)
-        o = _sigmoid(o)
-        f_list = [_sigmoid(f) for f in f_list]
+            a = xp.tanh(a)
+            i = _sigmoid(i)
+            o = _sigmoid(o)
+            f_list = [_sigmoid(f) for f in f_list]
 
-        c_next = a * i + sum(f * c for f, c in zip(f_list, cs))
-        y = o * xp.tanh(c_next)
+            c_next = a * i + sum(f * c for f, c in zip(f_list, cs))
+            y = o * xp.tanh(c_next)
+        else:
+            a = x.dot(W_xa) + b_a
+            i = x.dot(W_xi) + b_i
+            o = x.dot(W_xo) + b_o
+            a = xp.tanh(a)
+            i = _sigmoid(i)
+            o = _sigmoid(o)
+            c_next = a * i
+            y = o * xp.tanh(c_next)
     return c_next, y
 
 
@@ -97,7 +107,7 @@ def _nary_tree_lstm(func, *inputs):
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float32],
-    'n_ary': [2, 3],
+    'n_ary': [0, 1, 2, 3],
     'in_size': [6, 9],
     'out_size': [9],
     'model_type': ['ChildSumTreeLSTM', 'NaryTreeLSTM'],
@@ -109,6 +119,8 @@ class TestTreeLSTM(unittest.TestCase):
             self.link = links.ChildSumTreeLSTM(
                 self.in_size, self.out_size)
         elif self.model_type == 'NaryTreeLSTM':
+            if self.n_ary == 0:
+                self.n_ary = 1  # skip n_ary=1 test for NaryTreeLSTM
             self.link = links.NaryTreeLSTM(
                 self.in_size, self.out_size, n_ary=self.n_ary)
         else:
@@ -180,29 +192,34 @@ class TestTreeLSTM(unittest.TestCase):
     def check_forward_valid_none(self, *inputs_data):
         inputs_variable = [chainer.Variable(v)
                            if v is not None else v for v in inputs_data]
-        base = [v for v in inputs_data if v is not None][0]
-        xp = cuda.get_array_module(base)
+        xp = self.link.xp
         inputs_data = [xp.zeros(self.h_prevs[0].shape, dtype=self.dtype)
                        if v is None else v for v in inputs_data[:-1]] + \
             [xp.zeros(self.x.shape, dtype=self.dtype)
              if inputs_data[-1] is None else inputs_data[-1]]
 
-        c, h = self.link(*inputs_variable)
-        self.assertEqual(c.data.dtype, self.dtype)
-        self.assertEqual(h.data.dtype, self.dtype)
-
-        # Compute expected out
-        if self.model_type == 'ChildSumTreeLSTM':
-            c_expect, h_expect = _child_sum_tree_lstm(self.link, *inputs_data)
-        elif self.model_type == 'NaryTreeLSTM':
-            c_expect, h_expect = _nary_tree_lstm(self.link, *inputs_data)
+        if self.n_ary == 0:
+            # in this case for link(x) without cs and hs,
+            # it does not include any None.
+            pass
         else:
-            NotImplementedError()
+            c, h = self.link(*inputs_variable)
+            self.assertEqual(c.data.dtype, self.dtype)
+            self.assertEqual(h.data.dtype, self.dtype)
 
-        testing.assert_allclose(
-            c_expect, c.data, **self.check_forward_options)
-        testing.assert_allclose(
-            h_expect, h.data, **self.check_forward_options)
+            # Compute expected out
+            if self.model_type == 'ChildSumTreeLSTM':
+                c_expect, h_expect = _child_sum_tree_lstm(
+                    self.link, *inputs_data)
+            elif self.model_type == 'NaryTreeLSTM':
+                c_expect, h_expect = _nary_tree_lstm(self.link, *inputs_data)
+            else:
+                NotImplementedError()
+
+            testing.assert_allclose(
+                c_expect, c.data, **self.check_forward_options)
+            testing.assert_allclose(
+                h_expect, h.data, **self.check_forward_options)
 
     def test_forward_none_ch_cpu(self):
         inputs = [None] * len(self.c_prevs) + \

--- a/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
@@ -39,21 +39,19 @@ def _child_sum_tree_lstm(func, *inputs):
             i = x.dot(W_xi) + sum_h.dot(W_hi) + b_i
             o = x.dot(W_xo) + sum_h.dot(W_ho) + b_o
             f_list = [x.dot(W_xf) + h.dot(W_hf) + b_f for h in hs]
-
-            a = xp.tanh(a)
-            i = _sigmoid(i)
-            o = _sigmoid(o)
-            f_list = [_sigmoid(f) for f in f_list]
-
-            c_next = sum([f * c for f, c in zip(f_list, cs)], a * i)
-            y = o * xp.tanh(c_next)
         else:
             a = x.dot(W_xa) + b_a
             i = x.dot(W_xi) + b_i
             o = x.dot(W_xo) + b_o
-            a = xp.tanh(a)
-            i = _sigmoid(i)
-            o = _sigmoid(o)
+        a = xp.tanh(a)
+        i = _sigmoid(i)
+        o = _sigmoid(o)
+
+        if len(hs) >= 1:
+            f_list = [_sigmoid(f) for f in f_list]
+            c_next = sum([f * c for f, c in zip(f_list, cs)], a * i)
+            y = o * xp.tanh(c_next)
+        else:
             c_next = a * i
             y = o * xp.tanh(c_next)
     return c_next, y

--- a/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
@@ -45,7 +45,7 @@ def _child_sum_tree_lstm(func, *inputs):
             o = _sigmoid(o)
             f_list = [_sigmoid(f) for f in f_list]
 
-            c_next = a * i + sum(f * c for f, c in zip(f_list, cs))
+            c_next = sum([f * c for f, c in zip(f_list, cs)], a * i)
             y = o * xp.tanh(c_next)
         else:
             a = x.dot(W_xa) + b_a


### PR DESCRIPTION
Fix #3680 

ChildSumTreeLSTM should have been able to accept `link(x)` and `link(c, h, x)`. But, they were not allowed, while only `link(c1, c2, ..., h1, h2, ..., x)` (with more than 1 children) was allowed.
This PR fixed it.