### PR TITLE
fix docs in {convolution,deconvolution}_2d

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -513,12 +513,15 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, cover_all=False, **kwargs):
         pad (:class:`int` or pair of :class:`int` s):
             Spatial padding width for input arrays.
             ``pad=p`` and ``pad=(p, p)`` are equivalent.
-        cover_all (bool): If ``True``, all spatial locations are convoluted
-            into some output pixels.
-        dilate (int or pair of ints): Dilation factor of filter applications.
+        cover_all (:class:`bool`):
+            If ``True``, all spatial locations are convoluted into some output
+            pixels.
+        dilate (:class:`int` or pair of :class:`int` s):
+            Dilation factor of filter applications.
             ``dilate=d`` and ``dilate=(d, d)`` are equivalent.
-        groups (int): The number of groups to use grouped convolution. The
-            default is one, where grouped convolution is not used.
+        groups (:class:`int`):
+            The number of groups to use grouped convolution.
+            The default is one, where grouped convolution is not used.
 
     Returns:
         ~chainer.Variable:

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -299,7 +299,7 @@ class Deconvolution2DFunction(function_node.FunctionNode):
 
 
 def deconvolution_2d(x, W, b=None, stride=1, pad=0, outsize=None, **kwargs):
-    """deconvolution_2d(x, W, b=None, stride=1, pad=0, outsize=None, *, groups=1)
+    """deconvolution_2d(x, W, b=None, stride=1, pad=0, outsize=None, *, dilate=1, groups=1)
 
     Two dimensional deconvolution function.
 
@@ -371,8 +371,12 @@ http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf
             It should be pair of height and width :math:`(h_O, w_O)`.
             Default value is ``None`` and the outsize is estimated by
             input size, stride and pad.
-        groups (int): The number of groups to use grouped deconvolution. The
-            default is one, where grouped deconvolution is not used.
+        dilate (:class:`int` or pair of :class:`int` s):
+            Dilation factor of filter applications.
+            ``dilate=d`` and ``dilate=(d, d)`` are equivalent.
+        groups (:class:`int`):
+            The number of groups to use grouped deconvolution.
+            The default is one, where grouped deconvolution is not used.
 
     Returns:
         ~chainer.Variable:
@@ -405,7 +409,7 @@ astype(np.float32)
         True
 
 
-    """
+    """  # NOQA
     argument.check_unexpected_kwargs(
         kwargs, deterministic="deterministic argument is not "
         "supported anymore. "

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -7,7 +7,7 @@ from chainer import variable
 
 class Convolution2D(link.Link):
 
-    """__init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0, nobias=False, initialW=None, initial_bias=None, *, groups=1)
+    """__init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0, nobias=False, initialW=None, initial_bias=None, *, dilate=1, groups=1)
 
     Two-dimensional convolutional layer.
 
@@ -48,6 +48,9 @@ class Convolution2D(link.Link):
         initial_bias (:ref:`initializer <initializer>`): Initializer to
             initialize the bias. If ``None``, the bias will be initialized to
             zero. When it is :class:`numpy.ndarray`, its ``ndim`` should be 1.
+        dilate (int or pair of ints):
+            Dilation factor of filter applications.
+            ``dilate=d`` and ``dilate=(d, d)`` are equivalent.
         groups (int): The number of groups to use grouped convolution. The
             default is one, where grouped convolution is not used.
 


### PR DESCRIPTION
``dilated`` option were not completely documented.
I also unified the usage of `:class:` in each pydoc.