### PR TITLE
Use version in external URL

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,15 @@ __version__ = pkg_resources.get_distribution('chainer').version
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
+rtd_version = os.environ.get('READTHEDOCS_VERSION')
+if rtd_version == 'latest':
+    tag = 'master'
+else:
+    tag = 'v{}'.format(__version__)
+extlinks = {
+    'blob': ('https://github.com/chainer/chainer/blob/{}/%s'.format(tag), ''),
+    'tree': ('https://github.com/chainer/chainer/tree/{}/%s'.format(tag), ''),
+}
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -45,6 +54,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.doctest',
+              'sphinx.ext.extlinks',
               'sphinx.ext.intersphinx',
               'sphinx.ext.mathjax',
               'sphinx.ext.napoleon',
@@ -428,12 +438,6 @@ def _get_sourcefile_and_linenumber(obj):
 def linkcode_resolve(domain, info):
     if domain != 'py' or not info['module']:
         return None
-
-    rtd_version = os.environ.get('READTHEDOCS_VERSION')
-    if rtd_version == 'latest':
-        tag = 'master'
-    else:
-        tag = 'v{}'.format(__version__)
 
     # Import the object from module path
     obj = _import_object_from_name(info['module'], info['fullname'])

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -328,7 +328,7 @@ If you modify the code related to existing unit tests, you must run appropriate 
 Test File and Directory Naming Conventions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tests are put into the ``tests/chainer_tests`` directory.
+Tests are put into the :tree:`tests/chainer_tests` directory.
 In order to enable test runner to find test scripts correctly, we are using special naming convention for the test subdirectories and the test scripts.
 
 * The name of each subdirectory of ``tests`` must end with the ``_tests`` suffix.

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -340,7 +340,7 @@ For example, if you want to write a test for a module ``chainer.x.y.z``, the tes
 How to Write Tests
 ~~~~~~~~~~~~~~~~~~
 
-There are many examples of unit tests under the ``tests`` directory, so reading some of them is a good and recommended way to learn how to write tests for Chainer.
+There are many examples of unit tests under the :tree:`tests` directory, so reading some of them is a good and recommended way to learn how to write tests for Chainer.
 They simply use the ``unittest`` package of the standard library, while some tests are using utilities from :mod:`chainer.testing`.
 
 Even if your patch includes GPU-related code, your tests should not fail without GPU capability.

--- a/docs/source/tutorial/basic.rst
+++ b/docs/source/tutorial/basic.rst
@@ -465,7 +465,7 @@ Example: Multi-layer Perceptron on MNIST
 
 Now you can solve a multiclass classification task using a multi-layer perceptron (MLP).
 We use a hand-written digits dataset called `MNIST <http://yann.lecun.com/exdb/mnist/>`_, which is one of the long-standing de facto "hello world" examples used in machine learning.
-This MNIST example is also found in the `examples/mnist <https://github.com/chainer/chainer/tree/master/examples/mnist>`_ directory of the official repository.
+This MNIST example is also found in the :tree:`examples/mnist` directory of the official repository.
 We show how to use :class:`~training.Trainer` to construct and run the training loop in this section.
 
 We first have to prepare the MNIST dataset.
@@ -619,4 +619,4 @@ These extensions perform the following tasks:
 There are many extensions implemented in the :mod:`chainer.training.extensions` module.
 The most important one that is not included above is :func:`~training.extensions.snapshot`, which saves the snapshot of the training procedure (i.e., the Trainer object) to a file in the output directory.
 
-The `example code <https://github.com/chainer/chainer/blob/master/examples/mnist/train_mnist.py>`_ in the `examples/mnist` directory additionally contains GPU support, though the essential part is the same as the code in this tutorial. We will review in later sections how to use GPU(s).
+The :blob:`example code <examples/mnist/train_mnist.py>` in the :tree:`examples/mnist` directory additionally contains GPU support, though the essential part is the same as the code in this tutorial. We will review in later sections how to use GPU(s).

--- a/docs/source/tutorial/function.rst
+++ b/docs/source/tutorial/function.rst
@@ -608,4 +608,4 @@ offers a utility function :func:`chainer.gradient_check.check_backward` that fol
    unittest.TextTestRunner().run(suite)
 
 
-You can find many examples of function tests under ``tests/chainer_tests/function_tests`` directory.
+You can find many examples of function tests under :tree:`tests/chainer_tests/function_tests` directory.

--- a/docs/source/tutorial/function.rst
+++ b/docs/source/tutorial/function.rst
@@ -608,4 +608,4 @@ offers a utility function :func:`chainer.gradient_check.check_backward` that fol
    unittest.TextTestRunner().run(suite)
 
 
-You can find many examples of function tests under :tree:`tests/chainer_tests/function_tests` directory.
+You can find many examples of function tests under :tree:`tests/chainer_tests/functions_tests` directory.

--- a/docs/source/tutorial/gpu.rst
+++ b/docs/source/tutorial/gpu.rst
@@ -440,6 +440,6 @@ So we must manually copy them to ``model_1`` using :meth:`Link.copyparams` metho
 --------
 
 Now you can use Chainer with GPUs.
