### PR TITLE
Automatic broadcast in basic_math and matmul

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -253,6 +253,7 @@ from chainer.functions.math.squared_difference import squared_difference  # NOQA
 from chainer.functions.math.squared_difference import SquaredDifference  # NOQA
 from chainer.functions.math.sum import sum  # NOQA
 from chainer.functions.math.sum import Sum  # NOQA
+from chainer.functions.math.sum import sum_to  # NOQA
 from chainer.functions.math.tensordot import tensordot  # NOQA
 from chainer.functions.math.trigonometric import arccos  # NOQA
 from chainer.functions.math.trigonometric import Arccos  # NOQA

--- a/chainer/functions/array/broadcast.py
+++ b/chainer/functions/array/broadcast.py
@@ -31,7 +31,8 @@ class Broadcast(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         return tuple([None if grad_outputs[i] is None else
-                      chainer.functions.sum_to(grad_outputs[i], self.inputs[i].shape)
+                      chainer.functions.sum_to(
+                          grad_outputs[i], self.inputs[i].shape)
                       for i in indexes])
 
 

--- a/chainer/functions/array/broadcast.py
+++ b/chainer/functions/array/broadcast.py
@@ -6,19 +6,6 @@ from chainer import function_node
 from chainer.utils import type_check
 
 
-def _backward_one(g, shape):
-    if g.shape == shape:
-        return g
-    ndim = len(shape)
-    lead = g.ndim - ndim
-    lead_axis = tuple(six.moves.range(lead))
-    axis = [i + lead for i, sx in enumerate(shape) if sx == 1]
-    g = chainer.functions.sum(g, lead_axis + tuple(axis), True)
-    if lead > 0:
-        return chainer.functions.squeeze(g, lead_axis)
-    return g
-
-
 class Broadcast(function_node.FunctionNode):
 
     """Function that broadcasts given arrays."""
@@ -44,7 +31,7 @@ class Broadcast(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         return tuple([None if grad_outputs[i] is None else
-                      _backward_one(grad_outputs[i], self.inputs[i].shape)
+                      chainer.functions.sum_to(grad_outputs[i], self.inputs[i].shape)
                       for i in indexes])
 
 
@@ -116,7 +103,8 @@ class BroadcastTo(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         gx, = grad_outputs
-        return _backward_one(gx, self.inputs[0].shape),
+        x_node, = self.inputs
+        return chainer.functions.sum_to(gx, x_node.shape),
 
 
 def broadcast_to(x, shape):

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -148,6 +148,8 @@ class Add(function_node.FunctionNode):
         type_check.expect(
             in_types[0].dtype == in_types[1].dtype,
         )
+        type_check.expect_broadcast_shapes(
+            in_types[0].shape, in_types[1].shape)
 
     def forward(self, x):
         # may broadcast
@@ -236,6 +238,8 @@ class Sub(function_node.FunctionNode):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         type_check.expect(in_types[0].dtype == in_types[1].dtype)
+        type_check.expect_broadcast_shapes(
+            in_types[0].shape, in_types[1].shape)
 
     def forward(self, x):
         # may broadcast
@@ -308,6 +312,8 @@ class Mul(function_node.FunctionNode):
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,
         )
+        type_check.expect_broadcast_shapes(
+            in_types[0].shape, in_types[1].shape)
 
     def forward(self, x):
         self.retain_inputs((0, 1))
@@ -368,6 +374,8 @@ class Div(function_node.FunctionNode):
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,
         )
+        type_check.expect_broadcast_shapes(
+            in_types[0].shape, in_types[1].shape)
 
     def forward(self, x):
         self.retain_inputs((0, 1))
@@ -532,6 +540,8 @@ class PowVarVar(function_node.FunctionNode):
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,
         )
+        type_check.expect_broadcast_shapes(
+            in_types[0].shape, in_types[1].shape)
 
     def forward(self, x):
         self.retain_inputs((0, 1))

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -35,7 +35,7 @@ def _check_constant_type(value):
     elif isinstance(value, (numpy.ndarray, cuda.ndarray)):
         return
     else:
-        raise ValueError(
+        raise TypeError(
             'Value must be a scalar, `numpy.ndarray`, `cupy.ndarray` '
             'or a `Variable`.\nActual: {}'.format(type(value)))
 
@@ -49,6 +49,13 @@ def _preprocess_const(x, value):
     b = xp.broadcast(x, value)
     if b.shape != x.shape:
         raise ValueError('Failed to broadcast arrays')
+    return utils.force_type(x.dtype, value)
+
+
+def _preprocess_rhs(x, value):
+    if isinstance(value, chainer.Variable):
+        return value
+    _check_constant_type(value)
     return utils.force_type(x.dtype, value)
 
 
@@ -140,15 +147,16 @@ class Add(function_node.FunctionNode):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
             in_types[0].dtype == in_types[1].dtype,
-            in_types[0].shape == in_types[1].shape
         )
 
     def forward(self, x):
+        # may broadcast
         y = utils.force_array(x[0] + x[1])
         return y,
 
     def backward(self, indexes, gy):
-        return gy[0], gy[0]
+        return tuple(chainer.functions.sum_to(gy[0], self.inputs[i].shape)
+                     for i in indexes)
 
 
 class AddConstant(function_node.FunctionNode):
@@ -168,17 +176,15 @@ class AddConstant(function_node.FunctionNode):
         return utils.force_array(x[0] + value),
 
     def backward(self, indexes, gy):
-        return gy[0],
+        x_node, = self.inputs
+        return gy
 
 
 class MultiAdd(function_node.FunctionNode):
 
     def check_type_forward(self, in_types):
         for in_type in in_types:
-            type_check.expect(
-                in_types[0].dtype == in_type.dtype,
-                in_types[0].shape == in_type.shape
-            )
+            type_check.expect(in_types[0].dtype == in_type.dtype)
 
     def forward(self, xs):
         self.len = len(xs)
@@ -186,19 +192,23 @@ class MultiAdd(function_node.FunctionNode):
             return xs
         if (intel64.should_use_ideep('>=auto')
                 and intel64.inputs_all_ready(xs)):
+            xs = numpy.broadcast_arrays(xs)
             y = intel64.ideep.multi_add(xs)
         else:
             # The output should be a new array. Add the first 2 arrays
             # and get the result y. Then add the rest arrays to y.
             y = xs[0] + xs[1]
             for x in xs[2:]:
-                y += x
+                if x.shape == y.shape:
+                    y += x
+                else:
+                    y = x + y
 
         return utils.force_array(y),
 
     def backward(self, indexes, gy):
-        gys = (gy[0],) * self.len
-        return gys
+        return tuple(chainer.functions.sum_to(gy[0], x_node.shape)
+                     for x_node in self.inputs)
 
 
 def add(*xs):  # lhs + rhs or add more than 2 variables
