### PR TITLE
[backport] Fix backward of BatchRenormalizationFunction and add tests 

### DIFF
--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -164,7 +164,7 @@ class BatchRenormalizationFunction(function.Function):
             # This case is unlikely to be used in practice and so does not
             # need to be optimized for performance.
             mean = inputs[3]
-            var = inputs[4]
+            var = inputs[4] + self.eps
             std = xp.sqrt(var, dtype=var.dtype)
             gs = gamma / std
             gbeta = gy.sum(axis=axis)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -22,10 +22,12 @@ def _batch_renormalization(expander, gamma, beta, x, mean, var, r, d):
 @testing.parameterize(*(testing.product({
     'param_shape': [(3, 4), (3, 2, 3)],
     'ndim': [0, 1, 2],
+    'eps': [2e-5, 1e-1],
     'dtype': [numpy.float32],
 }) + testing.product({
     'param_shape': [(3,)],
     'ndim': [1],
+    'eps': [2e-5, 1e-1],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 })))
 class TestBatchRenormalization(unittest.TestCase):
@@ -33,7 +35,6 @@ class TestBatchRenormalization(unittest.TestCase):
     def setUp(self):
         self.expander = (None, Ellipsis) + (None,) * self.ndim
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
-        self.eps = 2e-5
         self.decay = 0.9
 
         self.rmax = self.dtype(3)
@@ -73,7 +74,7 @@ class TestBatchRenormalization(unittest.TestCase):
         self.assertEqual(y.data.dtype, self.dtype)
 
         sigma_batch = numpy.sqrt(self.var)
-        running_sigma = numpy.sqrt(self.running_var)
+        running_sigma = numpy.sqrt(self.running_var + self.eps)
         r = numpy.clip(sigma_batch / running_sigma, 1.0 / self.rmax, self.rmax)
         d = numpy.clip((self.mean - self.running_mean) / running_sigma,
                        -self.dmax, self.dmax)
@@ -121,6 +122,7 @@ class TestBatchRenormalization(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'ndim': [0, 1, 2, 3],
+    'eps': [2e-5, 1e-1],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestFixedBatchRenormalization(unittest.TestCase):
@@ -136,7 +138,6 @@ class TestFixedBatchRenormalization(unittest.TestCase):
         shape = (5, 3) + (2,) * self.ndim
         self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        self.eps = 2e-5
         self.decay = 0.0
         self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
 
@@ -160,7 +161,8 @@ class TestFixedBatchRenormalization(unittest.TestCase):
         self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_renormalization(
-            self.expander, self.gamma, self.beta, self.x, self.mean, self.var,
+            self.expander, self.gamma, self.beta, self.x, self.mean,
+            self.var + self.eps,
             1, 0)
 
         testing.assert_allclose(


### PR DESCRIPTION
This is backport of #4191 except fixing of `tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py` .