### PR TITLE
Fix document in NStepLSTM/GRU/RNN

### DIFF
--- a/chainer/functions/connection/n_step_gru.py
+++ b/chainer/functions/connection/n_step_gru.py
@@ -95,7 +95,7 @@ def n_step_gru(
             holding input values. Each element ``xs[t]`` holds input value
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is
             mini-batch size for time ``t``, and ``I`` is size of input units.
-            Note that this functions supports variable length sequences.
+            Note that this function supports variable length sequences.
             When sequneces has different lengths, sort sequences in descending
             order by length, and transpose the sorted sequence.
             :func:`~chainer.functions.transpose_sequence` transpose a list
@@ -104,7 +104,7 @@ def n_step_gru(
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
         ``hy`` and ``ys``.
 
         - ``hy`` is an updated hidden states whose shape is same as ``hx``.
@@ -196,7 +196,7 @@ def n_step_bigru(
             holding input values. Each element ``xs[t]`` holds input value
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is
             mini-batch size for time ``t``, and ``I`` is size of input units.
-            Note that this functions supports variable length sequences.
+            Note that this function supports variable length sequences.
             When sequneces has different lengths, sort sequences in descending
             order by length, and transpose the sorted sequence.
             :func:`~chainer.functions.transpose_sequence` transpose a list
@@ -207,7 +207,7 @@ def n_step_bigru(
             Bi-direction GRU.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
         ``hy`` and ``ys``.
 
         - ``hy`` is an updated hidden states whose shape is same as ``hx``.
@@ -266,7 +266,7 @@ def n_step_gru_base(n_layers, dropout_ratio, hx, ws, bs, xs,
             holding input values. Each element ``xs[t]`` holds input value
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is
             mini-batch size for time ``t``, and ``I`` is size of input units.
-            Note that this functions supports variable length sequences.
+            Note that this function supports variable length sequences.
             When sequneces has different lengths, sort sequences in descending
             order by length, and transpose the sorted sequence.
             :func:`~chainer.functions.transpose_sequence` transpose a list

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -117,7 +117,7 @@ def n_step_lstm(
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
         ``hy``, ``cy`` and ``ys``.
 
         - ``hy`` is an updated hidden states whose shape is the same as
@@ -284,7 +284,7 @@ def n_step_bilstm(
             ``xs[t].shape[0] >= xs[t + 1].shape[0]``.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
         ``hy``, ``cy`` and ``ys``.
 
         - ``hy`` is an updated hidden states whose shape is the same as
@@ -395,7 +395,7 @@ def n_step_lstm_base(
             LSTM.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
         ``hy``, ``cy`` and ``ys``.
 
             - ``hy`` is an updated hidden states whose shape is the same as

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -569,7 +569,7 @@ def n_step_rnn(
             holding input values. Each element ``xs[t]`` holds input value
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is
             mini-batch size for time ``t``, and ``I`` is size of input units.
-            Note that this functions supports variable length sequences.
+            Note that this function supports variable length sequences.
             When sequneces has different lengths, sort sequences in descending
             order by length, and transpose the sorted sequence.
             :func:`~chainer.functions.transpose_sequence` transpose a list
@@ -580,7 +580,7 @@ def n_step_rnn(
             Please select ``tanh`` or ``relu``.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
         ``hy`` and ``ys``.
 
         - ``hy`` is an updated hidden states whose shape is same as ``hx``.
@@ -679,7 +679,7 @@ def n_step_birnn(
             holding input values. Each element ``xs[t]`` holds input value
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is
             mini-batch size for time ``t``, and ``I`` is size of input units.
-            Note that this functions supports variable length sequences.
+            Note that this function supports variable length sequences.
             When sequneces has different lengths, sort sequences in descending
             order by length, and transpose the sorted sequence.
             :func:`~chainer.functions.transpose_sequence` transpose a list
@@ -690,7 +690,7 @@ def n_step_birnn(
             Please select ``tanh`` or ``relu``.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
         ``hy`` and ``ys``.
 
         - ``hy`` is an updated hidden states whose shape is same as ``hx``.
@@ -748,7 +748,7 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
             holding input values. Each element ``xs[t]`` holds input value
             for time ``t``. Its shape is ``(B_t, I)``, where ``B_t`` is
             mini-batch size for time ``t``, and ``I`` is size of input units.
-            Note that this functions supports variable length sequences.
+            Note that this function supports variable length sequences.
             When sequneces has different lengths, sort sequences in descending
             order by length, and transpose the sorted sequence.
             :func:`~chainer.functions.transpose_sequence` transpose a list
@@ -761,7 +761,7 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
             Bi-directional RNN.
 
     Returns:
-        tuple: This functions returns a tuple concaining three elements,
+        tuple: This function returns a tuple containing three elements,
             ``hy`` and ``ys``.
 
             - ``hy`` is an updated hidden states whose shape is same as ``hx``.

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -50,6 +50,22 @@ class NStepLSTMBase(n_step_rnn.NStepRNNBase):
             xs (list of ~chainer.Variable): List of input sequences.
                 Each element ``xs[i]`` is a :class:`chainer.Variable` holding
                 a sequence.
+
+        Returns:
+            tuple: This function returns a tuple containing three elements,
+            ``hy``, ``cy`` and ``ys``.
+
+            - ``hy`` is an updated hidden states whose shape is the same as
+              ``hx``.
+            - ``cy`` is an updated cell states whose shape is the same as
+              ``cx``.
+            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+              ``ys[t]`` holds hidden states of the last layer corresponding
+              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for 
+              uni-directional LSTM and ``(B_t, 2N)`` for bi-directional LSTM
+              where ``B_t`` is the mini-batch size for time ``t``, and ``N`` 
+              is size of hidden units. Note that ``B_t`` is the same value 
+              as ``xs[t]``.
         """
         (hy, cy), ys = self._call([hx, cx], xs, **kwargs)
         return hy, cy, ys

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -61,10 +61,10 @@ class NStepLSTMBase(n_step_rnn.NStepRNNBase):
               ``cx``.
             - ``ys`` is a list of :class:`~chainer.Variable` . Each element
               ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for 
+              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for
               uni-directional LSTM and ``(B_t, 2N)`` for bi-directional LSTM
-              where ``B_t`` is the mini-batch size for time ``t``, and ``N`` 
-              is size of hidden units. Note that ``B_t`` is the same value 
+              where ``B_t`` is the mini-batch size for time ``t``, and ``N``
+              is size of hidden units. Note that ``B_t`` is the same value
               as ``xs[t]``.
         """
         (hy, cy), ys = self._call([hx, cx], xs, **kwargs)

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -44,12 +44,19 @@ class NStepLSTMBase(n_step_rnn.NStepRNNBase):
 
         Args:
             hx (~chainer.Variable or None): Initial hidden states. If ``None``
-                is specified zero-vector is used.
+                is specified zero-vector is used. Its shape is ``(S, B, N)``
+                for uni-directional LSTM and ``(2S, B, N)`` for
+                bi-directional LSTM where ``S`` is the number of layers
+                and is equal to ``n_layers``, ``B`` is the mini-batch size,
+                and ``N`` is the dimension of the hidden units.
             cx (~chainer.Variable or None): Initial cell states. If ``None``
                 is specified zero-vector is used.
+                It has the same shape as ``hx``.
             xs (list of ~chainer.Variable): List of input sequences.
                 Each element ``xs[i]`` is a :class:`chainer.Variable` holding
-                a sequence.
+                a sequence. Its shape is ``(L_t, I)``, where ``L_t`` is the
+                length of a sequence for time ``t``, and ``I`` is the size of
+                the input and is equal to ``in_size``.
 
         Returns:
             tuple: This function returns a tuple containing three elements,
@@ -61,11 +68,10 @@ class NStepLSTMBase(n_step_rnn.NStepRNNBase):
               ``cx``.
             - ``ys`` is a list of :class:`~chainer.Variable` . Each element
               ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for
-              uni-directional LSTM and ``(B_t, 2N)`` for bi-directional LSTM
-              where ``B_t`` is the mini-batch size for time ``t``, and ``N``
-              is size of hidden units. Note that ``B_t`` is the same value
-              as ``xs[t]``.
+              to an input ``xs[t]``. Its shape is ``(L_t, N)`` for
+              uni-directional LSTM and ``(L_t, 2N)`` for bi-directional LSTM
+              where ``L_t`` is the length of a sequence for time ``t``,
+              and ``N`` is size of hidden units.
         """
         (hy, cy), ys = self._call([hx, cx], xs, **kwargs)
         return hy, cy, ys

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -129,10 +129,16 @@ class NStepRNNBase(link.ChainList):
 
         Args:
             hx (~chainer.Variable or None): Initial hidden states. If ``None``
-                is specified zero-vector is used.
+                is specified zero-vector is used. Its shape is ``(S, B, N)``
+                for uni-directional RNN and ``(2S, B, N)`` for
+                bi-directional RNN where ``S`` is the number of layers
+                and is equal to ``n_layers``, ``B`` is the mini-batch size,
+                and ``N`` is the dimension of the hidden units.
             xs (list of ~chainer.Variable): List of input sequences.
                 Each element ``xs[i]`` is a :class:`chainer.Variable` holding
-                a sequence.
+                a sequence. Its shape is ``(L_t, I)``, where ``L_t`` is the
+                length of a sequence for time ``t``, and ``I`` is the size of
+                the input and is equal to ``in_size``.
 
         Returns:
             tuple: This function returns a tuple containing three elements,
@@ -141,11 +147,10 @@ class NStepRNNBase(link.ChainList):
             - ``hy`` is an updated hidden states whose shape is same as ``hx``.
             - ``ys`` is a list of :class:`~chainer.Variable` . Each element
               ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for
-              uni-directional RNN and ``(B_t, 2N)`` for bi-directional RNN
-              where ``B_t`` is mini-batch size for time ``t``, and
-              ``N`` is size of hidden units. Note that ``B_t`` is the same
-              value as ``xs[t]``.
+              to an input ``xs[t]``. Its shape is ``(L_t, N)`` for
+              uni-directional RNN and ``(L_t, 2N)`` for bi-directional RNN
+              where ``L_t`` is the length of a sequence for time ``t``,
+              and ``N`` is size of hidden units.
         """
         (hy,), ys = self._call([hx], xs, **kwargs)
         return hy, ys

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -141,10 +141,10 @@ class NStepRNNBase(link.ChainList):
             - ``hy`` is an updated hidden states whose shape is same as ``hx``.
             - ``ys`` is a list of :class:`~chainer.Variable` . Each element
               ``ys[t]`` holds hidden states of the last layer corresponding
-              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for 
-              uni-directional RNN and ``(B_t, 2N)`` for bi-directional RNN 
-              where ``B_t`` is mini-batch size for time ``t``, and 
-              ``N`` is size of hidden units. Note that ``B_t`` is the same 
+              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for
+              uni-directional RNN and ``(B_t, 2N)`` for bi-directional RNN
+              where ``B_t`` is mini-batch size for time ``t``, and
+              ``N`` is size of hidden units. Note that ``B_t`` is the same
               value as ``xs[t]``.
         """
         (hy,), ys = self._call([hx], xs, **kwargs)

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -133,6 +133,19 @@ class NStepRNNBase(link.ChainList):
             xs (list of ~chainer.Variable): List of input sequences.
                 Each element ``xs[i]`` is a :class:`chainer.Variable` holding
                 a sequence.
+
+        Returns:
+            tuple: This function returns a tuple containing three elements,
+            ``hy`` and ``ys``.
+
+            - ``hy`` is an updated hidden states whose shape is same as ``hx``.
+            - ``ys`` is a list of :class:`~chainer.Variable` . Each element
+              ``ys[t]`` holds hidden states of the last layer corresponding
+              to an input ``xs[t]``. Its shape is ``(B_t, N)`` for 
+              uni-directional RNN and ``(B_t, 2N)`` for bi-directional RNN 
+              where ``B_t`` is mini-batch size for time ``t``, and 
+              ``N`` is size of hidden units. Note that ``B_t`` is the same 
+              value as ``xs[t]``.
         """
         (hy,), ys = self._call([hx], xs, **kwargs)
         return hy, ys


### PR DESCRIPTION
I fixed typo in NStepLSTM/GRU/RNN functions.
I also fix document in NStepLSTM/RNN links to contain return variable in __call__.
This PR is related to #3903.