### PR TITLE
Fix BatchMatMulGrad.backward

### DIFF
--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -244,8 +244,6 @@ class BatchMatMulGrad(function_node.FunctionNode):
             if 1 in indexes:
                 ret.append(gb)
         if 2 in indexes:
-            a = chainer.functions.reshape(a, (a.shape[:2] + (-1,)))
-            b = chainer.functions.reshape(b, (b.shape[:2] + (-1,)))
             ret.append(
                 BatchMatMul(self.transa, self.transb).apply((gga, b))[0] +
                 BatchMatMul(self.transa, self.transb).apply((a, ggb))[0])

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -4,7 +4,6 @@ import numpy
 
 from chainer.backends import cuda
 from chainer import function_node
-import chainer.functions
 from chainer import utils
 from chainer.utils import type_check
 

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -246,10 +246,10 @@ class BatchMatMulGrad(function_node.FunctionNode):
         if 2 in indexes:
             a = chainer.functions.reshape(a, (a.shape[:2] + (-1,)))
             b = chainer.functions.reshape(b, (b.shape[:2] + (-1,)))
-            ggy = \
-                BatchMatMul(self.transa, self.transb).apply((gga, b))[0] + \
-                BatchMatMul(self.transa, self.transb).apply((a, ggb))[0]
-        return ga, gb, ggy
+            ret.append(
+                BatchMatMul(self.transa, self.transb).apply((gga, b))[0] +
+                BatchMatMul(self.transa, self.transb).apply((a, ggb))[0])
+        return ret
 
 
 def batch_matmul(a, b, transa=False, transb=False):


### PR DESCRIPTION
If fewer indices are needed in `BatchMatMulGrad.backward`, it may cause `UnboundLocalError: local variable 'ggab' referenced before assignment`.  The bug was introduced in #3768.

Please review this after #4331 is merged.