### PR TITLE
Add n_cell property to NStepRNN family

### DIFF
--- a/chainer/links/connection/n_step_gru.py
+++ b/chainer/links/connection/n_step_gru.py
@@ -71,6 +71,10 @@ class NStepGRU(NStepGRUBase):
     def rnn(self, *args):
         return rnn.n_step_gru(*args)
 
+    @property
+    def n_cell(self):
+        return 2
+
 
 class NStepBiGRU(NStepGRUBase):
 
@@ -108,3 +112,7 @@ class NStepBiGRU(NStepGRUBase):
 
     def rnn(self, *args):
         return rnn.n_step_bigru(*args)
+
+    @property
+    def n_cell(self):
+        return 2

--- a/chainer/links/connection/n_step_gru.py
+++ b/chainer/links/connection/n_step_gru.py
@@ -73,7 +73,7 @@ class NStepGRU(NStepGRUBase):
 
     @property
     def n_cell(self):
-        return 2
+        return 1
 
 
 class NStepBiGRU(NStepGRUBase):
@@ -115,4 +115,4 @@ class NStepBiGRU(NStepGRUBase):
 
     @property
     def n_cell(self):
-        return 2
+        return 1

--- a/chainer/links/connection/n_step_gru.py
+++ b/chainer/links/connection/n_step_gru.py
@@ -72,7 +72,7 @@ class NStepGRU(NStepGRUBase):
         return rnn.n_step_gru(*args)
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 1
 
 
@@ -114,5 +114,5 @@ class NStepBiGRU(NStepGRUBase):
         return rnn.n_step_bigru(*args)
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 1

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -98,7 +98,7 @@ class NStepLSTM(NStepLSTMBase):
         return rnn.n_step_lstm(*args)
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 2
 
 
@@ -145,5 +145,5 @@ class NStepBiLSTM(NStepLSTMBase):
         return rnn.n_step_bilstm(*args)
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 2

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -97,6 +97,10 @@ class NStepLSTM(NStepLSTMBase):
     def rnn(self, *args):
         return rnn.n_step_lstm(*args)
 
+    @property
+    def n_cell(self):
+        return 2
+
 
 class NStepBiLSTM(NStepLSTMBase):
     """__init__(self, n_layers, in_size, out_size, dropout)
@@ -139,3 +143,7 @@ class NStepBiLSTM(NStepLSTMBase):
 
     def rnn(self, *args):
         return rnn.n_step_bilstm(*args)
+
+    @property
+    def n_cell(self):
+        return 2

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -117,8 +117,8 @@ class NStepRNNBase(link.ChainList):
         raise NotImplementedError
 
     @property
-    def n_cell(self):
-        """Return the number of cells.
+    def n_cells(self):
+        """Returns the number of cells.
 
         This function must be implemented in a child class.
         """
@@ -232,7 +232,7 @@ class NStepRNNTanh(NStepRNNBase):
         return rnn.n_step_rnn(*args, activation='tanh')
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 1
 
 
@@ -275,7 +275,7 @@ class NStepRNNReLU(NStepRNNBase):
         return rnn.n_step_rnn(*args, activation='relu')
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 1
 
 
@@ -319,7 +319,7 @@ class NStepBiRNNTanh(NStepRNNBase):
         return rnn.n_step_birnn(*args, activation='tanh')
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 1
 
 
@@ -362,5 +362,5 @@ class NStepBiRNNReLU(NStepRNNBase):
         return rnn.n_step_birnn(*args, activation='relu')
 
     @property
-    def n_cell(self):
+    def n_cells(self):
         return 1

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -116,6 +116,14 @@ class NStepRNNBase(link.ChainList):
         """
         raise NotImplementedError
 
+    @property
+    def n_cell(self):
+        """Return the number of cells.
+
+        This function must be implemented in a child class.
+        """
+        return NotImplementedError
+
     def __call__(self, hx, xs, **kwargs):
         """__call__(self, hx, xs)
 
@@ -223,6 +231,10 @@ class NStepRNNTanh(NStepRNNBase):
     def rnn(self, *args):
         return rnn.n_step_rnn(*args, activation='tanh')
 
