### PR TITLE
Fix custom loop examples to disable train mode during evaluation

### DIFF
--- a/examples/cifar/train_cifar_custom_loop.py
+++ b/examples/cifar/train_cifar_custom_loop.py
@@ -9,6 +9,7 @@ applies an optimizer to update the model.
 import argparse
 
 import chainer
+from chainer import configuration
 from chainer.dataset import convert
 import chainer.links as L
 from chainer import serializers
@@ -103,17 +104,16 @@ def main():
             # evaluation
             sum_accuracy = 0
             sum_loss = 0
-            model.predictor.train = False
-            for batch in test_iter:
-                x_array, t_array = convert.concat_examples(batch, args.gpu)
-                x = chainer.Variable(x_array)
-                t = chainer.Variable(t_array)
-                loss = model(x, t)
-                sum_loss += float(loss.data) * len(t.data)
-                sum_accuracy += float(model.accuracy.data) * len(t.data)
+            with configuration.using_config('train', False):
+                for batch in test_iter:
+                    x_array, t_array = convert.concat_examples(batch, args.gpu)
+                    x = chainer.Variable(x_array)
+                    t = chainer.Variable(t_array)
+                    loss = model(x, t)
+                    sum_loss += float(loss.data) * len(t.data)
+                    sum_accuracy += float(model.accuracy.data) * len(t.data)
 
             test_iter.reset()
-            model.predictor.train = True
             print('test mean  loss: {}, accuracy: {}'.format(
                 sum_loss / test_count, sum_accuracy / test_count))
             sum_accuracy = 0

--- a/examples/mnist/train_mnist_custom_loop.py
+++ b/examples/mnist/train_mnist_custom_loop.py
@@ -87,16 +87,19 @@ def main():
                 # evaluation
                 sum_accuracy = 0
                 sum_loss = 0
+                # Enable evaluation mode.
                 with configuration.using_config('train', False):
-                    for batch in test_iter:
-                        x_array, t_array = convert.concat_examples(batch,
-                                                                   args.gpu)
-                        x = chainer.Variable(x_array)
-                        t = chainer.Variable(t_array)
-                        loss = model(x, t)
-                        sum_loss += float(loss.data) * len(t.data)
-                        sum_accuracy += (float(model.accuracy.data) *
-                                         len(t.data))
+                    # This is optional but can reduce computational overhead.
+                    with chainer.using_config('enable_backprop', False):
+                        for batch in test_iter:
+                            x, t = convert.concat_examples(batch,
+                                                           args.gpu)
+                            x = chainer.Variable(x)
+                            t = chainer.Variable(t)
+                            loss = model(x, t)
+                            sum_loss += float(loss.data) * len(t.data)
+                            sum_accuracy += (float(model.accuracy.data) *
+                                             len(t.data))
 
                 test_iter.reset()
                 print('test mean  loss: {}, accuracy: {}'.format(

--- a/examples/mnist/train_mnist_custom_loop.py
+++ b/examples/mnist/train_mnist_custom_loop.py
@@ -89,12 +89,14 @@ def main():
                 sum_loss = 0
                 with configuration.using_config('train', False):
                     for batch in test_iter:
-                        x_array, t_array = convert.concat_examples(batch, args.gpu)
+                        x_array, t_array = convert.concat_examples(batch,
+                                                                   args.gpu)
                         x = chainer.Variable(x_array)
                         t = chainer.Variable(t_array)
                         loss = model(x, t)
                         sum_loss += float(loss.data) * len(t.data)
-                        sum_accuracy += float(model.accuracy.data) * len(t.data)
+                        sum_accuracy += (float(model.accuracy.data) *
+                                         len(t.data))
 
                 test_iter.reset()
                 print('test mean  loss: {}, accuracy: {}'.format(

--- a/examples/mnist/train_mnist_custom_loop.py
+++ b/examples/mnist/train_mnist_custom_loop.py
@@ -10,6 +10,7 @@ applies an optimizer to update the model.
 import argparse
 
 import chainer
+from chainer import configuration
 from chainer.dataset import convert
 import chainer.links as L
 from chainer import serializers
@@ -85,13 +86,14 @@ def main():
             # evaluation
             sum_accuracy = 0
             sum_loss = 0
-            for batch in test_iter:
-                x_array, t_array = convert.concat_examples(batch, args.gpu)
-                x = chainer.Variable(x_array)
-                t = chainer.Variable(t_array)
-                loss = model(x, t)
-                sum_loss += float(loss.data) * len(t.data)
-                sum_accuracy += float(model.accuracy.data) * len(t.data)
+            with configuration.using_config('train', False):
+                for batch in test_iter:
+                    x_array, t_array = convert.concat_examples(batch, args.gpu)
+                    x = chainer.Variable(x_array)
+                    t = chainer.Variable(t_array)
+                    loss = model(x, t)
+                    sum_loss += float(loss.data) * len(t.data)
+                    sum_accuracy += float(model.accuracy.data) * len(t.data)
 
             test_iter.reset()
             print('test mean  loss: {}, accuracy: {}'.format(

--- a/examples/ptb/train_ptb_custom_loop.py
+++ b/examples/ptb/train_ptb_custom_loop.py
@@ -52,12 +52,15 @@ def main():
         evaluator.predictor.reset_state()  # initialize state
         sum_perp = 0
         data_count = 0
+        # Enable evaluation mode.
         with configuration.using_config('train', False):
-            for batch in copy.copy(iter):
-                x, t = convert.concat_examples(batch, args.gpu)
-                loss = evaluator(x, t)
-                sum_perp += loss.data
-                data_count += 1
+            # This is optional but can reduce computational overhead.
+            with chainer.using_config('enable_backprop', False):
+                for batch in copy.copy(iter):
+                    x, t = convert.concat_examples(batch, args.gpu)
+                    loss = evaluator(x, t)
+                    sum_perp += loss.data
+                    data_count += 1
         return np.exp(float(sum_perp) / data_count)
 
     # Load the Penn Tree Bank long word sequence dataset

--- a/examples/ptb/train_ptb_custom_loop.py
+++ b/examples/ptb/train_ptb_custom_loop.py
@@ -14,6 +14,7 @@ import copy
 import numpy as np
 
 import chainer
+from chainer import configuration
 from chainer.dataset import convert
 import chainer.links as L
 from chainer import serializers
@@ -47,18 +48,16 @@ def main():
 
     def evaluate(model, iter):
         # Evaluation routine to be used for validation and test.
-        model.predictor.train = False
         evaluator = model.copy()  # to use different state
         evaluator.predictor.reset_state()  # initialize state
-        evaluator.predictor.train = False  # dropout does nothing
         sum_perp = 0
         data_count = 0
-        for batch in copy.copy(iter):
-            x, t = convert.concat_examples(batch, args.gpu)
-            loss = evaluator(x, t)
-            sum_perp += loss.data
-            data_count += 1
-        model.predictor.train = True
+        with configuration.using_config('train', False):
+            for batch in copy.copy(iter):
+                x, t = convert.concat_examples(batch, args.gpu)
+                loss = evaluator(x, t)
+                sum_perp += loss.data
+                data_count += 1
         return np.exp(float(sum_perp) / data_count)
 
     # Load the Penn Tree Bank long word sequence dataset


### PR DESCRIPTION
The non-trainer examples (that is, the "custom training loop" examples) previously had a bug that the configuration remained in training mode during test/validation.