### PR TITLE
Remove Swish function class alias

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -32,7 +32,6 @@ from chainer.functions.activation.softmax import Softmax  # NOQA
 from chainer.functions.activation.softplus import softplus  # NOQA
 from chainer.functions.activation.softplus import Softplus  # NOQA
 from chainer.functions.activation.swish import swish  # NOQA
-from chainer.functions.activation.swish import Swish  # NOQA
 from chainer.functions.activation.tanh import tanh  # NOQA
 from chainer.functions.activation.tanh import Tanh  # NOQA
 from chainer.functions.activation.tree_lstm import tree_lstm  # NOQA


### PR DESCRIPTION
Remove `chainer.functions.Swish` class alias, which should not be public.

(Added in #4262)