### PR TITLE
Add chainer.config.dtype and use it in initializers and dataset loaders.

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -142,7 +142,12 @@ global_config.autotune = False
 global_config.use_ideep = os.environ.get('CHAINER_USE_IDEEP', 'never')
 global_config.lazy_grad_sum = bool(int(
     os.environ.get('CHAINER_LAZY_GRAD_SUM', '0')))
-global_config.dtype = numpy.dtype(os.environ.get('CHAINER_DTYPE', 'float32'))
+
+_chainer_dtype = os.environ.get('CHAINER_DTYPE', 'float32')
+if _chainer_dtype not in ('float16', 'float32', 'float64'):
+    raise TypeError('incorrect dtype name in CHAINER_DTYPE: "{}". '
+                    'Only float16/32/64 are allowed.'.format(_chainer_dtype))
+global_config.dtype = numpy.dtype(_chainer_dtype)
 
 
 def is_debug():

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -142,6 +142,7 @@ global_config.autotune = False
 global_config.use_ideep = os.environ.get('CHAINER_USE_IDEEP', 'never')
 global_config.lazy_grad_sum = bool(int(
     os.environ.get('CHAINER_LAZY_GRAD_SUM', '0')))
+global_config.dtype = numpy.dtype(os.environ.get('CHAINER_DTYPE', 'float32'))
 
 
 def is_debug():
@@ -194,6 +195,19 @@ class DebugMode(object):
 
     def __exit__(self, *args):
         self._using.__exit__(*args)
+
+
+def get_dtype(dtype=None):
+    """Resolves Chainer's default dtype.
+
+    Returns:
+        If ``dtype`` is not ``None``, it returns the dtype as is. Otherwise, it
+        returns ``chainer.config.dtype`` (see :ref:`configuration`).
+
+    """
+    if dtype is None:
+        return config.dtype
+    return dtype
 
 
 basic_math.install_variable_arithmetics()

--- a/chainer/datasets/cifar.py
+++ b/chainer/datasets/cifar.py
@@ -5,6 +5,7 @@ import tarfile
 import numpy
 import six.moves.cPickle as pickle
 
+import chainer
 from chainer.dataset import download
 from chainer.datasets import tuple_dataset
 
@@ -147,7 +148,7 @@ def _preprocess_cifar(images, labels, withlabel, ndim, scale, dtype):
         images = images.reshape(-1, 3, 32, 32)
     else:
         raise ValueError('invalid ndim for CIFAR dataset')
-    dtype = chainer._get_dtype(dtype)
+    dtype = chainer.get_dtype(dtype)
     images = images.astype(dtype)
     images *= scale / 255.
 

--- a/chainer/datasets/cifar.py
+++ b/chainer/datasets/cifar.py
@@ -9,7 +9,7 @@ from chainer.dataset import download
 from chainer.datasets import tuple_dataset
 
 
-def get_cifar10(withlabel=True, ndim=3, scale=1.):
+def get_cifar10(withlabel=True, ndim=3, scale=1., dtype=None):
     """Gets the CIFAR-10 dataset.
 
     `CIFAR-10 <https://www.cs.toronto.edu/~kriz/cifar.html>`_ is a set of small
@@ -34,6 +34,8 @@ def get_cifar10(withlabel=True, ndim=3, scale=1.):
 
         scale (float): Pixel value scale. If it is 1 (default), pixels are
             scaled to the interval ``[0, 1]``.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
 
     Returns:
         A tuple of two datasets. If ``withlabel`` is ``True``, both datasets
@@ -41,10 +43,10 @@ def get_cifar10(withlabel=True, ndim=3, scale=1.):
         datasets are arrays of images.
 
     """
-    return _get_cifar('cifar-10', withlabel, ndim, scale)
+    return _get_cifar('cifar-10', withlabel, ndim, scale, dtype)
 
 
-def get_cifar100(withlabel=True, ndim=3, scale=1.):
+def get_cifar100(withlabel=True, ndim=3, scale=1., dtype=None):
     """Gets the CIFAR-100 dataset.
 
     `CIFAR-100 <https://www.cs.toronto.edu/~kriz/cifar.html>`_ is a set of
@@ -69,6 +71,8 @@ def get_cifar100(withlabel=True, ndim=3, scale=1.):
 
         scale (float): Pixel value scale. If it is 1 (default), pixels are
             scaled to the interval ``[0, 1]``.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
 
     Returns:
         A tuple of two datasets. If ``withlabel`` is ``True``, both
@@ -76,10 +80,10 @@ def get_cifar100(withlabel=True, ndim=3, scale=1.):
         datasets are arrays of images.
 
     """
