### PR TITLE
remove input type consistency checks

### DIFF
--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -79,11 +79,6 @@ class BilinearFunction(function_node.FunctionNode):
         e2 = _as_mat(inputs[1])
         W = inputs[2]
 
-        if not type_check.same_types(*inputs):
-            raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): {0}, type(e1): {1}, type(e2): {2}'
-                             .format(type(W), type(e1), type(e2)))
-
         xp = cuda.get_array_module(*inputs)
         y = xp.einsum('ij,ik,jkl->il', e1, e2, W)
 

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -156,16 +156,6 @@ class ConvolutionND(function_node.FunctionNode):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if not type_check.same_types(*inputs):
-            if b is not None:
-                raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): {0}, type(x): {1}, type(b): {2}'
-                                 .format(type(W), type(x), type(b)))
-            else:
-                raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): {0}, type(x): {1}'
-                                 .format(type(W), type(x)))
-
         xp = cuda.get_array_module(*inputs)
         if xp is numpy:
             return self._forward_xp(x, W, b, numpy)

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -159,16 +159,6 @@ class DeconvolutionND(function_node.FunctionNode):
         x, W = inputs[:2]
         b = inputs[2] if len(inputs) == 3 else None
 
-        if not type_check.same_types(*inputs):
-            if b is not None:
-                raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): {0}, type(x): {1}, type(b): {2}'
-                                 .format(type(W), type(x), type(b)))
-            else:
-                raise ValueError('numpy and cupy must not be used together\n'
-                                 'type(W): {0}, type(x): {1}'
-                                 .format(type(W), type(x)))
-
         if self.outs is None:
             dims = x.shape[2:]
             ksize = W.shape[2:]

--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -29,11 +29,6 @@ class EmbedIDFunction(function_node.FunctionNode):
         x, W = inputs
         self._w_shape = W.shape
 
-        if not type_check.same_types(*inputs):
-            raise ValueError('numpy and cupy must not be used together\n'
-                             'type(W): {0}, type(x): {1}'
-                             .format(type(W), type(x)))
-
         xp = cuda.get_array_module(*inputs)
         if chainer.is_debug():
             valid_x = xp.logical_and(0 <= x, x < len(W))


### PR DESCRIPTION
These codes are invalid as iDeep is now introduced.
Note that type consistency is now checked in FunctionNode level (#4029), so we can safely remove these checks.

Type check code in `F.linear` will be removed in #4278.