### PR TITLE
Fix installation order of hacking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ requirements = {
         cupy_requirement('cupy'),
     ],
     'stylecheck': [
-        'hacking',
         'autopep8',
+        'hacking',
     ],
     'test': [
         'pytest',


### PR DESCRIPTION
It seems pycodestyle==2.4.0 breaks something.  To keep hacking-related packages from being overwritten by pycodestyle, let's install hacking later.