### PR TITLE
Use the same code for calculating forward and backward probabilities in CTC

### DIFF
--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -207,7 +207,7 @@ class ConnectionistTemporalClassification(function.Function):
         # rotate yseq with path_length
         yseq_inv = _move_inputs(yseq, input_length, xp)[::-1]
         # move to back.
-        prob = _move_inputs(prob, input_length, xp)
+        prob = _move_inputs(prob, input_length, xp)[::-1]
 
         # backward computation.
         backward_prob_index = (
@@ -219,12 +219,12 @@ class ConnectionistTemporalClassification(function.Function):
             # calc backward probability
             backward_prob = self._computes_transition(
                 backward_prob, r_path, path_length)
-            prob[-i - 1] += xp.take(
+            prob[i] += xp.take(
                 backward_prob[:, ::-1], backward_prob_index)
             backward_prob += xp.take(y_inv, r_index)
 
         # move to front.
-        return _move_inputs(prob, -self.input_length, xp)
+        return _move_inputs(prob[::-1], -self.input_length, xp)
 
     def forward(self, inputs):
         xp = cuda.get_array_module(inputs[0])

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -194,7 +194,7 @@ class ConnectionistTemporalClassification(function.Function):
             outside = xp.arange(max_path_length) >= path_length[:, None]
             prob[outside] = self.zero_padding
             cum_prob += prob
-            batch_index = xp.arange(0, n_batch, dtype='i')
+            batch_index = xp.arange(n_batch, dtype='i')
             prob += y[batch_index[:, None], path]
         else:
             prob = xp.empty_like(prev_prob)
@@ -244,7 +244,7 @@ class ConnectionistTemporalClassification(function.Function):
         forward_prob[:, 0] = 0
         backward_prob = forward_prob
 
-        batch_index = xp.arange(0, n_batch, dtype='i')
+        batch_index = xp.arange(n_batch, dtype='i')
         seq_index = xp.arange(len(yseq), dtype='i')
         prob = yseq[seq_index[:, None, None], batch_index[:, None], path]
         # forward computation.

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -207,15 +207,15 @@ class ConnectionistTemporalClassification(function.Function):
         backward_prob = forward_prob
 
         batch_index = xp.arange(0, n_batch, dtype='i')
-        prob = xp.empty(
-            (max_input_length, n_batch, max_path_length), dtype='f')
+        seq_index = xp.arange(len(yseq), dtype='i')
+        prob = yseq[seq_index[:, None, None], batch_index[:, None], path]
         # forward computation.
         for i, y in enumerate(yseq):
             # calc forward probability in log scale
             forward_prob = self._computes_transition(
                 forward_prob, path, path_length)
+            prob[i] += forward_prob
             forward_prob += y[batch_index[:, None], path]
-            prob[i] = forward_prob
 
         r_path = _move_label_to_back(path, path_length, xp)
 


### PR DESCRIPTION
Calculation of forward and backward probabilities are very similar. I fixed matrix order and make them the same code. And after that, I combine all kernels and reduced the number of kernels. When batch size is small this code is 3x faster.
This fix also includes refactoring. I can split the PR.