### PR TITLE
fix debug mode documentation

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -153,21 +153,21 @@ global_config.lazy_grad_sum = bool(int(
 
 
 def is_debug():
-    """Get the debug mode.
+    """Returns if the debug mode is enabled or not in the current thread.
 
     Returns:
-        bool: Return ``True`` if Chainer is in debug mode.
+        bool:  ``True`` if the debug mode is enabled.
     """
     return bool(config.debug)
 
 
 def set_debug(debug):
-    """Set the debug mode.
+    """Enables or disables the debug mode in the current thread.
 
     .. note::
 
-        This method changes the global state. When you use this method on
-        multi-threading environment, it may affect other threads.
+        ``chainer.set_debug(value)`` is equivalent to
+        ``chainer.config.debug = value``.
 
     Args:
         debug (bool): New debug mode.

--- a/docs/source/reference/debug.rst
+++ b/docs/source/reference/debug.rst
@@ -1,26 +1,25 @@
 .. _debug:
 
-Debug mode
+Debug Mode
 ==========
 
-In debug mode, Chainer checks values of variables on runtime and shows more
-detailed error messages.
+In debug mode, Chainer checks values of variables on runtime and shows more detailed error messages.
 It helps you to debug your programs.
 However, it requires some additional overhead time.
 
-You can enable debug mode with :func:`chainer.using_config`:
+If you want to enable debug mode for the entire code, you can set ``CHAINER_DEBUG`` environment variable to ``1``.
+
+You can also enable or disable debug mode for the specific scope of code with :func:`chainer.using_config` or by changing ``chainer.config.debug`` configuration.
 
 .. testcode::
 
     with chainer.using_config('debug', True):
        ...
 
-See :ref:`configuration` for Chainer's configuration mechanism.
-
-You can also set ``CHAINER_DEBUG`` environment variable to ``1`` to enable this mode.
+See :ref:`configuration` for the details of Chainer's configuration mechanism.
 
 In debug mode, Chainer checks all results of forward and backward computation, and if it finds a NaN value, it raises :class:`RuntimeError`.
-Some functions and links also check validity of input values.
+Some functions and links also check validity of input values more strictly.
 
 You can check if debug mode is enabled with :func:`chainer.is_debug` function.
 


### PR DESCRIPTION
Currently `chainer.{set.is}_debug` say they operate against global state, but it is not true as the config is now thread-local.