### PR TITLE
Spatial pyramid pooling method specified by string instead of type

### DIFF
--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -5,7 +5,7 @@ import six
 import chainer
 
 
-def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_method):
+def spatial_pyramid_pooling_2d(x, pyramid_height, pooling):
     """Spatial pyramid pooling function.
 
     It outputs a fixed-length vector regardless of input feature map size.
@@ -38,7 +38,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_method):
         x (~chainer.Variable): Input variable. The shape of ``x`` should be
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): Number of pyramid levels
-        pooling_method (str):
+        pooling (str):
             Currently, only ``max`` is supported, which performs a 2d max
             pooling operation.
 
@@ -74,7 +74,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_method):
         ksize = (ksize_h, ksize_w)
         pad = (pad_h, pad_w)
 
-        if pooling_method == 'max':
+        if pooling == 'max':
             pooler = chainer.functions.MaxPooling2D(
                 ksize=ksize, stride=None, pad=pad, cover_all=True)
         else:

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -92,7 +92,8 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class=None,
             pooler = chainer.functions.MaxPooling2D(
                 ksize=ksize, stride=None, pad=pad, cover_all=True)
         else:
-            raise NotImplementedError()
+            pooler = pooling if pooling is not None else pooling_class
+            raise ValueError('Unsupported pooling operation: ', pooler)
 
         y_var = pooler.apply((x,))[0]
         n, c, h, w = y_var.shape

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -39,7 +39,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class=None,
         x (~chainer.Variable): Input variable. The shape of ``x`` should be
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): Number of pyramid levels
-        pooling_class (MaxPooling2D or AveragePooling2D):
+        pooling_class (MaxPooling2D):
             *(deprecated since v4.0.0)* Only MaxPooling2D is supported.
             Please use the ``pooling`` argument instead since this argument is
             deprecated.

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -5,7 +5,7 @@ import six
 import chainer
 
 
-def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class):
+def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_method):
     """Spatial pyramid pooling function.
 
     It outputs a fixed-length vector regardless of input feature map size.
@@ -38,8 +38,9 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class):
         x (~chainer.Variable): Input variable. The shape of ``x`` should be
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): Number of pyramid levels
-        pooling_class (MaxPooling2D or AveragePooling2D):
-            Only MaxPooling2D class can be available for now.
+        pooling_method (str):
+            Currently, only ``max`` is supported, which performs a 2d max
+            pooling operation.
 
     Returns:
         ~chainer.Variable: Output variable. The shape of the output variable
@@ -50,7 +51,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class):
     .. note::
 
         This function uses some pooling classes as components to perform
-        spatial pyramid pooling. Now it supports only
+        spatial pyramid pooling. Currently, it only supports
         :class:`~functions.MaxPooling2D` as elemental pooling operator so far.
 
     """
@@ -73,9 +74,9 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class):
         ksize = (ksize_h, ksize_w)
         pad = (pad_h, pad_w)
 
-        if pooling_class is chainer.functions.MaxPooling2D:
-            pooler = pooling_class(ksize=ksize, stride=None, pad=pad,
-                                   cover_all=True)
+        if pooling_method == 'max':
+            pooler = chainer.functions.MaxPooling2D(
+                ksize=ksize, stride=None, pad=pad, cover_all=True)
         else:
             raise NotImplementedError()
 

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -83,6 +83,10 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class=None,
             warnings.warn('pooling_class argument is deprecated. Please use '
                           'the pooling argument.', DeprecationWarning)
 
+        if not (pooling_class is None) ^ (pooling is None):
+            raise ValueError('Specify the pooling operation either using the '
+                             'pooling_class or the pooling argument.')
+
         if (pooling_class is chainer.functions.MaxPooling2D or
                 pooling == 'max'):
             pooler = chainer.functions.MaxPooling2D(

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -83,7 +83,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class=None,
             warnings.warn('pooling_class argument is deprecated. Please use '
                           'the pooling argument.', DeprecationWarning)
 
-        if not (pooling_class is None) ^ (pooling is None):
+        if (pooling_class is None) == (pooling is None):
             raise ValueError('Specify the pooling operation either using the '
                              'pooling_class or the pooling argument.')
 

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -1,11 +1,12 @@
 import math
-
 import six
+import warnings
 
 import chainer
 
 
-def spatial_pyramid_pooling_2d(x, pyramid_height, pooling):
+def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class=None,
+                               pooling=None):
     """Spatial pyramid pooling function.
 
     It outputs a fixed-length vector regardless of input feature map size.
