### PR TITLE
[RFC] Add error handler interface to trainer extensions

### DIFF
--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -98,6 +98,20 @@ class Extension(object):
         """
         pass
 
+    def on_error(self, exp, exc_info):
+        """Handle the error during training before finalize.
+
+        This method is called when an exception is thrown during the
+        training loop. An extension that needs different error handling from finalize,
+        can override this method to handle errors.
+
+        Args:
+             exp (Exception): arbitrary exception thrown during update loop.
+             exc_info: exception info e.g. stack trace
+
+        """
+        pass
+
     def serialize(self, serializer):
         """Serializes the extension state.
 
@@ -109,7 +123,7 @@ class Extension(object):
 
 
 def make_extension(trigger=None, default_name=None, priority=None,
-                   finalizer=None, initializer=None, **kwargs):
+                   finalizer=None, initializer=None, on_error=None, **kwargs):
     """Decorator to make given functions into trainer extensions.
 
     This decorator just adds some attributes to a given function. The value of
@@ -144,6 +158,7 @@ def make_extension(trigger=None, default_name=None, priority=None,
         ext.default_name = default_name or ext.__name__
         ext.priority = priority
         ext.finalize = finalizer
+        ext.on_error = on_error
         ext.initialize = initializer
         return ext
 

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -315,6 +315,10 @@ class Trainer(object):
                 traceback.print_tb(sys.exc_info()[2])
                 f.write('Will finalize trainer extensions and updater before '
                         'reraising the exception.\n')
+            for _, entry in extensions:
+                handler = getattr(entry.extension, 'on_error', None)
+                if handler:
+                    handler(e, sys.exc_info())
             six.reraise(*sys.exc_info())
         finally:
             for _, entry in extensions:

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -85,7 +85,7 @@ def main():
 
     # Take a snapshot for each specified epoch
     frequency = args.epoch if args.frequency == -1 else max(1, args.frequency)
-    trainer.extend(extensions.snapshot(), trigger=(frequency, 'epoch'))
+    trainer.extend(extensions.snapshot(snapshot_on_error=True), trigger=(frequency, 'epoch'))
 
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())


### PR DESCRIPTION
This is rather a request-for-comment to my suggestion to add error handling interface to trainer.

More than 90% use cases of trainer extensions just `finalize()` would be sufficient for cleaning up extensions. But for some use cases like snapshots, or [checkpoints](http://chainermn.readthedocs.io/en/stable/reference/#chainermn.create_multi_node_checkpointer) it would be nice if the trainer extensions have error handling interface to preserve the *latest* trainer image, or models. See changes in this PR on snapshot extension, which has additional `snapshot_on_error` flag for actual implementation.

Moreover, my fault tolerance prototyping work that is going underwater requires this feature to handle GPU failures by leaving the computing cluster in a graceful manner rather than just the process quitting with some signals.

Note: This pull request does not have enough documentation, nor any test codes. Not worth testing or merging for now. If the discussion goes well I'd like to put my time more.