-    return _get_cifar('cifar-100', withlabel, ndim, scale)
+    return _get_cifar('cifar-100', withlabel, ndim, scale, dtype)
 
 
-def _get_cifar(name, withlabel, ndim, scale):
+def _get_cifar(name, withlabel, ndim, scale, dtype):
     root = download.get_dataset_directory(os.path.join('pfnet', 'chainer',
                                                        'cifar'))
     npz_path = os.path.join(root, '{}.npz'.format(name))
@@ -130,20 +134,21 @@ def _get_cifar(name, withlabel, ndim, scale):
 
     raw = download.cache_or_load_file(npz_path, creator, numpy.load)
     train = _preprocess_cifar(raw['train_x'], raw['train_y'], withlabel,
-                              ndim, scale)
+                              ndim, scale, dtype)
     test = _preprocess_cifar(raw['test_x'], raw['test_y'], withlabel, ndim,
-                             scale)
+                             scale, dtype)
     return train, test
 
 
-def _preprocess_cifar(images, labels, withlabel, ndim, scale):
+def _preprocess_cifar(images, labels, withlabel, ndim, scale, dtype):
     if ndim == 1:
         images = images.reshape(-1, 3072)
     elif ndim == 3:
         images = images.reshape(-1, 3, 32, 32)
     else:
         raise ValueError('invalid ndim for CIFAR dataset')
-    images = images.astype(numpy.float32)
+    dtype = chainer._get_dtype(dtype)
+    images = images.astype(dtype)
     images *= scale / 255.
 
     if withlabel:

--- a/chainer/datasets/fashion_mnist.py
+++ b/chainer/datasets/fashion_mnist.py
@@ -2,12 +2,13 @@ import os
 
 import numpy
 
+import chainer
 from chainer.dataset import download
 from chainer.datasets._mnist_helper import make_npz
 from chainer.datasets._mnist_helper import preprocess_mnist
 
 