@@ -38,9 +39,13 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling):
         x (~chainer.Variable): Input variable. The shape of ``x`` should be
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): Number of pyramid levels
+        pooling_class (MaxPooling2D or AveragePooling2D):
+            *(deprecated since v4.0.0b)* Only MaxPooling2D is supported. Please
+            use the ``pooling`` argument instead since this argument is
+            deprecated.
         pooling (str):
             Currently, only ``max`` is supported, which performs a 2d max
-            pooling operation.
+            pooling operation. Replaces the ``pooling_class`` argument.
 
     Returns:
         ~chainer.Variable: Output variable. The shape of the output variable
@@ -74,7 +79,12 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling):
         ksize = (ksize_h, ksize_w)
         pad = (pad_h, pad_w)
 
-        if pooling == 'max':
+        if pooling_class is not None:
+            warnings.warn('pooling_class argument is deprecated. Please use '
+                          'the pooling argument.', DeprecationWarning)
+
+        if (pooling_class is chainer.functions.MaxPooling2D or
+                pooling == 'max'):
             pooler = chainer.functions.MaxPooling2D(
                 ksize=ksize, stride=None, pad=pad, cover_all=True)
         else:

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -40,7 +40,7 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class=None,
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): Number of pyramid levels
         pooling_class (MaxPooling2D or AveragePooling2D):
-            *(deprecated since v4.0.0rc1)* Only MaxPooling2D is supported.
+            *(deprecated since v4.0.0)* Only MaxPooling2D is supported.
             Please use the ``pooling`` argument instead since this argument is
             deprecated.
         pooling (str):

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -40,8 +40,8 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling_class=None,
             ``(batchsize, # of channels, height, width)``.
         pyramid_height (int): Number of pyramid levels
         pooling_class (MaxPooling2D or AveragePooling2D):
-            *(deprecated since v4.0.0b)* Only MaxPooling2D is supported. Please
-            use the ``pooling`` argument instead since this argument is
+            *(deprecated since v4.0.0rc1)* Only MaxPooling2D is supported.
+            Please use the ``pooling`` argument instead since this argument is
             deprecated.
         pooling (str):
             Currently, only ``max`` is supported, which performs a 2d max

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -176,19 +176,29 @@ class TestInvalidArguments(unittest.TestCase):
         self.x = numpy.random.randn(5, 3, 5, 5)
         self.v = chainer.Variable(self.x.astype(numpy.int32))
 
-    def check_ambiguous_pooling(self):
+    def check_ambiguous_poolings(self):
+        with self.assertRaises(ValueError):
+            functions.spatial_pyramid_pooling_2d(self.v, 3)
+
         with testing.assert_warns(DeprecationWarning), \
                 self.assertRaises(ValueError):
             functions.spatial_pyramid_pooling_2d(
                 self.v, 3, pooling_class=functions.MaxPooling2D, pooling='max')
 
-    def test_ambiguous_pooling(self):
-        self.check_ambiguous_pooling()
+    def check_invalid_poolings(self):
+        with self.assertRaises(ValueError):
+            functions.spatial_pyramid_pooling_2d(self.v, 3, pooling='avg')
 
-    @attr.gpu
-    def test_ambiguous_pooling_gpu(self):
-        self.v.to_gpu()
-        self.check_ambiguous_pooling()
+        with testing.assert_warns(DeprecationWarning), \
+                self.assertRaises(ValueError):
+            functions.spatial_pyramid_pooling_2d(
+                self.v, 3, pooling_class=functions.AveragePooling2D)
+
+    def test_ambiguous_pooling(self):
+        self.check_ambiguous_poolings()
+
+    def test_invalid_pooling(self):
+        self.check_invalid_poolings()
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -20,7 +20,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     pyramid_height = 3
     output_dim = 63  # channels(c=3) * (1 + 4 + 16) = 63
     n, c, h, w = 2, 3, 9, 8
-    pooling_method = 'max'
+    pooling = 'max'
 
     def setUp(self):
         # Spacial pyramid pooling uses max pooling in its implementation.
@@ -44,7 +44,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling_method)
+                x, self.pyramid_height, self.pooling)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -54,7 +54,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling_method)
+                x, self.pyramid_height, self.pooling)
         y_data = cuda.to_cpu(y.data)
 
         self.assertEqual(y_data.shape, (self.n, self.output_dim, 1, 1))
