### PR TITLE
Unchain function nodes in backward

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -911,7 +911,10 @@ Actual: {0}'''.format(type(data))
                 if e.status != 38:  # cudaErrorNoDevice
                     raise
 
-        enable_double_backprop = chainer.config.enable_backprop
+        unchain_creator_funcs = not (
+            chainer.config.enable_backprop
+            or chainer.config.keep_graph_on_report)
+
         is_debug = chainer.is_debug()
 
         cand_funcs = []
@@ -945,7 +948,7 @@ Actual: {0}'''.format(type(data))
 
         add_cand(self.creator_node)
 
-        if not enable_double_backprop:
+        if unchain_creator_funcs:
             self.unchain()
 
         def get_grad(node):
@@ -1063,7 +1066,7 @@ Actual: {0}'''.format(type(data))
 
                 if x.creator_node is not None:
                     add_cand(x.creator_node)
-                    if not enable_double_backprop:
+                    if unchain_creator_funcs:
                         x.unchain()
 
             del gxs  # to reduce memory usage

--- a/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_negative_sampling.py
@@ -85,11 +85,12 @@ class TestNegativeSampling(unittest.TestCase):
         x = chainer.Variable(self.x)
         t = chainer.Variable(self.t)
         y = self.link(x, t)
+        samples = y.creator.samples
         y.backward()
 
         # fix samples
         negative_sampling.NegativeSamplingFunction.samples = cuda.to_gpu(
-            y.creator.samples)
+            samples)
         self.link.to_gpu()
         del negative_sampling.NegativeSamplingFunction.samples
         xg = chainer.Variable(cuda.to_gpu(self.x))


### PR DESCRIPTION
Currently, all the function nodes in the computational graph is kept alive until whole backward computation is finished. Essentially, function nodes whose gradients are already propagated to all the input nodes are no longer needed and can be freed. If such function node holds large arrays as its attributes (usually in order to save common calculation between forward() and backward()) it unnecessarily occupies the memory.

This PR is to free such function nodes.

There are two types of references to such function nodes:
1. References from output variables' `creator` property.
2. `seen_set` in the backward graph traversal.

For 1., `creator` nodes of each variables are unchained as traversing backward.
For 2., weak references is used in `seen_set`.

## Code:
This is somewhat artificial example, but can demonstrate the effect.
```
import chainer
from chainer.backends import cuda
import cupy


class FooFunc(chainer.FunctionNode):
    def __init__(self, name):
        super().__init__()
        self.name = name

    def __del__(self):
        self.bar = None
        print("{:10d} DEL: {}".format(cuda.memory_pool.used_bytes(), self.name))

    def forward(self, inputs):
        # Dummy array which can be used in backward()
        self.bar = cupy.ones((100, 100, 100, 10), cupy.float32)
        x, = inputs
        y = x + 1
        print("{:10d} FWD: {}".format(cuda.memory_pool.used_bytes(), self.name))
        return y,

    def backward(self, indexes, grad_outputs):
        gy, = grad_outputs
        print("{:10d} BWD: {}".format(cuda.memory_pool.used_bytes(), self.name))
        return gy,


def func(x):
    hs = x,
    hs = FooFunc('a').apply(hs)
    hs = FooFunc('b').apply(hs)
    hs = FooFunc('c').apply(hs)
    hs = FooFunc('d').apply(hs)
    hs = FooFunc('e').apply(hs)
    h, = hs
    return h


def main():
    x = chainer.Variable(cupy.ones((2,)))
    y = func(x)
    y.grad = cupy.ones_like(y.data)
    y.backward()
    print(y, y.grad, x.grad)


main()
```

## Result (master):
```
  40001024 FWD: a
  80001536 FWD: b
 120001536 FWD: c
 160001536 FWD: d
 200001536 FWD: e
 200001536 BWD: e
 200001536 BWD: d
 200001536 BWD: c
 200001536 BWD: b
 200001536 BWD: a
variable([ 6.  6.]) [ 1.  1.] [ 1.  1.]
 160000512 DEL: e
 120000512 DEL: d
  80000512 DEL: c
  40000512 DEL: b
       512 DEL: a
```

## Result (This PR):
```
  40001024 FWD: a
  80001536 FWD: b
 120001536 FWD: c
 160001536 FWD: d
 200001536 FWD: e
 200001536 BWD: e
 160001536 DEL: e
 160001536 BWD: d
 120001536 DEL: d
 120001536 BWD: c
  80001536 DEL: c
  80001536 BWD: b
  40001536 DEL: b
  40001536 BWD: a
      1536 DEL: a
variable([ 6.  6.]) [ 1.  1.] [ 1.  1.]

```