-def get_fashion_mnist(withlabel=True, ndim=1, scale=1., dtype=numpy.float32,
+def get_fashion_mnist(withlabel=True, ndim=1, scale=1., dtype=None,
                       label_dtype=numpy.int32, rgb_format=False):
     """Gets the Fashion-MNIST dataset.
 
@@ -34,7 +35,8 @@ def get_fashion_mnist(withlabel=True, ndim=1, scale=1., dtype=numpy.float32,
 
         scale (float): Pixel value scale. If it is 1 (default), pixels are
             scaled to the interval ``[0, 1]``.
-        dtype: Data type of resulting image arrays.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
         label_dtype: Data type of the labels.
         rgb_format (bool): if ``ndim == 3`` and ``rgb_format`` is ``True``, the
             image will be converted to rgb format by duplicating the channels
@@ -47,6 +49,8 @@ def get_fashion_mnist(withlabel=True, ndim=1, scale=1., dtype=numpy.float32,
 
     """
     train_raw = _retrieve_fashion_mnist_training()
+    dtype = chainer.get_dtype(dtype)
+
     train = preprocess_mnist(train_raw, withlabel, ndim, scale, dtype,
                              label_dtype, rgb_format)
     test_raw = _retrieve_fashion_mnist_test()

--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -216,7 +216,7 @@ class ZippedImageDataset(dataset_mixin.DatasetMixin):
 
     """
 
-    def __init__(self, zipfilename, dtype=numpy.float32):
+    def __init__(self, zipfilename, dtype=None):
         self._zipfilename = zipfilename
         self._zf = zipfile.ZipFile(zipfilename)
         self._zf_pid = os.getpid()

--- a/chainer/datasets/image_dataset.py
+++ b/chainer/datasets/image_dataset.py
@@ -13,6 +13,7 @@ import six
 import threading
 import zipfile
 
+import chainer
 from chainer.dataset import dataset_mixin
 
 
@@ -69,18 +70,19 @@ class ImageDataset(dataset_mixin.DatasetMixin):
             ``i``-th image. In both cases, each path is a relative one from the
             root path given by another argument.
         root (str): Root directory to retrieve images from.
-        dtype: Data type of resulting image arrays.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
 
     """
 
-    def __init__(self, paths, root='.', dtype=numpy.float32):
+    def __init__(self, paths, root='.', dtype=None):
         _check_pillow_availability()
         if isinstance(paths, six.string_types):
             with open(paths) as paths_file:
                 paths = [path.strip() for path in paths_file]
         self._paths = paths
         self._root = root
-        self._dtype = dtype
+        self._dtype = chainer.get_dtype(dtype)
 
     def __len__(self):
         return len(self._paths)
@@ -125,13 +127,13 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
             each path is a relative one from the root path given by another
             argument.
         root (str): Root directory to retrieve images from.
-        dtype: Data type of resulting image arrays.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
         label_dtype: Data type of the labels.
 
     """
 
-    def __init__(self, pairs, root='.', dtype=numpy.float32,
-                 label_dtype=numpy.int32):
+    def __init__(self, pairs, root='.', dtype=None, label_dtype=numpy.int32):
         _check_pillow_availability()
         if isinstance(pairs, six.string_types):
             pairs_path = pairs
@@ -146,7 +148,7 @@ class LabeledImageDataset(dataset_mixin.DatasetMixin):
                     pairs.append((pair[0], int(pair[1])))
         self._pairs = pairs
         self._root = root
-        self._dtype = dtype
+        self._dtype = chainer.get_dtype(dtype)
         self._label_dtype = label_dtype
 
     def __len__(self):
@@ -172,10 +174,11 @@ class MultiZippedImageDataset(dataset_mixin.DatasetMixin):
 
     Args:
         zipfilenames (list of strings): List of zipped archive filename.
-        dtype: Data type of resulting image arrays.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
     """
 
-    def __init__(self, zipfilenames, dtype=numpy.float32):
+    def __init__(self, zipfilenames, dtype=None):
         self._zfs = [ZippedImageDataset(fn, dtype) for fn in zipfilenames]
         self._zpaths_accumlens = [0]
         zplen = 0
@@ -208,7 +211,8 @@ class ZippedImageDataset(dataset_mixin.DatasetMixin):
 
     Args:
         zipfilename (str): a string to point zipfile path
-        dtype: Data type of resulting image arrays
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
 
     """
 
@@ -216,7 +220,7 @@ class ZippedImageDataset(dataset_mixin.DatasetMixin):
         self._zipfilename = zipfilename
         self._zf = zipfile.ZipFile(zipfilename)
         self._zf_pid = os.getpid()
-        self._dtype = dtype
+        self._dtype = chainer.get_dtype(dtype)
         self._paths = [x for x in self._zf.namelist() if not x.endswith('/')]
         self._lock = threading.Lock()
 

--- a/chainer/datasets/mnist.py
+++ b/chainer/datasets/mnist.py
@@ -2,12 +2,13 @@ import os
 
 import numpy
 
+import chainer
 from chainer.dataset import download
 from chainer.datasets._mnist_helper import make_npz
 from chainer.datasets._mnist_helper import preprocess_mnist
 
 
-def get_mnist(withlabel=True, ndim=1, scale=1., dtype=numpy.float32,
+def get_mnist(withlabel=True, ndim=1, scale=1., dtype=None,
               label_dtype=numpy.int32, rgb_format=False):
     """Gets the MNIST dataset.
 
@@ -33,7 +34,8 @@ def get_mnist(withlabel=True, ndim=1, scale=1., dtype=numpy.float32,
 
         scale (float): Pixel value scale. If it is 1 (default), pixels are
             scaled to the interval ``[0, 1]``.
-        dtype: Data type of resulting image arrays.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
         label_dtype: Data type of the labels.
         rgb_format (bool): if ``ndim == 3`` and ``rgb_format`` is ``True``, the
             image will be converted to rgb format by duplicating the channels
@@ -45,6 +47,7 @@ def get_mnist(withlabel=True, ndim=1, scale=1., dtype=numpy.float32,
         datasets are arrays of images.
 
     """
+    dtype = chainer.get_dtype(dtype)
     train_raw = _retrieve_mnist_training()
     train = preprocess_mnist(train_raw, withlabel, ndim, scale, dtype,
                              label_dtype, rgb_format)

--- a/chainer/datasets/svhn.py
+++ b/chainer/datasets/svhn.py
@@ -8,12 +8,13 @@ except Exception as e:
     _error = e
     _scipy_available = False
 
+import chainer
 from chainer.dataset import download
 from chainer.datasets import tuple_dataset
 
 
-def get_svhn(withlabel=True, scale=1., dtype=numpy.float32,
-             label_dtype=numpy.int32, add_extra=False):
+def get_svhn(withlabel=True, scale=1., dtype=None, label_dtype=numpy.int32,
+             add_extra=False):
     """Gets the SVHN dataset.
 
     `The Street View House Numbers (SVHN) dataset <http://ufldl.stanford.edu/housenumbers/>`_
@@ -32,7 +33,8 @@ def get_svhn(withlabel=True, scale=1., dtype=numpy.float32,
             the datasets only contain images.
         scale (float): Pixel value scale. If it is 1 (default), pixels are
             scaled to the interval ``[0, 1]``.
-        dtype: Data type of resulting image arrays.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
         label_dtype: Data type of the labels.
         add_extra: Use extra training set.
 
@@ -47,6 +49,8 @@ def get_svhn(withlabel=True, scale=1., dtype=numpy.float32,
         raise RuntimeError('SciPy is not available: %s' % _error)
 
     train_raw = _retrieve_svhn_training()
+    dtype = chainer.get_dtype(dtype)
+
     train = _preprocess_svhn(train_raw, withlabel, scale, dtype,
                              label_dtype)
     test_raw = _retrieve_svhn_test()

--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -1,5 +1,7 @@
 import numpy
 
+import chainer
+
 # import classes and functions
 from chainer.initializers.constant import Constant
 from chainer.initializers.constant import Identity  # NOQA

--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -21,8 +21,9 @@ def generate_array(initializer, shape, xp):
     """Return initialized array.
 
     The algorithms used to make the new values depend on the
-    concrete derived classes. The dtype of a generated array depends on
-    ``initializer.dtype``.
+    concrete derived classes. If the initializer has the ``dtype`` attribute,
+    it is used to construct the array. Otherwise, ``chainer.config.dtype`` is
+    used instead. See :ref:`configuration` for the dtype config.
 
     Args:
         initializer: A callable object that takes :class:`numpy.ndarray`
@@ -34,9 +35,7 @@ def generate_array(initializer, shape, xp):
         numpy.ndarray or cupy.ndarray: An initialized array.
 
     """
-    dtype = numpy.float32
-    if hasattr(initializer, 'dtype') and initializer.dtype is not None:
-        dtype = initializer.dtype
+    dtype = chainer.get_dtype(getattr(initializer, 'dtype', None))
     array = xp.empty(shape, dtype=dtype)
     initializer(array)
     return array

--- a/docs/source/reference/configuration.rst
+++ b/docs/source/reference/configuration.rst
@@ -35,6 +35,10 @@ Note that the default values are set in the global config.
    If it is ``True``, Chainer runs in the debug mode.
    See :ref:`debug` for more information of the debug mode.
    The default value is given by ``CHAINER_DEBUG`` environment variable (set to 0 or 1) if available, otherwise uses ``False``.
+``chainer.config.dtype``
+   Default floating point data type.
+   Chainer uses this dtype to construct arrays when the dtype is not specified (e.g. initializers).
+   The default valus is given by ``CHAINER_DTYPE`` environment variable if available, otherwise uses ``numpy.float32``.
 ``chainer.config.enable_backprop``
    Flag to enable backpropagation support.
    If it is ``True``, computational graphs are created during forward passes by :class:`FunctionNode`\\ s, allowing backpropagation to start from any :class:`Variable` in the graph.
@@ -163,6 +167,17 @@ There are two ways:
    chainer.using_config
    chainer.configuration.GlobalConfig
    chainer.configuration.LocalConfig
+
+
+Related functions
+~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.get_dtype
+
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/reference/initializers.rst
+++ b/docs/source/reference/initializers.rst
@@ -30,6 +30,11 @@ Base class
 
 .. module:: chainer.initializers
 
+..
+   This currentmodule directive is to avoid the reference error due to
+   initializers/__init__.py importing chainer.
+.. currentmodule:: chainer
+
 Concrete initializers
 ---------------------
 

--- a/tests/chainer_tests/initializer_tests/test_init.py
+++ b/tests/chainer_tests/initializer_tests/test_init.py
@@ -1,9 +1,33 @@
+import os
 import unittest
 
+import chainer
 from chainer import initializers
 from chainer import testing
 
 import numpy
+
+
+class TestGenerateArray(unittest.TestCase):
+
+    def _generate_array(self, dtype=None):
+        initializer = initializers.Zero(dtype)
+        return initializers.generate_array(initializer, (), numpy)
+
+    def test_default_init(self):
+        default_dtype = os.environ.get('CHAINER_DTYPE', 'float32')
+        array = self._generate_array()
+        self.assertEqual(default_dtype, array.dtype)
+
+    def test_custom_init(self):
+        with chainer.using_config('dtype', 'float16'):
+            array = self._generate_array()
+        self.assertEqual('float16', array.dtype)
+
+    def test_init_with_initializer_dtype(self):
+        with chainer.using_config('dtype', 'float16'):
+            array = self._generate_array('float64')
+        self.assertEqual('float64', array.dtype)
 
 
 class TestGetInitializer(unittest.TestCase):


### PR DESCRIPTION
This PR aims at making it easy to use fp16. By setting an environment variable `CHAINER_DTYPE=float16`, you can let weight initializers and datasets generate fp16 arrays by default instead of fp32. It makes each model definition independent from which dtype to use.

I confirmed that MNIST example runs without modifying other parts (except the eps parameter of Adam, whose default value is too small for fp16). This change does not alter the behavior of existing code unless `CHAINER_DTYPE` is set.