@@ -81,7 +81,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     def check_backward(self, x_data, y_grad, use_cudnn='always'):
         def f(x_data):
             return functions.spatial_pyramid_pooling_2d(
-                x_data, self.pyramid_height, self.pooling_method)
+                x_data, self.pyramid_height, self.pooling)
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 f, x_data, y_grad, dtype=numpy.float64, atol=5e-4, rtol=5e-3)
@@ -104,7 +104,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
                               use_cudnn='always'):
         def f(x):
             y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling_method)
+                x, self.pyramid_height, self.pooling)
             return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -55,6 +55,8 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
             with testing.assert_warns(DeprecationWarning):
                 y = functions.spatial_pyramid_pooling_2d(
                     x, self.pyramid_height, self.pooling_class)
+        else:
+            raise ValueError('Pooling operation must be specified.')
         return y
 
     def check_forward(self, x_data, use_cudnn='always'):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -20,7 +20,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     pyramid_height = 3
     output_dim = 63  # channels(c=3) * (1 + 4 + 16) = 63
     n, c, h, w = 2, 3, 9, 8
-    pooling_class = functions.MaxPooling2D
+    pooling_method = 'max'
 
     def setUp(self):
         # Spacial pyramid pooling uses max pooling in its implementation.
@@ -44,7 +44,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling_class)
+                x, self.pyramid_height, self.pooling_method)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -54,7 +54,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
             y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling_class)
+                x, self.pyramid_height, self.pooling_method)
         y_data = cuda.to_cpu(y.data)
 
         self.assertEqual(y_data.shape, (self.n, self.output_dim, 1, 1))
@@ -81,7 +81,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     def check_backward(self, x_data, y_grad, use_cudnn='always'):
         def f(x_data):
             return functions.spatial_pyramid_pooling_2d(
-                x_data, self.pyramid_height, self.pooling_class)
+                x_data, self.pyramid_height, self.pooling_method)
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
                 f, x_data, y_grad, dtype=numpy.float64, atol=5e-4, rtol=5e-3)
@@ -104,7 +104,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
                               use_cudnn='always'):
         def f(x):
             y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling_class)
+                x, self.pyramid_height, self.pooling_method)
             return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
@@ -145,7 +145,7 @@ class TestInvalidDtype(unittest.TestCase):
 
     def check_invalid_dtype(self):
         functions.spatial_pyramid_pooling_2d(
-            self.v, 3, functions.MaxPooling2D)
+            self.v, 3, 'max')
 
     def test_invalid_dtype_cpu(self):
         with self.assertRaises(type_check.InvalidType):
@@ -175,7 +175,7 @@ class TestMaxPooling2DCudnnCall(unittest.TestCase):
     def forward(self):
         x = chainer.Variable(self.x)
         return functions.spatial_pyramid_pooling_2d(
-            x, 3, functions.MaxPooling2D)
+            x, 3, 'max')
 
     def test_call_cudnn_forward(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -13,14 +13,21 @@ from chainer.testing import condition
 from chainer.utils import type_check
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
+@testing.parameterize(*testing.product_dict(
+    [
+        {'pyramid_height': 3, 'output_dim': 63, 'n': 2, 'c': 3, 'h': 9, 'w': 8}
+    ],
+    [
+        {'pooling': 'max'},
+        {'pooling_class': functions.MaxPooling2D}  # Test deprecated argument
+    ],
+    [
+        {'dtype': numpy.float16},
+        {'dtype': numpy.float32},
+        {'dtype': numpy.float64}
+    ]
+))
 class TestSpatialPyramidPooling2D(unittest.TestCase):
-    pyramid_height = 3
-    output_dim = 63  # channels(c=3) * (1 + 4 + 16) = 63
-    n, c, h, w = 2, 3, 9, 8
-    pooling = 'max'
 
     def setUp(self):
         # Spacial pyramid pooling uses max pooling in its implementation.
@@ -40,11 +47,20 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
             -1, 1, (self.n, self.output_dim, 1, 1)).astype(self.dtype)
         self.ggx = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
 