+    @property
+    def n_cell(self):
+        return 1
+
 
 class NStepRNNReLU(NStepRNNBase):
     """__init__(self, n_layers, in_size, out_size, dropout)
@@ -261,6 +273,10 @@ class NStepRNNReLU(NStepRNNBase):
 
     def rnn(self, *args):
         return rnn.n_step_rnn(*args, activation='relu')
+
+    @property
+    def n_cell(self):
+        return 1
 
 
 class NStepBiRNNTanh(NStepRNNBase):
@@ -302,6 +318,10 @@ class NStepBiRNNTanh(NStepRNNBase):
     def rnn(self, *args):
         return rnn.n_step_birnn(*args, activation='tanh')
 
+    @property
+    def n_cell(self):
+        return 1
+
 
 class NStepBiRNNReLU(NStepRNNBase):
     """__init__(self, n_layers, in_size, out_size, dropout)
@@ -340,3 +360,7 @@ class NStepBiRNNReLU(NStepRNNBase):
 
     def rnn(self, *args):
         return rnn.n_step_birnn(*args, activation='relu')
+
+    @property
+    def n_cell(self):
+        return 1

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_gru.py
@@ -154,6 +154,9 @@ class TestNStepGRU(unittest.TestCase):
                 cuda.to_gpu(self.gh),
                 [cuda.to_gpu(gy) for gy in self.gys])
 
+    def test_n_cells(self):
+        self.assertEqual(self.rnn.n_cells, 1)
+
 
 @testing.parameterize(*testing.product({
     'hidden_none': [True, False],
@@ -321,6 +324,9 @@ class TestNStepBiGRU(unittest.TestCase):
                 [cuda.to_gpu(x) for x in self.xs],
                 cuda.to_gpu(self.gh),
                 [cuda.to_gpu(gy) for gy in self.gys])
+
+    def test_n_cells(self):
+        self.assertEqual(self.rnn.n_cells, 1)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
@@ -168,6 +168,9 @@ class TestNStepLSTM(unittest.TestCase):
                 cuda.to_gpu(self.gc),
                 [cuda.to_gpu(gy) for gy in self.gys])
 
+    def test_n_cells(self):
+        self.assertEqual(self.rnn.n_cells, 2)
+
 
 @testing.parameterize(*testing.product({
     'hidden_none': [True, False],
@@ -359,6 +362,9 @@ class TestNStepBiLSTM(unittest.TestCase):
                 cuda.to_gpu(self.gh),
                 cuda.to_gpu(self.gc),
                 [cuda.to_gpu(gy) for gy in self.gys])
+
+    def test_n_cells(self):
+        self.assertEqual(self.rnn.n_cells, 2)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -161,6 +161,9 @@ class TestNStepRNN(unittest.TestCase):
                 cuda.to_gpu(self.gh),
                 [cuda.to_gpu(gy) for gy in self.gys])
 
+    def test_n_cells(self):
+        self.assertEqual(self.rnn.n_cells, 1)
+
 
 @testing.parameterize(*testing.product({
     'hidden_none': [True, False],
@@ -329,6 +332,9 @@ class TestNStepBiRNN(unittest.TestCase):
                 [cuda.to_gpu(x) for x in self.xs],
                 cuda.to_gpu(self.gh),
                 [cuda.to_gpu(gy) for gy in self.gys])
+
+    def test_n_cells(self):
+        self.assertEqual(self.rnn.n_cells, 1)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
ChainerMN needs this change in order to parallelize NStepRNN ([MultiNodeNStepRNN](https://github.com/chainer/chainermn/blob/master/chainermn/links/n_step_rnn.py)), where each cell is transferred to the neighbour process and thus it needs the number of cells in advance.

### Can it be completed inside of ChainerMN?

Unfortunately, no. Currently, we prepare [a table to obtain the number of cells](https://github.com/chainer/chainermn/pull/205/files#diff-1ed392351c4f47516bae8214681548eeR11), but this solution requires high maintenance cost to keep consistency between Chainer and ChainerMN, and hinders users to define original RNNs.

I tried whether we can avoid hard-coding, but I couldn't. If there is any nice solution, I would be happy to update.