### PR TITLE
Fix group argument of {de,}convolution_2d to keyword-only argument. 

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -556,7 +556,7 @@ cover_all=True)
         >>> y.shape == (n, c_o, h_o, w_o + 1)
         True
 
-    """
+    """  # NOQA
     argument.check_unexpected_kwargs(
         kwargs, deterministic="deterministic argument is not "
         "supported anymore. "

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -25,7 +25,7 @@ class Convolution2DFunction(function_node.FunctionNode):
 
     _use_ideep = False
 
-    def __init__(self, stride=1, pad=0, cover_all=False, groups=1, **kwargs):
+    def __init__(self, stride=1, pad=0, cover_all=False, **kwargs):
         argument.check_unexpected_kwargs(
             kwargs,
             deterministic="deterministic argument is not supported anymore. "
@@ -36,7 +36,8 @@ class Convolution2DFunction(function_node.FunctionNode):
             "the gradient w.r.t. x is automatically decided during "
             "backpropagation."
         )
-        dilate, = argument.parse_kwargs(kwargs, ('dilate', 1))
+        dilate, groups = argument.parse_kwargs(kwargs,
+                                               ('dilate', 1), ('groups', 1))
 
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
@@ -426,9 +427,8 @@ class Convolution2DGradW(function_node.FunctionNode):
         return ret
 
 
-def convolution_2d(x, W, b=None, stride=1, pad=0, cover_all=False, groups=1,
-                   **kwargs):
-    """convolution_2d(x, W, b=None, stride=1, pad=0, cover_all=False, *, dilate=1)
+def convolution_2d(x, W, b=None, stride=1, pad=0, cover_all=False, **kwargs):
+    """convolution_2d(x, W, b=None, stride=1, pad=0, cover_all=False, *, dilate=1, groups=1)
 
     Two-dimensional convolution function.
 
@@ -517,6 +517,8 @@ def convolution_2d(x, W, b=None, stride=1, pad=0, cover_all=False, groups=1,
             into some output pixels.
         dilate (int or pair of ints): Dilation factor of filter applications.
             ``dilate=d`` and ``dilate=(d, d)`` are equivalent.
+        groups (int): The number of groups to use grouped convolution. The
+            default is one, where grouped convolution is not used.
 
     Returns:
         ~chainer.Variable:
@@ -560,7 +562,8 @@ cover_all=True)
         "supported anymore. "
         "Use chainer.using_config('cudnn_deterministic', value) "
         "context where value is either `True` or `False`.")
-    dilate, = argument.parse_kwargs(kwargs, ('dilate', 1))
+    dilate, groups = argument.parse_kwargs(kwargs,
+                                           ('dilate', 1), ('groups', 1))
 
     fnode = Convolution2DFunction(stride, pad, cover_all, dilate=dilate,
                                   groups=groups)

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -27,7 +27,7 @@ class Deconvolution2DFunction(function_node.FunctionNode):
     cover_all = None
     _use_ideep = False
 
-    def __init__(self, stride=1, pad=0, outsize=None, groups=1, **kwargs):
+    def __init__(self, stride=1, pad=0, outsize=None, **kwargs):
         argument.check_unexpected_kwargs(
             kwargs,
             deterministic="deterministic argument is not supported anymore. "
@@ -38,7 +38,8 @@ class Deconvolution2DFunction(function_node.FunctionNode):
             "the gradient w.r.t. x is automatically decided during "
             "backpropagation."
         )
-        dilate, = argument.parse_kwargs(kwargs, ('dilate', 1))
+        dilate, groups = argument.parse_kwargs(kwargs,
+                                               ('dilate', 1), ('groups', 1))
 
         self.sy, self.sx = _pair(stride)
         self.ph, self.pw = _pair(pad)
@@ -297,9 +298,8 @@ class Deconvolution2DFunction(function_node.FunctionNode):
                                           self.pw, d=self.dx))
 
 
-def deconvolution_2d(x, W, b=None, stride=1, pad=0, outsize=None, groups=1,
-                     **kwargs):
-    """deconvolution_2d(x, W, b=None, stride=1, pad=0, outsize=None)
+def deconvolution_2d(x, W, b=None, stride=1, pad=0, outsize=None, **kwargs):
+    """deconvolution_2d(x, W, b=None, stride=1, pad=0, outsize=None, *, groups=1)
 
     Two dimensional deconvolution function.
 
@@ -371,6 +371,8 @@ http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf
             It should be pair of height and width :math:`(h_O, w_O)`.
             Default value is ``None`` and the outsize is estimated by
             input size, stride and pad.
+        groups (int): The number of groups to use grouped deconvolution. The
+            default is one, where grouped deconvolution is not used.
 
     Returns:
         ~chainer.Variable:
@@ -409,7 +411,8 @@ astype(np.float32)
         "supported anymore. "
         "Use chainer.using_config('cudnn_deterministic', value) "
         "context where value is either `True` or `False`.")
