### PR TITLE
Fix error messages for incompatible arrays

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -225,7 +225,7 @@ Use apply() method instead.\
         # Check for input array types
         if not chainer.is_arrays_compatible(in_data):
             raise ValueError(
-                'numpy and cupy arrays are mixed in the forward input '
+                'incompatible array types are mixed in the forward input '
                 '({}).\n'
                 '{}'.format(
                     self.label,
@@ -262,7 +262,7 @@ Use apply() method instead.\
 
         if not chainer.is_arrays_compatible(outputs):
             raise ValueError(
-                'numpy and cupy arrays are mixed in the forward output '
+                'incompatible array types are mixed in the forward output '
                 '({}).\n'
                 '{}'.format(
                     self.label,

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -42,7 +42,7 @@ Suppose the following code:
    F.maximum(v1, v2)
 
 Prior to v4, the above code raises an exception like ``ValueError: object __array__ method not producing an array``, which was difficult to understand.
-In v4, the error message would become ``ValueError: numpy and cupy arrays are mixed in the forward input (Maximum)``.
+In v4, the error message would become ``ValueError: incompatible array types are mixed in the forward input (Maximum)``.
 This kind of error usually occurs by mistake (for example, not performing ``to_gpu`` for some variables).
 
 .. attention::


### PR DESCRIPTION
Now that `ideep.mdarray` is introduced, current error message is not preciese.