### PR TITLE
Cast to int type in split_axis

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -95,7 +95,7 @@ class SplitAxis(function_node.FunctionNode):
         axis = self.axis % x.ndim
         if isinstance(ios, collections.Iterable):
             for i in ios:
-                offsets.push_back(i)
+                offsets.push_back(int(i))
         else:
             d = x.shape[self.axis]
             step = d // ios

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -69,6 +69,10 @@ def inject_backend_tests(method_names):
         {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': [2, 3, 5],
          'slices': [slice(None, 2), slice(2, 3), slice(3, 5), slice(5, None)]
          },
+        {'shape': (10, 4, 3, 2), 'axis': 0,
+         'ys_section': numpy.asarray([2, 3, 5]),
+         'slices': [slice(None, 2), slice(2, 3), slice(3, 5), slice(5, None)]
+         },
         {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': [2, 3, 3, 5],
          'slices': [slice(None, 2), slice(2, 3), slice(3, 3), slice(3, 5),
                     slice(5, None)]


### PR DESCRIPTION
Fix bug when we use Python3 with iDeep.
