### PR TITLE
Add tests for copy() from ChainList

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -1015,12 +1015,12 @@ class ChainList(Link):
         link.name = str(len(self._children))
         self._children.append(link)
 
-    def copy(self):
+    def copy(self, mode='share'):
         ret = super(ChainList, self).copy()
         ret._children = list(ret._children)  # copy
         children = ret._children
         for i, child in enumerate(children):
-            child = child.copy()
+            child = child.copy(mode)
             child.name = str(i)
             children[i] = child
         return ret

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -671,6 +671,13 @@ class TestChain(unittest.TestCase):
         self.assertNotIn('l1', self.c1._children)
 
     def test_copy_with_share_mode(self):
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
+
         c2 = self.c2.copy(mode='share')
         self.assertIs(c2.name, None)
         self.assertIsInstance(c2._children, set)
@@ -755,7 +762,9 @@ class TestChain(unittest.TestCase):
         self.assertIsNot(c2.c1.l1.x, self.l1.x)
         self.assertIsNot(c2.c1.l1.x.data, self.l1.x.data)
         self.assertFalse(numpy.array_equal(c2.c1.l1.x.data, self.l1.x.data))
-        self.assertIsNot(c2.c1.l1.x.grad, None)
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2.c1.l1.x.grad).all())
 
         self.assertTrue(hasattr(c2.c1, 'l2'))
         self.assertEqual(c2.c1.l2.name, 'l2')
@@ -763,13 +772,17 @@ class TestChain(unittest.TestCase):
         self.assertIsNot(c2.c1.l2.x, self.l2.x)
         self.assertIsNot(c2.c1.l2.x.data, self.l2.x.data)
         self.assertFalse(numpy.array_equal(c2.c1.l2.x.data, self.l2.x.data))
-        self.assertIsNot(c2.c1.l2.x.grad, None)
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2.c1.l2.x.grad).all())
 
         self.assertTrue(hasattr(c2, 'l3'))
         self.assertEqual(c2.l3.name, 'l3')
         self.assertIsNot(c2.l3, self.l3)
         self.assertIsNot(c2.l3.x, self.l3.x)
         self.assertIs(c2.l3.x.data, self.l3.x.data)
+        # A Parameter constructed with shape argument but not initialized
+        # has None in grad
         self.assertIs(c2.l3.x.grad, None)
 
     def test_to_cpu_on_cpu(self):
@@ -1030,6 +1043,9 @@ class TestChainRepeat(unittest.TestCase):
         self.assertIsNot(ret[0], ret[1])
         self.assertIsNot(ret[0].link, self.chain.link)
         self.assertIsNot(ret[1].link, self.chain.link)
+        self.assertIsNot(ret[0].link, ret[1].link)
+        self.assertIsNot(ret[0].link.x, self.chain.link.x)
+        self.assertIsNot(ret[1].link.x, self.chain.link.x)
         self.assertIsNot(ret[0].link.x, ret[1].link.x)
         self.assertIs(ret[0].link.x.data, self.chain.link.x.data)
         self.assertIs(ret[0].link.x.data, ret[1].link.x.data)
@@ -1046,6 +1062,9 @@ class TestChainRepeat(unittest.TestCase):
         self.assertIsNot(ret[0], ret[1])
         self.assertIsNot(ret[0].link, self.chain.link)
         self.assertIsNot(ret[1].link, self.chain.link)
+        self.assertIsNot(ret[0].link, ret[1].link)
+        self.assertIsNot(ret[0].link.x, self.link.x)
+        self.assertIsNot(ret[1].link.x, self.link.x)
         self.assertIsNot(ret[0].link.x, ret[1].link.x)
         self.assertIsNot(ret[0].link.x.data, self.chain.link.x.data)
         self.assertIsNot(ret[1].link.x.data, self.chain.link.x.data)
@@ -1137,8 +1156,14 @@ class TestChainList(unittest.TestCase):
         self.assertEqual(len(self.c1), 2)
         self.assertEqual(len(self.c2), 2)
 
