### PR TITLE
Fix sectioning of "Datasets" reference

### DIFF
--- a/docs/source/reference/datasets.rst
+++ b/docs/source/reference/datasets.rst
@@ -1,7 +1,10 @@
 .. module:: chainer.dataset
 
+Datasets
+========
+
 Dataset Abstraction
-===================
+-------------------
 
 Chainer supports a common interface for training and validation of datasets. The dataset support consists of three components: datasets, iterators, and batch conversion functions.
 
@@ -67,7 +70,7 @@ Dataset Management
 .. _datasets:
 
 Examples
-========
+--------
 
 The most basic :mod:`~chainer.dataset` implementation is an array.
 Both NumPy and CuPy arrays can be used directly as datasets.
@@ -82,7 +85,7 @@ The other one is a group of concrete, popular datasets.
 These concrete examples use the downloading utilities in the :mod:`chainer.dataset` module to cache downloaded and converted datasets.
 
 General Datasets
-================
+----------------
 
 General datasets are further divided into four types.
 
@@ -166,7 +169,7 @@ LabeledImageDataset
    chainer.datasets.LabeledImageDataset
 
 Concrete Datasets
-~~~~~~~~~~~~~~~~~
+-----------------
 
 .. autosummary::
    :toctree: generated/


### PR DESCRIPTION
I found that the toc of reference manual has incorrect section levels. This PR fixes it.

Before:
![image](https://user-images.githubusercontent.com/392019/37580230-f36cc918-2b85-11e8-9d14-29307b472da3.png)

After:
![image](https://user-images.githubusercontent.com/392019/37580272-2eb4d8e4-2b86-11e8-9b90-fa306d7dc399.png)

