### PR TITLE
fix document in EarlyStoppingTrigger

### DIFF
--- a/chainer/training/triggers/early_stopping_trigger.py
+++ b/chainer/training/triggers/early_stopping_trigger.py
@@ -33,7 +33,7 @@ class EarlyStoppingTrigger(object):
             It is used to determine how to compare the monitored values.
         verbose (bool) : Enable verbose output.
             If verbose is true, you can get more information
-        max_trigger (int) : Upper bound of the number of training loops
+        max_trigger: Upper bound of the number of training loops
     """
 
     def __init__(self, check_trigger=(1, 'epoch'), monitor='main/loss',


### PR DESCRIPTION
Fixed a mistake in the docs of EarlyStoppingTrigger.
The type of max_trigger should be 'trigger object' but it was int.