### PR TITLE
Warn only if the BN input tensor is 2-dimensional

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -87,7 +87,7 @@ class BatchNormalization(function_node.FunctionNode):
         self.retain_inputs((0, 1))
         x, gamma, beta = inputs
 
-        if x.shape[0] == 1:
+        if x.shape[0] == 1 and len(x.shape) == 2:
             warnings.warn(
                 'A batch with no more than one sample has been given'
                 ' to F.batch_normalization. F.batch_normalization'

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -87,18 +87,6 @@ class BatchNormalization(function_node.FunctionNode):
         self.retain_inputs((0, 1))
         x, gamma, beta = inputs
 
-        if x.shape[0] == 1 and len(x.shape) == 2:
-            warnings.warn(
-                'A batch with no more than one sample has been given'
-                ' to F.batch_normalization. F.batch_normalization'
-                ' will always output a zero tensor for such batches.'
-                ' This could be caused by incorrect configuration in'
-                ' your code (such as running evaluation while'
-                ' chainer.config.train=True),'
-                ' but could also happen in the last batch of training'
-                ' if non-repeating iterator is used.',
-                UserWarning)
-
         xp = cuda.get_array_module(x)
         if self.running_mean is None:
             self.running_mean = xp.zeros_like(gamma)
@@ -106,6 +94,26 @@ class BatchNormalization(function_node.FunctionNode):
 
         self.axis = _compute_axis(x.ndim, gamma.ndim, self.axis)
         self.key_axis = _compute_key_axis(x.ndim, gamma.ndim, self.axis)
+
+        if all(x.shape[i] == 1 for i in self.axis):
+            if x.shape[0] == 1:
+                warnings.warn(
+                    'A batch with no more than one sample has been given'
+                    ' to F.batch_normalization. F.batch_normalization'
+                    ' will always output a zero tensor for such batches.'
+                    ' This could be caused by incorrect configuration in'
+                    ' your code (such as running evaluation while'
+                    ' chainer.config.train=True),'
+                    ' but could also happen in the last batch of training'
+                    ' if non-repeating iterator is used.',
+                    UserWarning)
+            else:
+                warnings.warn(
+                    'F.batch_normalization received a batch with single'
+                    ' dimensions along all axes that are used for aggregating'
+                    ' statistics. F.batch_normalization'
+                    ' will always output a zero tensor for such batches.',
+                    UserWarning)
 
         # TODO(niboshi): Refactor calculation of expander and axis into a
         # function and call it just before they are used.

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -96,7 +96,7 @@ class BatchNormalization(function_node.FunctionNode):
         self.key_axis = _compute_key_axis(x.ndim, gamma.ndim, self.axis)
 
         if all(x.shape[i] == 1 for i in self.axis):
-            if x.shape[0] == 1:
+            if 0 in self.axis:
                 warnings.warn(
                     'A batch with no more than one sample has been given'
                     ' to F.batch_normalization. F.batch_normalization'

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -425,5 +425,4 @@ class TestBatchNormalizationWarning(unittest.TestCase):
                                      'but it should not be.')
 
 
-
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -402,10 +402,10 @@ class TestBatchNormalizationWarning(unittest.TestCase):
     def create_batch(self, ndim):
         param_shape = (3,)
         dtype = numpy.float32
-        gamma = cuda.cupy.random.uniform(.5, 1, param_shape).astype(dtype)
-        beta = cuda.cupy.random.uniform(-1, 1, param_shape).astype(dtype)
+        gamma = numpy.random.uniform(.5, 1, param_shape).astype(dtype)
+        beta = numpy.random.uniform(-1, 1, param_shape).astype(dtype)
         shape = (1,) + param_shape + (2,) * ndim
-        x = cuda.cupy.random.uniform(-1, 1, shape).astype(dtype)
+        x = numpy.random.uniform(-1, 1, shape).astype(dtype)
         args = [x, gamma, beta]
         return args
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 import six
+import warnings
 
 import chainer
 from chainer.backends import cuda
@@ -392,6 +393,37 @@ class TestBatchNormalizationCudnnEps(unittest.TestCase):
     def test_invalid(self):
         with self.assertRaises(RuntimeError):
             functions.batch_normalization(*self.args, eps=2e-6)
+
+
+class TestBatchNormalizationWarning(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def create_batch(self, ndim):
+        param_shape = (3,)
+        dtype = numpy.float32
+        gamma = cuda.cupy.random.uniform(.5, 1, param_shape).astype(dtype)
+        beta = cuda.cupy.random.uniform(-1, 1, param_shape).astype(dtype)
+        shape = (1,) + param_shape + (2,) * ndim
+        x = cuda.cupy.random.uniform(-1, 1, shape).astype(dtype)
+        args = [x, gamma, beta]
+        return args
+
+    def test_invalid_batch(self):
+        args = self.create_batch(0)
+        with testing.assert_warns(UserWarning):
+            functions.batch_normalization(*args)
+
+    def test_valid_batch(self):
+        args = self.create_batch(2)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                functions.batch_normalization(*args)
+            except UserWarning:
+                raise AssertionError('UserWarning was triggered, '
+                                     'but it should not be.')
+
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -399,30 +399,35 @@ class TestBatchNormalizationWarning(unittest.TestCase):
     def setUp(self):
         pass
 
-    def create_batch(self, ndim):
-        param_shape = (3,)
+    def create_batch(self, param_shape, x_shape):
         dtype = numpy.float32
         gamma = numpy.random.uniform(.5, 1, param_shape).astype(dtype)
         beta = numpy.random.uniform(-1, 1, param_shape).astype(dtype)
-        shape = (1,) + param_shape + (2,) * ndim
-        x = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        x = numpy.random.uniform(-1, 1, x_shape).astype(dtype)
         args = [x, gamma, beta]
         return args
 
     def test_invalid_batch(self):
-        args = self.create_batch(0)
+        args = self.create_batch((3,), (1, 3))
         with testing.assert_warns(UserWarning):
             functions.batch_normalization(*args)
 
+    def test_invalid_batch_no_batch_axis(self):
+        args = self.create_batch((1, 3,), (1, 3, 1))
+        with testing.assert_warns(UserWarning):
+            functions.batch_normalization(*args, axis=2)
+
     def test_valid_batch(self):
-        args = self.create_batch(2)
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error')
-            try:
-                functions.batch_normalization(*args)
-            except UserWarning:
-                raise AssertionError('UserWarning was triggered, '
-                                     'but it should not be.')
+        args = self.create_batch((3,), (1, 3, 2, 2))
+        with warnings.catch_warnings(record=True) as w:
+            functions.batch_normalization(*args)
+            assert len(w) == 0
+
+    def test_valid_batch_no_batch_axis(self):
+        args = self.create_batch((1, 3,), (1, 3, 2))
+        with warnings.catch_warnings(record=True) as w:
+            functions.batch_normalization(*args, axis=2)
+            assert len(w) == 0
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fixes #4662.

I fixed the false warning that appeared in #3996 when the input tensor has more than 2 dimensions. Note that this PR only fixes the standard case when `axis=None`. A more sophisticated check is needed to not give false warnings for the other axis options introduced in #4266.

The following illustrates the behavior due to this PR:
```
In [1]: import numpy as np

In [2]: import chainer

In [3]: bn = chainer.links.BatchNormalization(4)

In [4]: x = np.random.rand(1, 4).astype(np.float32)

In [5]: bn(x)
/home/tommi/.pyenv/versions/3.4.3/envs/chainer-dev3.4.3/lib/python3.4/site-packages/chainer-5.0.0a1-py3.4.egg/chainer/functions/normalization/batch_normalization.py:100: UserWarning: A batch with no more than one sample has been given to F.batch_normalization. F.batch_normalization will always output a zero tensor for such batches. This could be caused by incorrect configuration in your code (such as running evaluation while chainer.config.train=True), but could also happen in the last batch of training if non-repeating iterator is used.
  UserWarning)
Out[5]: variable([[ 0.,  0.,  0.,  0.]])

In [6]: x = np.random.rand(1, 4, 5, 6).astype(np.float32)

In [7]: bn(x)
Out[7]: 
variable([[[[ 0.88383329,  0.24783106, -0.35056776,  0.45682225,
             -1.38407457, -0.39653379],
            [-0.97899908, -1.57535398, -1.38358796, -1.27693629,
             -2.20569324,  1.22138727],
            [ 0.14362516,  1.36604619, -0.4590117 ,  1.38188398,
             -0.74986064,  0.87933534],
            [ 0.80834419, -0.79376137,  1.31242239, -0.29662037,
             -0.34697992, -0.72915429],
            [ 0.5668816 ,  0.69676024,  1.37218988,  0.01948533,
              1.22701776,  0.34326702]],

           [[ 0.0104244 ,  1.07958531,  0.40102562,  0.67557257,
              0.8304196 ,  0.16076598],
            [ 0.99945849, -1.11169207, -0.48962063, -1.03725564,
              1.56631446,  0.33011672],
            [-1.57883441,  1.61516035,  0.01796032, -0.55186921,
             -1.66364145, -1.5349046 ],
            [-0.28114355,  0.95056921, -1.64674163,  0.83853984,
             -1.0257318 ,  1.12100112],
            [-1.56099236,  0.22759983,  0.25137761,  1.24357152,
             -0.04931128,  0.21227953]],

           [[-1.93279457,  0.64842421,  0.81283778,  0.79755312,
              0.31647423, -0.10959966],
            [-0.39431885, -1.4173367 ,  0.52795428,  1.86794317,
              0.3631916 , -0.34962398],
            [-1.275949  , -1.08183765,  1.81970918, -1.66731   ,
             -0.16015647,  0.36299735],
            [ 0.97641951,  0.40229759,  0.53101915,  0.96606696,
             -0.64821613,  0.00826658],
            [ 0.7754072 , -1.11620092, -1.27183533, -0.00277958,
              1.33899188, -1.08759546]],

           [[-0.06503277, -0.78476042,  0.61540544,  1.42846644,
             -1.09960437, -1.429672  ],
            [-1.32273185,  1.62729824,  1.4065882 ,  0.27002716,
             -1.22050107, -0.65235502],
            [ 1.27065504, -0.62376803,  0.42506689, -0.64073187,
             -1.28400862,  0.5179444 ],
            [ 0.34610024, -0.22061768, -0.50182396, -1.0034554 ,
             -0.81978297,  1.3319149 ],
            [ 1.39201581,  1.34085441,  0.9786694 , -0.60437816,
              0.57300836, -1.25078964]]]])
```
