### PR TITLE
 Add different ResNet in which stride 2 is on 1x1 conv or 3x3 conv 

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -71,6 +71,8 @@ class ResNetLayers(link.Chain):
             ``chainer.initializers.HeNormal(scale=1.0)``.
         n_layers (int): The number of layers of this model. It should be either
             50, 101, or 152.
+        stride_1x1 (bool): Whether to place stride 2 on the 1x1 convolution.
+            Use True only for the original MSRA ResNet.
 
     Attributes:
         ~ResNetLayers.available_layers (list of str): The list of available
@@ -324,6 +326,8 @@ class ResNet50Layers(ResNetLayers):
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.HeNormal(scale=1.0)``.
+        stride_1x1 (bool): Whether to place stride 2 on the 1x1 convolution.
+            Use True only for the original MSRA ResNet.
 
     Attributes:
         ~ResNet50Layers.available_layers (list of str): The list of available
@@ -377,6 +381,8 @@ class ResNet101Layers(ResNetLayers):
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.HeNormal(scale=1.0)``.
+        stride_1x1 (bool): Whether to place stride 2 on the 1x1 convolution.
+            Use True only for the original MSRA ResNet.
 
     Attributes:
         ~ResNet101Layers.available_layers (list of str): The list of available
@@ -429,6 +435,8 @@ class ResNet152Layers(ResNetLayers):
             are not initialized by the pre-trained model, but the default
             initializer used in the original paper, i.e.,
             ``chainer.initializers.HeNormal(scale=1.0)``.
+        stride_1x1 (bool): Whether to place stride 2 on the 1x1 convolution.
+            Use True only for the original MSRA ResNet.
 
     Attributes:
         ~ResNet152Layers.available_layers (list of str): The list of available
@@ -502,6 +510,8 @@ class BuildingBlock(link.Chain):
         stride (int or tuple of ints): Stride of filter application.
         initialW (4-D array): Initial weight value used in
             the convolutional layers.
+        stride_1x1 (bool): Whether to place stride 2 on the 1x1 convolution.
+            Use True only for the original MSRA ResNet.
     """
 
     def __init__(self, n_layer, in_channels, mid_channels,
@@ -539,12 +549,16 @@ class BottleneckA(link.Chain):
         stride (int or tuple of ints): Stride of filter application.
         initialW (4-D array): Initial weight value used in
             the convolutional layers.
+        stride_1x1 (bool): Whether to place stride 2 on the 1x1 convolution.
+            Use True only for the original MSRA ResNet.
     """
 
     def __init__(self, in_channels, mid_channels, out_channels,
                  stride=2, initialW=None, stride_1x1=True):
         super(BottleneckA, self).__init__()
 
+        # In original MSRA ResNet, stride=2 is on 1x1 convolution.
+        # In facebook Torch ResNet, stride=2 is on 3x3 convolution.
         str1x1, str3x3 = (stride, 1) if stride_1x1 else (1, stride)
 
         with self.init_scope():

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -393,7 +393,8 @@ class ResNet101Layers(ResNetLayers):
     def __init__(self, pretrained_model='auto', stride_1x1=True):
         if pretrained_model == 'auto':
             pretrained_model = 'ResNet-101-model.caffemodel'
-        super(ResNet101Layers, self).__init__(pretrained_model, 101, stride_1x1)
+        super(ResNet101Layers, self).__init__(
+            pretrained_model, 101, stride_1x1)
 
 
 class ResNet152Layers(ResNetLayers):
@@ -447,7 +448,8 @@ class ResNet152Layers(ResNetLayers):
     def __init__(self, pretrained_model='auto', stride_1x1=True):
         if pretrained_model == 'auto':
             pretrained_model = 'ResNet-152-model.caffemodel'
-        super(ResNet152Layers, self).__init__(pretrained_model, 152, stride_1x1)
+        super(ResNet152Layers, self).__init__(
+            pretrained_model, 152, stride_1x1)
 
 
 def prepare(image, size=(224, 224)):
@@ -518,8 +520,8 @@ class BuildingBlock(link.Chain):
                  out_channels, stride, initialW=None, stride_1x1=True):
         super(BuildingBlock, self).__init__()
         with self.init_scope():
-            self.a = BottleneckA(in_channels, mid_channels, out_channels, stride,
-                                 initialW, stride_1x1)
+            self.a = BottleneckA(in_channels, mid_channels, out_channels,
+                                 stride, initialW, stride_1x1)
             self._forward = ["a"]
             for i in range(n_layer - 1):
                 name = 'b{}'.format(i + 1)

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -73,7 +73,7 @@ class ResNetLayers(link.Chain):
             50, 101, or 152.
         downsample_1x1 (bool): Perform downsampling by placing stride 2
             on the 1x1 convolutional layers or the 3x3 convolutional layers.
-            Use True only for the original MSRA ResNet.
+            Use ``True`` only for the original MSRA ResNet.
 
     Attributes:
         ~ResNetLayers.available_layers (list of str): The list of available