+    def func(self, x):
+        if hasattr(self, 'pooling'):
+            y = functions.spatial_pyramid_pooling_2d(
+                x, self.pyramid_height, pooling=self.pooling)
+        elif hasattr(self, 'pooling_class'):
+            with testing.assert_warns(DeprecationWarning):
+                y = functions.spatial_pyramid_pooling_2d(
+                    x, self.pyramid_height, self.pooling_class)
+        return y
+
     def check_forward(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
-            y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling)
+            y = self.func(x)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -53,8 +69,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     def check_forward_ones(self, x_data, use_cudnn='always'):
         x = chainer.Variable(x_data)
         with chainer.using_config('use_cudnn', use_cudnn):
-            y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling)
+            y = self.func(x)
         y_data = cuda.to_cpu(y.data)
 
         self.assertEqual(y_data.shape, (self.n, self.output_dim, 1, 1))
@@ -79,12 +94,10 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
         self.check_forward_ones(cuda.to_gpu(self.one), 'never')
 
     def check_backward(self, x_data, y_grad, use_cudnn='always'):
-        def f(x_data):
-            return functions.spatial_pyramid_pooling_2d(
-                x_data, self.pyramid_height, self.pooling)
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_backward(
-                f, x_data, y_grad, dtype=numpy.float64, atol=5e-4, rtol=5e-3)
+                self.func, x_data, y_grad,
+                dtype=numpy.float64, atol=5e-4, rtol=5e-3)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -103,8 +116,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
         def f(x):
-            y = functions.spatial_pyramid_pooling_2d(
-                x, self.pyramid_height, self.pooling)
+            y = self.func(x)
             return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
@@ -145,7 +157,7 @@ class TestInvalidDtype(unittest.TestCase):
 
     def check_invalid_dtype(self):
         functions.spatial_pyramid_pooling_2d(
-            self.v, 3, 'max')
+            self.v, 3, pooling='max')
 
     def test_invalid_dtype_cpu(self):
         with self.assertRaises(type_check.InvalidType):
@@ -175,7 +187,7 @@ class TestMaxPooling2DCudnnCall(unittest.TestCase):
     def forward(self):
         x = chainer.Variable(self.x)
         return functions.spatial_pyramid_pooling_2d(
-            x, 3, 'max')
+            x, 3, pooling='max')
 
     def test_call_cudnn_forward(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -170,6 +170,27 @@ class TestInvalidDtype(unittest.TestCase):
             self.check_invalid_dtype()
 
 
+class TestInvalidArguments(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.randn(5, 3, 5, 5)
+        self.v = chainer.Variable(self.x.astype(numpy.int32))
+
+    def check_ambiguous_pooling(self):
+        with testing.assert_warns(DeprecationWarning), \
+                self.assertRaises(ValueError):
+            functions.spatial_pyramid_pooling_2d(
+                self.v, 3, pooling_class=functions.MaxPooling2D, pooling='max')
+
+    def test_ambiguous_pooling(self):
+        self.check_ambiguous_pooling()
+
+    @attr.gpu
+    def test_ambiguous_pooling_gpu(self):
+        self.v.to_gpu()
+        self.check_ambiguous_pooling()
+
+
 @testing.parameterize(*testing.product({
     'use_cudnn': ['always', 'auto', 'never'],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -56,7 +56,7 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
                 y = functions.spatial_pyramid_pooling_2d(
                     x, self.pyramid_height, self.pooling_class)
         else:
-            raise ValueError('Pooling operation must be specified.')
+            assert False
         return y
 
     def check_forward(self, x_data, use_cudnn='always'):


### PR DESCRIPTION
Changed one of the argument types of `spatial_pyramid_pooling_2d` from a class type to `str`, since we preferably do not want to expose these classes (considered as function implementations).