### PR TITLE
Make updaters call `new_epoch` automatically

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -371,9 +371,10 @@ class Optimizer(object):
             :meth:`update` method.
         ~Optimizer.epoch: Current epoch. It is incremented by the
             :meth:`new_epoch` method.
-        use_auto_new_epoch: Boolean flag to indicate if :meth:`new_epoch` will
-            be called by the updater. Updater should set this flag to ``True``
-            if it automatically calls :meth:`new_epoch`.
+        ~Optimizer.use_auto_new_epoch: Boolean flag to indicate if
+            :meth:`new_epoch` will be called by the updater. Updater should
+            set this flag to ``True`` if it automatically calls
+            :meth:`new_epoch`.
 
     """
 

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -463,7 +463,8 @@ class Optimizer(object):
             if not self.use_auto_new_epoch:
                 raise RuntimeError(
                     'invalid new_epoch call with auto=True.\n'
-                    'Fix the updater to set optimizer.use_auto_new_epoch = True.')
+                    'Fix the updater to set '
+                    'optimizer.use_auto_new_epoch = True.')
         else:
             if self.use_auto_new_epoch:
                 raise RuntimeError(

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -371,6 +371,9 @@ class Optimizer(object):
             :meth:`update` method.
         ~Optimizer.epoch: Current epoch. It is incremented by the
             :meth:`new_epoch` method.
+        use_auto_new_epoch: Boolean flag to indicate if :meth:`new_epoch` will
+            be called by the updater. Updater should set this flag to ``True``
+            if it automatically calls :meth:`new_epoch`.
 
     """
 
@@ -380,6 +383,7 @@ class Optimizer(object):
     _pre_update_hooks = None
     _post_update_hooks = None
     _loss_scale = None
+    use_auto_new_epoch = False
 
     def setup(self, link):
         """Sets a target link and initializes the optimizer states.
@@ -442,14 +446,30 @@ class Optimizer(object):
         """
         raise NotImplementedError
 
-    def new_epoch(self):
+    def new_epoch(self, auto=False):
         """Starts a new epoch.
 
         This method increments the :attr:`epoch` count. Note that if the
         optimizer depends on the epoch count, then user should call this method
         appropriately at the beginning of each epoch.
 
+        Args:
+            auto (bool): Should be ``True`` if this method is called by an
+                updater. In this case, :attr:`use_auto_new_epoch` should be set
+                to ``True`` by the updater.
+
         """
+        if auto:
+            if not self.use_auto_new_epoch:
+                raise RuntimeError(
+                    'invalid new_epoch call with auto=True.\n'
+                    'Fix the updater to set optimizer.use_auto_new_epoch = True.')
+        else:
+            if self.use_auto_new_epoch:
+                raise RuntimeError(
+                    'duplicated new_epoch with the updater.\n'
+                    'Pass auto_new_epoch=False to the updater or stop calling '
+                    'new_epoch outside the updater.')
         self.epoch += 1
 
     def add_hook(self, hook, name=None, timing='auto'):

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -113,11 +113,15 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
         devices: Dictionary or list of devices to which the training data is
             sent. The master device will be the first one in the list or the
             value attached to the key ``'main'``.
