### PR TITLE
[backport] Fix to make it consistent with numpy.split and cupy.split

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -34,7 +34,7 @@ class SplitAxis(function_node.FunctionNode):
             if len(self.indices_or_sections) > 0:
                 max_index = type_check.make_variable(
                     self.indices_or_sections[-1], 'max_index')
-                type_check.expect(in_types[0].shape[self.axis] > max_index)
+                type_check.expect(in_types[0].shape[self.axis] >= max_index)
         else:
             sections = type_check.make_variable(
                 self.indices_or_sections, 'sections')

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -32,6 +32,63 @@ from chainer.testing import attr
         {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [0],
          'slices': [[slice(None), slice(None, 0)], [slice(None), slice(0, 7)]]
          },
+        {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [7],
+         'slices': [[slice(None), slice(None, 7)], [slice(None), slice(7, 7)]]
+         },
+        {'shape': (2, 7, 3, 2), 'axis': 1, 'ys_section': [2, 5],
+         'slices': [[slice(None), slice(None, 2)], [slice(None), slice(2, 5)],
+                    [slice(None), slice(5, None)]]},
+        {'shape': (2, 7, 3, 2), 'axis': 1, 'ys_section': [0],
+         'slices': [[slice(None), slice(None, 0)], [slice(None), slice(0, 7)]]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': 1,
+         'slices': [slice(None, None)]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': 2,
+         'slices': [slice(None, 5), slice(5, None)]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': [],
+         'slices': [slice(None, None)]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': [0, 5],
+         'slices': [slice(0, 0), slice(0, 5), slice(5, None)]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': [0, 0, 5],
+         'slices': [slice(0, 0), slice(0, 0), slice(None, 5), slice(5, None)]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': [2, 3, 5],
+         'slices': [slice(None, 2), slice(2, 3), slice(3, 5), slice(5, None)]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0,
+         'ys_section': numpy.asarray([2, 3, 5]),
+         'slices': [slice(None, 2), slice(2, 3), slice(3, 5), slice(5, None)]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': [2, 3, 3, 5],
+         'slices': [slice(None, 2), slice(2, 3), slice(3, 3), slice(3, 5),
+                    slice(5, None)]
+         },
+        {'shape': (5, 5, 3, 8), 'axis': 3, 'ys_section': 2,
+         'slices': [[slice(None, None), slice(None, None), slice(None, None),
+                     slice(None, 4)],
+                    [slice(None, None), slice(None, None), slice(None, None),
+                     slice(4, None)]]
+         },
+        {'shape': (5, 8, 3, 2), 'axis': -3, 'ys_section': 2,
+         'slices': [[slice(None, None), slice(None, 4)],
+                    [slice(None, None), slice(4, None)]]
+         },
+        {'shape': (5, 8, 3, 2), 'axis': 1, 'ys_section': 2,
+         'slices': [[slice(None, None), slice(None, 4)],
+                    [slice(None, None), slice(4, None)]]
+         },
+        {'shape': (5, 4, 3, 4), 'axis': -1, 'ys_section': 2,
+         'slices': [[slice(None, None), slice(None, None), slice(None, None),
+                     slice(None, 2)], [slice(None, None), slice(None, None),
+                                       slice(None, None), slice(2, None)]]
+         },
+        {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': numpy.array([]),
+         'slices': [slice(None, None)]
+         },
     ],
     [
         {'dtype': numpy.float16},
@@ -39,6 +96,7 @@ from chainer.testing import attr
         {'dtype': numpy.float64},
     ],
 ))
+@testing.with_requires('numpy>=1.10')
 class TestSplitAxis(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This PR is backport of #4153.