### PR TITLE
fix heading level of Caffe docs

### DIFF
--- a/docs/source/reference/caffe.rst
+++ b/docs/source/reference/caffe.rst
@@ -1,11 +1,14 @@
-Caffe Reference Model Support
-=============================
+Caffe Model Support
+===================
 
 .. module:: chainer.links.caffe
 
 `Caffe <http://caffe.berkeleyvision.org/>`_ is a popular framework maintained by `BVLC <http://bvlc.eecs.berkeley.edu/>`_ at UC Berkeley.
 It is widely used by computer vision communities, and aims at fast computation and easy usage without any programming.
 The BVLC team provides trained reference models in their `Model Zoo <http://caffe.berkeleyvision.org/model_zoo.html>`_, one of the reason why this framework gets popular.
+
+Import
+------
 
 Chainer can import the reference models and emulate the network by :class:`~chainer.Link` implementations.
 This functionality is provided by the :class:`chainer.links.caffe.CaffeFunction` class.
@@ -17,8 +20,8 @@ This functionality is provided by the :class:`chainer.links.caffe.CaffeFunction`
    chainer.links.caffe.CaffeFunction
 
 
-Caffe Model Export Support
-==========================
+Export
+------
 
 .. module:: chainer.exporters
 


### PR DESCRIPTION
Currently both "Caffe Reference Model Support" and "Caffe Model Export Support" appearing in the references on the left.