### PR TITLE
Accept concat array in NStepRNNs

### DIFF
--- a/chainer/functions/connection/n_step_gru.py
+++ b/chainer/functions/connection/n_step_gru.py
@@ -25,16 +25,18 @@ if cuda.cudnn_enabled:
 
 class NStepGRU(n_step_rnn.BaseNStepRNN):
 
-    def __init__(self, n_layers, states, **kwargs):
+    def __init__(self, n_layers, states, lengths, **kwargs):
         n_step_rnn.BaseNStepRNN.__init__(
-            self, n_layers, states, rnn_dir='uni', rnn_mode='gru', **kwargs)
+            self, n_layers, states, lengths,
+            rnn_dir='uni', rnn_mode='gru', **kwargs)
 
 
 class NStepBiGRU(n_step_rnn.BaseNStepRNN):
 
-    def __init__(self, n_layers, states, **kwargs):
+    def __init__(self, n_layers, states, lengths, **kwargs):
         n_step_rnn.BaseNStepRNN.__init__(
-            self, n_layers, states, rnn_dir='bi', rnn_mode='gru', **kwargs)
+            self, n_layers, states, lengths,
+            rnn_dir='bi', rnn_mode='gru', **kwargs)
 
 
 def n_step_gru(

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -31,16 +31,18 @@ def _stack_weight(ws):
 
 class NStepLSTM(n_step_rnn.BaseNStepRNN):
 
-    def __init__(self, n_layers, states):
-        n_step_rnn.BaseNStepRNN.__init__(self, n_layers, states,
-                                         rnn_dir='uni', rnn_mode='lstm')
+    def __init__(self, n_layers, states, lengths):
+        n_step_rnn.BaseNStepRNN.__init__(
+            self, n_layers, states, lengths,
+            rnn_dir='uni', rnn_mode='lstm')
 
 
 class NStepBiLSTM(n_step_rnn.BaseNStepRNN):
 
-    def __init__(self, n_layers, states):
-        n_step_rnn.BaseNStepRNN.__init__(self, n_layers, states,
-                                         rnn_dir='bi', rnn_mode='lstm')
+    def __init__(self, n_layers, states, lengths):
+        n_step_rnn.BaseNStepRNN.__init__(
+            self, n_layers, states, lengths,
+            rnn_dir='bi', rnn_mode='lstm')
 
 
 def n_step_lstm(

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -428,20 +428,22 @@ def n_step_lstm_base(
 
     if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
         states = get_random_state().create_dropout_states(dropout_ratio)
+        lengths = [len(x) for x in xs]
+        xs = chainer.functions.concat(xs, axis=0)
         # flatten all input variables
         inputs = tuple(itertools.chain(
             (hx, cx),
             itertools.chain.from_iterable(ws),
             itertools.chain.from_iterable(bs),
-            xs))
+            (xs,)))
         if use_bi_direction:
-            rnn = NStepBiLSTM(n_layers, states)
+            rnn = NStepBiLSTM
         else:
-            rnn = NStepLSTM(n_layers, states)
+            rnn = NStepLSTM
 
-        ret = rnn(*inputs)
-        hy, cy = ret[:2]
-        ys = ret[2:]
+        hy, cy, ys = rnn(n_layers, states, lengths)(*inputs)
+        sections = numpy.cumsum(lengths[:-1])
+        ys = chainer.functions.split_axis(ys, sections, 0)
         return hy, cy, ys
 
     else:

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -133,7 +133,7 @@ if cuda.cudnn_enabled and _cudnn_version >= 5000:
 
 class BaseNStepRNN(function.Function):
 
-    def __init__(self, n_layers, states, rnn_dir, rnn_mode, **kwargs):
+    def __init__(self, n_layers, states, lengths, rnn_dir, rnn_mode, **kwargs):
         argument.check_unexpected_kwargs(
             kwargs, train='train argument is not supported anymore. '
             'Use chainer.using_config')
@@ -472,30 +472,34 @@ class BaseNStepRNN(function.Function):
 
 class NStepRNNTanh(BaseNStepRNN):
 
-    def __init__(self, n_layers, states, **kwargs):
-        BaseNStepRNN.__init__(self, n_layers, states, rnn_dir='uni',
-                              rnn_mode='rnn_tanh', **kwargs)
+    def __init__(self, n_layers, states, lengths, **kwargs):
+        BaseNStepRNN.__init__(
+            self, n_layers, states, lengths,
+            rnn_dir='uni', rnn_mode='rnn_tanh', **kwargs)
 
 
 class NStepRNNReLU(BaseNStepRNN):
 
-    def __init__(self, n_layers, states, **kwargs):
-        BaseNStepRNN.__init__(self, n_layers, states, rnn_dir='uni',
-                              rnn_mode='rnn_relu', **kwargs)
+    def __init__(self, n_layers, states, lengths, **kwargs):
+        BaseNStepRNN.__init__(
+            self, n_layers, states, lengths,
+            rnn_dir='uni', rnn_mode='rnn_relu', **kwargs)
 
 
 class NStepBiRNNTanh(BaseNStepRNN):
 
-    def __init__(self, n_layers, states, **kwargs):
-        BaseNStepRNN.__init__(self, n_layers, states, rnn_dir='bi',
-                              rnn_mode='rnn_tanh', **kwargs)
+    def __init__(self, n_layers, states, lengths, **kwargs):
+        BaseNStepRNN.__init__(
+            self, n_layers, states, lengths,
+            rnn_dir='bi', rnn_mode='rnn_tanh', **kwargs)
 
 
 class NStepBiRNNReLU(BaseNStepRNN):
 
-    def __init__(self, n_layers, states, **kwargs):
-        BaseNStepRNN.__init__(self, n_layers, states, rnn_dir='bi',
-                              rnn_mode='rnn_relu', **kwargs)
+    def __init__(self, n_layers, states, lengths, **kwargs):
+        BaseNStepRNN.__init__(
+            self, n_layers, states, lengths,
+            rnn_dir='bi', rnn_mode='rnn_relu', **kwargs)
 
 
 def n_step_rnn(

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -154,6 +154,8 @@ class BaseNStepRNN(function.Function):
         self.states = states
         self.use_cell = _rnn_params_use_cell[self.rnn_mode]
         self.n_W = _rnn_n_params[self.rnn_mode]
+        self.lengths = lengths
+        self.sections = numpy.cumsum(lengths)
 
     @property
     def _n_cell(self):
@@ -167,7 +169,8 @@ class BaseNStepRNN(function.Function):
         return self.n_layers * self.rnn_direction * self.n_W
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() > self._n_cell + self._n_params * 2)
+        type_check.expect(
+            in_types.size() == self._n_cell + self._n_params * 2 + 1)
 
         if self.use_cell:
             (h_type, c_type), in_types = _split(in_types, 2)
@@ -201,19 +204,13 @@ class BaseNStepRNN(function.Function):
         w_types, in_types = _split(in_types, self._n_params)
         b_types, in_types = _split(in_types, self._n_params)
 
-        x_types = in_types
-        for x_type in x_types:
-            type_check.expect(
-                x_type.dtype == numpy.float32,
-                x_type.ndim == 2,
-            )
-        for x1_type, x2_type in six.moves.zip(x_types, x_types[1:]):
-            type_check.expect(
-                # Check if xs are sorted by descending lengths
-                x1_type.shape[0] >= x2_type.shape[0],
-                x1_type.shape[1] == x2_type.shape[1])
+        x_type = in_types[0]
+        type_check.expect(
+            x_type.dtype == numpy.float32,
+            x_type.ndim == 2,
+        )
 
-        in_size = x_types[0].shape[1]
+        in_size = x_type.shape[1]
         out_size = h_type.shape[2]
 
         for layer in six.moves.range(self.n_layers):
@@ -272,16 +269,14 @@ class BaseNStepRNN(function.Function):
 
         ws, inputs = _split(inputs, self._n_params)
         bs, inputs = _split(inputs, self._n_params)
-        x_list = inputs
+        xs = cuda.cupy.ascontiguousarray(inputs[0])
         hx = cuda.cupy.ascontiguousarray(hx)
-        x_desc = cudnn.create_tensor_nd_descriptor(x_list[0][..., None])
 
-        length = len(x_list)
+        length = len(self.lengths)
         n_units = hx.shape[2]
 
-        xs = cuda.cupy.concatenate(x_list, axis=0)
-        ys = cuda.cupy.empty((len(xs),
-                              n_units * self.rnn_direction), dtype=xs.dtype)
+        ys = cuda.cupy.empty(
+            (len(xs), n_units * self.rnn_direction), dtype=xs.dtype)
 
         handle = cudnn.get_handle()
         self.handle = handle
@@ -293,6 +288,8 @@ class BaseNStepRNN(function.Function):
             self.rnn_mode, libcudnn.CUDNN_DATA_FLOAT)
         self.rnn_desc = rnn_desc
 