@@ -209,10 +219,10 @@ def add(*xs):  # lhs + rhs or add more than 2 variables
     """
     if len(xs) == 2:
         lhs, rhs = xs
-        if isinstance(rhs, variable.Variable):
-            return Add().apply((lhs, rhs))[0]
-        _check_constant_type(rhs)
-        return AddConstant(rhs).apply((lhs,))[0]
+        if numpy.isscalar(rhs):
+            return AddConstant(rhs).apply((lhs,))[0]
+        rhs = _preprocess_rhs(lhs, rhs)
+        return Add().apply((lhs, rhs))[0]
     else:
         return MultiAdd().apply(xs)[0]
 
@@ -225,16 +235,19 @@ class Sub(function_node.FunctionNode):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
-        type_check.expect(
-            in_types[0].dtype == in_types[1].dtype,
-            in_types[0].shape == in_types[1].shape
-        )
+        type_check.expect(in_types[0].dtype == in_types[1].dtype)
 
     def forward(self, x):
+        # may broadcast
         return utils.force_array(x[0] - x[1]),
 
     def backward(self, indexes, gy):
-        return gy[0], -gy[0]
+        x1, x2 = self.inputs
+        g, = gy
+        return (
+            chainer.functions.sum_to(g, x1.shape) if 0 in indexes else None,
+            -chainer.functions.sum_to(g, x2.shape) if 1 in indexes else None,
+        )
 
 
 def sub(self, rhs):  # lhs - rhs
@@ -244,10 +257,10 @@ def sub(self, rhs):  # lhs - rhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return Sub().apply((self, rhs))[0]
-    _check_constant_type(rhs)
-    return AddConstant(-rhs).apply((self,))[0]
+    if numpy.isscalar(rhs):
+        return AddConstant(-rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return Sub().apply((self, rhs))[0]
 
 
 class SubFromConstant(function_node.FunctionNode):
@@ -263,12 +276,12 @@ class SubFromConstant(function_node.FunctionNode):
         type_check.expect(in_types.size() == 1)
 
     def forward(self, x):
-        self.retain_inputs(())
         value = _preprocess_const(x[0], self.value)
         return utils.force_array(value - x[0]),
 
     def backward(self, indexes, gy):
-        return -gy[0],
+        g, = gy
+        return -g,
 
 
 def rsub(self, rhs):  # rhs - lhs
@@ -277,10 +290,10 @@ def rsub(self, rhs):  # rhs - lhs
     Returns:
         ~chainer.Variable: Output variable.
     """
-    if isinstance(rhs, variable.Variable):
-        return Sub().apply((rhs, self))[0]
-    _check_constant_type(rhs)
-    return SubFromConstant(rhs).apply((self,))[0]
+    if numpy.isscalar(rhs):
+        return SubFromConstant(rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return Sub().apply((rhs, self))[0]
 
 
 class Mul(function_node.FunctionNode):
@@ -294,16 +307,19 @@ class Mul(function_node.FunctionNode):
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,
-            in_types[0].shape == in_types[1].shape
         )
 
     def forward(self, x):
         self.retain_inputs((0, 1))
+        # may broadcast
         return utils.force_array(x[0] * x[1]),
 
     def backward(self, indexes, gy):
         xs = self.get_retained_inputs()
-        return tuple(gy[0] * xs[1 - i] for i in indexes)
+        return tuple(
+            chainer.functions.sum_to(gy[0] * xs[1 - i], xs[i].shape)
+            for i in indexes
+        )
 
 
 class MulConstant(function_node.FunctionNode):
@@ -323,7 +339,8 @@ class MulConstant(function_node.FunctionNode):
         return utils.force_array(value * x[0]),
 
     def backward(self, indexes, gy):
-        return self.value * gy[0],
+        g, = gy
+        return self.value * g,
 
 
 def mul(self, rhs):  # lhs * rhs
@@ -333,10 +350,10 @@ def mul(self, rhs):  # lhs * rhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return Mul().apply((self, rhs))[0]
-    _check_constant_type(rhs)
-    return MulConstant(rhs).apply((self,))[0]
+    if numpy.isscalar(rhs):
+        return MulConstant(rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return Mul().apply((self, rhs))[0]
 
 
 class Div(function_node.FunctionNode):
@@ -350,11 +367,11 @@ class Div(function_node.FunctionNode):
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,
-            in_types[0].shape == in_types[1].shape
         )
 
     def forward(self, x):
         self.retain_inputs((0, 1))
+        # may broadcast
         return utils.force_array(x[0] / x[1]),
 
     def backward(self, indexes, grad_outputs):
@@ -368,18 +385,20 @@ class DivGrad(function_node.FunctionNode):
         self.retain_inputs((0, 1, 2))
         x0, x1, gy = inputs
         gx0 = utils.force_array(gy / x1)
-        return gx0, utils.force_array(-gx0 * x0 / x1)
+        gx1 = utils.force_array(-gx0 * x0 / x1)
+        return utils.sum_to(gx0, x0.shape), utils.sum_to(gx1, x1.shape)
 
     def forward_gpu(self, inputs):
         self.retain_inputs((0, 1, 2))
         x0, x1, gy = inputs
