### PR TITLE
iDeep: Add experimental warning

### DIFF
--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import chainer
 from chainer.configuration import config
+from chainer import utils
 
 
 _ideep_version = None
@@ -37,6 +38,8 @@ def check_ideep_available():
     When iDeep is correctly set up, nothing happens.
     Otherwise it raises ``RuntimeError``.
     """
+    utils.experimental('ideep')
+
     if _ideep_version is None:
         raise RuntimeError(
             'iDeep is not available.\n'
@@ -77,7 +80,10 @@ def should_use_ideep(level):
         raise ValueError('invalid use_ideep configuration: %s '
                          '(must be either of "always", "auto", or "never")' %
                          repr(use_ideep))
-    return flags[use_ideep]
+    ret = flags[use_ideep]
+    if ret:
+        utils.experimental('ideep')
+    return ret
 
 
 def inputs_all_ready(inputs, supported_ndim=(2, 4)):

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -745,6 +745,7 @@ Actual: {0}'''.format(type(data))
         If the array is not suited for intel64, it will be converted to
         :class:`numpy.ndarray`.
         """
+        intel64.check_ideep_available()
         data = self.data
         if data is not None:
             if isinstance(data, numpy.ndarray):


### PR DESCRIPTION
Add experimental warning in
* At `backends.intel64.check_ideep_available()`
* At `backends.intel64.should_use_ideep()`, if it's going to return `True`.

The warning will not be emitted from the following functions, because they are called from chainer even if ideep is not enabled by user.
* `backends.intel64.is_ideep_available()`
* `backends.intel64.inputs_all_ready()`
