### PR TITLE
Extract a function that concatenates weight and bias matrixes for cuDNN

### DIFF
--- a/chainer/functions/connection/n_step_gru.py
+++ b/chainer/functions/connection/n_step_gru.py
@@ -300,7 +300,7 @@ def n_step_gru_base(n_layers, dropout_ratio, hx, ws, bs, xs,
         xs = chainer.functions.concat(xs, axis=0)
 
         w = n_step_rnn.cudnn_rnn_weight_concat(
-            n_layers, states, use_bi_direction, 'lstm', ws, bs)
+            n_layers, states, use_bi_direction, 'gru', ws, bs)
 
         if use_bi_direction:
             rnn = NStepBiGRU

--- a/chainer/functions/connection/n_step_gru.py
+++ b/chainer/functions/connection/n_step_gru.py
@@ -1,5 +1,3 @@
-import itertools
-
 import numpy
 import six
 

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -1,5 +1,3 @@
-import itertools
-
 import numpy
 import six
 

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -150,7 +150,7 @@ class CudnnRNNWeightConcat(function.Function):
         type_check.expect(
             in_types.size() == n_params * 2)
 
-        w_types = in_types[0:n_params]
+        w_types = in_types[:n_params]
         b_types = in_types[n_params:]
 
         in_size = w_types[0].shape[1]

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -129,9 +129,9 @@ if cuda.cudnn_enabled and _cudnn_version >= 5000:
 
 class CudnnRNNWeightConcat(function.Function):
 
-    """Concatenates weight matrixes for cuDNN's RNN.
+    """Concatenates weight matrices for cuDNN's RNN.
 
-    This function concatenates weight matrixes for RNNs into one large array.
+    This function concatenates weight matrices for RNNs into one large array.
     Its format is defined in cuDNN's API.
 
     """


### PR DESCRIPTION
I extracted a function to concatenate weight matrixes `ws` and bias arrays `bs`. In the current implementation of `NStepRNNBase`, it makes a large weight array made by `getRNNParamsSize` in forward and splits it in backward. I extracted this feature into a function.
This fix is for providing an interface which skips concatenation to RNN link.
Note that this fix does not change interfaces for users.