### PR TITLE
Fix no_grads option of check_backward

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -358,8 +358,8 @@ def check_backward(
     If the function is non-differentiable with respect to some input objects,
     we can check its backprop to such objects by ``no_grads`` argument.
     ``gradient_check`` computes numerical backward to inputs that correspond to
-    ``False`` in ``no_grads``. It also asserts the backprop lefts gradient
-    ``None`` for inputs that correspond to ``True`` in ``no_grads``.
+    ``False`` in ``no_grads``. It also asserts that the backprop leaves
+    gradients ``None`` for inputs that correspond to ``True`` in ``no_grads``.
     The default of ``no_grads`` argument is the tuple of truth values whether
     input objects (``x1_data`` or/and ``x2_data`` in this example) represent
     integer variables.

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -481,10 +481,9 @@ def check_backward(
                 'Actual: {0} != {1}'.format(len(no_grads), len(xs)))
 
     for skip, x in six.moves.zip(no_grads, xs):
-        if skip:
-            if x.grad is not None:
-                raise RuntimeError(
-                    'gradient of int variable must be None')
+        if skip and x.grad is not None:
+            raise RuntimeError(
+                'gradient of int variable must be None')
 
     if len(xs) - no_grads.count(True) + len(params) == 0:
         # When there is no float variables, we need not to check gradient

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -581,7 +581,7 @@ class TestCheckBackward(unittest.TestCase):
             return s,
 
         self.assertRaises(RuntimeError, gradient_check.check_backward,
-                          f, (x1, x2), g1, no_grads=[False, False])
+                          f, (x1, x2), g1, no_grads=[True, True])
         gradient_check.check_backward(f, (x1, x2), g1, no_grads=[False, True])
 
     def test_no_grads_option_with_dtype(self):

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -577,11 +577,17 @@ class TestCheckBackward(unittest.TestCase):
         g1 = numpy.array([1], dtype='f')
 
         def f(x, y):
-            s = Ident()(x)
+            s = x + y.array
             return s,
 
-        self.assertRaises(RuntimeError, gradient_check.check_backward,
-                          f, (x1, x2), g1, no_grads=[True, True])
+        self.assertRaises(
+            RuntimeError,  # backward computes x1.grad
+            gradient_check.check_backward,
+            f, (x1, x2), g1, no_grads=[True, True])
+        self.assertRaises(
+            AssertionError,  # numerical backward to x2 is nonzero
+            gradient_check.check_backward,
+            f, (x1, x2), g1, no_grads=[False, False])
         gradient_check.check_backward(f, (x1, x2), g1, no_grads=[False, True])
 
     def test_no_grads_option_with_dtype(self):


### PR DESCRIPTION
- "their gradients are ignored" in the docstring was ambiguous.
- `check_backward` is supposed to compare backward with the numerical one. Do not check computational graph.