### PR TITLE
reset Link._device_id to None in to_intel64

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -393,6 +393,7 @@ Assign a Parameter object directly to an attribute within a \
                 d[name] = intel64.ideep.array(
                     value, itype=intel64.ideep.wgt_array)
         self._cpu = True
+        self._device_id = None
         return self
 
     def params(self, include_uninit=True):

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -1142,6 +1142,7 @@ class TestIntel64(unittest.TestCase):
     def test_cpu_to_intel64(self):
         link = self.link
         link.to_intel64()
+        self.assertEqual(link._device_id, None)
 
         # Arrays should be converted to ideep.mdarray
 
@@ -1164,6 +1165,7 @@ class TestIntel64(unittest.TestCase):
         prev_pa = link.pa
         prev_ps = link.ps
         link.to_intel64()
+        self.assertEqual(link._device_id, None)
 
         # Everything should be left untouched
 
@@ -1180,7 +1182,9 @@ class TestIntel64(unittest.TestCase):
     def test_gpu_to_intel64(self):
         link = self.link
         link.to_gpu()
+        self.assertEqual(link._device_id, 0)
         link.to_intel64()
+        self.assertEqual(link._device_id, None)
 
         # Arrays should be converted to ideep.mdarray
 
@@ -1199,7 +1203,9 @@ class TestIntel64(unittest.TestCase):
     def test_intel64_to_gpu(self):
         link = self.link
         link.to_intel64()
+        self.assertEqual(link._device_id, None)
         link.to_gpu()
+        self.assertEqual(link._device_id, 0)
 
         # Arrays should be converted to cupy.ndarray
 
@@ -1217,7 +1223,9 @@ class TestIntel64(unittest.TestCase):
     def test_intel64_to_cpu(self):
         link = self.link
         link.to_intel64()
+        self.assertEqual(link._device_id, None)
         link.to_cpu()
+        self.assertEqual(link._device_id, None)
 
         # Arrays should be converted to numpy.ndarray
 

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -1142,7 +1142,7 @@ class TestIntel64(unittest.TestCase):
     def test_cpu_to_intel64(self):
         link = self.link
         link.to_intel64()
-        self.assertEqual(link._device_id, None)
+        assert link._device_id is None
 
         # Arrays should be converted to ideep.mdarray
 
@@ -1165,7 +1165,7 @@ class TestIntel64(unittest.TestCase):
         prev_pa = link.pa
         prev_ps = link.ps
         link.to_intel64()
-        self.assertEqual(link._device_id, None)
+        assert link._device_id is None
 
         # Everything should be left untouched
 
@@ -1182,9 +1182,9 @@ class TestIntel64(unittest.TestCase):
     def test_gpu_to_intel64(self):
         link = self.link
         link.to_gpu()
-        self.assertEqual(link._device_id, 0)
+        assert link._device_id == 0
         link.to_intel64()
-        self.assertEqual(link._device_id, None)
+        assert link._device_id is None
 
         # Arrays should be converted to ideep.mdarray
 
@@ -1203,9 +1203,9 @@ class TestIntel64(unittest.TestCase):
     def test_intel64_to_gpu(self):
         link = self.link
         link.to_intel64()
-        self.assertEqual(link._device_id, None)
+        assert link._device_id is None
         link.to_gpu()
-        self.assertEqual(link._device_id, 0)
+        assert link._device_id == 0
 
         # Arrays should be converted to cupy.ndarray
 
@@ -1223,9 +1223,9 @@ class TestIntel64(unittest.TestCase):
     def test_intel64_to_cpu(self):
         link = self.link
         link.to_intel64()
-        self.assertEqual(link._device_id, None)
+        assert link._device_id is None
         link.to_cpu()
-        self.assertEqual(link._device_id, None)
+        assert link._device_id is None
 
         # Arrays should be converted to numpy.ndarray
 


### PR DESCRIPTION
`Link._device_id` does not change when transferred from GPU to intel64.