### PR TITLE
[backport] Fix `ChainList.copy` not supporting `mode` argument

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -620,7 +620,7 @@ Assign a Parameter object directly to an attribute within a \
             You can repeat the same link multiple times to create a longer
             :class:`~chainer.Sequential` block like this:
 
-            .. code-block:: python
+            .. testcode::
 
                 class ConvBNReLU(chainer.Chain):
 
@@ -1015,12 +1015,12 @@ class ChainList(Link):
         link.name = str(len(self._children))
         self._children.append(link)
 
-    def copy(self):
+    def copy(self, mode='share'):
         ret = super(ChainList, self).copy()
         ret._children = list(ret._children)  # copy
         children = ret._children
         for i, child in enumerate(children):
-            child = child.copy()
+            child = child.copy(mode)
             child.name = str(i)
             children[i] = child
         return ret

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -655,6 +655,13 @@ class TestChain(unittest.TestCase):
         self.assertNotIn('l1', self.c1._children)
 
     def test_copy_with_share_mode(self):
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
+
         c2 = self.c2.copy(mode='share')
         self.assertIs(c2.name, None)
         self.assertIsInstance(c2._children, set)
@@ -739,7 +746,9 @@ class TestChain(unittest.TestCase):
         self.assertIsNot(c2.c1.l1.x, self.l1.x)
         self.assertIsNot(c2.c1.l1.x.data, self.l1.x.data)
         self.assertFalse(numpy.array_equal(c2.c1.l1.x.data, self.l1.x.data))
-        self.assertIsNot(c2.c1.l1.x.grad, None)
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2.c1.l1.x.grad).all())
 
         self.assertTrue(hasattr(c2.c1, 'l2'))
         self.assertEqual(c2.c1.l2.name, 'l2')
@@ -747,13 +756,17 @@ class TestChain(unittest.TestCase):
         self.assertIsNot(c2.c1.l2.x, self.l2.x)
         self.assertIsNot(c2.c1.l2.x.data, self.l2.x.data)
         self.assertFalse(numpy.array_equal(c2.c1.l2.x.data, self.l2.x.data))
-        self.assertIsNot(c2.c1.l2.x.grad, None)
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2.c1.l2.x.grad).all())
 
         self.assertTrue(hasattr(c2, 'l3'))
         self.assertEqual(c2.l3.name, 'l3')
         self.assertIsNot(c2.l3, self.l3)
         self.assertIsNot(c2.l3.x, self.l3.x)
         self.assertIs(c2.l3.x.data, self.l3.x.data)
+        # A Parameter constructed with shape argument but not initialized
+        # has None in grad
         self.assertIs(c2.l3.x.grad, None)
 
     def test_to_cpu_on_cpu(self):
@@ -1000,6 +1013,9 @@ class TestChainRepeat(unittest.TestCase):
         self.assertIsNot(ret[0], ret[1])
         self.assertIsNot(ret[0].link, self.chain.link)
         self.assertIsNot(ret[1].link, self.chain.link)
+        self.assertIsNot(ret[0].link, ret[1].link)
+        self.assertIsNot(ret[0].link.x, self.chain.link.x)
+        self.assertIsNot(ret[1].link.x, self.chain.link.x)
         self.assertIsNot(ret[0].link.x, ret[1].link.x)
         self.assertIs(ret[0].link.x.data, self.chain.link.x.data)
         self.assertIs(ret[0].link.x.data, ret[1].link.x.data)
@@ -1016,6 +1032,9 @@ class TestChainRepeat(unittest.TestCase):
         self.assertIsNot(ret[0], ret[1])
         self.assertIsNot(ret[0].link, self.chain.link)
         self.assertIsNot(ret[1].link, self.chain.link)
+        self.assertIsNot(ret[0].link, ret[1].link)
+        self.assertIsNot(ret[0].link.x, self.link.x)
+        self.assertIsNot(ret[1].link.x, self.link.x)
         self.assertIsNot(ret[0].link.x, ret[1].link.x)
         self.assertIsNot(ret[0].link.x.data, self.chain.link.x.data)
         self.assertIsNot(ret[1].link.x.data, self.chain.link.x.data)
@@ -1107,8 +1126,14 @@ class TestChainList(unittest.TestCase):
         self.assertEqual(len(self.c1), 2)
         self.assertEqual(len(self.c2), 2)
 
-    def test_copy(self):
-        c2 = self.c2.copy()
+    def test_copy_with_share_mode(self):
+        c2 = self.c2.copy(mode='share')
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
 
         self.assertIs(c2.name, None)
         self.assertIsInstance(c2._children, list)
