### PR TITLE
Enable opt = optimizers.SGD().setup() syntax

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -602,6 +602,7 @@ class GradientMethod(Optimizer):
             param.update_rule = self.create_update_rule()
             if self._use_fp32_update:
                 param.update_rule.use_fp32_update()
+        return self
 
     def reallocate_cleared_grads(self):
         """Reallocate gradients cleared by :meth:`~chainer.Variable.cleargrad`.


### PR DESCRIPTION
Add `return self` to GradientMethod.setup to allow for:

```
opt = optimizers.SGD().setup(model)
```
instead of

```
opt = optimizers.SGD()
opt = opt.setup(model)
```