### PR TITLE
Implement interface to print runtime information

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -21,6 +21,8 @@ from chainer import training  # NOQA
 
 # import class and function
 # These functions from backends.cuda are kept for backward compatibility
+from chainer._runtime_info import get_runtime_info  # NOQA
+from chainer._runtime_info import print_runtime_info  # NOQA
 from chainer.backends.cuda import should_use_cudnn  # NOQA
 from chainer.backends.cuda import should_use_cudnn_tensor_core  # NOQA
 from chainer.configuration import config  # NOQA

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -21,7 +21,6 @@ from chainer import training  # NOQA
 
 # import class and function
 # These functions from backends.cuda are kept for backward compatibility
-from chainer._runtime_info import get_runtime_info  # NOQA
 from chainer._runtime_info import print_runtime_info  # NOQA
 from chainer.backends.cuda import should_use_cudnn  # NOQA
 from chainer.backends.cuda import should_use_cudnn_tensor_core  # NOQA

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -1,0 +1,41 @@
+import sys
+
+import numpy
+import six
+
+import chainer
+from chainer.backends import cuda
+
+
+class _RuntimeInfo(object):
+
+    chainer_version = None
+    numpy_version = None
+    cupy_info = None
+
+    def __init__(self):
+        self.chainer_version = chainer.__version__
+        self.numpy_version = numpy.__version__
+        self.cupy_info = cuda.get_runtime_info()
+
+    def __str__(self):
+        s = six.StringIO()
+        s.write('''Chainer: {}\n'''.format(self.chainer_version))
+        s.write('''NumPy: {}\n'''.format(self.numpy_version))
+        s.write(str(self.cupy_info))
+        return s.getvalue()
+
+
+def get_runtime_info(as_text=False):
+    ri = _RuntimeInfo()
+    if as_text:
+        return str(ri)
+    else:
+        return ri
+
+
+def print_runtime_info(out=None):
+    if out is None:
+        out = sys.stdout
+    text = get_runtime_info(as_text=True)
+    out.write(text)

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -11,18 +11,18 @@ class _RuntimeInfo(object):
 
     chainer_version = None
     numpy_version = None
-    cupy_info = None
+    cuda_info = None
 
     def __init__(self):
         self.chainer_version = chainer.__version__
         self.numpy_version = numpy.__version__
-        self.cupy_info = cuda.get_runtime_info()
+        self.cuda_info = cuda.get_runtime_info()
 
     def __str__(self):
         s = six.StringIO()
         s.write('''Chainer: {}\n'''.format(self.chainer_version))
         s.write('''NumPy: {}\n'''.format(self.numpy_version))
-        s.write(str(self.cupy_info))
+        s.write(str(self.cuda_info))
         return s.getvalue()
 
 

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -26,16 +26,11 @@ class _RuntimeInfo(object):
         return s.getvalue()
 
 
-def get_runtime_info(as_text=False):
-    ri = _RuntimeInfo()
-    if as_text:
-        return str(ri)
-    else:
-        return ri
+def get_runtime_info():
+    return _RuntimeInfo()
 
 
 def print_runtime_info(out=None):
     if out is None:
         out = sys.stdout
-    text = get_runtime_info(as_text=True)
-    out.write(text)
+    out.write(str(get_runtime_info()))

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -16,13 +16,15 @@ class _RuntimeInfo(object):
     def __init__(self):
         self.chainer_version = chainer.__version__
         self.numpy_version = numpy.__version__
-        self.cuda_info = cuda.get_runtime_info()
+        self.cuda_info = cuda.cupyx.get_runtime_info()
 
     def __str__(self):
         s = six.StringIO()
         s.write('''Chainer: {}\n'''.format(self.chainer_version))
         s.write('''NumPy: {}\n'''.format(self.numpy_version))
-        s.write(str(self.cuda_info))
+        s.write('''CuPy:\n''')
+        for line in str(self.cuda_info).splitlines():
+            s.write('''  {}\n'''.format(line))
         return s.getvalue()
 
 

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -42,4 +42,5 @@ def print_runtime_info(out=None):
     if out is None:
         out = sys.stdout
     out.write(str(get_runtime_info()))
-    out.flush()
+    if hasattr(out, 'flush'):
+        out.flush()

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -42,3 +42,4 @@ def print_runtime_info(out=None):
     if out is None:
         out = sys.stdout
     out.write(str(get_runtime_info()))
+    out.flush()

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -16,15 +16,21 @@ class _RuntimeInfo(object):
     def __init__(self):
         self.chainer_version = chainer.__version__
         self.numpy_version = numpy.__version__
-        self.cuda_info = cuda.cupyx.get_runtime_info()
+        if cuda.available:
+            self.cuda_info = cuda.cupyx.get_runtime_info()
+        else:
+            self.cuda_info = None
 
     def __str__(self):
         s = six.StringIO()
         s.write('''Chainer: {}\n'''.format(self.chainer_version))
         s.write('''NumPy: {}\n'''.format(self.numpy_version))
-        s.write('''CuPy:\n''')
-        for line in str(self.cuda_info).splitlines():
-            s.write('''  {}\n'''.format(line))
+        if self.cuda_info is None:
+            s.write('''CuPy: Not Available\n''')
+        else:
+            s.write('''CuPy:\n''')
+            for line in str(self.cuda_info).splitlines():
+                s.write('''  {}\n'''.format(line))
         return s.getvalue()
 
 

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -104,8 +104,8 @@ class _CudaRuntimeInfo(object):
         s = six.StringIO()
         s.write('''CuPy: {}\n'''.format(self.cupy_version))
         if self.cupy_version is not None:
