### PR TITLE
Fix some inconsistency in gradient variable names.

### DIFF
--- a/chainer/functions/activation/sigmoid.py
+++ b/chainer/functions/activation/sigmoid.py
@@ -87,8 +87,8 @@ class SigmoidGrad(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         y, gy = self.get_retained_inputs()
-        g, = grad_outputs
-        return g * gy * (1 - 2 * y), g * y * (1 - y)
+        ggx, = grad_outputs
+        return ggx * gy * (1 - 2 * y), ggx * y * (1 - y)
 
 
 def sigmoid(x):

--- a/chainer/functions/activation/softplus.py
+++ b/chainer/functions/activation/softplus.py
@@ -80,11 +80,11 @@ class SoftplusGrad(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         x, gy = self.get_retained_inputs()
-        g, = grad_outputs
+        ggx, = grad_outputs
         e = chainer.functions.exp(self.beta * x)
-        ggx = g * gy * self.beta * e / (1 + e) ** 2
-        ggy = SoftplusGrad((self.beta,)).apply((x, g))[0]
-        return ggx, ggy
+        gx = ggx * gy * self.beta * e / (1 + e) ** 2
+        ggy = SoftplusGrad((self.beta,)).apply((x, ggx))[0]
+        return gx, ggy
 
 
 def softplus(x, beta=1.0):

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -80,12 +80,12 @@ class TanhGrad(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         y, gy = self.get_retained_inputs()
-        g = grad_outputs[0]
+        ggx = grad_outputs[0]
 
-        y_mul_g = y * g
-        grad_y = -2 * gy * y_mul_g
-        ggy = g - y * y_mul_g
-        return grad_y, ggy
+        y_mul_ggx = y * ggx
+        gx = -2 * gy * y_mul_ggx
+        ggy = ggx - y * y_mul_ggx
+        return gx, ggy
 
 
 def tanh(x):

--- a/chainer/functions/activation/tanh.py
+++ b/chainer/functions/activation/tanh.py
@@ -83,9 +83,9 @@ class TanhGrad(function_node.FunctionNode):
         ggx = grad_outputs[0]
 
         y_mul_ggx = y * ggx
-        gx = -2 * gy * y_mul_ggx
+        grad_y = -2 * gy * y_mul_ggx
         ggy = ggx - y * y_mul_ggx
-        return gx, ggy
+        return grad_y, ggy
 
 
 def tanh(x):

--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -51,8 +51,8 @@ class SelectItem(function_node.FunctionNode):
         t = self.get_retained_inputs()[0]
         ret = []
         if 0 in indexes:
-            ggx = Assign(self._in_shape, self._in_dtype, t).apply(gy)[0]
-            ret.append(ggx)
+            gx = Assign(self._in_shape, self._in_dtype, t).apply(gy)[0]
+            ret.append(gx)
         if 1 in indexes:
             ret.append(None)
         return ret

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -348,18 +348,19 @@ class DivGrad(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         x0, x1, gy = self.get_retained_inputs()
+        ggx0, ggx1 = grad_outputs
+
         ret = []
         x1_square = x1 * x1
         if 0 in indexes:
-            ggx0 = - grad_outputs[1] * gy / x1_square
-            ret.append(ggx0)
+            gx0 = -ggx1 * gy / x1_square
+            ret.append(gx0)
         if 1 in indexes:
-            ggx1 = \
-                - grad_outputs[0] * gy / x1_square + \
-                grad_outputs[1] * 2 * gy * x0 / (x1_square * x1)
-            ret.append(ggx1)
+            gx1 = -ggx0 * gy / x1_square + \
+                ggx1 * 2 * gy * x0 / (x1_square * x1)
+            ret.append(gx1)
         if 2 in indexes:
-            ggy = grad_outputs[0] / x1 - grad_outputs[1] * x0 / x1_square
+            ggy = ggx0 / x1 - ggx1 * x0 / x1_square
             ret.append(ggy)
         return ret
 

--- a/chainer/functions/math/batch_l2_norm_squared.py
+++ b/chainer/functions/math/batch_l2_norm_squared.py
@@ -60,9 +60,9 @@ class BatchL2NormSquaredGrad(function_node.FunctionNode):
         x, gy0 = self.get_retained_inputs()
         gy0 = gy0.reshape(-1, *((1,) * (x.ndim - 1)))
         gy0 = chainer.functions.broadcast_to(gy0, x.shape)
-        gg2 = 2 * grad_outputs[0]
-        gx = gg2 * gy0
-        ggy0 = gg2 * x
+        ggx2 = 2 * grad_outputs[0]
+        gx = ggx2 * gy0
+        ggy0 = ggx2 * x
         return gx, _sum.sum(ggy0, axis=tuple(six.moves.range(1, ggy0.ndim)))
 
 

--- a/chainer/functions/math/linear_interpolate.py
+++ b/chainer/functions/math/linear_interpolate.py
@@ -35,8 +35,8 @@ class LinearInterpolate(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         p, x, y = self.get_retained_inputs()
-        g, = grad_outputs
-        return LinearInterpolateGrad().apply((p, x, y, g))
+        gz, = grad_outputs
+        return LinearInterpolateGrad().apply((p, x, y, gz))
 
 
 class LinearInterpolateGrad(function_node.FunctionNode):
@@ -63,13 +63,13 @@ class LinearInterpolateGrad(function_node.FunctionNode):
         )(p, x, y, g)
 
     def backward(self, indexes, grad_outputs):
-        p, x, y, g = self.get_retained_inputs()
-        g0, g1, g2 = grad_outputs
-        gp = g * (g1 - g2)
-        gx = g * g0
+        p, x, y, gz = self.get_retained_inputs()
+        ggp, ggx, ggy = grad_outputs
+        gp = gz * (ggx - ggy)
+        gx = gz * ggp
         gy = - gx
-        gg = (x - y) * g0 + p * g1 + (1 - p) * g2
-        return gp, gx, gy, gg
+        ggz = (x - y) * ggp + p * ggx + (1 - p) * ggy
+        return gp, gx, gy, ggz
 
 
 def linear_interpolate(p, x, y):

--- a/chainer/functions/math/linear_interpolate.py
+++ b/chainer/functions/math/linear_interpolate.py
@@ -43,24 +43,24 @@ class LinearInterpolateGrad(function_node.FunctionNode):
 
     def forward_cpu(self, inputs):
         self.retain_inputs((0, 1, 2, 3))
-        p, x, y, g = inputs
-        pg = p * g
-        return (utils.force_array((x - y) * g),
+        p, x, y, gz = inputs
+        pg = p * gz
+        return (utils.force_array((x - y) * gz),
                 utils.force_array(pg),
-                utils.force_array(g - pg))
+                utils.force_array(gz - pg))
 
     def forward_gpu(self, inputs):
         self.retain_inputs((0, 1, 2, 3))
-        p, x, y, g = inputs
+        p, x, y, gz = inputs
         return cuda.elementwise(
-            'T p, T x, T y, T g', 'T gp, T gx, T gy',
+            'T p, T x, T y, T gz', 'T gp, T gx, T gy',
             '''
-            gp = (x - y) * g;
-            gx = g * p;
-            gy = g * (1 - p);
+            gp = (x - y) * gz;
+            gx = gz * p;
+            gy = gz * (1 - p);
             ''',
             'linear_interpolate_bwd'
-        )(p, x, y, g)
+        )(p, x, y, gz)
 
     def backward(self, indexes, grad_outputs):
         p, x, y, gz = self.get_retained_inputs()

--- a/chainer/functions/math/trigonometric.py
+++ b/chainer/functions/math/trigonometric.py
@@ -390,7 +390,7 @@ class Arctan2Grad(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         x1, x2, gy = self.get_retained_inputs()
-        g1, g2 = grad_outputs
+        ggx1, ggx2 = grad_outputs
         x1_sq = x1 ** 2
         x2_sq = x2 ** 2
         sqnorm = x1_sq + x2_sq
@@ -398,12 +398,14 @@ class Arctan2Grad(function_node.FunctionNode):
         ret = []
         if 0 in indexes:
             ret.append(
-                (- g1 * 2 * x1 * x2 + g2 * (x1_sq - x2_sq)) * gy / sqnorm ** 2)
+                (- ggx1 * 2 * x1 * x2 + ggx2 * (x1_sq - x2_sq)) * gy /
+                sqnorm ** 2)
         if 1 in indexes:
             ret.append(
-                (g1 * (x1_sq - x2_sq) + g2 * (2 * x1 * x2)) * gy / sqnorm ** 2)
+                (ggx1 * (x1_sq - x2_sq) + ggx2 * (2 * x1 * x2)) * gy /
+                sqnorm ** 2)
         if 2 in indexes:
-            ret.append((g1 * x2 - g2 * x1) / sqnorm)
+            ret.append((ggx1 * x2 - ggx2 * x1) / sqnorm)
         return ret
 
 


### PR DESCRIPTION
According to the source code and [the slides about double backprop.](https://www.slideshare.net/KentaOono/comparison-of-deep-learning-frameworks-from-viewpoint-of-double-backpropagation), it seems a common practice to use `gx` and `ggx` to represent the gradients wrt `x` and `gx`.

However, some variables have contradictory names to this convention and new users may get confused about it. I hope they will be fixed by this PR.