+        auto_new_epoch (bool): If ``True``,
+            :meth:`~chainer.Optimizer.new_epoch` of the main optimizer is
+            automatically called when the ``is_new_poch`` attribute of the
+            main iterator is ``True``.
 
     """
 
     def __init__(self, iterators, optimizer, converter=convert.concat_examples,
-                 devices=None):
+                 devices=None, auto_new_epoch=True):
         if not MultiprocessParallelUpdater.available():
             raise Exception(
                 'NCCL is not enabled. MultiprocessParallelUpdater '
@@ -162,7 +166,8 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
         super(MultiprocessParallelUpdater, self).__init__(
             iterator=iterators[0],
             optimizer=optimizer,
-            converter=converter
+            converter=converter,
+            auto_new_epoch=auto_new_epoch,
         )
 
         if isinstance(devices, dict):
@@ -225,7 +230,8 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             self._master.cleargrads()
 
             optimizer = self.get_optimizer('main')
-            batch = self.get_iterator('main').next()
+            iterator = self.get_iterator('main')
+            batch = iterator.next()
             batch = self.converter(batch, self._devices[0])
 
             loss = _calc_loss(self._master, batch)
@@ -249,6 +255,9 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
                 nccl_data_type = _get_nccl_data_type(gp.dtype)
                 self.comm.bcast(gp.data.ptr, gp.size, nccl_data_type,
                                 0, null_stream.ptr)
+
+            if self.auto_new_epoch and iterator.is_new_epoch:
+                optimizer.new_epoch(auto=True)
 
     def finalize(self):
         self._send_message(('finalize', None))

--- a/chainer/training/updaters/parallel_updater.py
+++ b/chainer/training/updaters/parallel_updater.py
@@ -156,4 +156,4 @@ class ParallelUpdater(standard_updater.StandardUpdater):
             model.copyparams(model_main)
 
         if self.auto_new_epoch and iterator.is_new_epoch:
-            optimizer.new_epoch()
+            optimizer.new_epoch(auto=True)

--- a/chainer/training/updaters/parallel_updater.py
+++ b/chainer/training/updaters/parallel_updater.py
@@ -50,17 +50,23 @@ class ParallelUpdater(standard_updater.StandardUpdater):
             propagated to whole gradients in a computational graph along the
             backprop. The gradients of parameters are divided by the factor
             just before the parameters are to be updated.
+        auto_new_epoch (bool):  If ``True``,
+            :meth:`~chainer.Optimizer.new_epoch` of the main optimizer is
+            automatically called when the ``is_new_poch`` attribute of the
+            main iterator is ``True``.
 
     """
 
     def __init__(self, iterator, optimizer, converter=convert.concat_examples,
-                 models=None, devices=None, loss_func=None, loss_scale=None):
+                 models=None, devices=None, loss_func=None, loss_scale=None,
+                 auto_new_epoch=True):
         super(ParallelUpdater, self).__init__(
             iterator=iterator,
             optimizer=optimizer,
             converter=converter,
             loss_func=loss_func,
             loss_scale=loss_scale,
+            auto_new_epoch=auto_new_epoch,
         )
 
         if models is None:
@@ -100,7 +106,8 @@ class ParallelUpdater(standard_updater.StandardUpdater):
         models_others = {k: v for k, v in self._models.items()
                          if v is not model_main}
 
-        batch = self.get_iterator('main').next()
+        iterator = self.get_iterator('main')
+        batch = iterator.next()
 
         #
         # Split the batch to sub-batches.
@@ -147,3 +154,6 @@ class ParallelUpdater(standard_updater.StandardUpdater):
 
         for model in six.itervalues(models_others):
             model.copyparams(model_main)
+
+        if self.auto_new_epoch and iterator.is_new_epoch:
+            optimizer.new_epoch()

--- a/chainer/training/updaters/standard_updater.py
+++ b/chainer/training/updaters/standard_updater.py
@@ -42,6 +42,10 @@ class StandardUpdater(_updater.Updater):
             propagated to whole gradients in a computational graph along the
             backprop. The gradients of parameters are divided by the factor
             just before the parameters are to be updated.
+        auto_new_epoch (bool): If ``True``,
+            :meth:`~chainer.Optimizer.new_epoch` of the main optimizer is
+            automatically called when the ``is_new_poch`` attribute of the
+            main iterator is ``True``.
 
     Attributes:
         converter: Converter function.
@@ -49,11 +53,18 @@ class StandardUpdater(_updater.Updater):
                    main optimizer is used instead.
         device: Device to which the training data is sent.
         iteration: Current number of completed updates.
