### PR TITLE
Improve ideep import error message fror missing shared objects

### DIFF
--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -42,7 +42,7 @@ def check_ideep_available():
         # redirect to the ideep website.
         msg = str(_error)
         if 'cannot open shared object file' in msg:
-            msg += ('\n\nEnsure ideep requirements are satisfied: '
+            msg += ('\n\nEnsure iDeep requirements are satisfied: '
                     'https://github.com/intel/ideep')
         raise RuntimeError(
             'iDeep is not available.\n'

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -38,9 +38,15 @@ def check_ideep_available():
     Otherwise it raises ``RuntimeError``.
     """
     if _ideep_version is None:
+        # If the error is missing shared object, append a message to
+        # redirect to the ideep website.
+        msg = str(_error)
+        if 'cannot open shared object file' in msg:
+            msg += ('\n\nEnsure ideep requirements are satisfied: '
+                    'https://github.com/intel/ideep')
         raise RuntimeError(
             'iDeep is not available.\n'
-            'Reason: {}: {}'.format(type(_error).__name__, str(_error)))
+            'Reason: {}: {}'.format(type(_error).__name__, msg))
 
 
 def should_use_ideep(level):


### PR DESCRIPTION
Previous:
```
RuntimeError: iDeep is not available.
Reason: ImportError: libglog.so.0: cannot open shared object file: No such file or directory
```

This PR:
```
RuntimeError: iDeep is not available.
Reason: ImportError: libglog.so.0: cannot open shared object file: No such file or directory

Ensure ideep requirements are satisfied: https://github.com/intel/ideep
```