-    dilate, = argument.parse_kwargs(kwargs, ('dilate', 1))
+    dilate, groups = argument.parse_kwargs(kwargs,
+                                           ('dilate', 1), ('groups', 1))
 
     func = Deconvolution2DFunction(stride, pad, outsize, dilate=dilate,
                                    groups=groups)

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -14,8 +14,7 @@ class Convolution2D(link.Link):
     This link wraps the :func:`~chainer.functions.convolution_2d` function and
     holds the filter weight and bias vector as parameters.
 
-    The output of this functio
-    n can be non-deterministic when it uses cuDNN.
+    The output of this function can be non-deterministic when it uses cuDNN.
     If ``chainer.configuration.config.deterministic`` is ``True`` and
     cuDNN version is >= v3, it forces cuDNN to use a deterministic algorithm.
 

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -7,14 +7,15 @@ from chainer import variable
 
 class Convolution2D(link.Link):
 
-    """__init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0, nobias=False, initialW=None, initial_bias=None)
+    """__init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0, nobias=False, initialW=None, initial_bias=None, *, groups=1)
 
     Two-dimensional convolutional layer.
 
     This link wraps the :func:`~chainer.functions.convolution_2d` function and
     holds the filter weight and bias vector as parameters.
 
-    The output of this function can be non-deterministic when it uses cuDNN.
+    The output of this functio
+    n can be non-deterministic when it uses cuDNN.
     If ``chainer.configuration.config.deterministic`` is ``True`` and
     cuDNN version is >= v3, it forces cuDNN to use a deterministic algorithm.
 
@@ -48,6 +49,8 @@ class Convolution2D(link.Link):
         initial_bias (:ref:`initializer <initializer>`): Initializer to
             initialize the bias. If ``None``, the bias will be initialized to
             zero. When it is :class:`numpy.ndarray`, its ``ndim`` should be 1.
+        groups (int): The number of groups to use grouped convolution. The
+            default is one, where grouped convolution is not used.
 
     .. seealso::
        See :func:`chainer.functions.convolution_2d` for the definition of
@@ -103,8 +106,7 @@ class Convolution2D(link.Link):
     """  # NOQA
 
     def __init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0,
-                 nobias=False, initialW=None, initial_bias=None, groups=1,
-                 **kwargs):
+                 nobias=False, initialW=None, initial_bias=None, **kwargs):
         super(Convolution2D, self).__init__()
 
         argument.check_unexpected_kwargs(
@@ -112,7 +114,8 @@ class Convolution2D(link.Link):
             "supported anymore. "
             "Use chainer.using_config('cudnn_deterministic', value) "
             "context where value is either `True` or `False`.")
-        dilate, = argument.parse_kwargs(kwargs, ('dilate', 1))
+        dilate, groups = argument.parse_kwargs(kwargs,
+                                               ('dilate', 1), ('groups', 1))
 
         if ksize is None:
             out_channels, ksize, in_channels = in_channels, out_channels, None

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -10,7 +10,7 @@ from chainer import variable
 
 class Deconvolution2D(link.Link):
 
-    """__init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0, nobias=False, outsize=None, initialW=None, initial_bias=None)
+    """__init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0, nobias=False, outsize=None, initialW=None, initial_bias=None, *, groups=1)
 
     Two dimensional deconvolution function.
 
@@ -52,6 +52,8 @@ class Deconvolution2D(link.Link):
         initial_bias (:ref:`initializer <initializer>`): Initializer to
             initialize the bias. If ``None``, the bias will be initialized to
             zero. When it is :class:`numpy.ndarray`, its ``ndim`` should be 1.
+        groups (int): The number of groups to use grouped deconvolution. The
+            default is one, where grouped deconvolution is not used.
 
     The filter weight has four dimensions :math:`(c_I, c_O, k_H, k_W)`
     which indicate the number of input channels, output channels,
@@ -127,7 +129,7 @@ class Deconvolution2D(link.Link):
 
     def __init__(self, in_channels, out_channels, ksize=None, stride=1, pad=0,
                  nobias=False, outsize=None, initialW=None, initial_bias=None,
-                 groups=1, **kwargs):
+                 **kwargs):
         super(Deconvolution2D, self).__init__()
 
         argument.check_unexpected_kwargs(
@@ -135,7 +137,7 @@ class Deconvolution2D(link.Link):
             "supported anymore. "
             "Use chainer.using_config('cudnn_deterministic', value) "
             "context where value is either `True` or `False`.")
-        argument.assert_kwargs_empty(kwargs)
+        groups, = argument.parse_kwargs(kwargs, ('groups', 1))
 
         if ksize is None:
             out_channels, ksize, in_channels = in_channels, out_channels, None


### PR DESCRIPTION
I took over #4059. This PR contains fixing about incompatible interface bug.
