### PR TITLE
Simplify TestSoftmaxCrossEntropyInvalidReduce in test_softmax_cross_entropy

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -454,9 +454,6 @@ class TestElementwiseSoftmaxCrossEntropy(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'use_cudnn': ['always', 'auto', 'never'],
-    'normalize': [True, False],
-    'cache_score': [True, False],
     'enable_double_backprop': [True, False],
 }))
 class TestSoftmaxCrossEntropyInvalidReduce(unittest.TestCase):
@@ -466,12 +463,11 @@ class TestSoftmaxCrossEntropyInvalidReduce(unittest.TestCase):
         self.t = numpy.zeros((2,), 'i')
 
     def check_invalid_reduce(self, x, t):
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            with self.assertRaises(ValueError):
-                functions.softmax_cross_entropy(
-                    x, t, self.normalize, self.cache_score,
-                    reduce='unknown_reduce_type',
-                    enable_double_backprop=self.enable_double_backprop)
+        with self.assertRaises(ValueError):
+            functions.softmax_cross_entropy(
+                x, t,
+                reduce='unknown_reduce_type',
+                enable_double_backprop=self.enable_double_backprop)
 
     def test_invalid_reduce_cpu(self):
         self.check_invalid_reduce(self.x, self.t)


### PR DESCRIPTION
This test focuses on `reduce='unknown_reduce_type'`.
This PR is related to #3409.
