### PR TITLE
Support deserializing into array of different dtype

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -138,7 +138,7 @@ class HDF5Deserializer(serializer.Deserializer):
         if isinstance(value, numpy.ndarray):
             dataset.read_direct(value)
         elif isinstance(value, cuda.ndarray):
-            value.set(numpy.asarray(dataset))
+            value.set(numpy.asarray(dataset, dtype=value.dtype))
         else:
             value = type(value)(numpy.asarray(dataset))
         return value

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -148,7 +148,7 @@ class NpzDeserializer(serializer.Deserializer):
         elif isinstance(value, numpy.ndarray):
             numpy.copyto(value, dataset)
         elif isinstance(value, cuda.ndarray):
-            value.set(numpy.asarray(dataset))
+            value.set(numpy.asarray(dataset, dtype=value.dtype))
         else:
             value = type(value)(numpy.asarray(dataset))
         return value

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -153,6 +153,15 @@ class TestHDF5Deserializer(unittest.TestCase):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize_none_value(cuda.to_gpu(y))
 
+    def test_deserialize_different_dtype_cpu(self):
+        y = numpy.empty((2, 3), dtype=numpy.float16)
+        self.check_deserialize(y)
+
+    @attr.gpu
+    def test_deserialize_different_dtype_gpu(self):
+        y = numpy.empty((2, 3), dtype=numpy.float16)
+        self.check_deserialize(cuda.to_gpu(y))
+
     def test_deserialize_scalar(self):
         z = 5
         ret = self.deserializer('z', z)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -151,6 +151,20 @@ class TestNpzDeserializer(unittest.TestCase):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(cuda.to_gpu(y), '/y')
 
+    def test_deserialize_different_dtype_cpu(self):
+        y = numpy.empty((2, 3), dtype=numpy.float16)
+        ret = self.deserializer('y', y)
+        numpy.testing.assert_array_equal(y, self.data.astype(numpy.float16))
+        self.assertIs(ret, y)
+
+    @attr.gpu
+    def test_deserialize_different_dtype_gpu(self):
+        y = cuda.cupy.empty((2, 3), dtype=numpy.float16)
+        ret = self.deserializer('y', y)
+        numpy.testing.assert_array_equal(
+            y.get(), self.data.astype(numpy.float16))
+        self.assertIs(ret, y)
+
     def test_deserialize_scalar(self):
         z = 5
         ret = self.deserializer('z', z)


### PR DESCRIPTION
This PR makes deserializers support loading into arrays with different dtypes. It enables us to choose the dtype used in inference independently from the dtype used in training.