-            s.write('''CUDA runtime: {}\n'''.format(self.cuda_runtime_version))
             s.write('''CUDA driver: {}\n'''.format(self.cuda_driver_version))
+            s.write('''CUDA runtime: {}\n'''.format(self.cuda_runtime_version))
             s.write('''cuDNN: {}\n'''.format(self.cudnn_version))
             s.write('''cuDNN enabled: {}\n'''.format(self.cudnn_enabled))
             s.write('''NCCL: {}\n'''.format(self.nccl_version))

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -74,46 +74,7 @@ if available:
         cudnn = cupy.cudnn
         cudnn_enabled = not _cudnn_disabled_by_user
     except Exception as e:
-        cudnn = None
         _resolution_error = e
-
-
-class _CudaRuntimeInfo(object):
-
-    cupy_version = None
-    cuda_runtime_version = None
-    cuda_driver_version = None
-    cudnn_version = None
-    cudnn_enabled = False
-    nccl_version = None
-
-    def __init__(self):
-        if available:
-            self.cupy_version = cupy.__version__
-            self.cuda_runtime_version = cuda.runtime.runtimeGetVersion()
-            self.cuda_driver_version = cuda.runtime.driverGetVersion()
-            if cudnn is not None:
-                self.cudnn_version = cuda.cudnn.getVersion()
-                self.cudnn_enabled = cudnn_enabled
-            try:
-                self.nccl_version = cuda.nccl.get_version()
-            except AttributeError:
-                pass
-
-    def __str__(self):
-        s = six.StringIO()
-        s.write('''CuPy: {}\n'''.format(self.cupy_version))
-        if self.cupy_version is not None:
-            s.write('''CUDA driver: {}\n'''.format(self.cuda_driver_version))
-            s.write('''CUDA runtime: {}\n'''.format(self.cuda_runtime_version))
-            s.write('''cuDNN: {}\n'''.format(self.cudnn_version))
-            s.write('''cuDNN enabled: {}\n'''.format(self.cudnn_enabled))
-            s.write('''NCCL: {}\n'''.format(self.nccl_version))
-        return s.getvalue()
-
-
-def get_runtime_info():
-    return _CudaRuntimeInfo()
 
 
 def check_cuda_available():

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -74,7 +74,46 @@ if available:
         cudnn = cupy.cudnn
         cudnn_enabled = not _cudnn_disabled_by_user
     except Exception as e:
+        cudnn = None
         _resolution_error = e
+
+
+class _CudaRuntimeInfo(object):
+
+    cupy_version = None
+    cuda_runtime_version = None
+    cuda_driver_version = None
+    cudnn_version = None
+    cudnn_enabled = False
+    nccl_version = None
+
+    def __init__(self):
+        if available:
+            self.cupy_version = cupy.__version__
+            self.cuda_runtime_version = cuda.runtime.runtimeGetVersion()
+            self.cuda_driver_version = cuda.runtime.driverGetVersion()
+            if cudnn is not None:
+                self.cudnn_version = cuda.cudnn.getVersion()
+                self.cudnn_enabled = cudnn_enabled
+            try:
+                self.nccl_version = cuda.nccl.get_version()
+            except AttributeError:
+                pass
+
+    def __str__(self):
+        s = six.StringIO()
+        s.write('''CuPy: {}\n'''.format(self.cupy_version))
+        if self.cupy_version is not None:
+            s.write('''CUDA runtime: {}\n'''.format(self.cuda_runtime_version))
+            s.write('''CUDA driver: {}\n'''.format(self.cuda_driver_version))
+            s.write('''cuDNN: {}\n'''.format(self.cudnn_version))
+            s.write('''cuDNN enabled: {}\n'''.format(self.cudnn_enabled))
+            s.write('''NCCL: {}\n'''.format(self.nccl_version))
+        return s.getvalue()
+
+
+def get_runtime_info():
+    return _CudaRuntimeInfo()
 
 
 def check_cuda_available():

--- a/tests/chainer_tests/test_runtime_info.py
+++ b/tests/chainer_tests/test_runtime_info.py
@@ -1,0 +1,17 @@
+import unittest
+
+import six
+
+import chainer
+from chainer import _runtime_info
+
+
+class TestRuntimeInfo(unittest.TestCase):
+    def test_get_runtime_info(self):
+        info = _runtime_info.get_runtime_info()
+        assert chainer.__version__ in str(info)
+
+    def test_print_runtime_info(self):
+        out = six.StringIO()
+        _runtime_info.print_runtime_info(out)
+        assert out.getvalue() == str(_runtime_info.get_runtime_info())

--- a/tests/chainer_tests/test_runtime_info.py
+++ b/tests/chainer_tests/test_runtime_info.py
@@ -4,6 +4,7 @@ import six
 
 import chainer
 from chainer import _runtime_info
+from chainer import testing
 
 
 class TestRuntimeInfo(unittest.TestCase):
@@ -15,3 +16,6 @@ class TestRuntimeInfo(unittest.TestCase):
         out = six.StringIO()
         _runtime_info.print_runtime_info(out)
         assert out.getvalue() == str(_runtime_info.get_runtime_info())
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
Implements interface to print runtime information. Took over #4298.
Requires https://github.com/cupy/cupy/pull/1067.

~~TODO: add test.~~ (done)