### PR TITLE
Typecheck split_at

### DIFF
--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -96,6 +96,9 @@ def split_dataset(dataset, split_at, order=None):
 
     """
     n_examples = len(dataset)
+    if not isinstance(split_at, int):
+        raise TypeError('split_at must be int, got {} instead'
+                        .format(type(split_at)))
     if split_at < 0:
         raise ValueError('split_at must be non-negative')
     if split_at >= n_examples:

--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -96,7 +96,7 @@ def split_dataset(dataset, split_at, order=None):
 
     """
     n_examples = len(dataset)
-    if not isinstance(split_at, int):
+    if not isinstance(split_at, (six.integer_types, numpy.integer)):
         raise TypeError('split_at must be int, got {} instead'
                         .format(type(split_at)))
     if split_at < 0:

--- a/tests/chainer_tests/datasets_tests/test_sub_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_sub_dataset.py
@@ -54,6 +54,11 @@ class TestSplitDataset(unittest.TestCase):
         with self.assertRaises(ValueError):
             datasets.split_dataset(original, 5)
 
+    def test_split_dataset_invalid_type(self):
+        original = [1, 2, 3, 4, 5]
+        with self.assertRaises(TypeError):
+            datasets.split_dataset(original, 3.5)
+
     def test_permuted_split_dataset(self):
         original = [1, 2, 3, 4, 5]
         subset1, subset2 = datasets.split_dataset(original, 2, [2, 0, 3, 1, 4])


### PR DESCRIPTION
When we use `split_dataset` or `split_dataset_random`, it won't raise error when we set `float` value to the second argument of `split_at`.

It is likely happen when we want to split dataset according to the ratio of train/validation dataset.
e.g.,
```
train_ratio = 0.8
# here actually we must change type to int, but did not notice, because no error is raised!
train, val = split_dataset_random(dataset, len(dataset) * ratio)
```

This PR is to check type of `split_at` to be `int`. After this PR, above code will raise `TypeError`.