### PR TITLE
Prefer chainer.backends.cuda in recent added codes

### DIFF
--- a/chainer/functions/array/stack.py
+++ b/chainer/functions/array/stack.py
@@ -1,5 +1,5 @@
 import chainer
-from chainer import cuda
+from chainer.backends import cuda
 from chainer import function_node
 from chainer.utils import type_check
 

--- a/chainer/functions/math/erf.py
+++ b/chainer/functions/math/erf.py
@@ -4,7 +4,7 @@ import warnings
 import numpy
 
 import chainer
-from chainer import cuda
+from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check

--- a/chainer/functions/math/erfc.py
+++ b/chainer/functions/math/erfc.py
@@ -4,7 +4,7 @@ import warnings
 import numpy
 
 import chainer
-from chainer import cuda
+from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -346,7 +346,8 @@ doctest_global_setup = '''
 import numpy as np
 import cupy
 import chainer
-from chainer import cuda, Function, gradient_check, training, utils, Variable
+from chainer.backends import cuda
+from chainer import Function, gradient_check, training, utils, Variable
 from chainer import datasets, iterators, optimizers, serializers
 from chainer import Link, Chain, ChainList
 import chainer.functions as F

--- a/docs/source/imports.rst
+++ b/docs/source/imports.rst
@@ -5,7 +5,8 @@
 
      import numpy as np
      import chainer
-     from chainer import cuda, Function, gradient_check, report, training, utils, Variable
+     from chainer.backends import cuda
+     from chainer import Function, gradient_check, report, training, utils, Variable
      from chainer import datasets, iterators, optimizers, serializers
      from chainer import Link, Chain, ChainList
      import chainer.functions as F

--- a/tests/chainer_tests/functions_tests/activation_tests/test_swish.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_swish.py
@@ -3,7 +3,7 @@ import unittest
 import numpy
 
 import chainer
-from chainer import cuda
+from chainer.backends import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer import testing

--- a/tests/chainer_tests/links_tests/activation_tests/test_swish.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_swish.py
@@ -3,7 +3,7 @@ import unittest
 import numpy
 
 import chainer
-from chainer import cuda
+from chainer.backends import cuda
 from chainer import gradient_check
 from chainer import links
 from chainer import testing


### PR DESCRIPTION
Some recent added codes still use deprecated `chainer.cuda`, and accordingly, I modify them to conform to latest recommendation `chainer.backends.cuda`.