### PR TITLE
Avoid keeping reference to function nodes in TimerHook

### DIFF
--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -32,7 +32,7 @@ class TimerHook(function_hook.FunctionHook):
         and *Occurrence* is the number of calls.
     Attributes:
         call_history: List of measurement results. It consists of pairs of
-            the function that calls this hook and the elapsed time
+            the name of the function that calls this hook and the elapsed time
             the function consumes.
     """
 
@@ -75,7 +75,7 @@ class TimerHook(function_hook.FunctionHook):
             # Note that `get_elapsed_time` returns result in milliseconds
             elapsed_time = cuda.cupy.cuda.get_elapsed_time(
                 start, stop) / 1000
-        self.call_history.append((function, elapsed_time))
+        self.call_history.append((function._impl_name, elapsed_time))
 
         assert self._depth > 0
         self._depth -= 1
@@ -104,8 +104,7 @@ class TimerHook(function_hook.FunctionHook):
             values are dictionaries of `elapsed_time` and `occurrrence`.
         """
         summary = {}
-        for func, elapsed_time in self.call_history:
-            function_name = func._impl_name
+        for function_name, elapsed_time in self.call_history:
             if function_name not in summary:
                 summary[function_name] = {'elapsed_time': 0, 'occurrence': 0}
             record = summary[function_name]

--- a/tests/chainer_tests/function_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/function_hooks_tests/test_timer.py
@@ -14,8 +14,8 @@ from chainer.testing import attr
 
 
 def check_history(self, t, function_type, return_type):
-    func = getattr(t[0], 'function', t[0])
-    self.assertIsInstance(func, function_type)
+    func_name = t[0]
+    assert func_name == function_type.__name__
     self.assertIsInstance(t[1], return_type)
 
 
@@ -66,7 +66,7 @@ class TestTimerHookToLink(unittest.TestCase):
         # It includes forward of + that accumulates gradients to W and b
         self.assertEqual(3, len(self.h.call_history), self.h.call_history)
         for entry in self.h.call_history:
-            if entry[0].label == '_ + _':
+            if entry[0] == 'Add':
                 continue
             check_history(self, entry, basic_math.Mul, float)
 
@@ -130,10 +130,10 @@ class TestTimerHookToFunction(unittest.TestCase):
 
         history = dict(self.h.call_history)
         self.assertEqual(len(history), 2)
-        self.assertIn(self.f, history)
-        self.assertIn(g, history)
-        f_time = history[self.f]
-        g_time = history[g]
+        self.assertIn(self.f._impl_name, history)
+        self.assertIn(g._impl_name, history)
+        f_time = history[self.f._impl_name]
+        g_time = history[g._impl_name]
         self.assertLessEqual(g_time, t2 - t1)
         self.assertGreaterEqual(f_time, t2 - t1)
 


### PR DESCRIPTION
It's better to apply the same fix made in #4300 (CupyMemoryProfileHook).