### PR TITLE
prepare API to get/set RandomState instances unique to each batch index

### DIFF
--- a/chainer/iterators/__init__.py
+++ b/chainer/iterators/__init__.py
@@ -7,3 +7,5 @@ from chainer.iterators import serial_iterator  # NOQA
 from chainer.iterators.multiprocess_iterator import MultiprocessIterator  # NOQA
 from chainer.iterators.multithread_iterator import MultithreadIterator  # NOQA
 from chainer.iterators.serial_iterator import SerialIterator  # NOQA
+
+from chainer.iterators.random_state import get_random_state  # NOQA

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -14,7 +14,6 @@ from chainer.dataset import iterator
 
 
 _response_time = 1.
-_short_time = 0.001
 _PrefetchState = namedtuple('_PrefetchState', (
     'current_position', 'epoch', 'is_new_epoch',
     'previous_epoch_detail', 'order'))

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -278,11 +278,7 @@ class _PrefetchLoop(object):
 
         # Use a distinct RandomState in the thread
         # for deterministic random number generation.
-        # To support 32-bit platform and numpy < 1.11,
-        # the seed is taken in a verbose manner.
-        seed = numpy.asscalar(
-            numpy.random.randint(-(1 << 31), 1 << 31, 1).astype('uint32'))
-        self._random = numpy.random.RandomState(seed)
+        self._random = random_state.derive_random_state()
 
         self._interruption_testing = _interruption_testing
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -11,6 +11,7 @@ import numpy
 import six
 
 from chainer.dataset import iterator
+from chainer.iterators import random_state
 
 
 _response_time = 1.
@@ -93,7 +94,10 @@ class MultiprocessIterator(iterator.Iterator):
             self._previous_epoch_detail, self._order) = prefetch_state
         if batch is None:
             raise StopIteration
-        else:
+
+        def dummy_state():
+            raise NotImplementedError
+        with random_state.set_random_state(dummy_state):
             return batch
 
     next = __next__

--- a/chainer/iterators/multithread_iterator.py
+++ b/chainer/iterators/multithread_iterator.py
@@ -5,6 +5,7 @@ import numpy
 import six
 
 from chainer.dataset import iterator
+from chainer.iterators import random_state
 
 
 class MultithreadIterator(iterator.Iterator):
@@ -84,7 +85,11 @@ class MultithreadIterator(iterator.Iterator):
 
         batch = self._get()
         self._invoke_prefetch()  # prefetch for the next iteration
-        return batch
+
+        def dummy_state():
+            raise NotImplementedError
+        with random_state.set_random_state(dummy_state):
+            return batch
 
     next = __next__
 

--- a/chainer/iterators/random_state.py
+++ b/chainer/iterators/random_state.py
@@ -37,6 +37,41 @@ def get_random_state():
     return state
 
 
+def derive_random_state():
+    """Derive a new PRNG state from the global one.
+
+    The global state will be put one step forward.
+
+    It is likely that the derived state and the global one are far distant on
+    the PRNG state-transition sequence.  We need to rely on this empirical way,
+    as numpy doesn't implement `random.jumpahead` like functionality, which
+    allows making a jump on the state-transition sequence with arbitrary
+    length.
+
+    To support 32-bit platform and numpy < 1.11, the value is taken in
+    a verbose manner.
+
+    Returns:
+        A :class:`numpy.random.RandomState` instance.
+
+    """
+    seed = numpy.asscalar(
+        numpy.random.randint(-(1 << 31), 1 << 31, 1).astype('uint32'))
+    return numpy.random.RandomState(seed)
+
+
+def create_random_states(num):
+    """Derive new PRNG states from the global one.
+
+    Args:
+        num (int): The number of the states to be created.
+
+    Returns:
+        A list of :class:`numpy.random.RandomState` instances.
+    """
+    return [derive_random_state() for _ in range(num)]
+
+
 @contextlib.contextmanager
 def set_random_state(random_state):
     """Create a context for :meth:`get_random_state` with a given PRNG state.

--- a/chainer/iterators/random_state.py
+++ b/chainer/iterators/random_state.py
@@ -1,0 +1,54 @@
+import contextlib
+import threading
+
+import numpy
+
+
+_random_state = threading.local()
+_random_state.value = None
+
+
+def get_random_state():
+    """Get a :class:`~numpy.random.RandomState` during iteration.
+
+    The instance obtained is unique to each index on a batch.  You can
+    employ the state, for example, to perform random data augmentation.
+    No manual initialization is required even if you are using
+    :class:`~chainer.iterators.MultiprocessIterator` or
+    :class:`~chainer.iterators.MultithreadIterator`.
+
+    The state is deterministically determined by the initial state of
+    ``numpy.random``. Therefore you can reproduce the same result
+    if you set the same seed by :func:`numpy.random.seed` at the program
+    startup.
+
+    The states remain unchanged when an iterator is reset. Internal states
+    during prefetch are silently discarded.
+
+    Returns:
+        The :class:`numpy.random.RandomState` instance bound to the batch
+        index, if a :class:`~chainer.dataset.Iterator` instance is fetching
+        data; otherwise ``None``.
+
+    """
+    state = _random_state.value
+    if not isinstance(state, numpy.random.RandomState):
+        state = state()
+    return state
+
+
+@contextlib.contextmanager
+def set_random_state(random_state):
+    """Create a context for :meth:`get_random_state` with a given PRNG state.
+
+    This function shall be called by iterator implementation each time
+    it yields a batch.
+
+    Args:
+        random_state (numpy.random.RandomState or callable): a PRNG state.
+            If it is callable, it must return a :numpy.random.RandomState:
+            instance when called with no argument.
+    """
+    _random_state.value = random_state
+    yield
+    _random_state.value = None

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -3,6 +3,7 @@ from __future__ import division
 import numpy
 
 from chainer.dataset import iterator
+from chainer.iterators import random_state
 
 
 class SerialIterator(iterator.Iterator):
@@ -77,7 +78,10 @@ class SerialIterator(iterator.Iterator):
             self.is_new_epoch = False
             self.current_position = i_end
 
-        return batch
+        def dummy_state():
+            raise NotImplementedError
+        with random_state.set_random_state(dummy_state):
+            return batch
 
     next = __next__
 

--- a/docs/source/reference/iterators.rst
+++ b/docs/source/reference/iterators.rst
@@ -17,3 +17,13 @@ Chainer provides some iterators that implement typical strategies to create mini
    chainer.iterators.SerialIterator
    chainer.iterators.MultiprocessIterator
    chainer.iterators.MultithreadIterator
+
+
+Chainer also provides a handy way to use properly initialized :class:`numpy.random.RandomState` instances at iteration.
+
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.iterators.get_random_state


### PR DESCRIPTION
Part of #4230.

`iterators.get_random_state` (to be called by user) and `iterators.random_state.set_random_state` (to be called by iterator implementation) are implemented, and `get_random_state` is documented.

Currently iterators set dummy state by `set_random_state` which raises `NotImplementedError` immediately when `get_random_state` is called.