+        auto_new_epoch: If ``True``, :meth:`~chainer.Optimizer.new_epoch` is
+            automatically called by :meth:`update_core`. In this case, the
+            :attr:`~chainer.Optimizer.use_auto_new_epoch` attribute of each
+            optimizer is also set to ``True``. If :meth:`update_core` is
+            overridden, the implementation should correctly call
+            :meth:`~chainer.Optimizer.new_epoch` of each optimizer.
 
     """
 
     def __init__(self, iterator, optimizer, converter=convert.concat_examples,
-                 device=None, loss_func=None, loss_scale=None):
+                 device=None, loss_func=None, loss_scale=None,
+                 auto_new_epoch=True):
         if isinstance(iterator, iterator_module.Iterator):
             iterator = {'main': iterator}
         self._iterators = iterator
@@ -75,6 +86,11 @@ class StandardUpdater(_updater.Updater):
         if loss_scale is not None:
             for optimizer in six.itervalues(self._optimizers):
                 optimizer.set_loss_scale(loss_scale)
+
+        self.auto_new_epoch = auto_new_epoch
+        if auto_new_epoch:
+            for o in six.itervalues(self._optimizers):
+                o.use_auto_new_epoch = True
 
     @property
     def epoch(self):
@@ -150,7 +166,8 @@ class StandardUpdater(_updater.Updater):
         self.iteration += 1
 
     def update_core(self):
-        batch = self._iterators['main'].next()
+        iterator = self._iterators['main']
+        batch = iterator.next()
         in_arrays = self.converter(batch, self.device)
 
         optimizer = self._optimizers['main']
@@ -162,6 +179,9 @@ class StandardUpdater(_updater.Updater):
             optimizer.update(loss_func, **in_arrays)
         else:
             optimizer.update(loss_func, in_arrays)
+
+        if self.auto_new_epoch and iterator.is_new_epoch:
+            optimizer.new_epoch(auto=True)
 
     def serialize(self, serializer):
         """Serializes the current state of the updater object."""

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -191,6 +191,30 @@ class TestUpdateRule(unittest.TestCase):
         self.update_rule.update(self.var)
 
 
+class TestOptimizer(unittest.TestCase):
+
+    def setUp(self):
+        self.optimizer = optimizer.Optimizer()
+
+    def test_new_epoch(self):
+        self.optimizer.new_epoch()
+        self.assertEqual(1, self.optimizer.epoch)
+
+    def test_invalid_new_epoch(self):
+        self.optimizer.use_auto_new_epoch = True
+        with self.assertRaises(RuntimeError):
+            self.optimizer.new_epoch()
+
+    def test_auto_new_epoch(self):
+        self.optimizer.use_auto_new_epoch = True
+        self.optimizer.new_epoch(auto=True)
+        self.assertEqual(1, self.optimizer.epoch)
+
+    def test_invalid_auto_new_epoch(self):
+        with self.assertRaises(RuntimeError):
+            self.optimizer.new_epoch(auto=True)
+
+
 class TestOptimizerHook(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/training_tests/updaters_tests/test_standard_updater.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/test_standard_updater.py
@@ -90,7 +90,11 @@ class TestUpdater(unittest.TestCase):
     def test_update(self):
         self.updater.update()
         self.assertEqual(self.updater.iteration, 1)
+        self.assertEqual(self.optimizer.epoch, 1)
         self.assertEqual(self.iterator.next_called, 1)
+
+    def test_use_auto_new_epoch(self):
+        self.assertTrue(self.optimizer.use_auto_new_epoch)
 
     def test_finalizer(self):
         self.updater.finalize()


### PR DESCRIPTION
Fixed #3044. This PR lets the built-in updaters automatically call `Optimizer.new_epoch()` when `is_new_epoch` is true for the main iterator.

**This change is incompatible with v4.** To aid the incompatibility, I added `use_auto_new_epoch` flag to `Optimizer`, which is set by the updaters. When this flag is set, `new_epoch()` called outside the updater raises an error so that users can notice duplicated calls of `new_epoch()`. It means that existing code that uses any updater and `new_epoch` simultaneously will raise an error. This error can be fixed by 1) not calling `new_epoch` outside the updater, or 2) passing `auto_new_epoch=False` to the updater.