@@ -1132,6 +1157,77 @@ class TestChainList(unittest.TestCase):
         self.assertIsNot(c2[1].x, self.l3.x)
         self.assertIs(c2[1].x.data, self.l3.x.data)
         self.assertIs(c2[1].x.grad, None)
+
+    def test_copy_with_copy_mode(self):
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
+
+        c2 = self.c2.copy(mode='copy')
+        self.assertIs(c2.name, None)
+        self.assertIsInstance(c2._children, list)
+        self.assertEqual(c2[0].name, '0')
+        self.assertIsInstance(c2[0]._children, list)
+        self.assertIsNot(c2[0][0], self.l1)
+        self.assertEqual(c2[0][0].name, '0')
+        self.assertIsNot(c2[0][0].x, self.l1.x)
+        self.assertIsNot(c2[0][0].x.data, self.l1.x.data)
+        self.assertTrue(numpy.array_equal(c2[0][0].x.data, self.l1.x.data))
+        self.assertIs(c2[0][0].x.grad, None)
+
+        self.assertIsNot(c2[0][1], self.l2)
+        self.assertEqual(c2[0][1].name, '1')
+        self.assertIsNot(c2[0][1].x, self.l2.x)
+        self.assertIsNot(c2[0][1].x.data, self.l2.x.data)
+        self.assertTrue(numpy.array_equal(c2[0][1].x.data, self.l2.x.data))
+        self.assertIs(c2[0][1].x.grad, None)
+
+        self.assertIsNot(c2[1], self.l3)
+        self.assertEqual(c2[1].name, '1')
+        self.assertIsNot(c2[1].x, self.l3.x)
+        self.assertIsNot(c2[1].x.data, self.l3.x.data)
+        # l3 is constructed with shape argument but not initialized
+        self.assertTrue(numpy.isnan(c2[1].x.grad).all())
+
+    def test_copy_with_init_mode(self):
+        self.l1.x.initializer = initializers.Normal(
+            dtype=self.l1.x.initializer.dtype)
+        self.l1.x.initialize(self.l1.x.shape)
+        self.l2.x.initializer = initializers.Normal(
+            dtype=self.l2.x.initializer.dtype)
+        self.l2.x.initialize(self.l2.x.shape)
+
+        c2 = self.c2.copy(mode='init')
+        self.assertIs(c2.name, None)
+        self.assertIsInstance(c2._children, list)
+        self.assertEqual(c2[0].name, '0')
+        self.assertIsInstance(c2[0]._children, list)
+        self.assertIsNot(c2[0][0], self.l1)
+        self.assertEqual(c2[0][0].name, '0')
+        self.assertIsNot(c2[0][0].x, self.l1.x)
+        self.assertIsNot(c2[0][0].x.data, self.l1.x.data)
+        self.assertFalse(numpy.array_equal(c2[0][0].x.data, self.l1.x.data))
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2[0][0].x.grad).all())
+
+        self.assertIsNot(c2[0][1], self.l2)
+        self.assertEqual(c2[0][1].name, '1')
+        self.assertIsNot(c2[0][1].x, self.l2.x)
+        self.assertIsNot(c2[0][1].x.data, self.l2.x.data)
+        self.assertFalse(numpy.array_equal(c2[0][1].x.data, self.l2.x.data))
+        # _grad_initializer attribute in a copied Parameter has constant.NaN
+        # after calling initilize() method
+        self.assertTrue(numpy.isnan(c2[0][1].x.grad).all())
+
+        self.assertIsNot(c2[1], self.l3)
+        self.assertEqual(c2[1].name, '1')
+        self.assertIsNot(c2[1].x, self.l3.x)
+        self.assertTrue(numpy.isnan(c2[1].x.data).all())
+        self.assertTrue(numpy.isnan(c2[1].x.grad).all())
 
     @attr.gpu
     def test_copy_and_send_to_gpu(self):
@@ -1364,6 +1460,96 @@ class TestChainList(unittest.TestCase):
 
         mocks['0'].assert_called_with('y', l1.y.data)
         mocks['1'].assert_called_with('x', l2.x.data)
