### PR TITLE
Extract stack function from CTC loss

### DIFF
--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -117,18 +117,24 @@ class ConnectionistTemporalClassification(function.Function):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() > 3)  # TODO(okuta): > 3?
-        l_type = in_types[2]
-        type_check.expect(l_type.dtype == numpy.int32)
-
-        x_basetype = in_types[3]  # TODO(oktua): Check x_basetype size
-
-        for i in six.moves.range(3, len(in_types)):
-            x_type = in_types[i]
-            type_check.expect(
-                x_type.dtype == numpy.float32,
-                x_type.shape == x_basetype.shape,
-            )
+        type_check.expect(in_types.size() == 4)
+        input_length_type, label_length_type, t_type, x_type = in_types
+        type_check.expect(
+            input_length_type.dtype == numpy.int32,
+            input_length_type.ndim == 1,
+            label_length_type.dtype == numpy.int32,
+            label_length_type.ndim == 1,
+            t_type.ndim == 2,
+            t_type.dtype == numpy.int32,
+            x_type.ndim == 3,
+            x_type.dtype == numpy.float32,
+        )
+        n_batch = x_type.shape[1]
+        type_check.expect(
+            t_type.shape[0] == n_batch,
+            input_length_type.shape[0] == n_batch,
+            label_length_type.shape[0] == n_batch,
+        )
 
     def log_matrix(self, x, xp):
         if xp == numpy:
@@ -265,25 +271,15 @@ class ConnectionistTemporalClassification(function.Function):
 
     def forward(self, inputs):
         xp = cuda.get_array_module(inputs[0])
-        self.input_length = inputs[0]
-        label_length = inputs[1]
-        t = inputs[2]
-        xs = inputs[3:]
+        self.input_length, label_length, t, xs = inputs
 
         if chainer.is_debug():
-            # Batch size check.
-            assert len(xs[0]) == len(t)
-            assert len(xs[0]) == len(self.input_length)
-            assert len(xs[0]) == len(label_length)
-
-            # Length check.
             assert len(xs) >= xp.max(self.input_length)
-            assert len(t[0]) >= xp.max(label_length)
+            assert t.shape[1] >= xp.max(label_length)
 
         self.path_length = 2 * label_length + 1
 
-        yseq_shape = (len(xs),) + xs[0].shape
-        self.yseq = _softmax(xp.vstack(xs).reshape(yseq_shape), xp)
+        self.yseq = _softmax(xs, xp)
         log_yseq = self.log_matrix(self.yseq, xp)
         self.path = _label_to_path(t, self.blank_symbol, xp)
         self.prob_trans = self.calc_trans(
@@ -311,7 +307,7 @@ class ConnectionistTemporalClassification(function.Function):
         # mask
         self.yseq *= (
             xp.arange(len(self.yseq))[:, None] < self.input_length)[..., None]
-        return (None, None, None) + tuple([y for y in self.yseq])
+        return None, None, None, self.yseq
 
 
 def connectionist_temporal_classification(
@@ -399,4 +395,4 @@ def connectionist_temporal_classification(
         label_length = xp.full(len(t), t.shape[1], dtype=numpy.int32)
 
     return ConnectionistTemporalClassification(blank_symbol, reduce)(
-        input_length, label_length, t, *x)
+        input_length, label_length, t, chainer.functions.stack(x))

--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -113,7 +113,8 @@ class CTCTestBase(object):
     def check_backward(self, t_data, xs_data, l_length, x_length, gy_data):
         def f(input_length, label_length, t, *x):
             return functions.connectionist_temporal_classification(
-                x, t, self.blank_symbol, x_length, l_length, reduce=self.reduce)
+                x, t, self.blank_symbol, x_length, l_length,
+                reduce=self.reduce)
 
         gradient_check.check_backward(
             f, (x_length, l_length, t_data) + xs_data, gy_data,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -111,10 +111,12 @@ class CTCTestBase(object):
 
     # expected value(via numerical differentiation) from t_data
     def check_backward(self, t_data, xs_data, l_length, x_length, gy_data):
+        def f(input_length, label_length, t, *x):
+            return functions.connectionist_temporal_classification(
+                x, t, self.blank_symbol, x_length, l_length, reduce=self.reduce)
+
         gradient_check.check_backward(
-            functions.ConnectionistTemporalClassification(
-                self.blank_symbol, self.reduce),
-            (x_length, l_length, t_data) + xs_data, gy_data,
+            f, (x_length, l_length, t_data) + xs_data, gy_data,
             eps=1e-2, atol=1e-4)
 
     @condition.retry(3)


### PR DESCRIPTION
Current CTC loss function node class concatenates input variables in its implementation. We can extract this process as a stack function call.
This fix does not change the interface.