### PR TITLE
Improve error messages of array type check.

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -227,10 +227,10 @@ Use apply() method instead.\
 
         # Check for input array types
         if not chainer.is_arrays_compatible(in_data):
-            raise ValueError(
+            raise TypeError(
                 'incompatible array types are mixed in the forward input '
                 '({}).\n'
-                '{}'.format(
+                'Actual: {}'.format(
                     self.label,
                     ', '.join(str(type(x)) for x in in_data)))
 
@@ -264,10 +264,10 @@ Use apply() method instead.\
                 'Actual: {}'.format(self.label, type(outputs)))
 
         if not chainer.is_arrays_compatible(outputs):
-            raise ValueError(
+            raise TypeError(
                 'incompatible array types are mixed in the forward output '
                 '({}).\n'
-                '{}'.format(
+                'Actual: {}'.format(
                     self.label,
                     ', '.join(str(type(x)) for x in outputs)))
 

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -42,7 +42,7 @@ Suppose the following code:
    F.maximum(v1, v2)
 
 Prior to v4, the above code raises an exception like ``ValueError: object __array__ method not producing an array``, which was difficult to understand.
-In v4, the error message would become ``ValueError: incompatible array types are mixed in the forward input (Maximum)``.
+In v4, the error message would become ``TypeError: incompatible array types are mixed in the forward input (Maximum)``.
 This kind of error usually occurs by mistake (for example, not performing ``to_gpu`` for some variables).
 
 .. attention::

--- a/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_embed_id.py
@@ -56,13 +56,13 @@ class TestEmbedID(unittest.TestCase):
     @attr.gpu
     def test_forward_mixed_cpu_gpu_1(self):
         # self.link is not sent to gpu
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.check_forward(cuda.to_gpu(self.x))
 
     @attr.gpu
     def test_forward_mixed_cpu_gpu_2(self):
         self.link.to_gpu()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             # self.x is not sent to gpu
             self.check_forward(self.x)
 

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -337,7 +337,7 @@ class TestFunctionNodeInconsistentBackends(unittest.TestCase):
         x1 = chainer.Variable(x1)
         x2 = chainer.Variable(self.x2)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             f.apply((x1, x2))
 
     @attr.gpu
@@ -353,7 +353,7 @@ class TestFunctionNodeInconsistentBackends(unittest.TestCase):
         x1 = chainer.Variable(self.x1)
         x2 = chainer.Variable(self.x2)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             f.apply((x1, x2))
 
 


### PR DESCRIPTION
This is a proposal of improved error messages in `FunctionNode.apply()`. It also changes the type of exception.

The new message should be more understandable, for example, when a user forgot to use `utils.force_array()` in their own FunctionNode.

Original and new error messages look like these:

Original

```
ValueError: numpy and cupy arrays are mixed in the forward output (MyFunc).
<class 'cupy.core.core.ndarray'>, <class 'float'>
```

This PR

```
TypeError: forward outputs must be `ndarray`s of the same array module (numpy or cupy) (MyFunc).
Actual: <class 'cupy.core.core.ndarray'>, <class 'float'>
```