### PR TITLE
add cupy-cuda91 wheel dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ def find_any_distribution(pkgs):
 # Currently cupy provides source package (cupy) and binary wheel packages
 # (cupy-cudaXX). Chainer can use any one of these packages.
 cupy_pkg = find_any_distribution([
+    'cupy-cuda91',
     'cupy-cuda90',
     'cupy-cuda80',
     'cupy',


### PR DESCRIPTION
As CUDA 9.1 is now tested and confirmed to work, let's start distributing CUDA 9.1 wheels.
~~Depends on https://github.com/cupy/cupy-release-tools/pull/7~~ (merged)