### PR TITLE
add Codecov.io configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+comment: false
+
+coverage:
+  status:
+    # Disable coverage measurement for overall codebase.
+    project: off
+    # Enable coverage measurement for diff introduced in the pull-request,
+    # but do not mark "X" on commit status for now.
+    patch:
+      default:
+        target: '0%'


### PR DESCRIPTION
This PR introduces Codecov.io to measure test coverage for diff introduced in each Pull-Request (rather than overall coverage).
The coverage will be uploaded via Jenkins (chainer-test).

Codecov.io covers most of features in Coveralls, but it does not visualize branch coverage.
So I continue to keep Coveralls configuration as is.

The meaning of the configuration is:

* Disable commenting on PRs. Just leave commit status on PR (like Travis).
* Do not measure overall coverage (it is currently measured by Coveralls).
* Measure coverage for diffs introduced in PRs.
  For now, target (threshold to decide `✔︎` or `X`) is set to `0%` to avoid unnecessary confusion of contributors.
  We can reconsider this rate afterwards, if needed.