### PR TITLE
Sparse matmul support

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -235,6 +235,9 @@ from chainer.functions.math.prod import prod  # NOQA
 from chainer.functions.math.prod import Prod  # NOQA
 from chainer.functions.math.scale import scale  # NOQA
 from chainer.functions.math.sign import sign  # NOQA
+from chainer.functions.math.sparse_matmul import sparse_coo_matrix  # NOQA
+from chainer.functions.math.sparse_matmul import sparse_dense2coo  # NOQA
+from chainer.functions.math.sparse_matmul import sparse_matmul  # NOQA
 from chainer.functions.math.sqrt import rsqrt  # NOQA
 from chainer.functions.math.sqrt import sqrt  # NOQA
 from chainer.functions.math.sqrt import Sqrt  # NOQA

--- a/chainer/functions/math/sparse_matmul.py
+++ b/chainer/functions/math/sparse_matmul.py
@@ -1,0 +1,360 @@
+import chainer
+from chainer.backends import cuda
+from chainer import function_node
+from chainer import utils
+from chainer.utils import type_check
+import numpy
+
+
+class sparse_coo_matrix(object):
+
+    def __init__(self, data, row, col, shape, use_variable=False):
+        self.data = data
+        if use_variable:
+            self.data = chainer.Variable(self.data)
+        self.row = row
+        self.col = col
+        self.shape = shape  # (row, col)
+
+    def to_dense(self):
+        xp = cuda.get_array_module(self.data)
+        if self.data.ndim == 1:
+            x = xp.zeros(self.shape, dtype=self.data.dtype)
+            x[self.row, self.col] = self.data
+            return x
+        if self.data.ndim == 2:
+            nb = self.data.shape[0]
+            x = xp.zeros((nb, self.shape[0], self.shape[1]), dtype=self.data.dtype)
+            for i in range(nb):
+                nnz = len(xp.where(self.data[i] != 0)[0])
+                x[i, self.row[i, :nnz], self.col[i, :nnz]] = self.data[i, 0:nnz]
+            return x
+
+
+def sparse_dense2coo(x, ldnz=None, use_variable=False):
+    xp = cuda.get_array_module(x)
+    if x.ndim == 2:
+        _row, _col = xp.where(x != 0)
+        nnz = len(_row)
+        if ldnz is None or ldnz < nnz:
+            ldnz = nnz
+        data = xp.zeros((ldnz), dtype=x.dtype)
+        row = xp.full((ldnz), -1, dtype=xp.int32)
+        col = xp.full((ldnz), -1, dtype=xp.int32)
+        data[0:nnz] = x[_row, _col]
+        row[0:nnz] = xp.array(_row).astype(xp.int32)
+        col[0:nnz] = xp.array(_col).astype(xp.int32)
+        shape = x.shape
+        return sparse_coo_matrix(data, row, col, shape, use_variable)
+    elif x.ndim == 3:
+        # first axis is considered as batch axis
+        nb = x.shape[0]
+        if ldnz is None:
+            ldnz = 0
+        for i in range(nb):
+            ldnz = max(ldnz, len(xp.where(x[i] != 0)[0]))
+        data = xp.empty((nb, ldnz), dtype=x.dtype)
+        row = xp.empty((nb, ldnz), dtype=xp.int32)
+        col = xp.empty((nb, ldnz), dtype=xp.int32)
+        for i in range(nb):
+            coo = sparse_dense2coo(x[i], ldnz)
+            data[i] = coo.data
+            row[i] = coo.row
+            col[i] = coo.col
+        shape = x.shape[1:]
+        return sparse_coo_matrix(data, row, col, shape, use_variable)
+    else:
+        raise ValueError('')
+
+    
+def _sparse_matmul(sp_data, sp_row, sp_col, sp_shape, dn,
+                   transa, transb, transc):
+    xp = cuda.get_array_module(dn)
+    if xp is numpy:
+        raise RuntimeError('_sparse_matmul is available only on GPU')
+
+    A_data = sp_data
+    if transa:
+        A_row = sp_col
+        A_col = sp_row
+        A_shape = [sp_shape[1], sp_shape[0]]
+    else:
+        A_row = sp_row
+        A_col = sp_col
+        A_shape = sp_shape
+    if transb:
+        B = dn.swapaxes(-1, -2)
+    else:
+        B = dn
+
+    C_dtype = B.dtype
+    if B.dtype == xp.float16:
+        C_dtype = xp.float32
+        
+    _m, _ = A_shape
+    if dn.ndim == 2:
+        nb = 1
+        _k, _n = B.shape
+        nnz, = A_data.shape
+        C =  xp.zeros((_m, _n), dtype=C_dtype)
+    else:
+        nb, _k, _n = B.shape
+        _, nnz = A_data.shape
+        C =  xp.zeros((nb, _m, _n), dtype=C_dtype)
+
+    size = nb * nnz * _n
+    _cupy_sparse_matmul()(nb, _m, _n, _k, nnz, A_data, A_row, A_col, B, C, size=size)
+
+    if B.dtype == xp.float16:
+        C = C.astype(B.dtype)
+    if transc:
+        C = C.swapaxes(-1, -2)
+    return C
+
+
+def _cupy_sparse_matmul():
+    return cuda.cupy.ElementwiseKernel(
+        'int32 nb, int32 _m, int32 _n, int32 _k, int32 nnz, \
+         raw A A_data, raw T A_row, raw T A_col, \
+         raw B _B, raw C _C',
+        '',
+        '''
+        int i_n = (i % _n);
+        int i_A = (i / _n);
+        int i_b = (i / _n) / nnz;
+        if (i_b >= nb) {
+            continue;
+        }
+        int i_k = A_col[i_A];
+        if (i_k < 0) {
+            continue;
+        }
+        assert(i_k < _k);
+        int i_m = A_row[i_A];
+        if (i_m < 0) {
+            continue;
+        }
+        assert(i_m < _m);
+        int i_B = i_n + _n * (i_k + _k * i_b);
+        int i_C = i_n + _n * (i_m + _m * i_b);
+        A val_A = A_data[i_A];
+        atomicAdd(&_C[i_C], (C)(_B[i_B] * val_A));
+        ''',
+        'sparse_matmul')
+
+
+class SparseMatMul(function_node.FunctionNode):
+
+    def __init__(self, sp_row, sp_col, sp_shape,
+                 transa=False, transb=False, transc=False):
+        if sp_row.ndim != sp_col.ndim:
+            raise ValueError('ndim of sp_row and sp_col must be the same.')
+        if sp_row.ndim != 1 and sp_row.ndim != 2:
+            raise ValueError('ndim of sp_row and sp_col must be one or two.')
+        for i in range(sp_row.ndim):
+            if sp_row.shape[i] != sp_col.shape[i]:
+                raise ValueError('shape of sp_row and sp_col must be the same.')
+        if len(sp_shape) != 2:
+            raise ValueError('len(sp_shape) must be two.')
+        self.sp_row = sp_row
+        self.sp_col = sp_col
+        self.sp_shape = sp_shape
+        self.transa = transa
+        self.transb = transb
+        self.transc = transc
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+        sp_type, dn_type = in_types
+        type_check.expect(
+            sp_type.dtype.kind == 'f',
+            dn_type.dtype.kind == 'f',
+            sp_type.ndim == 1 or 2,
+            sp_type.ndim == dn_type.ndim - 1,
+        )
+        sp_ndim = type_check.eval(sp_type.ndim)
+        if sp_ndim == 2:
+            type_check.expect(
+                sp_type.shape[0] == self.sp_row.shape[0],
+                dn_type.shape[0] == self.sp_row.shape[0],
+            )            
+
+    def forward(self, inputs):
+        self.retain_inputs((0, 1))
+        sp, dn = inputs
+        c = _sparse_matmul(sp, self.sp_row, self.sp_col, self.sp_shape, dn,
+                           self.transa, self.transb, self.transc)
+        return utils.force_array(c),
+        
+    def backward(self, indexes, grad_outputs):
+        sp, dn = self.get_retained_inputs()
+        g_c, = grad_outputs
+
+        g_sp = None
+        if 0 in indexes:
+            g_sp = SparseMatMulGradSP(self.sp_row, self.sp_col, self.sp_shape,
+                                      self.transc,
+                                      not self.transb,
+                                      self.transa).apply((g_c, dn))[0]
+    
+        g_dn = None
+        if 1 in indexes:
+            g_dn = SparseMatMul(self.sp_row, self.sp_col, self.sp_shape,
+                                not self.transa,
+                                self.transc,
+                                self.transb).apply((sp, g_c))[0]
+                
+        return g_sp, g_dn
+
+
+def _sparse_matmul_gradsp(a, b, c_row, c_col, c_shape,
+                          transa, transb, transc):
+    xp = cuda.get_array_module(a)
+    if xp is numpy:
+        raise RuntimeError('_sparse_matmul_gradsp is available only on GPU')
+    
+    if transa:
+        A = a.swapaxes(-1, -2)
+    else:
+        A = a
+    if transb:
+        B = b.swapaxes(-1, -2)
+    else:
+        B = b
+    if transc:
+        C_row = c_col
+        C_col = c_row
+    else:
+        C_row = c_row
+        C_col = c_col
+
+    if A.ndim == 2:
+        nb = 1
+        _m, _k = A.shape
+        _, _n = B.shape
+        nnz, = C_row.shape
+        C_data = xp.zeros((nnz), dtype=A.dtype)
+    else:
+        nb, _m, _k = A.shape
+        _, _, _n = B.shape
+        _, nnz = C_row.shape
+        C_data = xp.zeros((nb, nnz), dtype=A.dtype)
+
+    size = nb * nnz;
+    _cupy_sparse_matmul_gradsp()(nb, _m, _n, _k, nnz, A, B, C_data, C_row, C_col, size=size)
+
+    return C_data
+
+    
+def _cupy_sparse_matmul_gradsp():
+    return cuda.cupy.ElementwiseKernel(
+        'int32 nb, int32 _m, int32 _n, int32 _k, int32 nnz, \
+         raw A _A, raw B _B, \
+         raw C C_data, raw T C_row, raw T C_col',
+        '',
+        '''
+        int i_nz = (i % nnz);
+        int i_b = (i / nnz);
+        if (i_b >= nb) {
+            continue;
+        }
+        int i_C = i;
+        int i_m = C_row[i_C];
+        if (i_m < 0) {
+            continue;
+        }
+        assert(i_m < _m);
+        int i_n = C_col[i_C];
+        if (i_n < 0) {
+            continue;
+        }
+        assert(i_n < _n);
+        C val_C = 0.0;
+        for (int i_k = 0; i_k < _k; i_k++) {
+            int i_A = i_k + _k * (i_m + _m * i_b);
+            int i_B = i_n + _n * (i_k + _k * i_b);
+            A val_A = _A[i_A];
+            B val_B = _B[i_B];
+            val_C += (C)(val_A * val_B);
+        }
+        C_data[i_C] = val_C;
+        ''',
+        'sparse_matmul_gradsp')
+
+
+class SparseMatMulGradSP(function_node.FunctionNode):
+
+    def __init__(self, sp_row, sp_col, sp_shape,
+                 transa=False, transb=False, transc=False):
+        if sp_row.ndim != sp_col.ndim:
+            raise ValueError('ndim of sp_row and sp_col must be the same.')
+        if sp_row.ndim != 1 and sp_row.ndim != 2:
+            raise ValueError('ndim of sp_row and sp_col must be one or two.')
+        for i in range(sp_row.ndim):
+            if sp_row.shape[i] != sp_col.shape[i]:
+                raise ValueError('shape of sp_row and sp_col must be the same.')
+        if len(sp_shape) != 2:
+            raise ValueError('len(sp_shape) must be two.')
+        self.sp_row = sp_row
+        self.sp_col = sp_col
+        self.sp_shape = sp_shape
+        self.transa = transa
+        self.transb = transb
+        self.transc = transc
+        
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+        a_type, b_type = in_types
+        type_check.expect(
+            a_type.dtype.kind == 'f',
+            b_type.dtype.kind == 'f',
+            a_type.ndim == 2 or 3,
+            a_type.ndim == b_type.ndim,
+        )
+        a_ndim = type_check.eval(a_type.ndim)
+        if a_ndim == 3:
+            type_check.expect(
+                a_type.shape[0] == self.sp_row.shape[0],
+                b_type.shape[0] == self.sp_row.shape[0],
+            )
+                
+    def forward(self, inputs):
+        self.retain_inputs((0, 1))
+        a, b = inputs
+        c = _sparse_matmul_gradsp(a, b, self.sp_row, self.sp_col, self.sp_shape,
+                                  self.transa, self.transb, self.transc)
+        return utils.force_array(c),
+
+        
+def sparse_matmul(a, b, transa=False, transb=False):
+    """Computes the batched multiplication of sparse and dense matrix.
+
+    The following use cases are supported:
+
+        1. C (dense) = A (sparse) * B (dense)
+        2. C (dense) = A (dense) * B (sparse)
+
+    Args:
+        a (Variable of sparse_coo_matrix): The left operand of mat-mul.
+        b (Variable of sparse_coo_matrix): The right operand of mat-mul.
+        transa (bool): If ``True``, each matrix in ``a`` will be transposed.
+        transb (bool): If ``True``, each matrix in ``b`` will be transposed.
+
+    Returns:
+        _chainer.Variable or sparse_coo_matrix: Result of matrix multiplication.
+    """
+    if (isinstance(a, sparse_coo_matrix) and
+          isinstance(b, (chainer.Variable, numpy.ndarray, cuda.ndarray))):
+        return SparseMatMul(a.row, a.col, a.shape,
+                            transa=transa,
+                            transb=transb,
+                            transc=False).apply((a.data, b))[0]
+    elif (isinstance(a, (chainer.Variable, numpy.ndarray, cuda.ndarray)) and
+        isinstance(b, sparse_coo_matrix)):
+        return SparseMatMul(b.row, b.col, b.shape,
+                            transa=not transb,
+                            transb=not transa,
+                            transc=True).apply((b.data, a))[0]
+    else:
+        _msg = 'This combination of inputs is not supported.'
+        raise ValueError(_msg)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sparse_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sparse_matmul.py
@@ -1,0 +1,143 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer import cuda
+import chainer.functions as F
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+
+
+@testing.parameterize(*testing.product_dict(
+    [
+        {'m': 3, 'n': 4, 'k': 2},
+        {'m': 2, 'n': 3, 'k': 4},
+    ],
+    [
+        {'transa': False, 'transb': False},
+        {'transa': False, 'transb': True},
+        {'transa': True, 'transb': False},
+        {'transa': True, 'transb': True},
+    ],
+    [
+        {'nbatch': 0},
+        {'nbatch': 1},
+        {'nbatch': 4},
+    ],
+    [
+        {'a_dtype': numpy.float16},
+        {'a_dtype': numpy.float32},
+        {'a_dtype': numpy.float64},
+    ],
+    [
+        {'b_dtype': numpy.float16},
+        {'b_dtype': numpy.float32},
+        {'b_dtype': numpy.float64},
+    ]
+))
+class TestSparseMatMul(unittest.TestCase):
+
+    def setUp(self):
+        a_shape = self._set_shape([self.m, self.k], self.transa)
+        b_shape = self._set_shape([self.k, self.n], self.transb)
+        c_shape = self._set_shape([self.m, self.n], False)
+        self.c_dtype = numpy.result_type(self.a_dtype, self.b_dtype)
+        self.a = self._setup_tensor(.5, 1, a_shape, self.a_dtype)
+        self.a[numpy.where(self.a < .75)] = 0
+        self.b = self._setup_tensor(.5, 1, b_shape, self.b_dtype)
+        self.b[numpy.where(self.b < .75)] = 0
+        self.gc = self._setup_tensor(-1, 1, c_shape, self.c_dtype)
+        # self.gga = self._setup_tensor(.5, 1, a_shape, self.a_dtype)
+        # self.ggb = self._setup_tensor(.5, 1, b_shape, self.b_dtype)
+        self.forward_answer = self._matmul(self.a, self.b)
+
+    def _set_shape(self, shape, trans):
+        if trans:
+            shape = [shape[1], shape[0]]
+        if self.nbatch > 0:
+            return [self.nbatch, shape[0], shape[1]]
+        else:
+            return shape
+
+    def _setup_tensor(self, _min, _max, shape, dtype):
+        return numpy.random.uniform(_min, _max, shape).astype(dtype)
+
+    def _matmul(self, a, b):
+        if self.transa:
+            a = a.swapaxes(-1, -2)
+        if self.transb:
+            b = b.swapaxes(-1, -2)
+        return numpy.matmul(a, b)
+
+    #
+    # SPDN: sparse A * dense B
+    #
+    def check_SPDN_forward(self, a_data, b_data, atol=1e-4, rtol=1e-5):
+        sp_a = F.sparse_dense2coo(a_data, use_variable=True)
+        b = chainer.Variable(b_data)
+        c = F.sparse_matmul(sp_a, b, transa=self.transa, transb=self.transb)
+        testing.assert_allclose(self.forward_answer, c.data, atol, rtol)
+
+    @attr.gpu
+    def test_SPDN_sparse_matmul_forward_gpu(self):
+        a = cuda.to_gpu(self.a)
+        b = cuda.to_gpu(self.b)
+        if self.a_dtype == numpy.float16 or self.b_dtype == numpy.float16:
+            self.check_SPDN_forward(a, b, atol=1e-3, rtol=1e-3)
+        else:
+            self.check_SPDN_forward(a, b)
+
+    def check_SPDN_backward(self, a_data, b_data, c_grad, atol, rtol):
+        sp_a = F.sparse_dense2coo(a_data)
+        func = F.math.sparse_matmul.SparseMatMul(
+            sp_a.row, sp_a.col, sp_a.shape,
+            transa=self.transa, transb=self.transb, transc=False)
+        op = lambda a, b: func.apply((a, b))[0]
+        gradient_check.check_backward(
+            op, (sp_a.data, b_data), c_grad, atol=atol, rtol=rtol,
+            dtype=numpy.float32)
+
+    @attr.gpu
+    def test_SPDN_sparse_matmul_backward_gpu(self):
+        self.check_SPDN_backward(
+            cuda.to_gpu(self.a), cuda.to_gpu(self.b),
+            cuda.to_gpu(self.gc), atol=1e-2, rtol=1e-2)
+
+    #
+    # DNSP: dense A * sparse B
+    #
+    def check_DNSP_forward(self, a_data, b_data, atol=1e-4, rtol=1e-5):
+        a = chainer.Variable(a_data)
+        sp_b = F.sparse_dense2coo(b_data, use_variable=True)
+        c = F.sparse_matmul(a, sp_b, transa=self.transa, transb=self.transb)
+        testing.assert_allclose(self.forward_answer, c.data, atol, rtol)
+
+    @attr.gpu
+    def test_DNSP_sparse_matmul_forward_gpu(self):
+        a = cuda.to_gpu(self.a)
+        b = cuda.to_gpu(self.b)
+        if self.a_dtype == numpy.float16 or self.b_dtype == numpy.float16:
+            self.check_DNSP_forward(a, b, atol=1e-3, rtol=1e-3)
+        else:
+            self.check_DNSP_forward(a, b)
+
+    def check_DNSP_backward(self, a_data, b_data, c_grad, atol, rtol):
+        sp_b = F.sparse_dense2coo(b_data)
+        func = F.math.sparse_matmul.SparseMatMul(
+            sp_b.row, sp_b.col, sp_b.shape,
+            transa=not self.transb, transb=not self.transa, transc=True)
+        op = lambda b, a: func.apply((b, a))[0]
+        gradient_check.check_backward(
+            op, (sp_b.data, a_data), c_grad, atol=atol, rtol=rtol,
+            dtype=numpy.float32)
+
+    @attr.gpu
+    def test_DNSP_tensordot_backward_gpu(self):
+        self.check_DNSP_backward(
+            cuda.to_gpu(self.a), cuda.to_gpu(self.b),
+            cuda.to_gpu(self.gc), atol=1e-2, rtol=1e-2)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sparse_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sparse_matmul.py
@@ -8,6 +8,11 @@ import chainer.functions as F
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
+from chainer.utils import type_check
+
+
+def _setup_tensor(_min, _max, shape, dtype):
+    return numpy.random.uniform(_min, _max, shape).astype(dtype)
 
 
 @testing.parameterize(*testing.product_dict(
@@ -44,13 +49,15 @@ class TestSparseMatMul(unittest.TestCase):
         b_shape = self._set_shape([self.k, self.n], self.transb)
         c_shape = self._set_shape([self.m, self.n], False)
         self.c_dtype = numpy.result_type(self.a_dtype, self.b_dtype)
-        self.a = self._setup_tensor(.5, 1, a_shape, self.a_dtype)
+        self.a = _setup_tensor(.5, 1, a_shape, self.a_dtype)
         self.a[numpy.where(self.a < .75)] = 0
-        self.b = self._setup_tensor(.5, 1, b_shape, self.b_dtype)
+        self.b = _setup_tensor(.5, 1, b_shape, self.b_dtype)
         self.b[numpy.where(self.b < .75)] = 0
-        self.gc = self._setup_tensor(-1, 1, c_shape, self.c_dtype)
-        # self.gga = self._setup_tensor(.5, 1, a_shape, self.a_dtype)
-        # self.ggb = self._setup_tensor(.5, 1, b_shape, self.b_dtype)
+        self.gc = _setup_tensor(-1, 1, c_shape, self.c_dtype)
+        self.gga = _setup_tensor(.5, 1, a_shape, self.a_dtype)
+        self.gga[numpy.where(self.a < .75)] = 0
+        self.ggb = _setup_tensor(.5, 1, b_shape, self.b_dtype)
+        self.ggb[numpy.where(self.b < .75)] = 0
         self.forward_answer = self._matmul(self.a, self.b)
 
     def _set_shape(self, shape, trans):
@@ -60,9 +67,6 @@ class TestSparseMatMul(unittest.TestCase):
             return [self.nbatch, shape[0], shape[1]]
         else:
             return shape
-
-    def _setup_tensor(self, _min, _max, shape, dtype):
-        return numpy.random.uniform(_min, _max, shape).astype(dtype)
 
     def _matmul(self, a, b):
         if self.transa:
@@ -105,6 +109,26 @@ class TestSparseMatMul(unittest.TestCase):
             cuda.to_gpu(self.a), cuda.to_gpu(self.b),
             cuda.to_gpu(self.gc), atol=1e-2, rtol=1e-2)
 
+    def check_SPDN_double_backward(
+            self, a_data, b_data, c_grad, a_grad_grad, b_grad_grad,
+            atol, rtol):
+        sp_a = F.sparse_dense2coo(a_data)
+        sp_gga = F.sparse_dense2coo(a_grad_grad)
+        func = F.math.sparse_matmul.SparseMatMul(
+            sp_a.row, sp_a.col, sp_a.shape,
+            transa=self.transa, transb=self.transb, transc=False)
+        op = lambda a, b: func.apply((a, b))[0]
+        gradient_check.check_double_backward(
+            op, (sp_a.data, b_data), c_grad, (sp_gga.data, b_grad_grad),
+            atol=atol, rtol=rtol, dtype=numpy.float32)
+
+    @attr.gpu
+    def test_SPDN_sparse_matmul_double_backward_gpu(self):
+        self.check_SPDN_double_backward(
+            cuda.to_gpu(self.a), cuda.to_gpu(self.b),
+            cuda.to_gpu(self.gc), cuda.to_gpu(self.gga),
+            cuda.to_gpu(self.ggb), atol=1e-2, rtol=1e-2)
+
     #
     # DNSP: dense A * sparse B
     #
@@ -138,6 +162,77 @@ class TestSparseMatMul(unittest.TestCase):
         self.check_DNSP_backward(
             cuda.to_gpu(self.a), cuda.to_gpu(self.b),
             cuda.to_gpu(self.gc), atol=1e-2, rtol=1e-2)
+
+    def check_DNSP_double_backward(
+            self, a_data, b_data, c_grad, a_grad_grad, b_grad_grad,
+            atol, rtol):
+        sp_b = F.sparse_dense2coo(b_data)
+        sp_ggb = F.sparse_dense2coo(b_grad_grad)
+        func = F.math.sparse_matmul.SparseMatMul(
+            sp_b.row, sp_b.col, sp_b.shape,
+            transa=not self.transb, transb=not self.transa, transc=True)
+        op = lambda b, a: func.apply((b, a))[0]
+        gradient_check.check_double_backward(
+            op, (sp_b.data, a_data), c_grad, (sp_ggb.data, a_grad_grad),
+            atol=atol, rtol=rtol, dtype=numpy.float32)
+
+    @attr.gpu
+    def test_DNSP_sparse_matmul_double_backward_gpu(self):
+        self.check_DNSP_double_backward(
+            cuda.to_gpu(self.a), cuda.to_gpu(self.b),
+            cuda.to_gpu(self.gc), cuda.to_gpu(self.gga),
+            cuda.to_gpu(self.ggb), atol=1e-2, rtol=1e-2)
+
+
+class TestSparseMatMulInvalid(unittest.TestCase):
+
+    def test_invalid_ndim(self):
+        a = _setup_tensor(.5, 1, (2, 3, 3), numpy.float32)
+        a[numpy.where(a < .75)] = 0
+        sp_a = F.sparse_dense2coo(a)
+        b = _setup_tensor(.5, 1, (3, 3), numpy.float32)
+        b[numpy.where(b < .75)] = 0
+        sp_b = F.sparse_dense2coo(b)
+        with self.assertRaises(type_check.InvalidType):
+            F.sparse_matmul(sp_a, b)
+        with self.assertRaises(type_check.InvalidType):
+            F.sparse_matmul(a, sp_b)
+
+    def test_invalid_nbatch(self):
+        a = _setup_tensor(.5, 1, (2, 3, 3), numpy.float32)
+        a[numpy.where(a < .75)] = 0
+        sp_a = F.sparse_dense2coo(a)
+        b = _setup_tensor(.5, 1, (3, 3, 3), numpy.float32)
+        b[numpy.where(b < .75)] = 0
+        sp_b = F.sparse_dense2coo(b)
+        with self.assertRaises(type_check.InvalidType):
+            F.sparse_matmul(sp_a, b)
+        with self.assertRaises(type_check.InvalidType):
+            F.sparse_matmul(a, sp_b)
+
+    def test_invalid_shape(self):
+        a = _setup_tensor(.5, 1, (1, 2, 3), numpy.float32)
+        a[numpy.where(a < .75)] = 0
+        sp_a = F.sparse_dense2coo(a)
+        b = _setup_tensor(.5, 1, (1, 4, 5), numpy.float32)
+        b[numpy.where(b < .75)] = 0
+        sp_b = F.sparse_dense2coo(b)
+        with self.assertRaises(ValueError):
+            F.sparse_matmul(sp_a, b)
+        with self.assertRaises(ValueError):
+            F.sparse_matmul(a, sp_b)
+
+    def test_invalid_inputs(self):
+        a = _setup_tensor(.5, 1, (1, 2, 3), numpy.float32)
+        a[numpy.where(a < .75)] = 0
+        sp_a = F.sparse_dense2coo(a)
+        b = _setup_tensor(.5, 1, (1, 4, 5), numpy.float32)
+        b[numpy.where(b < .75)] = 0
+        sp_b = F.sparse_dense2coo(b)
+        with self.assertRaises(ValueError):
+            F.sparse_matmul(sp_a, sp_b)
+        with self.assertRaises(ValueError):
+            F.sparse_matmul(a, b)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR aims to support sparse matmul in Chainer (this is related to https://github.com/chainer/chainer/issues/4377 and https://github.com/pfnet-research/chainer-chemistry/pull/90).

I implemented a function named `sparse_matmul` which computes matrix multiplication of sparse and dense matrix. The usage of this function is as follows (assuming `a` and `b` are matrix or 3D tensor).

    sp_a = F.sparse_dense2coo(a)
    c = F.sparse_matmul(sp_a, b)

You can also use this function for batched sparse matrix multiplication (actually this is my main focus) like `matmul`. It supports backward and double-backward, so that you can compute gradients of sparse and dense matrix and gradients of gradients as well.

Please note that CPU version is not implemented now because I don't have good idea on efficient CPU implementation using numpy or scipy for batched sparse matrix multiplication.