### PR TITLE
Add error handler interface to trainer extensions

### DIFF
--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -103,6 +103,22 @@ class Extension(object):
         """
         pass
 
+    def on_error(self, trainer, exc, tb):
+        """Handles the error raised during training before finalization.
+
+        This method is called when an exception is thrown during the
+        training loop, before finalize. An extension that needs
+        different error handling from finalize, can override this
+        method to handle errors.
+
+        Args:
+            trainer (Trainer): Trainer object that runs the training loop.
+            exp (Exception): arbitrary exception thrown during update loop.
+            tb (traceback): traceback object of the exception
+
+        """
+        pass
+
     def serialize(self, serializer):
         """Serializes the extension state.
 
@@ -114,7 +130,7 @@ class Extension(object):
 
 
 def make_extension(trigger=None, default_name=None, priority=None,
-                   finalizer=None, initializer=None, **kwargs):
+                   finalizer=None, initializer=None, on_error=None, **kwargs):
     """Decorator to make given functions into trainer extensions.
 
     This decorator just adds some attributes to a given function. The value of
@@ -132,6 +148,8 @@ def make_extension(trigger=None, default_name=None, priority=None,
             called at the end of the training loop.
         initializer: Initializer function of this extension. It is called at
             the beginning of the training loop.
+        on_error: Error handler callback function of this extension. It is
+            called after an error is raised during the trainer loop.
 
     """
     if kwargs:
@@ -150,6 +168,7 @@ def make_extension(trigger=None, default_name=None, priority=None,
         ext.default_name = default_name or ext.__name__
         ext.priority = priority
         ext.finalize = finalizer
+        ext.on_error = on_error
         ext.initialize = initializer
         return ext
 

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -6,7 +6,7 @@ from chainer.training import extension
 from chainer import utils
 
 
-def snapshot_object(target, filename, savefun=npz.save_npz):
+def snapshot_object(target, filename, savefun=npz.save_npz, **kwargs):
     """Returns a trainer extension to take snapshots of a given object.
 
     This extension serializes the given object and saves it to the output
@@ -29,20 +29,38 @@ def snapshot_object(target, filename, savefun=npz.save_npz):
             ``'snapshot_10000'`` at the 10,000th iteration.
         savefun: Function to save the object. It takes two arguments: the
             output file path and the object to serialize.
+        snapshot_on_error (bool): Whether to take a snapshot in case trainer
+            loop has been failed.
 
     Returns:
         An extension function.
 
     """
-    @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
+
+    snapshot_on_error = utils.argument.parse_kwargs(
+        kwargs, ('snapshot_on_error', False),
+        deterministic="deterministic argument is not supported anymore. "
+        "Use chainer.using_config('cudnn_deterministic', value) "
+        "context where value is either `True` or `False`.")
+
+    error_handler = None
+    if snapshot_on_error:
+        def h(trainer, exception, exc_info):
+            _snapshot_object(trainer, trainer, filename.format(trainer),
+                             savefun)
+        error_handler = h
+
+    @extension.make_extension(trigger=(1, 'epoch'), priority=-100,
+                              on_error=error_handler)
     def snapshot_object(trainer):
-        _snapshot_object(trainer, target, filename.format(trainer), savefun)
+        _snapshot_object(trainer, target, filename.format(trainer),
+                         savefun)
 
     return snapshot_object
 
 
 def snapshot(savefun=npz.save_npz,
-             filename='snapshot_iter_{.updater.iteration}'):
+             filename='snapshot_iter_{.updater.iteration}', **kwargs):
     """Returns a trainer extension to take snapshots of the trainer.
 
     This extension serializes the trainer object and saves it to the output
@@ -69,11 +87,28 @@ def snapshot(savefun=npz.save_npz,
         filename (str): Name of the file into which the trainer is serialized.
             It can be a format string, where the trainer object is passed to
             the :meth:`str.format` method.
+        snapshot_on_error (bool): Whether to take a snapshot in case trainer
+            loop has been failed.
 
     """
-    @extension.make_extension(trigger=(1, 'epoch'), priority=-100)
+    snapshot_on_error = utils.argument.parse_kwargs(
+        kwargs, ('snapshot_on_error', False),
+        deterministic="deterministic argument is not supported anymore. "
+        "Use chainer.using_config('cudnn_deterministic', value) "
+        "context where value is either `True` or `False`.")
+
+    error_handler = None
+    if snapshot_on_error:
+        def h(trainer, exception, exc_info):
+            _snapshot_object(trainer, trainer, filename.format(trainer),
+                             savefun)
+        error_handler = h
+
+    @extension.make_extension(trigger=(1, 'epoch'), priority=-100,
+                              on_error=error_handler)
     def snapshot(trainer):