+        x_list = cuda.cupy.split(xs, self.sections[:-1])
+        x_desc = cudnn.create_tensor_nd_descriptor(x_list[0][..., None])
         c_x_descs = _make_tensor_descriptor_array(x_list)
         hx_desc = cudnn.create_tensor_nd_descriptor(hx)
 
@@ -320,8 +317,7 @@ class BaseNStepRNN(function.Function):
         self.w = w
         self.w_desc = w_desc
 
-        sections = numpy.cumsum([len(x) for x in x_list[:-1]])
-        y_list = cuda.cupy.split(ys, sections)
+        y_list = cuda.cupy.split(ys, self.sections[:-1])
 
         c_y_descs = _make_tensor_descriptor_array(y_list)
         hy = cuda.cupy.empty_like(hx)
@@ -359,10 +355,10 @@ class BaseNStepRNN(function.Function):
 
         if self.use_cell:
             # LSTM
-            return tuple([hy, cy] + y_list)
+            return hy, cy, ys
         else:
             # GRU, RNN
-            return tuple([hy, ] + y_list)
+            return hy, ys
 
     def backward(self, inputs, grads):
         if self.use_cell:
@@ -396,28 +392,25 @@ class BaseNStepRNN(function.Function):
         ws_size = self.n_layers * self.rnn_direction * self.n_W
         ws, inputs = _split(inputs, ws_size)
         bs, inputs = _split(inputs, ws_size)