+
+
+class TestChainListRepeat(unittest.TestCase):
+
+    def setUp(self):
+        class ChainListForTest(chainer.ChainList):
+            def __init__(self):
+                super(ChainListForTest, self).__init__(chainer.Link())
+
+            def __call__(self):
+                pass
+
+        self.chainlist = ChainListForTest()
+        self.link = self.chainlist[0]
+        with self.link.init_scope():
+            self.link.x = chainer.Parameter(
+                chainer.initializers.Normal(), shape=(2, 3))
+
+    def test_no_repeat(self):
+        ret = self.chainlist.repeat(0)
+        self.assertEqual(len(ret), 0)
+
+    def test_repeat_with_share_mode(self):
+        ret = self.chainlist.repeat(2, mode='share')
+        self.assertEqual(len(ret), 2)
+        self.assertIsNot(ret[0], self.chainlist)
+        self.assertIsNot(ret[1], self.chainlist)
+        self.assertIsNot(ret[0], ret[1])
+        self.assertIsNot(ret[0][0], self.chainlist[0])
+        self.assertIsNot(ret[1][0], self.chainlist[0])
+        self.assertIsNot(ret[0][0], ret[1][0])
+        self.assertIsNot(ret[0][0].x, self.chainlist[0].x)
+        self.assertIsNot(ret[1][0].x, self.chainlist[0].x)
+        self.assertIsNot(ret[0][0].x, ret[1][0].x)
+        self.assertIs(ret[0][0].x.data, self.chainlist[0].x.data)
+        self.assertIs(ret[0][0].x.data, ret[1][0].x.data)
+        self.assertEqual(ret[0][0].x.shape, self.chainlist[0].x.shape)
+        self.assertEqual(ret[0][0].x.shape, ret[1][0].x.shape)
+        self.assertEqual(ret[0][0].x.dtype, self.chainlist[0].x.dtype)
+        self.assertEqual(ret[0][0].x.dtype, ret[1][0].x.dtype)
+
+    def test_repeat_with_copy_mode(self):
+        ret = self.chainlist.repeat(2, mode='copy')
+        self.assertEqual(len(ret), 2)
+        self.assertIsNot(ret[0], self.chainlist)
+        self.assertIsNot(ret[1], self.chainlist)
+        self.assertIsNot(ret[0], ret[1])
+        self.assertIsNot(ret[0][0], self.chainlist[0])
+        self.assertIsNot(ret[1][0], self.chainlist[0])
+        self.assertIsNot(ret[0][0], ret[1][0])
+        self.assertIsNot(ret[0][0].x, self.chainlist[0].x)
+        self.assertIsNot(ret[1][0].x, self.chainlist[0].x)
+        self.assertIsNot(ret[0][0].x, ret[1][0].x)
+        self.assertIsNot(ret[0][0].x.data, self.chainlist[0].x.data)
+        self.assertIsNot(ret[1][0].x.data, self.chainlist[0].x.data)
+        self.assertIsNot(ret[0][0].x.data, ret[1][0].x.data)
+        self.assertTrue(numpy.array_equal(
+            ret[0][0].x.data, self.chainlist[0].x.data))
+        self.assertTrue(numpy.array_equal(
+            ret[0][0].x.data, ret[1][0].x.data))
+        self.assertEqual(ret[0][0].x.shape, self.chainlist[0].x.shape)
+        self.assertEqual(ret[0][0].x.shape, ret[1][0].x.shape)
+        self.assertEqual(ret[0][0].x.dtype, self.chainlist[0].x.dtype)
+        self.assertEqual(ret[0][0].x.dtype, ret[1][0].x.dtype)
+
+    def test_repeat_with_init_mode(self):
+        ret = self.chainlist.repeat(2, mode='init')
+        self.assertEqual(len(ret), 2)
+        self.assertIsNot(ret[0], self.chainlist)
+        self.assertIsNot(ret[1], self.chainlist)
+        self.assertIsNot(ret[0], ret[1])
+        self.assertIsNot(ret[0][0], self.chainlist[0])
+        self.assertIsNot(ret[1][0], self.chainlist[0])
+        self.assertIsNot(ret[0][0], ret[1][0])
+        self.assertIsNot(ret[0][0].x, self.chainlist[0].x)
+        self.assertIsNot(ret[1][0].x, self.chainlist[0].x)
+        self.assertIsNot(ret[0][0].x, ret[1][0].x)
+        self.assertIsNot(ret[0][0].x.data, self.chainlist[0].x.data)
+        self.assertIsNot(ret[1][0].x.data, self.chainlist[0].x.data)
+        self.assertIsNot(ret[0][0].x.data, ret[1][0].x.data)
+        self.assertFalse(numpy.array_equal(
+            ret[0][0].x.data, self.chainlist[0].x.data))
+        self.assertFalse(numpy.array_equal(
+            ret[1][0].x.data, self.chainlist[0].x.data))
+        self.assertFalse(numpy.array_equal(
+            ret[0][0].x.data, ret[1][0].x.data))
+        self.assertEqual(ret[0][0].x.shape, self.chainlist[0].x.shape)
+        self.assertEqual(ret[0][0].x.shape, ret[1][0].x.shape)
+        self.assertEqual(ret[0][0].x.dtype, self.chainlist[0].x.dtype)
+        self.assertEqual(ret[0][0].x.dtype, ret[1][0].x.dtype)
 
 
 @attr.ideep


### PR DESCRIPTION
Backport of #4652