### PR TITLE
Add Group Normalization

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -280,6 +280,7 @@ from chainer.functions.normalization.batch_normalization import batch_normalizat
 from chainer.functions.normalization.batch_normalization import fixed_batch_normalization  # NOQA
 from chainer.functions.normalization.batch_renormalization import batch_renormalization  # NOQA
 from chainer.functions.normalization.batch_renormalization import fixed_batch_renormalization  # NOQA
+from chainer.functions.normalization.group_normalization import group_normalization  # NOQA
 from chainer.functions.normalization.l2_normalization import normalize  # NOQA
 from chainer.functions.normalization.l2_normalization import NormalizeL2  # NOQA
 from chainer.functions.normalization.layer_normalization import layer_normalization  # NOQA

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -1,0 +1,70 @@
+import six
+import warnings
+
+from chainer.backends import cuda
+from chainer.functions.array import broadcast
+from chainer.functions.array import reshape
+from chainer.functions.normalization import batch_normalization
+
+
+def group_normalization(x, groups, gamma, beta, eps=1e-5):
+    """Group normalization.
+
+    This function implements a "group normalization"
+    which divides the channels into groups and computes within each group
+    the mean and variance, then normalize by these statistics,
+    scales and shifts them.
+
+
+    Args:
+        x (~chainer.Variable): Batch tensors.
+            First dimension of this value must be the size of minibatch and
+            second dimension must be the number of channels.
+            Moreover, this value must have one or more following dimensions,
+            such as height and width.
+        groups (int):
+            The number of channel groups.
+            This value must be a divisor of the number of channels.
+        gamma (~chainer.Variable): Scaling parameter.
+        beta (~chainer.Variable): Shifting parameter.
+        eps (float): Epsilon value for numerical stability of normalization.
+
+
+    Returns:
+        ~chainer.Variable: The output variable which has the same shape
+        as :math:`x`.
+
+    See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
+    """
+    if x.ndim <= 2:
+        raise ValueError('Input dimension must be bigger than 2.')
+
+    xp = cuda.get_array_module(x)
+
+    batch_size, channels = x.shape[:2]
+    original_shape = x.shape
+
+    if channels % groups != 0:
+        raise ValueError(
+            'Argument \'groups\' must be a divisor of the number of channel.')
+
+    # By doing this reshaping, calling batch_normalization function is
+    # equivalent to Group Normalization.
+    x = reshape.reshape(x, (1, batch_size * groups, -1))
+    dummy_gamma = (xp.ones(batch_size * groups).astype(xp.float32))
+    dummy_beta = (xp.zeros(batch_size * groups).astype(xp.float32))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        x = batch_normalization.batch_normalization(
+            x, dummy_gamma, dummy_beta, eps=eps)
+
+    x = reshape.reshape(x, original_shape)
+
+    target_shape = [1, channels] + [1 for _ in six.moves.xrange(x.ndim - 2)]
+    gamma_broadcast = broadcast.broadcast_to(
+        reshape.reshape(gamma, target_shape), x.shape)
+    beta_broadcast = broadcast.broadcast_to(
+        reshape.reshape(beta, target_shape), x.shape)
+
+    return x * gamma_broadcast + beta_broadcast

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -38,7 +38,9 @@ def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
     See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
     """
     if x.ndim <= 2:
-        raise ValueError('Input dimension must be bigger than 2.')
+        raise ValueError('Input dimension must be bigger than 2, '
+                         'excluding batch size dimension '
+                         '(first dimension).')
 
     if not isinstance(n_groups, int):
         raise TypeError('Argument: \'n_groups\' type must be (int).')
@@ -49,7 +51,7 @@ def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
     original_shape = x.shape
 
     if channels % n_groups != 0:
-        raise ValueError('Argument: \'n_groups\' must be a divisor'
+        raise ValueError('Argument: \'n_groups\' must be a divisor '
                          'of the number of channel.')
 
     # By doing this reshaping, calling batch_normalization function becomes

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -56,7 +56,8 @@ def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
 
     # By doing this reshaping, calling batch_normalization function becomes
     # equivalent to Group Normalization.
-    x = reshape.reshape(x, (1, batch_size * n_groups, -1))
+    # And redundant dimension is added in order to utilize ideep64/cuDNN.
+    x = reshape.reshape(x, (1, batch_size * n_groups, -1, 1))
     dummy_gamma = xp.ones(batch_size * n_groups).astype(xp.float32)
     dummy_beta = xp.zeros(batch_size * n_groups).astype(xp.float32)
 

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -58,7 +58,7 @@ def group_normalization(x, groups, gamma, beta, eps=1e-5):
     # And redundant dimension is added in order to utilize ideep64/cuDNN.
     x = reshape.reshape(x, (1, batch_size * groups, -1, 1))
 
-    with cuda.get_device_from_array(x):
+    with cuda.get_device_from_array(x.array):
         dummy_gamma = xp.ones(batch_size * groups).astype(xp.float32)
         dummy_beta = xp.zeros(batch_size * groups).astype(xp.float32)
 

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -38,8 +38,8 @@ def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
     See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
     """
     if x.ndim <= 2:
-        raise ValueError('Input dimension must be bigger than 2, '
-                         'excluding batch size dimension '
+        raise ValueError('Input dimension must be grater than 2, '
+                         'including batch size dimension '
                          '(first dimension).')
 
     if not isinstance(n_groups, int):

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -55,8 +55,8 @@ def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
     # By doing this reshaping, calling batch_normalization function becomes
     # equivalent to Group Normalization.
     x = reshape.reshape(x, (1, batch_size * n_groups, -1))
-    dummy_gamma = (xp.ones(batch_size * n_groups).astype(xp.float32))
-    dummy_beta = (xp.zeros(batch_size * n_groups).astype(xp.float32))
+    dummy_gamma = xp.ones(batch_size * n_groups).astype(xp.float32)
+    dummy_beta = xp.zeros(batch_size * n_groups).astype(xp.float32)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -7,7 +7,7 @@ from chainer.functions.array import reshape
 from chainer.functions.normalization import batch_normalization
 
 
-def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
+def group_normalization(x, groups, gamma, beta, eps=1e-5):
     """Group normalization function.
 
     This function implements a "group normalization"
@@ -23,7 +23,7 @@ def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
             second dimension must be the number of channels.
             Moreover, this value must have one or more following dimensions,
             such as height and width.
-        n_groups (int):
+        groups (int):
             The number of channel groups.
             This value must be a divisor of the number of channels.
         gamma (~chainer.Variable): Scaling parameter.
@@ -42,24 +42,24 @@ def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
                          'including batch size dimension '
                          '(first dimension).')
 
-    if not isinstance(n_groups, int):
-        raise TypeError('Argument: \'n_groups\' type must be (int).')
+    if not isinstance(groups, int):
+        raise TypeError('Argument: \'groups\' type must be (int).')
 
     xp = cuda.get_array_module(x)
 
     batch_size, channels = x.shape[:2]
     original_shape = x.shape
 
-    if channels % n_groups != 0:
-        raise ValueError('Argument: \'n_groups\' must be a divisor '
+    if channels % groups != 0:
+        raise ValueError('Argument: \'groups\' must be a divisor '
                          'of the number of channel.')
 
     # By doing this reshaping, calling batch_normalization function becomes
     # equivalent to Group Normalization.
     # And redundant dimension is added in order to utilize ideep64/cuDNN.
-    x = reshape.reshape(x, (1, batch_size * n_groups, -1, 1))
-    dummy_gamma = xp.ones(batch_size * n_groups).astype(xp.float32)
-    dummy_beta = xp.zeros(batch_size * n_groups).astype(xp.float32)
+    x = reshape.reshape(x, (1, batch_size * groups, -1, 1))
+    dummy_gamma = xp.ones(batch_size * groups).astype(xp.float32)
+    dummy_beta = xp.zeros(batch_size * groups).astype(xp.float32)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -8,7 +8,7 @@ from chainer.functions.normalization import batch_normalization
 
 
 def group_normalization(x, n_groups, gamma, beta, eps=1e-5):
-    """Group normalization.
+    """Group normalization function.
 
     This function implements a "group normalization"
     which divides the channels into groups and computes within each group

--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -52,5 +52,6 @@ from chainer.links.model.vision.resnet import ResNet50Layers  # NOQA
 from chainer.links.model.vision.vgg import VGG16Layers  # NOQA
 from chainer.links.normalization.batch_normalization import BatchNormalization  # NOQA
 from chainer.links.normalization.batch_renormalization import BatchRenormalization  # NOQA
+from chainer.links.normalization.group_normalization import GroupNormalization  # NOQA
 from chainer.links.normalization.layer_normalization import LayerNormalization  # NOQA
 from chainer.links.theano.theano_function import TheanoFunction  # NOQA

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -4,9 +4,9 @@ from chainer import variable
 
 
 class GroupNormalization(link.Link):
-    """Group normalization.
+    """Group normalization layer on outputs of linear or convolution functions.
 
-    This function implements a "group normalization"
+    This link implements a "group normalization"
     which divides the channels into groups and computes within each group
     the mean and variance, then normalize by these statistics,
     scales and shifts them.
@@ -15,7 +15,7 @@ class GroupNormalization(link.Link):
 
 
     Args:
-        groups (int):
+        n_groups (int):
             The number of channel groups.
             This value must be a divisor of the number of channels.
         size (int): Size of input units. If ``None``, parameter initialization

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -79,8 +79,8 @@ class GroupNormalization(link.Link):
         """
         if self.gamma.data is None:
             if x.ndim <= 2:
-                raise ValueError('Input dimension must be bigger than 2, '
-                                 'excluding batch size dimension '
+                raise ValueError('Input dimension must be grater than 2, '
+                                 'including batch size dimension '
                                  '(first dimension).')
             channels = x.shape[1]
             self._initialize_params(channels)

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -1,6 +1,6 @@
+from chainer.functions.normalization import group_normalization
 from chainer import link
 from chainer import variable
-from chainer.functions.normalization import group_normalization
 
 
 class GroupNormalization(link.Link):
@@ -41,6 +41,7 @@ class GroupNormalization(link.Link):
 
     See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
     """
+
     def __init__(self, n_groups, size=None, eps=1e-5, initial_gamma=None,
                  initial_beta=None):
         super(GroupNormalization, self).__init__()

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -1,0 +1,85 @@
+from chainer import link
+from chainer import variable
+from chainer.functions.normalization import group_normalization
+
+
+class GroupNormalization(link.Link):
+    """Group normalization.
+
+    This function implements a "group normalization"
+    which divides the channels into groups and computes within each group
+    the mean and variance, then normalize by these statistics,
+    scales and shifts them.
+    Parameter initialization will be deferred until
+    the first forward data pass at which time the size will be determined.
+
+
+    Args:
+        groups (int):
+            The number of channel groups.
+            This value must be a divisor of the number of channels.
+        size (int): Size of input units. If ``None``, parameter initialization
+            will be deferred until the first forward data pass at which time
+            the size will be determined.
+        eps (float): Epsilon value for numerical stability of normalization.
+        initial_gamma (~chainer.Initializer): Initializer for
+            scaling parameter.
+            If ``None``, then the vector is filled by 1.
+            If a scalar, the vector is filled by it.
+            If ``numpy.ndarray``, the vector is set by it.
+        initial_beta (~chainer.Initializer): Initializer for
+            shifting parameter.
+            If ``None``, then the vector is filled by 0.
+            If a scalar, the vector is filled by it.
+            If ``numpy.ndarray``, the vector is set by it.
+
+    Attributes:
+        groups (int): The number of channel groups.
+        gamma (~chainer.Parameter): Scaling parameter.
+        beta (~chainer.Parameter): Shifting parameter.
+        ~GroupNormalization.eps (float): Epsilon value for numerical stability.
+
+    See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
+    """
+    def __init__(self, groups, size=None, eps=1e-5, initial_gamma=None,
+                 initial_beta=None):
+        super(GroupNormalization, self).__init__()
+        if initial_gamma is None:
+            initial_gamma = 1
+        if initial_beta is None:
+            initial_beta = 0
+
+        with self.init_scope():
+            self.groups = groups
+            self.gamma = variable.Parameter(initial_gamma)
+            self.beta = variable.Parameter(initial_beta)
+            self.eps = eps
+
+        if size is not None:
+            self._initialize_params(size)
+
+    def _initialize_params(self, size):
+        self.gamma.initialize(size)
+        self.beta.initialize(size)
+
+    def __call__(self, x):
+        """Apply group normalization to given input.
+
+        Args:
+            x (~chainer.Variable): Batch tensors.
+                First dimension of this value must be the size of minibatch and
+                second dimension must be the number of channels.
+                Moreover, this value must have one or more following
+                dimensions, such as height and width.
+
+        Returns:
+            ~chainer.Variable: Output of the group normalization.
+
+        """
+
+        if self.gamma.data is None:
+            channels = x.shape[1]
+            self._initialize_params(channels)
+
+        return group_normalization.group_normalization(
+            x, self.groups, self.gamma, self.beta, self.eps)

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -34,14 +34,14 @@ class GroupNormalization(link.Link):
             If ``numpy.ndarray``, the vector is set by it.
 
     Attributes:
-        groups (int): The number of channel groups.
+        n_groups (int): The number of channel groups.
         gamma (~chainer.Parameter): Scaling parameter.
         beta (~chainer.Parameter): Shifting parameter.
         ~GroupNormalization.eps (float): Epsilon value for numerical stability.
 
     See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
     """
-    def __init__(self, groups, size=None, eps=1e-5, initial_gamma=None,
+    def __init__(self, n_groups, size=None, eps=1e-5, initial_gamma=None,
                  initial_beta=None):
         super(GroupNormalization, self).__init__()
         if initial_gamma is None:
@@ -50,7 +50,7 @@ class GroupNormalization(link.Link):
             initial_beta = 0
 
         with self.init_scope():
-            self.groups = groups
+            self.n_groups = n_groups
             self.gamma = variable.Parameter(initial_gamma)
             self.beta = variable.Parameter(initial_beta)
             self.eps = eps
@@ -76,10 +76,11 @@ class GroupNormalization(link.Link):
             ~chainer.Variable: Output of the group normalization.
 
         """
-
         if self.gamma.data is None:
+            if x.ndim <= 2:
+                raise ValueError('Input dimension must be bigger than 2.')
             channels = x.shape[1]
             self._initialize_params(channels)
 
         return group_normalization.group_normalization(
-            x, self.groups, self.gamma, self.beta, self.eps)
+            x, self.n_groups, self.gamma, self.beta, self.eps)

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -15,7 +15,7 @@ class GroupNormalization(link.Link):
 
 
     Args:
-        n_groups (int):
+        groups (int):
             The number of channel groups.
             This value must be a divisor of the number of channels.
         size (int): Size of input units. If ``None``, parameter initialization
@@ -34,7 +34,7 @@ class GroupNormalization(link.Link):
             If ``numpy.ndarray``, the vector is set by it.
 
     Attributes:
-        n_groups (int): The number of channel groups.
+        groups (int): The number of channel groups.
         gamma (~chainer.Parameter): Scaling parameter.
         beta (~chainer.Parameter): Shifting parameter.
         ~GroupNormalization.eps (float): Epsilon value for numerical stability.
@@ -42,7 +42,7 @@ class GroupNormalization(link.Link):
     See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
     """
 
-    def __init__(self, n_groups, size=None, eps=1e-5, initial_gamma=None,
+    def __init__(self, groups, size=None, eps=1e-5, initial_gamma=None,
                  initial_beta=None):
         super(GroupNormalization, self).__init__()
         if initial_gamma is None:
@@ -51,7 +51,7 @@ class GroupNormalization(link.Link):
             initial_beta = 0
 
         with self.init_scope():
-            self.n_groups = n_groups
+            self.groups = groups
             self.gamma = variable.Parameter(initial_gamma)
             self.beta = variable.Parameter(initial_beta)
             self.eps = eps
@@ -86,4 +86,4 @@ class GroupNormalization(link.Link):
             self._initialize_params(channels)
 
         return group_normalization.group_normalization(
-            x, self.n_groups, self.gamma, self.beta, self.eps)
+            x, self.groups, self.gamma, self.beta, self.eps)

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -4,7 +4,7 @@ from chainer import variable
 
 
 class GroupNormalization(link.Link):
-    """Group normalization layer on outputs of linear or convolution functions.
+    """Group normalization layer on outputs of convolution functions.
 
     This link implements a "group normalization"
     which divides the channels into groups and computes within each group
@@ -79,7 +79,9 @@ class GroupNormalization(link.Link):
         """
         if self.gamma.data is None:
             if x.ndim <= 2:
-                raise ValueError('Input dimension must be bigger than 2.')
+                raise ValueError('Input dimension must be bigger than 2, '
+                                 'excluding batch size dimension '
+                                 '(first dimension).')
             channels = x.shape[1]
             self._initialize_params(channels)
 

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -259,6 +259,7 @@ Normalization functions
    chainer.functions.batch_renormalization
    chainer.functions.fixed_batch_normalization
    chainer.functions.fixed_batch_renormalization
+   chainer.functions.group_normalization
    chainer.functions.layer_normalization
    chainer.functions.local_response_normalization
    chainer.functions.normalize

--- a/docs/source/reference/links.rst
+++ b/docs/source/reference/links.rst
@@ -66,6 +66,7 @@ Activation/loss/normalization functions with parameters
 
    chainer.links.BatchNormalization
    chainer.links.BatchRenormalization
+   chainer.links.GroupNormalization
    chainer.links.LayerNormalization
    chainer.links.BinaryHierarchicalSoftmax
    chainer.links.BlackOut

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
@@ -1,0 +1,94 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer.backends import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+
+
+@testing.parameterize(*(testing.product({
+    'shape': [(1, 4, 2, 2), (5, 4, 2)],
+    'n_groups': [1, 2, 4],
+    'dtype': [numpy.float32],
+})))
+class TestGroupNormalization(unittest.TestCase):
+
+    def setUp(self):
+        x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        gamma = numpy.random.uniform(-1, 1, self.shape[1]).astype(self.dtype)
+        beta = numpy.random.uniform(-1, 1, self.shape[1]).astype(self.dtype)
+        self.args = [x, gamma, beta]
+        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.ggx = [numpy.random.uniform(-1, 1, arg.shape).astype(arg.dtype)
+                    for arg in self.args]
+
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+
+    def check_forward(self, args):
+        def func(*args_):
+            return functions.group_normalization(
+                *[args_[0], self.n_groups, args_[1], args_[2]])
+
+        y = func(*args)
+        self.assertEqual(y.data.dtype, self.dtype)
+
+        # Verify that forward isn't be affected by batch size
+        if self.shape[0] > 1:
+            xp = cuda.get_array_module(*args)
+            y_one_each = chainer.functions.concat(
+                [func(*[xp.expand_dims(one_x, axis=0), args[1], args[2]])
+                 for one_x in args[0]], axis=0)
+            testing.assert_allclose(
+                y.data, y_one_each.data, **self.check_forward_options)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.args)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward([cuda.to_gpu(arg) for arg in self.args])
+
+    def check_backward(self, args, y_grad):
+        def func(*args_):
+            return functions.group_normalization(
+                *[args_[0], self.n_groups, args_[1], args_[2]])
+
+        gradient_check.check_backward(
+            func, args, y_grad,
+            eps=1e-2, **self.check_backward_options)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.args, self.gy)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(
+            [cuda.to_gpu(arg) for arg in self.args], cuda.to_gpu(self.gy))
+
+    def check_double_backward(self, args, y_grad, x_grad_grad):
+        def func(*args_):
+            y = functions.group_normalization(
+                *[args_[0], self.n_groups, args_[1], args_[2]])
+            return y * y
+
+        gradient_check.check_double_backward(
+            func, args, y_grad, x_grad_grad,
+            eps=1e-2, **self.check_double_backward_options)
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(self.args, self.gy, self.ggx)
+
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_double_backward(
+            [cuda.to_gpu(arg) for arg in self.args],
+            cuda.to_gpu(self.gy), [cuda.to_gpu(ggx_) for ggx_ in self.ggx])
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -169,8 +169,8 @@ class TestInvalidInput(unittest.TestCase):
 class TestInvalidInitialize(unittest.TestCase):
 
     def setUp(self):
-        self.shape = (2, 5, 2)
-        self.x = chainer.Variable(numpy.zeros(self.shape, dtype='f'))
+        shape = (2, 5, 2)
+        self.x = chainer.Variable(numpy.zeros(shape, dtype='f'))
 
     def test_invalid_n_groups(self):
         self.link = links.GroupNormalization(n_groups=3)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -1,0 +1,186 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer.backends import cuda
+from chainer import gradient_check
+from chainer import links
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+
+@testing.parameterize(*(testing.product({
+    'shape': [(1, 4, 2, 2), (5, 4, 2)],
+    'n_groups': [1, 2, 4],
+    'dtype': [numpy.float32],
+})))
+class GroupNormalizationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.GroupNormalization(self.n_groups)
+        self.link.cleargrads()
+
+        self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+
+    def check_forward(self, x_data):
+        y = self.link(x_data)
+        self.assertEqual(y.data.dtype, self.dtype)
+
+        # Verify that forward isn't be affected by batch size
+        if self.shape[0] > 1:
+            xp = cuda.get_array_module(x_data)
+            y_one_each = chainer.functions.concat(
+                [self.link(xp.expand_dims(one_x, axis=0))
+                 for one_x in x_data], axis=0)
+            testing.assert_allclose(
+                y.data, y_one_each.data, **self.check_forward_options)
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.link.to_gpu()
+        self.check_forward(cuda.to_gpu(self.x))
+
+    @attr.cudnn
+    def test_forward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.test_forward_gpu()
+
+    @attr.multi_gpu(2)
+    @condition.retry(3)
+    def test_forward_multi_gpu(self):
+        with cuda.get_device_from_id(1):
+            self.link.to_gpu()
+            x = cuda.to_gpu(self.x)
+        with cuda.get_device_from_id(0):
+            self.check_forward(x)
+
+    def check_backward(self, x_data, y_grad):
+        gradient_check.check_backward(
+            self.link, x_data, y_grad,
+            (self.link.gamma, self.link.beta),
+            eps=1e-2, **self.check_backward_options)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.link(numpy.zeros(self.shape, dtype='f'))
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.link.to_gpu()
+        self.link(cuda.cupy.zeros(self.shape, dtype='f'))
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    @attr.cudnn
+    def test_backward_gpu_without_cudnn(self):
+        self.link.use_cudnn = False
+        self.link(numpy.zeros(self.shape, dtype='f'))
+        self.test_backward_gpu()
+
+
+@testing.parameterize(*testing.product({
+    'size': [3, 30],
+    'n_groups': [1, 3]
+}))
+class TestInitialize(unittest.TestCase):
+
+    def setUp(self):
+        self.initial_gamma = numpy.random.uniform(-1, 1, self.size)
+        self.initial_gamma = self.initial_gamma.astype(numpy.float32)
+        self.initial_beta = numpy.random.uniform(-1, 1, self.size)
+        self.initial_beta = self.initial_beta.astype(numpy.float32)
+        self.link = links.GroupNormalization(self.n_groups,
+                                             initial_gamma=self.initial_gamma,
+                                             initial_beta=self.initial_beta)
+        self.shape = (1, self.size, 1)
+
+    @condition.retry(3)
+    def test_initialize_cpu(self):
+        self.link(numpy.zeros(self.shape, dtype='f'))
+        testing.assert_allclose(self.initial_gamma, self.link.gamma.data)
+        testing.assert_allclose(self.initial_beta, self.link.beta.data)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_initialize_gpu(self):
+        self.link.to_gpu()
+        self.link(cuda.cupy.zeros(self.shape, dtype='f'))
+        testing.assert_allclose(self.initial_gamma, self.link.gamma.data)
+        testing.assert_allclose(self.initial_beta, self.link.beta.data)
+
+
+@testing.parameterize(*testing.product({
+    'size': [3, 30],
+    'n_groups': [1, 3]
+}))
+class TestDefaultInitializer(unittest.TestCase):
+
+    def setUp(self):
+        self.size = 3
+        self.link = links.GroupNormalization(self.n_groups)
+        self.shape = (1, self.size, 1)
+
+    def test_initialize_cpu(self):
+        self.link(numpy.zeros(self.shape, dtype='f'))
+        testing.assert_allclose(numpy.ones(self.size), self.link.gamma.data)
+        testing.assert_allclose(
+            numpy.zeros(self.size), self.link.beta.data)
+
+    @attr.gpu
+    def test_initialize_gpu(self):
+        self.link.to_gpu()
+        self.link(cuda.cupy.zeros(self.shape, dtype='f'))
+        testing.assert_allclose(numpy.ones(self.size), self.link.gamma.data)
+        testing.assert_allclose(
+            numpy.zeros(self.size), self.link.beta.data)
+
+
+@testing.parameterize(*testing.product({
+    'shape': [(2,), (2, 3)],
+}))
+class TestInvalidInput(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.GroupNormalization(n_groups=3)
+
+    def test_invalid_shape_cpu(self):
+        with self.assertRaises(ValueError):
+            self.link(chainer.Variable(numpy.zeros(self.shape, dtype='f')))
+
+    @attr.gpu
+    def test_invalid_shape_gpu(self):
+        self.link.to_gpu()
+        with self.assertRaises(ValueError):
+            self.link(chainer.Variable(cuda.cupy.zeros(self.shape, dtype='f')))
+
+
+class TestInvalidInitialize(unittest.TestCase):
+
+    def setUp(self):
+        self.shape = (2, 5, 2)
+        self.x = chainer.Variable(numpy.zeros(self.shape, dtype='f'))
+
+    def test_invalid_n_groups(self):
+        self.link = links.GroupNormalization(n_groups=3)
+        with self.assertRaises(ValueError):
+            self.link(self.x)
+
+    def test_invalid_type_n_groups(self):
+        self.link = links.GroupNormalization(n_groups=3.5)
+        with self.assertRaises(TypeError):
+            self.link(self.x)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -13,13 +13,13 @@ from chainer.testing import condition
 
 @testing.parameterize(*(testing.product({
     'shape': [(1, 4, 5, 5), (5, 4, 15)],
-    'n_groups': [1, 2, 4],
+    'groups': [1, 2, 4],
     'dtype': [numpy.float32],
 })))
 class GroupNormalizationTest(unittest.TestCase):
 
     def setUp(self):
-        self.link = links.GroupNormalization(self.n_groups)
+        self.link = links.GroupNormalization(self.groups)
         self.link.cleargrads()
 
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
@@ -92,7 +92,7 @@ class GroupNormalizationTest(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'size': [3, 30],
-    'n_groups': [1, 3]
+    'groups': [1, 3]
 }))
 class TestInitialize(unittest.TestCase):
 
@@ -101,7 +101,7 @@ class TestInitialize(unittest.TestCase):
         self.initial_gamma = self.initial_gamma.astype(numpy.float32)
         self.initial_beta = numpy.random.uniform(-1, 1, self.size)
         self.initial_beta = self.initial_beta.astype(numpy.float32)
-        self.link = links.GroupNormalization(self.n_groups,
+        self.link = links.GroupNormalization(self.groups,
                                              initial_gamma=self.initial_gamma,
                                              initial_beta=self.initial_beta)
         self.shape = (1, self.size, 1)
@@ -123,13 +123,13 @@ class TestInitialize(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'size': [3, 30],
-    'n_groups': [1, 3]
+    'groups': [1, 3]
 }))
 class TestDefaultInitializer(unittest.TestCase):
 
     def setUp(self):
         self.size = 3
-        self.link = links.GroupNormalization(self.n_groups)
+        self.link = links.GroupNormalization(self.groups)
         self.shape = (1, self.size, 1)
 
     def test_initialize_cpu(self):
@@ -153,7 +153,7 @@ class TestDefaultInitializer(unittest.TestCase):
 class TestInvalidInput(unittest.TestCase):
 
     def setUp(self):
-        self.link = links.GroupNormalization(n_groups=3)
+        self.link = links.GroupNormalization(groups=3)
 
     def test_invalid_shape_cpu(self):
         with self.assertRaises(ValueError):
@@ -172,13 +172,13 @@ class TestInvalidInitialize(unittest.TestCase):
         shape = (2, 5, 2)
         self.x = chainer.Variable(numpy.zeros(shape, dtype='f'))
 
-    def test_invalid_n_groups(self):
-        self.link = links.GroupNormalization(n_groups=3)
+    def test_invalid_groups(self):
+        self.link = links.GroupNormalization(groups=3)
         with self.assertRaises(ValueError):
             self.link(self.x)
 
-    def test_invalid_type_n_groups(self):
-        self.link = links.GroupNormalization(n_groups=3.5)
+    def test_invalid_type_groups(self):
+        self.link = links.GroupNormalization(groups=3.5)
         with self.assertRaises(TypeError):
             self.link(self.x)
 

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -12,7 +12,7 @@ from chainer.testing import condition
 
 
 @testing.parameterize(*(testing.product({
-    'shape': [(1, 4, 2, 2), (5, 4, 2)],
+    'shape': [(1, 4, 5, 5), (5, 4, 15)],
     'n_groups': [1, 2, 4],
     'dtype': [numpy.float32],
 })))


### PR DESCRIPTION
It is an implementation of GroupNormalization.
https://arxiv.org/pdf/1803.08494.pdf 

GN can outperform in tasks such as time-series, GANs, and object detection.
This implementation uses batch normalization internally because we can exploit their optimized implementation with less effort.