### PR TITLE
avoid running TestSplitAxis tests on NumPy 1.10

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -109,7 +109,7 @@ def inject_backend_tests(method_names):
         {'dtype': numpy.float64},
     ],
 ))
-@testing.with_requires('numpy>=1.10')
+@testing.with_requires('numpy>=1.11')
 @inject_backend_tests(['test_forward', 'test_backward'])
 class TestSplitAxis(unittest.TestCase):
 


### PR DESCRIPTION
Fix regression introduced in #4153.