### PR TITLE
Remove future.types.newint

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -144,12 +144,6 @@ if available:
 
 
 _integer_types = six.integer_types + (numpy.integer,)
-if six.PY2:
-    try:
-        from future.types.newint import newint as _newint
-        _integer_types += (_newint,)
-    except ImportError:
-        pass
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Now that we use `isinstance` to check if a variable is integer, `newint` is no longer needed.

Related: #1629, #4380