### PR TITLE
Save snapshot in the OS default permission

### DIFF
--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -87,7 +87,5 @@ def _snapshot_object(trainer, target, filename, savefun):
     try:
         savefun(tmppath, target)
         shutil.move(tmppath, os.path.join(trainer.out, fn))
-    except Exception as e:
-        raise e
     finally:
         shutil.rmtree(tmpdir)

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -82,13 +82,12 @@ def _snapshot_object(trainer, target, filename, savefun):
     fn = filename.format(trainer)
     prefix = 'tmp' + fn
 
-    tmpdir = tempfile.TemporaryDirectory(dir=trainer.out)
-    tmppath = os.path.join(tmpdir.name, fn)
-    print(tmpdir.name)
+    tmpdir = tempfile.mkdtemp(prefix=prefix, dir=trainer.out)
+    tmppath = os.path.join(tmpdir, fn)
     try:
         savefun(tmppath, target)
         shutil.move(tmppath, os.path.join(trainer.out, fn))
     except Exception as e:
         raise e
     finally:
-        tmpdir.cleanup()
+        shutil.rmtree(tmpdir)

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -68,9 +68,7 @@ def snapshot(savefun=npz.save_npz,
             output file path and the trainer object.
         filename (str): Name of the file into which the trainer is serialized.
             It can be a format string, where the trainer object is passed to
-            the :meth:`str.format` method. Permission of the target file will
-            be OS default. See :meth:`umask` command to confirm the default
-            permission.
+            the :meth:`str.format` method.
 
     """
     @extension.make_extension(trigger=(1, 'epoch'), priority=-100)

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -83,15 +83,14 @@ def snapshot(savefun=npz.save_npz,
 def _snapshot_object(trainer, target, filename, savefun):
     fn = filename.format(trainer)
     prefix = 'tmp' + fn
-    fd, tmppath = tempfile.mkstemp(prefix=prefix, dir=trainer.out)
-    umask = os.umask(0)
-    os.umask(umask)
-    os.chmod(tmppath, 0o666 & ~umask)
+
+    tmpdir = tempfile.TemporaryDirectory(dir=trainer.out)
+    tmppath = os.path.join(tmpdir.name, fn)
+    print(tmpdir.name)
     try:
         savefun(tmppath, target)
-    except Exception:
-        os.close(fd)
-        os.remove(tmppath)
-        raise
-    os.close(fd)
-    shutil.move(tmppath, os.path.join(trainer.out, fn))
+        shutil.move(tmppath, os.path.join(trainer.out, fn))
+    except Exception as e:
+        raise e
+    finally:
+        tmpdir.cleanup()

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -68,7 +68,9 @@ def snapshot(savefun=npz.save_npz,
             output file path and the trainer object.
         filename (str): Name of the file into which the trainer is serialized.
             It can be a format string, where the trainer object is passed to
-            the :meth:`str.format` method.
+            the :meth:`str.format` method. Permission of the target file will
+            be OS default. See :meth:`umask` command to confirm the default
+            permission.
 
     """
     @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
@@ -82,6 +84,9 @@ def _snapshot_object(trainer, target, filename, savefun):
     fn = filename.format(trainer)
     prefix = 'tmp' + fn
     fd, tmppath = tempfile.mkstemp(prefix=prefix, dir=trainer.out)
+    umask = os.umask(0)
+    os.umask(umask)
+    os.chmod(tmppath, 0o666 & ~umask)
     try:
         savefun(tmppath, target)
     except Exception:

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
@@ -1,7 +1,7 @@
+import os
 import unittest
 
 import mock
-import os
 
 from chainer import testing
 from chainer.training import extensions
@@ -29,6 +29,10 @@ class TestSnapshotSaveFile(unittest.TestCase):
         self.trainer.out = '.'
         self.trainer._done = True
 
+    def tearDown(self):
+        if os.path.exists('myfile.dat'):
+            os.remove('myfile.dat')
+
     def test_save_file(self):
         snapshot = extensions.snapshot_object(self.trainer, 'myfile.dat')
         snapshot(self.trainer)
@@ -41,10 +45,6 @@ class TestSnapshotSaveFile(unittest.TestCase):
 
         left_tmps = [fn for fn in os.listdir('.') if fn.startswith('tmp')]
         self.assertEqual(len(left_tmps), 0)
-
-    def tearDown(self):
-        if os.path.exists('myfile.dat'):
-            os.remove('myfile.dat')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
@@ -1,6 +1,7 @@
 import unittest
 
 import mock
+import os
 
 from chainer import testing
 from chainer.training import extensions
@@ -19,6 +20,31 @@ class TestSnapshot(unittest.TestCase):
     def test_trigger(self):
         snapshot = extensions.snapshot()
         self.assertEqual(snapshot.trigger, (1, 'epoch'))
+
+
+class TestSnapshotSaveFile(unittest.TestCase):
+
+    def setUp(self):
+        self.trainer = testing.get_trainer_with_mock_updater()
+        self.trainer.out = '.'
+        self.trainer._done = True
+
+    def test_save_file(self):
+        snapshot = extensions.snapshot_object(self.trainer, 'myfile.dat')
+        snapshot(self.trainer)
+
+        self.assertTrue(os.path.exists('myfile.dat'))
+
+    def test_clean_up_tempdir(self):
+        snapshot = extensions.snapshot_object(self.trainer, 'myfile.dat')
+        snapshot(self.trainer)
+
+        left_tmps = [fn for fn in os.listdir('.') if fn.startswith('tmp')]
+        self.assertEqual(len(left_tmps), 0)
+
+    def tearDown(self):
+        if os.path.exists('myfile.dat'):
+            os.remove('myfile.dat')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
@@ -43,7 +43,8 @@ class TestSnapshotSaveFile(unittest.TestCase):
         snapshot = extensions.snapshot_object(self.trainer, 'myfile.dat')
         snapshot(self.trainer)
 
-        left_tmps = [fn for fn in os.listdir('.') if fn.startswith('tmp')]
+        left_tmps = [fn for fn in os.listdir('.')
+                     if fn.startswith('tmpmyfile.dat')]
         self.assertEqual(len(left_tmps), 0)
 
 


### PR DESCRIPTION
Currently Chainer saves every snapshots in `rw-------` permission, since it uses tempfile inside.
I think this behavior is a bit different from what users usually expect, because for example `chainer.serializers.save_npz` writes output in the OS default permission, which is typically `rw-r--r--`. File creation through Python (or OS/shell) will also follow that rule by default.

This PR creates temporary directory and write a target file into the tmp dir then move to target directory, instead of using tempfile. By this approach, snapshot will automatically have OS default permission,

#### ToDo
* ~Tests~ Done
* ~Check compatibility with older Python, other OS, ...~ (CI will do?)