### PR TITLE
Fix to disable using iDeep in optimizers if to_intel64 is not called

### DIFF
--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -37,10 +37,10 @@ class MomentumSGDRule(optimizer.UpdateRule):
             self.state['v'] = xp.zeros_like(param.data)
 
         # For iDeep
-        if isinstance(param.data, intel64.mdarray):
-            if intel64.inputs_all_ready((self.state['v'],)):
-                self.state['v'] = intel64.ideep.array(
-                    self.state['v'], itype=intel64.ideep.wgt_array)
+        if (isinstance(param.data, intel64.mdarray) and
+                intel64.inputs_all_ready((self.state['v'],))):
+            self.state['v'] = intel64.ideep.array(
+                self.state['v'], itype=intel64.ideep.wgt_array)
 
     def update_core_cpu(self, param):
         grad = param.grad

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -37,9 +37,10 @@ class MomentumSGDRule(optimizer.UpdateRule):
             self.state['v'] = xp.zeros_like(param.data)
 
         # For iDeep
-        if intel64.inputs_all_ready((self.state['v'],)):
-            self.state['v'] = intel64.ideep.array(
-                self.state['v'], itype=intel64.ideep.wgt_array)
+        if isinstance(param.data, intel64.mdarray):
+            if intel64.inputs_all_ready((self.state['v'],)):
+                self.state['v'] = intel64.ideep.array(
+                    self.state['v'], itype=intel64.ideep.wgt_array)
 
     def update_core_cpu(self, param):
         grad = param.grad

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1274,6 +1274,7 @@ class Parameter(Variable):
 
     initializer = None
     _grad_initializer = None
+    _initial_backend = None
     _initial_device = None
 
     def __init__(self, initializer=None, shape=None, name=None):
@@ -1314,6 +1315,7 @@ class Parameter(Variable):
     def to_cpu(self):
         super(Parameter, self).to_cpu()
         if self.data is None:
+            self._initial_backend = None
             self._initial_device = None
 
     def to_gpu(self, device=None):
@@ -1321,11 +1323,13 @@ class Parameter(Variable):
         if self.data is None:
             if device is None:
                 device = cuda.Device().id
+            self._initial_backend = 'cuda'
             self._initial_device = device
 
     def to_intel64(self):
         super(Parameter, self).to_intel64()
         if self.data is None:
+            self._initial_backend = 'intel64'
             self._initial_device = None
 
     def cleargrad(self):
@@ -1360,6 +1364,10 @@ class Parameter(Variable):
 
         self.data = data
         self.grad = grad
+
+        # Convert the array for iDeep.
+        if self._initial_backend == 'intel64':
+            self.to_intel64()
 
     def update(self):
         """Updates the data array using the gradient and the update rule.

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1352,7 +1352,7 @@ class Parameter(Variable):
             shape (tuple of int): Shape of the data array.
 
         """
-        xp = numpy if self._initial_device is None else cuda.cupy
+        xp = numpy if self._initial_backend != 'cuda' else cuda.cupy
         with cuda.get_device_from_id(self._initial_device):
             data = initializers.generate_array(self.initializer, shape, xp)
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -728,8 +728,6 @@ Actual: {0}'''.format(type(data))
 
         """
         if self.data is None:
-            self._initial_device = (cuda.Device().id
-                                    if device is None else device)
             self._data = [None]  # Renew placeholder to break sharing
         else:
             self._data = [cuda.to_gpu(self.data, device)]

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -855,6 +855,16 @@ class TestUninitializedParameter(unittest.TestCase):
         x.to_cpu()
         self.check_constant_initialization(x, self.a, np)
 
+    @attr.ideep
+    def test_initialize_to_intel64(self):
+        x = chainer.Parameter(initializer=initializers.Constant(self.a))
+        assert x.data is None
+        x.to_intel64()
+        x.initialize(self.a.shape)
+        assert isinstance(x.data, intel64.mdarray)
+        np.testing.assert_array_equal(x.data, self.a)
+        np.testing.assert_array_equal(x.grad, np.float32('nan'))
+
     def test_copy_to_initialize(self):
         # This test intends the use case of link.copy() method.
         x = chainer.Parameter()


### PR DESCRIPTION
Currently iDeep cannot be disabled when `MomentumSGD` is used.
This makes performance worse due to the copy overhead.
