### PR TITLE
Group imports in the order mentioned in the contribution guide

### DIFF
--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -1,4 +1,5 @@
 import collections
+
 import numpy
 import six
 

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -1,9 +1,10 @@
+import numpy
+
 import chainer
 from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check
-import numpy
 
 
 if cuda.cudnn_enabled:

--- a/chainer/functions/activation/softplus.py
+++ b/chainer/functions/activation/softplus.py
@@ -1,9 +1,8 @@
 import numpy
 
-import chainer.functions
-
 from chainer.backends import cuda
 from chainer import function_node
+import chainer.functions
 from chainer import utils
 from chainer.utils import type_check
 

--- a/chainer/functions/array/flip.py
+++ b/chainer/functions/array/flip.py
@@ -1,7 +1,8 @@
+import six
+
 from chainer.backends import cuda
 from chainer import function_node
 from chainer.utils import type_check
-import six
 
 
 def _flip(array, axis):

--- a/chainer/functions/array/im2col.py
+++ b/chainer/functions/array/im2col.py
@@ -1,7 +1,6 @@
 import numpy
 
 from chainer import function_node
-
 from chainer.utils.conv import col2im_cpu
 from chainer.utils.conv import col2im_gpu
 from chainer.utils.conv import im2col_cpu

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -1,5 +1,4 @@
 import numpy
-
 from six import moves
 
 import chainer

--- a/chainer/functions/math/tensordot.py
+++ b/chainer/functions/math/tensordot.py
@@ -1,4 +1,5 @@
 import collections
+
 import numpy
 import six
 

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -2,7 +2,6 @@ import numpy
 
 from chainer.backends import cuda
 from chainer import configuration
-
 from chainer import function
 from chainer.utils import type_check
 

--- a/chainer/functions/pooling/average_pooling_nd.py
+++ b/chainer/functions/pooling/average_pooling_nd.py
@@ -1,7 +1,7 @@
-import numpy
-
 import functools
 import operator
+
+import numpy
 import six
 
 import chainer

--- a/chainer/functions/pooling/max_pooling_nd.py
+++ b/chainer/functions/pooling/max_pooling_nd.py
@@ -1,7 +1,7 @@
-import numpy
-
 import functools
 from operator import mul
+
+import numpy
 import six
 
 import chainer

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -3,9 +3,8 @@ from chainer.functions.activation import tanh
 from chainer.functions.activation import tree_lstm
 from chainer.functions.array import concat
 from chainer.functions.array import split_axis
-from chainer.links.connection import linear
-
 from chainer import link
+from chainer.links.connection import linear
 from chainer import utils
 
 

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import math
 
-import numpy as np
+import numpy
 
 from chainer.backends import cuda
 from chainer import optimizer
@@ -105,10 +105,10 @@ class AdamRule(optimizer.UpdateRule):
 
         if hp.amsgrad:
             vhat = self.state['vhat']
-            np.maximum(vhat, v, out=vhat)
+            numpy.maximum(vhat, v, out=vhat)
         else:
             vhat = v
-        param.data -= hp.eta * (self.lr * m / (np.sqrt(vhat) + hp.eps) +
+        param.data -= hp.eta * (self.lr * m / (numpy.sqrt(vhat) + hp.eps) +
                                 hp.weight_decay_rate * param.data)
 
     def update_core_gpu(self, param):

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -1,5 +1,4 @@
 import numpy
-
 import six
 
 from chainer.backends import cuda

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -1,5 +1,6 @@
-import numpy
 import unittest
+
+import numpy
 
 from chainer.backends import cuda
 from chainer import function

--- a/chainer/training/extensions/exponential_shift.py
+++ b/chainer/training/extensions/exponential_shift.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-import numpy as np
+import numpy
 
 from chainer.training import extension
 
@@ -72,8 +72,8 @@ class ExponentialShift(extension.Extension):
     def serialize(self, serializer):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
-        if isinstance(self._last_value, np.ndarray):
-            self._last_value = np.asscalar(self._last_value)
+        if isinstance(self._last_value, numpy.ndarray):
+            self._last_value = numpy.asscalar(self._last_value)
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/chainer/training/extensions/linear_shift.py
+++ b/chainer/training/extensions/linear_shift.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-import numpy as np
+import numpy
 
 from chainer.training import extension
 
@@ -57,8 +57,8 @@ class LinearShift(extension.Extension):
     def serialize(self, serializer):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
-        if isinstance(self._last_value, np.ndarray):
-            self._last_value = np.asscalar(self._last_value)
+        if isinstance(self._last_value, numpy.ndarray):
+            self._last_value = numpy.asscalar(self._last_value)
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/chainer/training/extensions/variable_statistics_plot.py
+++ b/chainer/training/extensions/variable_statistics_plot.py
@@ -1,9 +1,9 @@
 from __future__ import division
 import os
-import six
 import warnings
 
 import numpy
+import six
 
 import chainer
 from chainer.backends import cuda

--- a/chainer/training/triggers/early_stopping_trigger.py
+++ b/chainer/training/triggers/early_stopping_trigger.py
@@ -1,8 +1,8 @@
-from chainer import reporter
-from chainer.training import util
-
 import operator
 import warnings
+
+from chainer import reporter
+from chainer.training import util
 
 
 class EarlyStoppingTrigger(object):

--- a/chainer/training/updaters/parallel_updater.py
+++ b/chainer/training/updaters/parallel_updater.py
@@ -1,4 +1,5 @@
 import copy
+
 import six
 
 from chainer.dataset import convert

--- a/chainer/utils/conv_nd.py
+++ b/chainer/utils/conv_nd.py
@@ -1,4 +1,5 @@
 import itertools
+
 import numpy
 import six
 

--- a/chainer/utils/conv_nd_kernel.py
+++ b/chainer/utils/conv_nd_kernel.py
@@ -1,4 +1,5 @@
 import functools
+
 import six
 
 from chainer.backends import cuda

--- a/chainer/utils/experimental.py
+++ b/chainer/utils/experimental.py
@@ -1,5 +1,6 @@
-import chainer
 import warnings
+
+import chainer
 
 
 def experimental(api_name):


### PR DESCRIPTION
According to contribution guide, import statements must be organized into three parts: standard libraries, third-party libraries, and internal imports. Consequently, I make corresponding adjustments.