-        _snapshot_object(trainer, trainer, filename.format(trainer), savefun)
+        _snapshot_object(trainer, trainer, filename.format(trainer),
+                         savefun)
 
     return snapshot
 

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -38,11 +38,7 @@ def snapshot_object(target, filename, savefun=npz.save_npz, **kwargs):
     """
 
     snapshot_on_error = utils.argument.parse_kwargs(
-        kwargs, ('snapshot_on_error', False),
-        deterministic="deterministic argument is not supported anymore. "
-        "Use chainer.using_config('cudnn_deterministic', value) "
-        "context where value is either `True` or `False`.")
-
+        kwargs, ('snapshot_on_error', False))
     error_handler = None
     if snapshot_on_error:
         def h(trainer, exception, exc_info):
@@ -92,10 +88,7 @@ def snapshot(savefun=npz.save_npz,
 
     """
     snapshot_on_error = utils.argument.parse_kwargs(
-        kwargs, ('snapshot_on_error', False),
-        deterministic="deterministic argument is not supported anymore. "
-        "Use chainer.using_config('cudnn_deterministic', value) "
-        "context where value is either `True` or `False`.")
+        kwargs, ('snapshot_on_error', False))
 
     error_handler = None
     if snapshot_on_error:

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -326,7 +326,26 @@ class Trainer(object):
                 traceback.print_tb(sys.exc_info()[2])
                 f.write('Will finalize trainer extensions and updater before '
                         'reraising the exception.\n')
-            six.reraise(*sys.exc_info())
+
+            # In Python 2, sys.exc_info() is updated if any folloing
+            # exceptions happens even if it's in a limited scope (like
+            # try-catch clause below). Thus the exception from main
+            # loop is preserved here.
+            exc_info = sys.exc_info()
+            for _, entry in extensions:
+                handler = getattr(entry.extension, 'on_error', None)
+                if handler:
+                    try:
+                        # It is guaranteed all handlers are called,
+                        # but exceptions thrown by those handlers are
+                        # just printed and ignored, as well as its
+                        # return values.
+                        handler(self, e, sys.exc_info()[2])
+                    except Exception as he:
+                        f.write('Exception in error handler: {}\n'.format(he))
+                        f.write('Traceback (most recent call last):\n')
+                        traceback.print_tb(sys.exc_info()[2])
+            six.reraise(*exc_info)
         finally:
             for _, entry in extensions:
                 finalize = getattr(entry.extension, 'finalize', None)

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -85,7 +85,8 @@ def main():
 
     # Take a snapshot for each specified epoch
     frequency = args.epoch if args.frequency == -1 else max(1, args.frequency)
-    trainer.extend(extensions.snapshot(), trigger=(frequency, 'epoch'))
+    trainer.extend(extensions.snapshot(snapshot_on_error=True),
+                   trigger=(frequency, 'epoch'))
 
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -85,8 +85,7 @@ def main():
 
     # Take a snapshot for each specified epoch
     frequency = args.epoch if args.frequency == -1 else max(1, args.frequency)
-    trainer.extend(extensions.snapshot(snapshot_on_error=True),
-                   trigger=(frequency, 'epoch'))
+    trainer.extend(extensions.snapshot(), trigger=(frequency, 'epoch'))
 
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
@@ -4,6 +4,7 @@ import unittest
 import mock
 
 from chainer import testing
+from chainer import training
 from chainer.training import extensions
 
 
@@ -46,6 +47,39 @@ class TestSnapshotSaveFile(unittest.TestCase):
         left_tmps = [fn for fn in os.listdir('.')
                      if fn.startswith('tmpmyfile.dat')]
         self.assertEqual(len(left_tmps), 0)
+
+
+class TestSnapshotOnError(unittest.TestCase):
+
+    def setUp(self):
+        self.trainer = testing.get_trainer_with_mock_updater()
+        self.trainer.out = '.'
+        self.filename = 'myfile-deadbeef.dat'
+
+    def tearDown(self):
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
+
+    def test_on_error(self):
+
+        class TheOnlyError(Exception):
+            pass
+
+        @training.make_extension(trigger=(1, 'iteration'), priority=100)
+        def exception_raiser(trainer):
+            raise TheOnlyError()
+        self.trainer.extend(exception_raiser)
+
+        snapshot = extensions.snapshot_object(self.trainer, self.filename,
+                                              snapshot_on_error=True)
+        self.trainer.extend(snapshot)
+
+        self.assertFalse(os.path.exists(self.filename))
+
+        with self.assertRaises(TheOnlyError):
+            self.trainer.run()
+
+        self.assertTrue(os.path.exists(self.filename))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This commit also adds `snapshot_on_error` option to snapshot extension as a simple example of error handling in extensions, which I suggested at #4566. Use cases are:

* use cases like snapshots, or [checkpoints](http://chainermn.readthedocs.io/en/stable/reference/#chainermn.create_multi_node_checkpointer) it would be nice if the trainer extensions have error handling interface to preserve the *latest* trainer image, or models. See changes in this PR on snapshot extension, which has additional `snapshot_on_error` flag for actual implementation.
* ChainerUI currently just become silent when the training script dies, but it's nice if friendly message and stacktrace can be displayed on the Web UI.
* To handle some cases node failure or GPU failure in parallel training by ChainerMN.