-        return cuda.elementwise(
+        gx0, gx1 = cuda.elementwise(
             'T x0, T x1, T gy',
             'T gx0, T gx1',
             '''
                gx0 = gy / x1;
                gx1 = -gx0 * x0 / x1;
             ''', 'div_bwd')(x0, x1, gy)
+        return utils.sum_to(gx0, x0.shape), utils.sum_to(gx1, x1.shape)
 
     def backward(self, indexes, grad_outputs):
         x0, x1, gy = self.get_retained_inputs()
@@ -389,11 +408,11 @@ class DivGrad(function_node.FunctionNode):
         x1_square = x1 * x1
         if 0 in indexes:
             gx0 = -ggx1 * gy / x1_square
-            ret.append(gx0)
+            ret.append(chainer.functions.sum_to(gx0, x0.shape))
         if 1 in indexes:
             gx1 = -ggx0 * gy / x1_square + \
-                ggx1 * 2 * gy * x0 / (x1_square * x1)
-            ret.append(gx1)
+                  ggx1 * 2 * gy * x0 / (x1_square * x1)
+            ret.append(chainer.functions.sum_to(gx1, x1.shape))
         if 2 in indexes:
             ggy = ggx0 / x1 - ggx1 * x0 / x1_square
             ret.append(ggy)
@@ -407,10 +426,10 @@ def div(self, rhs):  # lhs / rhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return Div().apply((self, rhs))[0]
-    _check_constant_type(rhs)
-    return MulConstant(1. / rhs).apply((self,))[0]
+    if numpy.isscalar(rhs):
+        return MulConstant(1. / rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return Div().apply((self, rhs))[0]
 
 
 class DivFromConstant(function_node.FunctionNode):
@@ -453,10 +472,9 @@ class DivFromConstantGrad(function_node.FunctionNode):
         x, gy = inputs
         # TODO(beam2d): Make it not use the input
         value = _preprocess_const(x, self.value)
-        gx = cuda.elementwise('T x, T gy, T value', 'T gx',
-                              'gx = -value * gy / (x * x)',
-                              'div_from_const_bwd')(x, gy, value)
-        return gx,
+        return cuda.elementwise('T x, T gy, T value', 'T gx',
+                                'gx = -value * gy / (x * x)',
+                                'div_from_const_bwd')(x, gy, value),
 
     def backward(self, indexes, grad_outputs):
         x, gy = self.get_retained_inputs()
@@ -476,10 +494,10 @@ def rdiv(self, rhs):  # rhs / lhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return Div().apply((rhs, self))[0]
-    _check_constant_type(rhs)
-    return DivFromConstant(rhs).apply((self,))[0]
+    if numpy.isscalar(rhs):
+        return DivFromConstant(rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return Div().apply((rhs, self))[0]
 
 
 def floordiv(self, rhs):  # lhs // rhs
@@ -513,11 +531,11 @@ class PowVarVar(function_node.FunctionNode):
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,
-            in_types[0].shape == in_types[1].shape
         )
 
     def forward(self, x):
         self.retain_inputs((0, 1))
+        # may broadcast
         self.y = x[0] ** x[1]
         return utils.force_array(self.y),
 
@@ -536,9 +554,7 @@ class PowVarVarGrad(function_node.FunctionNode):
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,
-            in_types[0].shape == in_types[1].shape,
             in_types[0].dtype == in_types[2].dtype,
-            in_types[0].shape == in_types[2].shape,
         )
 
     def forward_cpu(self, inputs):
@@ -546,8 +562,10 @@ class PowVarVarGrad(function_node.FunctionNode):
         x0, x1, gy = inputs
 
         one = x1.dtype.type(1)
-        gx0 = utils.force_array(x1 * (x0 ** (x1 - one)) * gy)
-        gx1 = utils.force_array(numpy.log(x0) * self.y * gy)
+        gx0 = utils.sum_to(
+            utils.force_array(x1 * (x0 ** (x1 - one)) * gy), x0.shape)
+        gx1 = utils.sum_to(
+            utils.force_array(numpy.log(x0) * self.y * gy), x1.shape)
         return gx0, gx1
 
     def forward_gpu(self, inputs):
@@ -560,6 +578,10 @@ class PowVarVarGrad(function_node.FunctionNode):
             gx0 = x1 * pow(x0, x1 - 1) * gy;
             gx1 = log(x0) * y * gy;
             ''', 'pow_var_var_bwd')(x0, x1, gy, self.y)
+
+        gx0 = utils.sum_to(gx0, x0.shape)
+        gx1 = utils.sum_to(gx1, x1.shape)
+
         return gx0, gx1
 
     def backward(self, indexes, ggx):
@@ -573,15 +595,23 @@ class PowVarVarGrad(function_node.FunctionNode):
 
         ret = []
         if 0 in indexes:
-            gx0 = (ggx0 * x1 * (x1 - 1) * pow_x0_x1_2 +
-                   ggx1 * pow_x0_x1_1 * (log_x0 * x1 + 1)) * gy
-            ret.append(gx0)
+            gx0_0 = (0 if ggx0 is None else
+                     ggx0 * x1 * (x1 - 1) * pow_x0_x1_2)
+            gx0_1 = (0 if ggx1 is None else
+                     ggx1 * pow_x0_x1_1 * (log_x0 * x1 + 1))
+            gx0 = (gx0_0 + gx0_1) * gy
+            ret.append(chainer.functions.sum_to(gx0, x0.shape))
         if 1 in indexes:
-            gx1 = (ggx0 * pow_x0_x1_1 * (log_x0 * x1 + 1) +
-                   ggx1 * log_x0 * log_x0 * pow_x0_x1) * gy
-            ret.append(gx1)
+            gx1_0 = (0 if ggx0 is None else
+                     ggx0 * pow_x0_x1_1 * (log_x0 * x1 + 1))
+            gx1_1 = (0 if ggx1 is None else
+                     ggx1 * log_x0 * log_x0 * pow_x0_x1)
+            gx1 = (gx1_0 + gx1_1) * gy
+            ret.append(chainer.functions.sum_to(gx1, x1.shape))
         if 2 in indexes:
-            ggy = ggx0 * x1 * pow_x0_x1_1 + ggx1 * log_x0 * pow_x0_x1
+            ggy_0 = 0 if ggx0 is None else ggx0 * x1 * pow_x0_x1_1
+            ggy_1 = 0 if ggx1 is None else ggx1 * log_x0 * pow_x0_x1
+            ggy = ggy_0 + ggy_1
             ret.append(ggy)
         return ret
 
@@ -667,10 +697,10 @@ def pow(self, rhs):  # lhs ** rhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return PowVarVar().apply((self, rhs))[0]
-    _check_constant_type(rhs)
-    return PowVarConst(rhs).apply((self,))[0]
+    if numpy.isscalar(rhs):
+        return PowVarConst(rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return PowVarVar().apply((self, rhs))[0]
 
 
 class PowConstVar(function_node.FunctionNode):
@@ -751,117 +781,10 @@ def rpow(self, rhs):  # rhs ** lhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return PowVarVar().apply((rhs, self))[0]
-    _check_constant_type(rhs)
-    return PowConstVar(rhs).apply((self,))[0]
-
-
-class MatMulVarVar(_matmul.MatMul):
-
-    @property
-    def label(self):
-        return '_ @ _'
-
-
-class MatMulVarConst(function_node.FunctionNode):
-
-    def __init__(self, value):
-        self.value = value
-
-    @property
-    def label(self):
-        return '_ @ %s' % _convert_value_to_string(self.value)
-
-    def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
-        a_type = in_types[0]
-        b_type = self.value
-
-        type_check.expect(
-            a_type.dtype.kind == 'f',
-            b_type.dtype.kind == 'f',
-            a_type.ndim >= 1,
-            a_type.ndim == b_type.ndim,
-        )
-
-        ndim = type_check.eval(a_type.ndim)
-        if ndim == 1:
-            type_check.expect(a_type.shape == b_type.shape)
-        else:
-            a_idx = _matmul._get_check_index(False, False,
-                                             row_idx=-2, col_idx=-1)
-            b_idx = _matmul._get_check_index(False, True,
-                                             row_idx=-2, col_idx=-1)
-            type_check.expect(
-                a_type.shape[:-2] == b_type.shape[:-2],
-                a_type.shape[a_idx] == b_type.shape[b_idx],
-            )
-
-    def forward(self, x):
-        self.retain_inputs((0,))
-        return utils.force_array(_matmul._matmul(x[0], self.value)),
-
-    def backward(self, indexes, gy):
-        x = self.get_retained_inputs()
-        if gy[0].ndim == 0:
-            gx0 = chainer.functions.broadcast_to(
-                gy[0], self.value.shape) * self.value
-        else:
-            gx0 = chainer.functions.reshape(
-                chainer.functions.matmul(gy[0], self.value, False, True),
-                x[0].shape)
-        return gx0,
-
-
-class MatMulConstVar(function_node.FunctionNode):
-
-    def __init__(self, value):
-        self.value = value
-
-    @property
-    def label(self):
-        return '%s @ _' % _convert_value_to_string(self.value)
-
-    def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
-        a_type = self.value
-        b_type = in_types[0]
-
-        type_check.expect(
-            a_type.dtype.kind == 'f',
-            b_type.dtype.kind == 'f',
-            a_type.ndim >= 1,
-            a_type.ndim == b_type.ndim,
-        )
-
-        ndim = type_check.eval(a_type.ndim)
-        if ndim == 1:
-            type_check.expect(a_type.shape == b_type.shape)
-        else:
-            a_idx = _matmul._get_check_index(False, False,
-                                             row_idx=-2, col_idx=-1)
-            b_idx = _matmul._get_check_index(False, True,
-                                             row_idx=-2, col_idx=-1)
-            type_check.expect(
-                a_type.shape[:-2] == b_type.shape[:-2],
-                a_type.shape[a_idx] == b_type.shape[b_idx],
-            )
-
-    def forward(self, x):
-        self.retain_inputs((0,))
-        return utils.force_array(_matmul._matmul(self.value, x[0])),
-
-    def backward(self, x, gy):
-        x = self.get_retained_inputs()
-        if gy[0].ndim == 0:
-            gx1 = chainer.functions.broadcast_to(
-                gy[0], self.value.shape) * self.value
-        else:
-            gx1 = chainer.functions.reshape(
-                chainer.functions.matmul(self.value, gy[0], True, False),
-                x[0].shape)
-        return gx1,
+    if numpy.isscalar(rhs):
+        return PowConstVar(rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return PowVarVar().apply((rhs, self))[0]
 
 
 def matmul(self, rhs):  # lhs @ rhs
@@ -871,10 +794,8 @@ def matmul(self, rhs):  # lhs @ rhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return MatMulVarVar().apply((self, rhs))[0]
-    _check_constant_type(rhs)
-    return MatMulVarConst(rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return chainer.functions.matmul(self, rhs)
 
 
 def rmatmul(self, rhs):  # rhs @ lhs
@@ -884,10 +805,8 @@ def rmatmul(self, rhs):  # rhs @ lhs
         ~chainer.Variable: Output variable.
     """
 
-    if isinstance(rhs, variable.Variable):
-        return MatMulVarVar().apply((rhs, self))[0]
-    _check_constant_type(rhs)
-    return MatMulConstVar(rhs).apply((self,))[0]
+    rhs = _preprocess_rhs(self, rhs)
+    return chainer.functions.matmul(rhs, self)
 
 
 def install_variable_arithmetics():

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -191,11 +191,12 @@ class MultiAdd(function_node.FunctionNode):
         self.len = len(xs)
         if len(xs) == 1:
             return xs
-        if (intel64.should_use_ideep('>=auto')
-                and intel64.inputs_all_ready(xs)
-                and all(x.shape == xs[0].shape for x in xs[1:])):
-            y = intel64.ideep.multi_add(xs)
-        else:
+        y = None
+        if intel64.should_use_ideep('>=auto'):
+            bxs = numpy.broadcast_arrays(xs)
+            if intel64.inputs_all_ready(bxs):
+                y = intel64.ideep.multi_add(bxs)
+        if y is None:
             # The output should be a new array. Add the first 2 arrays
             # and get the result y. Then add the rest arrays to y.
             y = xs[0] + xs[1]

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -6,7 +6,6 @@ from chainer.backends import intel64
 from chainer import function_node
 import chainer.functions
 from chainer.functions.math import floor as _floor
-from chainer.functions.math import matmul as _matmul
 from chainer import utils
 from chainer.utils import type_check
 from chainer import variable
@@ -419,7 +418,7 @@ class DivGrad(function_node.FunctionNode):
             ret.append(chainer.functions.sum_to(gx0, x0.shape))
         if 1 in indexes:
             gx1 = -ggx0 * gy / x1_square + \
-                  ggx1 * 2 * gy * x0 / (x1_square * x1)
+                ggx1 * 2 * gy * x0 / (x1_square * x1)
             ret.append(chainer.functions.sum_to(gx1, x1.shape))
         if 2 in indexes:
             ggy = ggx0 / x1 - ggx1 * x0 / x1_square

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -191,11 +191,12 @@ class MultiAdd(function_node.FunctionNode):
         self.len = len(xs)
         if len(xs) == 1:
             return xs
-        if (intel64.should_use_ideep('>=auto')
-                and intel64.inputs_all_ready(xs)):
-            xs = numpy.broadcast_arrays(xs)
-            y = intel64.ideep.multi_add(xs)
-        else:
+        y = None
+        if intel64.should_use_ideep('>=auto'):
+            bxs = numpy.broadcast_arrays(xs)
+            if intel64.inputs_all_ready(bxs):
+                y = intel64.ideep.multi_add(bxs)
+        if y is None:
             # The output should be a new array. Add the first 2 arrays
             # and get the result y. Then add the rest arrays to y.
             y = xs[0] + xs[1]

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -424,7 +424,7 @@ class DivGrad(function_node.FunctionNode):
         if 1 in indexes:
             gx1 = None if ggx0 is None else -ggx0 * gy / x1_square
             gx1_1 = (None if ggx1 is None else
-                     ggx1 * 2 * gy * x0 * (x1_square * x1))
+                     ggx1 * 2 * gy * x0 / (x1_square * x1))
             if gx1 is None:
                 gx1 = gx1_1
             elif gx1_1 is not None:

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -191,12 +191,11 @@ class MultiAdd(function_node.FunctionNode):
         self.len = len(xs)
         if len(xs) == 1:
             return xs
-        y = None
-        if intel64.should_use_ideep('>=auto'):
-            bxs = numpy.broadcast_arrays(xs)
-            if intel64.inputs_all_ready(bxs):
-                y = intel64.ideep.multi_add(bxs)
-        if y is None:
+        if (intel64.should_use_ideep('>=auto')
+                and intel64.inputs_all_ready(xs)
+                and all(x.shape == xs[0].shape for x in xs[1:])):
+            y = intel64.ideep.multi_add(xs)
+        else:
             # The output should be a new array. Add the first 2 arrays
             # and get the result y. Then add the rest arrays to y.
             y = xs[0] + xs[1]

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -193,7 +193,7 @@ class MultiAdd(function_node.FunctionNode):
             return xs
         y = None
         if intel64.should_use_ideep('>=auto'):
-            bxs = numpy.broadcast_arrays(xs)
+            bxs = numpy.broadcast_arrays(*xs)
             if intel64.inputs_all_ready(bxs):
                 y = intel64.ideep.multi_add(bxs)
         if y is None:

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -102,19 +102,8 @@ class MatMul(function_node.FunctionNode):
             type_check.expect(
                 a_type.shape[a_idx] == b_type.shape[b_idx],
             )
-
-            # TODO(beam2d): add a utility tool for checking broadcastability
-            a_bc_ndim = a_ndim - 2
-            b_bc_ndim = b_ndim - 2
-            a_shape = type_check.eval(a_type.shape)
-            b_shape = type_check.eval(b_type.shape)
-            for i in range(min(a_bc_ndim, b_bc_ndim)):
-                a_i = a_bc_ndim - i - 1
-                b_i = b_bc_ndim - i - 1
-                if a_shape[a_i] != 1 and b_shape[b_i] != 1:
-                    type_check.expect(
-                        a_type.shape[a_i] == b_type.shape[b_i]
-                    )
+            type_check.expect_broadcast_shapes(
+                a_type.shape, b_type.shape, ignore_tail=2)
 
     def forward(self, x):
         self.retain_inputs((0, 1))

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -105,7 +105,7 @@ class MatMul(function_node.FunctionNode):
                 a_type.shape[a_idx] == b_type.shape[b_idx],
             )
             type_check.expect_broadcast_shapes(
-                a_type.shape, b_type.shape, ignore_tail=2)
+                a_type.shape[:-2], b_type.shape[:-2])
 
     def forward(self, x):
         self.retain_inputs((0, 1))

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -48,7 +48,7 @@ def _matmul(a, b, transa=False, transb=False, transout=False):
 
     if hasattr(xp, 'matmul'):  # numpy.matmul is supported from version 1.10.0
         return xp.matmul(a, b)
-    if a.ndim <= 2:
+    if a.ndim <= 2 or b.ndim <= 2:
         return numpy.dot(a, b)
     else:
         return numpy.einsum('...ij,...jk->...ik', a, b)

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -4,7 +4,7 @@ import numpy
 
 from chainer.backends import cuda
 from chainer import function_node
-from chainer import functions
+import chainer.functions
 from chainer import utils
 from chainer.utils import type_check
 
@@ -128,40 +128,42 @@ class MatMul(function_node.FunctionNode):
         ret = []
         if 0 in indexes:
             if is_b_vector:
-                u, v = functions.cast(gy, b.dtype), b
+                u, v = chainer.functions.cast(gy, b.dtype), b
                 if not is_a_vector:
                     if self.transa:
                         u, v = v, u
-                    u = functions.expand_dims(u, -1)
-                    v = functions.expand_dims(v, -2) if v.ndim > 1 else v
-                ga = functions.cast(u * v, a.dtype)
+                    u = chainer.functions.expand_dims(u, -1)
+                    v = (chainer.functions.expand_dims(v, -2) if v.ndim > 1
+                         else v)
+                ga = chainer.functions.cast(u * v, a.dtype)
             elif is_a_vector:
-                bt = functions.rollaxis(b, -1 if self.transb else -2)
-                ga = functions.tensordot(bt, gy, axes=gy.ndim)
-                ga = functions.cast(ga, a.dtype)
+                bt = chainer.functions.rollaxis(b, -1 if self.transb else -2)
+                ga = chainer.functions.tensordot(bt, gy, axes=gy.ndim)
+                ga = chainer.functions.cast(ga, a.dtype)
             else:
                 ga, = MatMul(self.transc, not self.transb, self.transa,
                              a.dtype).apply((gy, b))
-                ga = functions.sum_to(ga, a.shape)
+                ga = chainer.functions.sum_to(ga, a.shape)
             ret.append(ga)
 
         if 1 in indexes:
             if is_a_vector:
-                u, v = a, functions.cast(gy, a.dtype)
+                u, v = a, chainer.functions.cast(gy, a.dtype)
                 if not is_b_vector:
                     if self.transb:
                         u, v = v, u
-                    u = functions.expand_dims(u, -1)
-                    v = functions.expand_dims(v, -2) if v.ndim > 1 else v
-                gb = functions.cast(u * v, b.dtype)
+                    u = chainer.functions.expand_dims(u, -1)
+                    v = (chainer.functions.expand_dims(v, -2) if v.ndim > 1
+                         else v)
+                gb = chainer.functions.cast(u * v, b.dtype)
             elif is_b_vector:
-                at = functions.rollaxis(a, -2 if self.transa else -1)
-                gb = functions.tensordot(at, gy, axes=gy.ndim)
-                gb = functions.cast(gb, b.dtype)
+                at = chainer.functions.rollaxis(a, -2 if self.transa else -1)
+                gb = chainer.functions.tensordot(at, gy, axes=gy.ndim)
+                gb = chainer.functions.cast(gb, b.dtype)
             else:
                 gb, = MatMul(not self.transa, self.transc, self.transb,
                              b.dtype).apply((a, gy))
-                gb = functions.sum_to(gb, b.shape)
+                gb = chainer.functions.sum_to(gb, b.shape)
             ret.append(gb)
 
         return ret

--- a/chainer/functions/math/matmul.py
+++ b/chainer/functions/math/matmul.py
@@ -116,7 +116,7 @@ class MatMul(function_node.FunctionNode):
         if self.dtype is not None:
             dtype = self.dtype
         else:
-            dtype = a.dtype
+            dtype = y.dtype
         return utils.force_array(y, dtype),
 
     def backward(self, indexes, grad_outputs):

--- a/chainer/functions/math/sum.py
+++ b/chainer/functions/math/sum.py
@@ -1,5 +1,4 @@
 import numpy
-import six
 
 import chainer
 from chainer.backends import cuda

--- a/chainer/functions/math/sum.py
+++ b/chainer/functions/math/sum.py
@@ -1,8 +1,10 @@
 import numpy
+import six
 
 import chainer
 from chainer.backends import cuda
 from chainer import function_node
+from chainer import utils
 from chainer.utils import type_check
 
 
@@ -105,4 +107,54 @@ def sum(x, axis=None, keepdims=False):
 
     """
     y, = Sum(axis, keepdims).apply((x,))
+    return y
+
+
+class SumTo(function_node.FunctionNode):
+
+    """Sum axes to output an array of a given shape."""
+
+    def __init__(self, shape):
+        self._shape = shape
+
+    def forward(self, inputs):
+        x, = inputs
+        return utils.sum_to(x, self._shape),
+
+    def backward(self, indexes, grad_outputs):
+        gy, = grad_outputs
+        x_node, = self.inputs
+        return chainer.functions.broadcast_to(gy, x_node.shape),
+
+
+def sum_to(x, shape):
+    """Sum elements along axes to output an array of a given shape.
+
+    Args:
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`):
+            Input variable.
+        shape (tuple of int): The target shape.
+
+    Returns:
+        ~chainer.Variable: Output variable of shape ``shape``.
+
+    .. admonition:: Example
+
+        >>> x = np.array([[1., 2., 3.], [4., 5., 6.]])
+        >>> x
+        array([[1., 2., 3.],
+               [4., 5., 6.]])
+        >>> y = F.sum_to(x, (1, 3))
+        >>> y
+        variable([[5., 7., 9.]])
+        >>> z = F.sum_to(x, (2, 1))
+        >>> z
+        variable([[ 6.],
+                  [15.]])
+
+    """
+    if x.shape == shape:
+        return chainer.as_variable(x)
+    y, = SumTo(shape).apply((x,))
     return y

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -5,6 +5,7 @@ import tempfile
 import numpy
 
 # import classes and functions
+from chainer.utils.array import sum_to  # NOQA
 from chainer.utils.conv import get_conv_outsize  # NOQA
 from chainer.utils.conv import get_deconv_outsize  # NOQA
 from chainer.utils.experimental import experimental  # NOQA

--- a/chainer/utils/array.py
+++ b/chainer/utils/array.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy
+import six
 
 from chainer.backends import cuda
 
@@ -35,3 +36,16 @@ def empty_like(x):
         return cuda.cupy.empty_like(x)
     else:
         return numpy.empty_like(x)
+
+
+def sum_to(x, shape):
+    if x.shape == shape:
+        return x
+    ndim = len(shape)
+    lead = x.ndim - ndim
+    lead_axis = tuple(six.moves.range(lead))
+    axis = tuple([i + lead for i, sx in enumerate(shape) if sx == 1])
+    y = x.sum(lead_axis + axis, keepdims=True)
+    if lead > 0:
+        y = y.squeeze(lead_axis)
+    return y

--- a/chainer/utils/array.py
+++ b/chainer/utils/array.py
@@ -3,7 +3,9 @@ import warnings
 import numpy
 import six
 
+import chainer
 from chainer.backends import cuda
+from chainer import functions
 
 
 def as_vec(x):
@@ -41,6 +43,10 @@ def empty_like(x):
 def sum_to(x, shape):
     if x.shape == shape:
         return x
+    if isinstance(x, chainer.Variable):
+        raise TypeError(
+            'chainer.utils.sum_to does not support Variable input. '
+            'Use chainer.functions.sum_to instead.')
     ndim = len(shape)
     lead = x.ndim - ndim
     lead_axis = tuple(six.moves.range(lead))

--- a/chainer/utils/array.py
+++ b/chainer/utils/array.py
@@ -5,7 +5,6 @@ import six
 
 import chainer
 from chainer.backends import cuda
-from chainer import functions
 
 
 def as_vec(x):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -9,7 +9,6 @@ import six
 
 import chainer
 from chainer.backends import cuda
-from chainer.utils import argument
 
 
 _thread_local = threading.local()

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -597,6 +597,7 @@ def expect_broadcast_shapes(*shape_types, **kwargs):
     """
     ignore_tail, = argument.parse_kwargs(kwargs, ('ignore_tail', 0))
     shapes = [eval(s) for s in shape_types]
+    error = None
     try:
         numpy.broadcast(*[
             numpy.empty(s[:len(s) - ignore_tail] + (0,)) for s in shapes
@@ -610,4 +611,6 @@ def expect_broadcast_shapes(*shape_types, **kwargs):
         msgs = [msg]
         for shape_type, shape in six.moves.zip(shape_types, shapes):
             msgs.append('{} = {}'.format(shape_type, shape))
-        raise InvalidType('', '', msg='\n'.join(msgs))
+        error = InvalidType('', '', msg='\n'.join(msgs))
+    if error is not None:
+        raise error

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -587,29 +587,20 @@ def prod(xs):
         return _prod(xs)
 
 
-def expect_broadcast_shapes(*shape_types, **kwargs):
-    """Checks if two shapes are broadcastable at first some axes.
+def expect_broadcast_shapes(*shape_types):
+    """Checks if shapes can be broadcasted together.
 
     Args:
         shapes_types: Type-checked shapes of the arrays to broadcast.
-        ignore_tail (int): Number of axes at the tail to ignore.
 
     """
-    ignore_tail, = argument.parse_kwargs(kwargs, ('ignore_tail', 0))
     shapes = [eval(s) for s in shape_types]
     error = None
     try:
         # simulate the shape calculation using zero-sized arrays
-        numpy.broadcast(*[
-            numpy.empty(s[:len(s) - ignore_tail] + (0,)) for s in shapes
-        ])
+        numpy.broadcast(*[numpy.empty(s + (0,)) for s in shapes])
     except ValueError:
-        if ignore_tail > 0:
-            msg = ('cannot broadcast inputs of the following shapes '
-                   'along all axes but the last {}:'.format(ignore_tail))
-        else:
-            msg = 'cannot broadcast inputs of the following shapes:'
-        msgs = [msg]
+        msgs = ['cannot broadcast inputs of the following shapes:']
         for shape_type, shape in six.moves.zip(shape_types, shapes):
             msgs.append('{} = {}'.format(shape_type, shape))
         error = InvalidType('', '', msg='\n'.join(msgs))

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -599,6 +599,7 @@ def expect_broadcast_shapes(*shape_types, **kwargs):
     shapes = [eval(s) for s in shape_types]
     error = None
     try:
+        # simulate the shape calculation using zero-sized arrays
         numpy.broadcast(*[
             numpy.empty(s[:len(s) - ignore_tail] + (0,)) for s in shapes
         ])

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -5,6 +5,7 @@ import sys
 import threading
 
 import numpy
+import six
 
 import chainer
 from chainer.backends import cuda
@@ -583,3 +584,24 @@ def prod(xs):
         return _prod_impl(xs)
     else:
         return _prod(xs)
+
+
+def expect_broadcast_shapes(shape1_type, shape2_type, ignore_tail=0):
+    """Checks if two shapes are broadcastable at first some axes.
+
+    Args:
+        shape1_type: Type-checked shape of the first array.
+        shape2_type: Type-checked shape of the second array.
+        ignore_tail (int): Number of axes at the tail to ignore.
+
+    """
+    shape1 = eval(shape1_type)
+    shape2 = eval(shape2_type)
+    print(shape1, shape2)
+    ndim1 = len(shape1) - ignore_tail
+    ndim2 = len(shape2) - ignore_tail
+    for i in six.moves.range(min(ndim1, ndim2)):
+        i1 = ndim1 - i - 1
+        i2 = ndim2 - i - 1
+        if shape1[i1] != 1 and shape2[i2] != 1:
+            expect(shape1_type[i1] == shape2_type[i2])

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -9,6 +9,7 @@ import six
 
 import chainer
 from chainer.backends import cuda
+from chainer.utils import argument
 
 
 _thread_local = threading.local()
@@ -586,22 +587,27 @@ def prod(xs):
         return _prod(xs)
 
 
-def expect_broadcast_shapes(shape1_type, shape2_type, ignore_tail=0):
+def expect_broadcast_shapes(*shape_types, **kwargs):
     """Checks if two shapes are broadcastable at first some axes.
 
     Args:
-        shape1_type: Type-checked shape of the first array.
-        shape2_type: Type-checked shape of the second array.
+        shapes_types: Type-checked shapes of the arrays to broadcast.
         ignore_tail (int): Number of axes at the tail to ignore.
 
     """
-    shape1 = eval(shape1_type)
-    shape2 = eval(shape2_type)
-    print(shape1, shape2)
-    ndim1 = len(shape1) - ignore_tail
-    ndim2 = len(shape2) - ignore_tail
-    for i in six.moves.range(min(ndim1, ndim2)):
-        i1 = ndim1 - i - 1
-        i2 = ndim2 - i - 1
-        if shape1[i1] != 1 and shape2[i2] != 1:
-            expect(shape1_type[i1] == shape2_type[i2])
+    ignore_tail, = argument.parse_kwargs(kwargs, ('ignore_tail', 0))
+    shapes = [eval(s) for s in shape_types]
+    try:
+        numpy.broadcast(*[
+            numpy.empty(s[:len(s) - ignore_tail] + (0,)) for s in shapes
+        ])
+    except ValueError:
+        if ignore_tail > 0:
+            msg = ('cannot broadcast inputs of the following shapes '
+                   'along all axes but the last {}:'.format(ignore_tail))
+        else:
+            msg = 'cannot broadcast inputs of the following shapes:'
+        msgs = [msg]
+        for shape_type, shape in six.moves.zip(shape_types, shapes):
+            msgs.append('{} = {}'.format(shape_type, shape))
+        raise InvalidType('', '', msg='\n'.join(msgs))

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -238,6 +238,7 @@ Mathematical functions
    chainer.functions.square
    chainer.functions.squared_difference
    chainer.functions.sum
+   chainer.functions.sum_to
    chainer.functions.tanh
    chainer.functions.tan
    chainer.functions.tensordot

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -241,7 +241,7 @@ class TestBinaryOp(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), ()],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'dtype': [numpy.float16, numpy.float64],
 }))
 @backend.inject_backend_tests(
     ['test_forward', 'test_backward', 'test_double_backward'],

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -15,17 +15,23 @@ from chainer.testing import backend
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(3, 2), ()],
+    'shape': [
+        # x1, x2, y
+        ((3, 2), (3, 2), (3, 2)),
+        ((), (), ()),
+        ((3, 2), (3, 1), (3, 2)),
+        ((2,), (3, 2), (3, 2)),
+    ],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestBinaryOp(unittest.TestCase):
 
     def setUp(self):
-        self.x1 = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        self.x2 = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx1 = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx2 = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.x1 = numpy.random.uniform(.5, 1, self.shape[0]).astype(self.dtype)
+        self.x2 = numpy.random.uniform(.5, 1, self.shape[1]).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, self.shape[2]).astype(self.dtype)
+        self.ggx1 = numpy.random.uniform(-1, 1, self.shape[0]).astype(self.dtype)
+        self.ggx2 = numpy.random.uniform(-1, 1, self.shape[1]).astype(self.dtype)
 
     def check_forward(self, op, x1_data, x2_data):
         x1 = chainer.Variable(x1_data)
@@ -381,22 +387,16 @@ class TestBinaryOpConstant(unittest.TestCase):
         x_data = numpy.array([1.0, 2.0], self.dtype)
 
         self._test_constant_array_one(
-            func, x_data, numpy.array([3.0, 4.0], numpy.int32))
-        self._test_constant_array_one(
-            func, x_data, numpy.array([3.0, 4.0], numpy.int64))
-        self._test_constant_array_one(
-            func, x_data, numpy.array([3.0, 4.0], numpy.float32))
-        self._test_constant_array_one(
-            func, x_data, numpy.array([3.0, 4.0], numpy.float64))
+            func, x_data, numpy.array([3.0, 4.0], self.dtype))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self._test_constant_array_one(func, x_data, [3.0, 4.0])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self._test_constant_array_one(func, x_data, (3.0, 4.0))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self._test_constant_array_one(func, x_data, [3.0, 4.0, 5.0])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self._test_constant_array_one(func, x_data, (3.0, 4.0, 5.0))
         with self.assertRaises(ValueError):
             self._test_constant_array_one(
@@ -414,23 +414,12 @@ class TestBinaryOpConstant(unittest.TestCase):
         x_data = numpy.array([1.0, 2.0], self.dtype)
 
         self._test_constant_array_gpu_one(
-            func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0], numpy.int32)))
-        self._test_constant_array_gpu_one(
-            func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0], numpy.int64)))
-        self._test_constant_array_gpu_one(
-            func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0], numpy.float32)))
-        self._test_constant_array_gpu_one(
-            func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0], numpy.float64)))
+            func, x_data, cuda.to_gpu(numpy.array([3.0, 4.0], self.dtype)))
 
         with self.assertRaises(exception):
             self._test_constant_array_one(
                 func, x_data, cuda.to_gpu(
                     numpy.array([3.0, 4.0, 5.0], self.dtype)))
-
-        with six.assertRaisesRegex(self, ValueError, 'broadcast'):
-            self._test_constant_array_gpu_one(
-                func, x_data, cuda.to_gpu(
-                    numpy.array([[3.0, 4.0], [5.0, 6.0]], self.dtype)))
 
     def test_add_constant(self):
         self._test_constant(lambda x, y: x + y)
@@ -1190,12 +1179,16 @@ class TestNegativePow(unittest.TestCase):
     ], [
         {'x_shape': (3, 2), 'y_shape': (2, 4), 'z_shape': (3, 4)},
         {'x_shape': (2, 3, 2), 'y_shape': (2, 2, 4), 'z_shape': (2, 3, 4)},
+        {'x_shape': (2, 1, 3, 4),
+         'y_shape': (2, 4, 2),
+         'z_shape': (2, 2, 3, 2)},
+        {'x_shape': (2, 3, 2), 'y_shape': (2, 4), 'z_shape': (2, 3, 4)},
         {'x_shape': (3,), 'y_shape': (3,), 'z_shape': ()},
     ]
 ))
 @unittest.skipUnless(sys.version_info >= (3, 5),
                      'Only for Python3.5 or higher')
-class TestMatMulVarVar(unittest.TestCase):
+class TestMatMul(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.x_shape).astype(self.dtype)
@@ -1268,13 +1261,13 @@ class TestMatMulVarVar(unittest.TestCase):
             self, x_data, y_data, z_grad, x_grad_grad, y_grad_grad):
         if self.right_const:
             def op(x):
-                z = operator.matmul(x, y_data)
+                z = operator.matmul(x, y_data.astype(x.dtype))
                 return z * z
             data = x_data,
             grad_grad = x_grad_grad,
         elif self.left_const:
             def op(y):
-                z = operator.matmul(x_data, y)
+                z = operator.matmul(x_data.astype(y.dtype), y)
                 return z * z
             data = y_data,
             grad_grad = y_grad_grad,
@@ -1417,19 +1410,6 @@ class TestLabel(unittest.TestCase):
 
     def test_pow_const_var(self):
         self.assertEqual(basic_math.PowConstVar(2.0).label, '2.0 ** _')
-
-    def test_matmul_var_var(self):
-        self.assertEqual(basic_math.MatMulVarVar().label, '_ @ _')
-
-    def test_matmul_var_const(self):
-        self.assertEqual(
-            basic_math.MatMulVarConst(numpy.zeros((2, 2))).label,
-            '_ @ constant array')
-
-    def test_matmul_const_var(self):
-        self.assertEqual(
-            basic_math.MatMulConstVar(numpy.zeros((2, 2))).label,
-            'constant array @ _')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -240,7 +240,13 @@ class TestBinaryOp(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(3, 2), ()],
+    'in_shapes': [
+        ((3, 2),) * 3,
+        ((),) * 3,
+        ((1, 3), (), (2, 1, 2, 1)),
+        ((), (2, 1, 2), (3, 1)),
+        ((3, 1), (1, 1), (2,)),
+    ],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @backend.inject_backend_tests(
@@ -258,13 +264,15 @@ class TestBinaryOp(unittest.TestCase):
 class TestMultipleAdd(unittest.TestCase):
 
     def setUp(self):
-        self.x1 = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        self.x2 = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        self.x3 = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx1 = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx2 = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx3 = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        x1_shape, x2_shape, x3_shape = self.in_shapes
+        self.x1 = numpy.random.uniform(.5, 1, x1_shape).astype(self.dtype)
+        self.x2 = numpy.random.uniform(.5, 1, x2_shape).astype(self.dtype)
+        self.x3 = numpy.random.uniform(.5, 1, x3_shape).astype(self.dtype)
+        y_shape = numpy.broadcast(self.x1, self.x2, self.x3).shape
+        self.gy = numpy.random.uniform(-1, 1, y_shape).astype(self.dtype)
+        self.ggx1 = numpy.random.uniform(-1, 1, x1_shape).astype(self.dtype)
+        self.ggx2 = numpy.random.uniform(-1, 1, x2_shape).astype(self.dtype)
+        self.ggx3 = numpy.random.uniform(-1, 1, x3_shape).astype(self.dtype)
 
     def check_forward(self, func, x1_data, x2_data, x3_data, backend_config):
         # convert to cupy.ndarray for GPU tests

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -3,7 +3,6 @@ import sys
 import unittest
 
 import numpy
-import six
 
 import chainer
 from chainer.backends import cuda
@@ -31,8 +30,10 @@ class TestBinaryOp(unittest.TestCase):
         self.x1 = numpy.random.uniform(.5, 1, self.shape[0]).astype(self.dtype)
         self.x2 = numpy.random.uniform(.5, 1, self.shape[1]).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, self.shape[2]).astype(self.dtype)
-        self.ggx1 = numpy.random.uniform(-1, 1, self.shape[0]).astype(self.dtype)
-        self.ggx2 = numpy.random.uniform(-1, 1, self.shape[1]).astype(self.dtype)
+        self.ggx1 = numpy.random.uniform(-1, 1, self.shape[0]).astype(
+            self.dtype)
+        self.ggx2 = numpy.random.uniform(-1, 1, self.shape[1]).astype(
+            self.dtype)
 
     def check_forward(self, op, x1_data, x2_data):
         x1 = chainer.Variable(x1_data)

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -241,7 +241,7 @@ class TestBinaryOp(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), ()],
-    'dtype': [numpy.float16, numpy.float64],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @backend.inject_backend_tests(
     ['test_forward', 'test_backward', 'test_double_backward'],

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1206,6 +1206,10 @@ class TestMatMul(unittest.TestCase):
     def _get_forward_answer(self, x, y):
         if x.ndim <= 2 or y.ndim == 1:
             return numpy.dot(x, y)
+        elif hasattr(numpy, 'matmul'):
+            # Note: NumPy 1.14.0 has a bug in einsum (numpy/numpy#10343),
+            # so we use matmul if available to avoid it
+            return numpy.matmul(x, y)
         else:
             return numpy.einsum('...ij,...jk->...ik', x, y)
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1183,6 +1183,8 @@ class TestNegativePow(unittest.TestCase):
         {'x_shape': (2, 1, 3, 4),
          'y_shape': (2, 4, 2),
          'z_shape': (2, 2, 3, 2)},
+        {'x_shape': (5, 3, 2), 'y_shape': (2,), 'z_shape': (5, 3)},
+        {'x_shape': (2,), 'y_shape': (5, 2, 4), 'z_shape': (5, 4)},
         {'x_shape': (2, 3, 2), 'y_shape': (2, 4), 'z_shape': (2, 3, 4)},
         {'x_shape': (3,), 'y_shape': (3,), 'z_shape': ()},
     ]
@@ -1201,7 +1203,7 @@ class TestMatMul(unittest.TestCase):
             -1, 1, self.y_shape).astype(self.dtype)
 
     def _get_forward_answer(self, x, y):
-        if x.ndim <= 2:
+        if x.ndim <= 2 or y.ndim == 1:
             return numpy.dot(x, y)
         else:
             return numpy.einsum('...ij,...jk->...ik', x, y)

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -12,6 +12,7 @@ from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import backend
+from chainer.utils import type_check
 
 
 @testing.parameterize(*testing.product({
@@ -398,7 +399,7 @@ class TestBinaryOpConstant(unittest.TestCase):
             self._test_constant_array_one(func, x_data, [3.0, 4.0, 5.0])
         with self.assertRaises(TypeError):
             self._test_constant_array_one(func, x_data, (3.0, 4.0, 5.0))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(type_check.InvalidType):
             self._test_constant_array_one(
                 func, x_data, numpy.array([3.0, 4.0, 5.0], self.dtype))
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -29,6 +29,20 @@ from chainer.utils import type_check
         {'x1_shape': (5,), 'x2_shape': (5,), 'gy_shape': (),
          'transa': False, 'transb': True},
 
+        # matrix-vector
+        {'x1_shape': (5,), 'x2_shape': (5, 2), 'gy_shape': (2,),
+         'transa': False, 'transb': False},
+        {'x1_shape': (5,), 'x2_shape': (5, 2), 'gy_shape': (2,),
+         'transa': True, 'transb': False},
+        {'x1_shape': (5,), 'x2_shape': (2, 5), 'gy_shape': (2,),
+         'transa': False, 'transb': True},
+        {'x1_shape': (2, 5), 'x2_shape': (5,), 'gy_shape': (2,),
+         'transa': False, 'transb': False},
+        {'x1_shape': (5, 2), 'x2_shape': (5,), 'gy_shape': (2,),
+         'transa': True, 'transb': False},
+        {'x1_shape': (2, 5), 'x2_shape': (5,), 'gy_shape': (2,),
+         'transa': False, 'transb': True},
+
         # batched matmul
         {'x1_shape': (6, 2, 5), 'x2_shape': (6, 5, 10), 'gy_shape': (6, 2, 10),
          'transa': False, 'transb': False},

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -52,6 +52,10 @@ from chainer.utils import type_check
          'transa': False, 'transb': True},
         {'x1_shape': (6, 5, 2), 'x2_shape': (6, 10, 5), 'gy_shape': (6, 2, 10),
          'transa': True, 'transb': True},
+        {'x1_shape': (2, 3, 4), 'x2_shape': (4,), 'gy_shape': (2, 3),
+         'transa': False, 'transb': False},
+        {'x1_shape': (4,), 'x2_shape': (2, 4, 3), 'gy_shape': (2, 3),
+         'transa': False, 'transb': False},
 
         # batchsize = 1
         {'x1_shape': (1, 2, 5), 'x2_shape': (1, 5, 10), 'gy_shape': (1, 2, 10),
@@ -99,7 +103,7 @@ class TestMatMul(unittest.TestCase):
         if transb and x2.ndim >= 2:
             x2 = x2.swapaxes(-1, -2)
 
-        if x1.ndim <= 2:
+        if x1.ndim <= 2 or x2.ndim <= 2:
             return numpy.dot(x1, x2)
         else:
             return numpy.einsum('...ij,...jk->...ik', x1, x2)

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -281,7 +281,7 @@ class TestMatMulInvalid(unittest.TestCase):
 
     def test_invalid_shape(self):
         x_data = numpy.zeros((2, 3, 4), dtype=numpy.float32)
-        y_data = numpy.zeros((1, 4, 3), dtype=numpy.float32)
+        y_data = numpy.zeros((3, 4, 3), dtype=numpy.float32)
         x = chainer.Variable(x_data)
         y = chainer.Variable(y_data)
 

--- a/tests/chainer_tests/utils_tests/test_array.py
+++ b/tests/chainer_tests/utils_tests/test_array.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy
+
+from chainer import testing
+from chainer.utils import array
+
+
+@testing.parameterize(
+    {'in_shape': (), 'out_shape': (), 'axis': (), 'lead': 0},
+    {'in_shape': (3,), 'out_shape': (), 'axis': (0,), 'lead': 1},
+    {'in_shape': (3,), 'out_shape': (1,), 'axis': (0,), 'lead': 0},
+    {'in_shape': (3,), 'out_shape': (3,), 'axis': (), 'lead': 0},
+    {'in_shape': (2, 3), 'out_shape': (), 'axis': (0, 1), 'lead': 2},
+    {'in_shape': (2, 3), 'out_shape': (3,), 'axis': (0,), 'lead': 1},
+    {'in_shape': (2, 3), 'out_shape': (1, 3), 'axis': (0,), 'lead': 0},
+    {'in_shape': (2, 3), 'out_shape': (2, 1), 'axis': (1,), 'lead': 0},
+    {'in_shape': (2, 3), 'out_shape': (2, 3), 'axis': (), 'lead': 0},
+    {'in_shape': (2, 3, 4), 'out_shape': (3, 1), 'axis': (0, 2), 'lead': 1},
+)
+class TestSumTo(unittest.TestCase):
+
+    def test_sum_to(self):
+        n_elems = numpy.prod(self.in_shape)
+        x = numpy.arange(1, n_elems + 1, dtype=numpy.float32).reshape(self.in_shape)
+        y_actual = array.sum_to(x, self.out_shape)
+
+        y_expect = numpy.squeeze(x.sum(self.axis, keepdims=True), tuple(range(self.lead)))
+        numpy.testing.assert_array_equal(y_expect, y_actual)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_array.py
+++ b/tests/chainer_tests/utils_tests/test_array.py
@@ -22,10 +22,12 @@ class TestSumTo(unittest.TestCase):
 
     def test_sum_to(self):
         n_elems = numpy.prod(self.in_shape)
-        x = numpy.arange(1, n_elems + 1, dtype=numpy.float32).reshape(self.in_shape)
+        x = numpy.arange(1, n_elems + 1, dtype=numpy.float32).reshape(
+            self.in_shape)
         y_actual = array.sum_to(x, self.out_shape)
 
-        y_expect = numpy.squeeze(x.sum(self.axis, keepdims=True), tuple(range(self.lead)))
+        y_expect = numpy.squeeze(x.sum(self.axis, keepdims=True),
+                                 tuple(range(self.lead)))
         numpy.testing.assert_array_equal(y_expect, y_actual)
 
 


### PR DESCRIPTION
This PR makes Variable operators broadcast operands automatically. To make the implementation simple, I added `utils.sum_to` and `F.sum_to`, which computes the gradient of broadcast. Note that other functions that should support automatic broadcast (e.g. `where`) are not covered in this PR. A part of #3968.