-All examples in the ``examples`` directory support GPU computation, so please refer to them if you want to know more practices on using GPUs.
+All examples in the :tree:`examples` directory support GPU computation, so please refer to them if you want to know more practices on using GPUs.
 In the next section, we will show how to define a differentiable (i.e. *backpropable*) function on Variable objects.
 We will also show there how to write a simple (elementwise) CUDA kernel using Chainer's CUDA utilities.

--- a/docs/source/tutorial/gpu.rst
+++ b/docs/source/tutorial/gpu.rst
@@ -305,7 +305,7 @@ The copy supports backprop, which just reversely transfers an output gradient to
    Above code is not parallelized on CPU, but is parallelized on GPU.
    This is because all the functions in the above code run asynchronously to the host CPU.
 
-An almost identical example code can be found at `examples/mnist/train_mnist_model_parallel.py <https://github.com/chainer/chainer/blob/master/examples/mnist/train_mnist_model_parallel.py>`_.
+An almost identical example code can be found at :blob:`examples/mnist/train_mnist_model_parallel.py`.
 
 
 Data-parallel Computation on Multiple GPUs with Trainer
@@ -342,7 +342,7 @@ In the above example, the model is also cloned and sent to GPU 1.
 Half of each mini-batch is fed to this cloned model.
 After every backward computation, the gradient is accumulated into the main device, the parameter update runs on it, and then the updated parameters are sent to GPU 1 again.
 
-See also the example code in `examples/mnist/train_mnist_data_parallel.py <https://github.com/chainer/chainer/blob/master/examples/mnist/train_mnist_data_parallel.py>`_.
+See also the example code in :blob:`examples/mnist/train_mnist_data_parallel.py`.
 
 
 Data-parallel Computation on Multiple GPUs without Trainer

--- a/docs/source/tutorial/ptb.rst
+++ b/docs/source/tutorial/ptb.rst
@@ -108,7 +108,7 @@ where :math:`\hat P` is the empirical distribution of a sequence in the training
 
 **There is an example of RNN language model in the official repository, so we will
 explain how to implement a RNNLM in Chainer based on that:**
-`chainer/examples/ptb <https://github.com/chainer/chainer/tree/master/examples/ptb>`_
+:tree:`examples/ptb`
 
 2.1 Model Overview
 -------------------
@@ -334,7 +334,7 @@ outside of :class:`~chainer.training.Trainer`.
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can train the model with the script:
-`chainer/examples/ptb/train_ptb.py <https://github.com/chainer/chainer/tree/master/examples/ptb/train_ptb.py>`_
+:blob:`examples/ptb/train_ptb.py`
 
 .. code-block:: console
 
@@ -354,7 +354,7 @@ You can train the model with the script:
 You can generate the sentence which starts with a word in the vocabulary. In this example,
 we generate a sentence which starts with the word apple.
 We use the script in the PTB example of the official repository:
-`chainer/examples/ptb/gentxt.py <https://github.com/chainer/chainer/tree/master/examples/ptb/gentxt.py>`_
+:blob:`examples/ptb/gentxt.py`
 
 .. code-block:: console
 

--- a/docs/source/tutorial/recurrentnet.rst
+++ b/docs/source/tutorial/recurrentnet.rst
@@ -235,7 +235,7 @@ In order to implement this training procedure, we have to customize the followin
 When we write a dataset iterator dedicated to the dataset, the dataset implementation can be arbitrary; even the interface is not fixed.
 On the other hand, the iterator must support the :class:`~chainer.dataset.Iterator` interface.
 The important methods and attributes to implement are ``batch_size``, ``epoch``, ``epoch_detail``, ``is_new_epoch``, ``iteration``, ``__next__``, and ``serialize``.
-Following is a code from the official example in the ``examples/ptb`` directory.
+Following is a code from the official example in the :tree:`examples/ptb` directory.
 
 .. code-block:: python
 
@@ -333,5 +333,5 @@ The rest of the code for setting up Trainer is almost same as one given in the p
 ---------
 
 In this section we have demonstrated how to write recurrent nets in Chainer and some fundamental techniques to manage the history of computation (a.k.a. computational graph).
-The example in the ``examples/ptb`` directory implements truncated backprop learning of a LSTM language model from the Penn Treebank corpus.
+The example in the :tree:`examples/ptb` directory implements truncated backprop learning of a LSTM language model from the Penn Treebank corpus.
 In the next section, we will review how to use GPU(s) in Chainer.

--- a/docs/source/tutorial/word2vec.rst
+++ b/docs/source/tutorial/word2vec.rst
@@ -166,7 +166,7 @@ Since there should be more than one context word, repeat the following process f
 
 There is an example of Word2vec in the official repository of Chainer,
 so we will explain how to implement Skip-gram based on this:
-`chainer/examples/word2vec <https://github.com/chainer/chainer/tree/master/examples/word2vec>`_
+:tree:`examples/word2vec`
 
 4.1 Preparation
 --------------------------


### PR DESCRIPTION
Some external URLs in the document directly refer to the master branch, and they should be pointed to the corresponding tag.

I utilize sphinx.ext.extlinks to achieve this goal. However, I wonder if it is appropriate to use names 'blob' and 'tree', and actually github automatically redirects to correct URL whichever original URL is blob or tree. 