### PR TITLE
Use ResNeXt in the ImageNet example

### DIFF
--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -74,7 +74,8 @@ def main():
         'googlenetbn': googlenetbn.GoogLeNetBN,
         'googlenetbn_fp16': googlenetbn.GoogLeNetBNFp16,
         'nin': nin.NIN,
-        'resnet50': resnet50.ResNet50
+        'resnet50': resnet50.ResNet50,
+        'resnext50': resnet50.ResNeXt50,
     }
 
     parser = argparse.ArgumentParser(

--- a/examples/imagenet/train_imagenet_data_parallel.py
+++ b/examples/imagenet/train_imagenet_data_parallel.py
@@ -38,7 +38,8 @@ def main():
         'googlenetbn': googlenetbn.GoogLeNetBN,
         'googlenetbn_fp16': googlenetbn.GoogLeNetBNFp16,
         'nin': nin.NIN,
-        'resnet50': resnet50.ResNet50
+        'resnet50': resnet50.ResNet50,
+        'resnext50': resnet50.ResNeXt50,
     }
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
It's a pity that ResNeXt has been implemented but not used in the ImageNet example. 