### PR TITLE
Fix numpy dtypes bug in cuda.to_gpu and cuda.copy

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -218,8 +218,7 @@ def get_device(*args):
 
 def _get_device(*args):
     for arg in args:
-        if isinstance(arg, _integer_types) and not numpy.issubdtype(
-                type(arg), numpy.bool_):
+        if type(arg) is not bool and isinstance(arg, _integer_types):
             check_cuda_available()
             return Device(arg)
         if isinstance(arg, ndarray):

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -138,14 +138,13 @@ if available:
     pinned_memory_pool = cupy.get_default_pinned_memory_pool()
 
 
+_integer_types = six.integer_types + (numpy.integer,)
 if six.PY2:
     try:
         from future.types.newint import newint as _newint
-        _integer_types = six.integer_types + (numpy.integer,) + (_newint,)
+        _integer_types += (_newint,)
     except ImportError:
-        _integer_types = six.integer_types + (numpy.integer,)
-else:
-    _integer_types = six.integer_types + (numpy.integer,)
+        pass
 
 
 # ------------------------------------------------------------------------------
@@ -219,7 +218,8 @@ def get_device(*args):
 
 def _get_device(*args):
     for arg in args:
-        if isinstance(arg, _integer_types):
+        if isinstance(arg, _integer_types) and not numpy.issubdtype(
+                type(arg), numpy.bool_):
             check_cuda_available()
             return Device(arg)
         if isinstance(arg, ndarray):

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -141,11 +141,11 @@ if available:
 if six.PY2:
     try:
         from future.types.newint import newint as _newint
-        _integer_types = six.integer_types + (_newint,)
+        _integer_types = six.integer_types + (numpy.integer,) + (_newint,)
     except ImportError:
-        _integer_types = six.integer_types
+        _integer_types = six.integer_types + (numpy.integer,)
 else:
-    _integer_types = six.integer_types
+    _integer_types = six.integer_types + (numpy.integer,)
 
 
 # ------------------------------------------------------------------------------
@@ -219,7 +219,7 @@ def get_device(*args):
 
 def _get_device(*args):
     for arg in args:
-        if type(arg) in _integer_types:
+        if isinstance(arg, _integer_types):
             check_cuda_available()
             return Device(arg)
         if isinstance(arg, ndarray):

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -323,7 +323,7 @@ class TestWorkspace(unittest.TestCase):
 }) + testing.product({
     'c_contiguous': [False],
     'device_dtype': [int]
-    }))
+}))
 )
 class TestToGPU(unittest.TestCase):
 

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -315,9 +315,15 @@ class TestWorkspace(unittest.TestCase):
         self.assertEqual(size, cuda.get_max_workspace_size())
 
 
-@testing.parameterize(
-    {'c_contiguous': True},
-    {'c_contiguous': False},
+@testing.parameterize(*(testing.product({
+    'c_contiguous': [True],
+    'device_dtype': [int, numpy.uint8, numpy.int8, numpy.uint16,
+                     numpy.int16, numpy.uint32, numpy.int32, numpy.uint64,
+                     numpy.int64]
+}) + testing.product({
+    'c_contiguous': [False],
+    'device_dtype': [int]
+    }))
 )
 class TestToGPU(unittest.TestCase):
 
@@ -341,11 +347,11 @@ class TestToGPU(unittest.TestCase):
 
     @attr.multi_gpu(2)
     def test_cupy_array2(self):
-        x = cuda.to_gpu(self.x, device=0)
+        x = cuda.to_gpu(self.x, device=self.device_dtype(0))
         with x.device:
             if not self.c_contiguous:
                 x = cuda.cupy.asfortranarray(x)
-        y = cuda.to_gpu(x, device=1)
+        y = cuda.to_gpu(x, device=self.device_dtype(1))
         self.assertIsInstance(y, cuda.ndarray)
         self.assertEqual(int(y.device), 1)
 
@@ -359,7 +365,8 @@ class TestToGPU(unittest.TestCase):
     @attr.multi_gpu(2)
     def test_numpy_array_async2(self):
         with testing.assert_warns(DeprecationWarning):
-            y = cuda.to_gpu(self.x, device=1, stream=cuda.Stream.null)
+            y = cuda.to_gpu(self.x, device=self.device_dtype(1),
+                            stream=cuda.Stream.null)
         self.assertIsInstance(y, cuda.ndarray)
         cuda.cupy.testing.assert_array_equal(self.x, y)
         self.assertEqual(int(y.device), 1)
@@ -386,12 +393,13 @@ class TestToGPU(unittest.TestCase):
 
     @attr.multi_gpu(2)
     def test_cupy_array_async2(self):
-        x = cuda.to_gpu(self.x, device=0)
+        x = cuda.to_gpu(self.x, device=self.device_dtype(0))
         with x.device:
             if not self.c_contiguous:
                 x = cuda.cupy.asfortranarray(x)
         with testing.assert_warns(DeprecationWarning):
-            y = cuda.to_gpu(x, device=1, stream=cuda.Stream.null)
+            y = cuda.to_gpu(x, device=self.device_dtype(1),
+                            stream=cuda.Stream.null)
         self.assertIsInstance(y, cuda.ndarray)
         self.assertIsNot(x, y)  # Do copy
         cuda.cupy.testing.assert_array_equal(x, y)


### PR DESCRIPTION
I found a bug in `cuda.to_gpu` and `cuda.copy` that would not change the device when the device identifier is a numpy dtype. Users might use numpy to generate the device ids, and would therefore be subject to this subtle bug.

## MWE
Illustrating the problem for `to_gpu`, but the same thing happens for `copy`.
```
from chainer import cuda
import numpy as np

gpus = [0, 1, 2, 3]
batch_size = 2
eval_gpus = np.repeat(gpus, batch_size)

xs = []
for gpu in eval_gpus:
    y = np.ones(1)
    x = cuda.to_gpu(y, device=gpu)
    xs.append(x)

for x in xs:
    print(x.device)
```

## Output

Without this PR:
```
<CUDA Device 0>
<CUDA Device 0>
<CUDA Device 0>
<CUDA Device 0>
<CUDA Device 0>
<CUDA Device 0>
<CUDA Device 0>
<CUDA Device 0>
```

With this PR (expected):
```
<CUDA Device 0>
<CUDA Device 0>
<CUDA Device 1>
<CUDA Device 1>
<CUDA Device 2>
<CUDA Device 2>
<CUDA Device 3>
<CUDA Device 3>
```