@@ -329,7 +329,7 @@ class ResNet50Layers(ResNetLayers):
             ``chainer.initializers.HeNormal(scale=1.0)``.
         downsample_1x1 (bool): Perform downsampling by placing stride 2
             on the 1x1 convolutional layers or the 3x3 convolutional layers.
-            Use True only for the original MSRA ResNet.
+            Use ``True`` only for the original MSRA ResNet.
 
     Attributes:
         ~ResNet50Layers.available_layers (list of str): The list of available
@@ -386,7 +386,7 @@ class ResNet101Layers(ResNetLayers):
             ``chainer.initializers.HeNormal(scale=1.0)``.
         downsample_1x1 (bool): Perform downsampling by placing stride 2
             on the 1x1 convolutional layers or the 3x3 convolutional layers.
-            Use True only for the original MSRA ResNet.
+            Use ``True`` only for the original MSRA ResNet.
 
     Attributes:
         ~ResNet101Layers.available_layers (list of str): The list of available
@@ -442,7 +442,7 @@ class ResNet152Layers(ResNetLayers):
             ``chainer.initializers.HeNormal(scale=1.0)``.
         downsample_1x1 (bool): Perform downsampling by placing stride 2
             on the 1x1 convolutional layers or the 3x3 convolutional layers.
-            Use True only for the original MSRA ResNet.
+            Use ``True`` only for the original MSRA ResNet.
 
     Attributes:
         ~ResNet152Layers.available_layers (list of str): The list of available
@@ -519,7 +519,7 @@ class BuildingBlock(link.Chain):
             the convolutional layers.
         downsample_1x1 (bool): Perform downsampling by placing stride 2
             on the 1x1 convolutional layers or the 3x3 convolutional layers.
-            Use True only for the original MSRA ResNet.
+            Use ``True`` only for the original MSRA ResNet.
     """
 
     def __init__(self, n_layer, in_channels, mid_channels,
@@ -559,7 +559,7 @@ class BottleneckA(link.Chain):
             the convolutional layers.
         downsample_1x1 (bool): Perform downsampling by placing stride 2
             on the 1x1 convolutional layers or the 3x3 convolutional layers.
-            Use True only for the original MSRA ResNet.
+            Use ``True`` only for the original MSRA ResNet.
     """
 
     def __init__(self, in_channels, mid_channels, out_channels,

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -13,6 +13,7 @@ from chainer.variable import Variable
 
 @testing.parameterize(*testing.product({
     'n_layers': [50, 101, 152],
+    'stride_1x1': [True, False],
 }))
 @unittest.skipUnless(resnet.available, 'Pillow is required')
 @attr.slow
@@ -20,11 +21,14 @@ class TestResNetLayers(unittest.TestCase):
 
     def setUp(self):
         if self.n_layers == 50:
-            self.link = resnet.ResNet50Layers(pretrained_model=None)
+            self.link = resnet.ResNet50Layers(pretrained_model=None,
+                                              stride_1x1=self.stride_1x1)
         elif self.n_layers == 101:
-            self.link = resnet.ResNet101Layers(pretrained_model=None)
+            self.link = resnet.ResNet101Layers(pretrained_model=None,
+                                               stride_1x1=self.stride_1x1)
         elif self.n_layers == 152:
-            self.link = resnet.ResNet152Layers(pretrained_model=None)
+            self.link = resnet.ResNet152Layers(pretrained_model=None,
+                                               stride_1x1=self.stride_1x1)
 
     def test_available_layers(self):
         result = self.link.available_layers

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -13,7 +13,7 @@ from chainer.variable import Variable
 
 @testing.parameterize(*testing.product({
     'n_layers': [50, 101, 152],
-    'stride_1x1': [True, False],
+    'downsample_1x1': [True, False],
 }))
 @unittest.skipUnless(resnet.available, 'Pillow is required')
 @attr.slow
@@ -21,14 +21,14 @@ class TestResNetLayers(unittest.TestCase):
 
     def setUp(self):
         if self.n_layers == 50:
-            self.link = resnet.ResNet50Layers(pretrained_model=None,
-                                              stride_1x1=self.stride_1x1)
+            self.link = resnet.ResNet50Layers(
+                pretrained_model=None, downsample_1x1=self.downsample_1x1)
         elif self.n_layers == 101:
-            self.link = resnet.ResNet101Layers(pretrained_model=None,
-                                               stride_1x1=self.stride_1x1)
+            self.link = resnet.ResNet101Layers(
+                pretrained_model=None, downsample_1x1=self.downsample_1x1)
         elif self.n_layers == 152:
-            self.link = resnet.ResNet152Layers(pretrained_model=None,
-                                               stride_1x1=self.stride_1x1)
+            self.link = resnet.ResNet152Layers(
+                pretrained_model=None, downsample_1x1=self.downsample_1x1)
 
     def test_available_layers(self):
         result = self.link.available_layers


### PR DESCRIPTION
Superseded by #4479 

In the original MSRA ResNet, stride 2 is applied on the 1x1 convolution of bottleneck, while in the facebook Torch model, stride 2 is placed on the 3x3 convolution of bottleneck. Accordingly, I append this different version ResNet.