-    def test_copy(self):
-        c2 = self.c2.copy()
+    def test_copy_with_share_mode(self):
+        c2 = self.c2.copy(mode='share')
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
 
         self.assertIs(c2.name, None)
         self.assertIsInstance(c2._children, list)
@@ -1162,6 +1187,77 @@ class TestChainList(unittest.TestCase):
         self.assertIsNot(c2[1].x, self.l3.x)
         self.assertIs(c2[1].x.data, self.l3.x.data)
         self.assertIs(c2[1].x.grad, None)
+
+    def test_copy_with_copy_mode(self):
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
+
+        c2 = self.c2.copy(mode='copy')
+        self.assertIs(c2.name, None)
+        self.assertIsInstance(c2._children, list)
+        self.assertEqual(c2[0].name, '0')
+        self.assertIsInstance(c2[0]._children, list)
+        self.assertIsNot(c2[0][0], self.l1)
+        self.assertIsNot(c2[0][0].name, '0')
+        self.assertIsNot(c2[0][0].x, self.l1.x)
+        self.assertIsNot(c2[0][0].x.data, self.l1.x.data)
+        self.assertTrue(numpy.array_equal(c2[0][0].x.data, self.l1.x.data))
+        self.assertIs(c2[0][0].x.grad, None)
+
+        self.assertIsNot(c2[0][1], self.l2)
+        self.assertIsNot(c2[0][1].name, '1')
+        self.assertIsNot(c2[0][1].x, self.l2.x)
+        self.assertIsNot(c2[0][1].x.data, self.l2.x.data)
+        self.assertTrue(numpy.array_equal(c2[0][1].x.data, self.l2.x.data))
+        self.assertIs(c2[0][1].x.grad, None)
+
+        self.assertIsNot(c2[1], self.l3)
+        self.assertIsNot(c2[1].name, '1')
+        self.assertIsNot(c2[1].x, self.l3.x)
+        self.assertIsNot(c2[1].x.data, self.l3.x.data)
+        # l3 is constructed with shape argument but not initialized
+        self.assertTrue(numpy.isnan(c2[1].x.grad).all())
+
+    def test_copy_with_init_mode(self):
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
+
+        c2 = self.c2.copy(mode='init')
+        self.assertIs(c2.name, None)
+        self.assertIsInstance(c2._children, list)
+        self.assertEqual(c2[0].name, '0')
+        self.assertIsInstance(c2[0]._children, list)
+        self.assertIsNot(c2[0][0], self.l1)
+        self.assertIsNot(c2[0][0].name, '0')
+        self.assertIsNot(c2[0][0].x, self.l1.x)
+        self.assertIsNot(c2[0][0].x.data, self.l1.x.data)
+        self.assertFalse(numpy.array_equal(c2[0][0].x.data, self.l1.x.data))
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2[0][0].x.grad).all())
+
+        self.assertIsNot(c2[0][1], self.l2)
+        self.assertIsNot(c2[0][1].name, '1')
+        self.assertIsNot(c2[0][1].x, self.l2.x)
+        self.assertIsNot(c2[0][1].x.data, self.l2.x.data)
+        self.assertFalse(numpy.array_equal(c2[0][1].x.data, self.l2.x.data))
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2[0][1].x.grad).all())
+
+        self.assertIsNot(c2[1], self.l3)
+        self.assertIsNot(c2[1].name, '1')
+        self.assertIsNot(c2[1].x, self.l3.x)
+        self.assertTrue(numpy.isnan(c2[1].x.data).all())
+        self.assertTrue(numpy.isnan(c2[1].x.grad).all())
 
     @attr.gpu
     def test_copy_and_send_to_gpu(self):


### PR DESCRIPTION
Related to #4649. `copy()` method in `ChainList` should also be fixed and the example in the docstring of `Link.repeat()` method should be tested.