### PR TITLE
Fix Variable tests

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -956,7 +956,7 @@ Actual: {0}'''.format(type(data))
         if self.data.size == 1 and self._grad_var is None:
             if self.data.ndim != 0:
                 warnings.warn(
-                    'Treating as a scalar a variable with only one element'
+                    'Treating a scalar as a variable with only one element'
                     ' in Variable.backward is deprecated. A scalar variable'
                     ' must be a 0-dimensional array. Apply'
                     ' chainer.functions.squeeze to obtain a scalar variable.'

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1558,14 +1558,14 @@ class TestVariableDoubleBackward(unittest.TestCase):
             x.grad_var.backward()
 
     def test_grad_raise_double_backprop(self):
-        x = chainer.Variable(np.empty(1, np.float32))
+        x = chainer.Variable(np.empty((), np.float32))
         y = IdentityFunction()(x)
         y.backward(enable_double_backprop=True)
         with self.assertRaises(RuntimeError):
             chainer.grad([x.grad_var], [y.grad_var])
 
     def test_grad_raise_double_backprop_2(self):
-        x = chainer.Variable(np.empty(1, np.float32))
+        x = chainer.Variable(np.empty((), np.float32))
         z = F.identity(x)  # new style
         y = IdentityFunction()(z)  # old style
         y.backward(enable_double_backprop=True)


### PR DESCRIPTION
Variable tests failed due to warnings caused by Variables with scalar arrays.