-        x_list = inputs
+        xs = cuda.cupy.ascontiguousarray(inputs[0])
         hx = cuda.cupy.ascontiguousarray(hx)
 
         if dhy is None:
             dhy = cuda.cupy.zeros_like(hx)
 
-        dy_list = list(grads[self._n_cell:])
-        for i in six.moves.range(len(dy_list)):
-            if dy_list[i] is None:
-                shape = (x_list[i].shape[0], self.rnn_direction * hx.shape[2])
-                dy_list[i] = cuda.cupy.zeros(shape, dtype='f')
+        dys = grads[self._n_cell]
+        if dys is None:
+            dys = cuda.cupy.zeros_like(self.ys)
 
-        xs = cuda.cupy.concatenate(x_list, axis=0)
-        length = len(x_list)
+        length = len(self.lengths)
 
         dhx = cuda.cupy.empty_like(hx)
 
         hx_desc = cudnn.create_tensor_nd_descriptor(hx)
         dhy_desc = cudnn.create_tensor_nd_descriptor(dhy)
 
+        dy_list = cuda.cupy.split(dys, self.sections[:-1], 0)
         c_dy_descs = _make_tensor_descriptor_array(dy_list)
-        dys = cuda.cupy.concatenate(dy_list, axis=0)
 
         rnn_desc = self.rnn_desc
         handle = self.handle
@@ -428,8 +421,7 @@ class BaseNStepRNN(function.Function):
         dhx_desc = cudnn.create_tensor_nd_descriptor(dhx)
 
         dxs = cuda.cupy.empty_like(xs)
-        sections = numpy.cumsum([len(x) for x in x_list[:-1]])
-        dx_list = cuda.cupy.split(dxs, sections, 0)
+        dx_list = cuda.cupy.split(dxs, self.sections[:-1], 0)
         c_dx_descs = _make_tensor_descriptor_array(dx_list)
 
         libcudnn.RNNBackwardData(
@@ -472,10 +464,10 @@ class BaseNStepRNN(function.Function):
 
         if self.use_cell:
             # LSTM
-            return tuple([dhx, dcx] + dws + dbs + dx_list)
+            return tuple([dhx, dcx] + dws + dbs + [dxs])
         else:
             # GRU, RNN
-            return tuple([dhx, ] + dws + dbs + dx_list)
+            return tuple([dhx] + dws + dbs + [dxs])
 
 
 class NStepRNNTanh(BaseNStepRNN):
@@ -799,28 +791,30 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
 
     if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
         states = get_random_state().create_dropout_states(dropout_ratio)
+        lengths = [len(x) for x in xs]
+        xs = chainer.functions.concat(xs, axis=0)
         # flatten all input variables
         inputs = tuple(itertools.chain(
-            (hx, ),
+            (hx,),
             itertools.chain.from_iterable(ws),
             itertools.chain.from_iterable(bs),
-            xs))
+            (xs,)))
         if use_bi_direction:
             # Bi-directional RNN
             if activation == 'tanh':
-                rnn = NStepBiRNNTanh(n_layers, states)
+                rnn = NStepBiRNNTanh
             elif activation == 'relu':
-                rnn = NStepBiRNNReLU(n_layers, states)
+                rnn = NStepBiRNNReLU
         else:
             # Uni-directional RNN
             if activation == 'tanh':
-                rnn = NStepRNNTanh(n_layers, states)
+                rnn = NStepRNNTanh
             elif activation == 'relu':
-                rnn = NStepRNNReLU(n_layers, states)
+                rnn = NStepRNNReLU
 
-        ret = rnn(*inputs)
-        hy, = ret[:1]
-        ys = ret[1:]
+        hy, ys = rnn(n_layers, states, lengths)(*inputs)
+        sections = numpy.cumsum(lengths[:-1])
+        ys = chainer.functions.split_axis(ys, sections, 0)
         return hy, ys
 
     else:


### PR DESCRIPTION
I refactored BaseNStepRNN to accept concatenated arrays. With this fix, BaseNStepRNN accepts concatenated arrays. And instead, it requires length array. Arrays are concatenated with `chainer.functions.concat` in `n_step_rnn` function. This fix doesn't change the interface. After merging this fix, I'll add an argument to select if `concat` is called or not.