### PR TITLE
Add cuDNN support for clipped_relu

### DIFF
--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -1,8 +1,14 @@
+import chainer
 from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check
 import numpy
+
+
+if cuda.cudnn_enabled:
+    cudnn = cuda.cudnn
+    _mode = cuda.cuda.cudnn.CUDNN_ACTIVATION_CLIPPED_RELU
 
 
 class ClippedReLU(function_node.FunctionNode):
@@ -14,6 +20,8 @@ class ClippedReLU(function_node.FunctionNode):
     where :math:`z(>0)` is a parameter to cap return value of ReLU.
 
     """
+
+    _use_cudnn = False
 
     def __init__(self, z):
         if not isinstance(z, float):
@@ -36,16 +44,27 @@ class ClippedReLU(function_node.FunctionNode):
     def forward_gpu(self, inputs):
         self.retain_inputs((0,))
         x, = inputs
-        return cuda.elementwise(
-            'T x, T cap', 'T y', 'y = min(max(x, (T)0), cap)',
-            'clipped_relu_fwd')(x, self.cap),
+        if chainer.should_use_cudnn('==always') and x.flags.c_contiguous:
+            self._use_cudnn = True
+            y = cudnn.activation_forward(x, _mode, self.cap)
+            self.retain_outputs((0,))
+        else:
+            return cuda.elementwise(
+                'T x, T cap', 'T y', 'y = min(max(x, (T)0), cap)',
+                'clipped_relu_fwd')(x, self.cap),
+        return y,
 
     def backward(self, indexes, grad_outputs):
         x, = self.get_retained_inputs()
-        return ClippedReLUGrad(x.data, self.cap).apply(grad_outputs)
+        if chainer.should_use_cudnn('==always') and self._use_cudnn:
+            y = self.get_retained_outputs()[0]
+            return ClippedReLUGrad3(x.data, y.data, self.cap).apply(
+                grad_outputs)
+        else:
+            return ClippedReLUGrad2(x.data, self.cap).apply(grad_outputs)
 
 
-class ClippedReLUGrad(function_node.FunctionNode):
+class ClippedReLUGrad2(function_node.FunctionNode):
 
     """Clipped Rectifier Unit gradient function."""
 
@@ -71,7 +90,34 @@ class ClippedReLUGrad(function_node.FunctionNode):
         return gx,
 
     def backward(self, indexes, grad_outputs):
-        return ClippedReLUGrad(self.x, self.cap).apply(grad_outputs)
+        return ClippedReLUGrad2(self.x, self.cap).apply(grad_outputs)
+
+
+class ClippedReLUGrad3(function_node.FunctionNode):
+
+    """Clipped Rectifier Unit gradient function."""
+
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.cap = z
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 1)
+        type_check.expect(in_types[0].dtype.kind == 'f')
+
+    def forward_cpu(self, inputs):
+        gy, = inputs
+        return utils.force_array(
+            gy * (0 < self.x) * (self.x < self.cap), self.x.dtype),
+
+    def forward_gpu(self, inputs):
+        assert chainer.should_use_cudnn('==always')
+        return cudnn.activation_backward(self.x, self.y, inputs[0], _mode,
+                                         self.cap),
+
+    def backward(self, indexes, grad_outputs):
+        return ClippedReLUGrad3(self.x, self.y, self.cap).apply(grad_outputs)
 
 
 def clipped_relu(x, z=20.0):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -1,5 +1,6 @@
 import unittest
 
+import mock
 import numpy
 
 import chainer
@@ -34,9 +35,10 @@ class TestClippedReLU(unittest.TestCase):
             self.check_backward_options = {}
             self.check_double_backward_options = {}
 
-    def check_forward(self, x_data):
+    def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
-        y = functions.clipped_relu(x, self.z)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            y = functions.clipped_relu(x, self.z)
         self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = self.x.clip(0, self.z)
@@ -50,13 +52,18 @@ class TestClippedReLU(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
-    def check_backward(self, x_data, y_grad):
+    @attr.gpu
+    def test_forward_gpu_no_cudnn(self):
+        self.check_forward(cuda.to_gpu(self.x), 'never')
+
+    def check_backward(self, x_data, y_grad, use_cudnn='always'):
         def f(x):
             return functions.clipped_relu(x, self.z)
 
-        gradient_check.check_backward(
-            f, x_data, y_grad, dtype=numpy.float64,
-            **self.check_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_backward(
+                f, x_data, y_grad, dtype=numpy.float64,
+                **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
@@ -65,14 +72,25 @@ class TestClippedReLU(unittest.TestCase):
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
-    def check_double_backward(self, x_data, y_grad, x_grad_grad):
+    @attr.gpu
+    def test_backward_gpu_non_contiguous(self):
+        self.check_backward(cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+                            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
+
+    @attr.gpu
+    def test_backward_gpu_no_cudnn(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
+
+    def check_double_backward(self, x_data, y_grad, x_grad_grad,
+                              use_cudnn='always'):
         def f(x):
             y = functions.clipped_relu(x, self.z)
             return y * y
 
-        gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
-            **self.check_double_backward_options)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_double_backward(
+                f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+                **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)
@@ -81,6 +99,57 @@ class TestClippedReLU(unittest.TestCase):
     def test_double_backward_gpu(self):
         self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy),
                                    cuda.to_gpu(self.ggx))
+
+    @attr.gpu
+    def test_double_backward_gpu_non_contiguous(self):
+        self.check_double_backward(
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
+
+    @attr.gpu
+    def test_double_backward_gpu_no_cudnn(self):
+        self.check_double_backward(cuda.to_gpu(self.x),
+                                   cuda.to_gpu(self.gy),
+                                   cuda.to_gpu(self.ggx),
+                                   'never')
+
+
+@testing.parameterize(*testing.product({
+    'use_cudnn': ['always', 'auto', 'never'],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+@attr.cudnn
+class TestClippedReLUCudnnCall(unittest.TestCase):
+
+    def setUp(self):
+        self.x = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
+        self.gy = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
+        self.z = 0.75
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            self.expect = chainer.should_use_cudnn('==always')
+
+    def forward(self):
+        x = chainer.Variable(self.x)
+        return functions.clipped_relu(x, self.z)
+
+    def test_call_cudnn_forward(self):
+        default_func = cuda.cupy.cudnn.activation_forward
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            with mock.patch('cupy.cudnn.activation_forward') as func:
+                func.side_effect = default_func
+                self.forward()
+                self.assertEqual(func.called, self.expect)
+
+    def test_call_cudnn_backward(self):
+        with chainer.using_config('use_cudnn', self.use_cudnn):
+            y = self.forward()
+            y.grad = self.gy
+            default_func = cuda.cupy.cudnn.activation_backward
+            with mock.patch('cupy.cudnn.activation_backward') as func:
+                func.side_effect = default_func
+                y.backward()
+                self.assertEqual(func.called, self.expect)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
I added cuDNN support for `clipped_relu`. This is useful for speeding up e.g. ReLU6, which has shown to be beneficial when preparing a model trained in FP32 mode to be run in FP16 precision.
It's recently being used in MobileNetV2.

Note that this PR depends on the following CuPy PR: https://github.com/cupy/cupy/pull/938

References: 
https://arxiv.org/abs/1801.04381
https://www.reddit.com/r/MachineLearning/comments/3s65x8/tensorflow_relu6_minmaxfeatures_0_6/
http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf