### PR TITLE
assign user-friendly name for better type check exception message

### DIFF
--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -14,7 +14,7 @@ class LinearFunction(function_node.FunctionNode):
         n_in = in_types.size()
         type_check.expect(2 <= n_in, n_in <= 3)
         x_type, w_type = in_types[:2]
-        type_check.args((x_type, w_type), ('x', 'W'))
+        type_check.argname((x_type, w_type), ('x', 'W'))
 
         type_check.expect(
             x_type.dtype.kind == 'f',
@@ -25,7 +25,7 @@ class LinearFunction(function_node.FunctionNode):
         )
         if type_check.eval(n_in) == 3:
             b_type = in_types[2]
-            type_check.args((b_type,), ('b',))
+            type_check.argname((b_type,), ('b',))
             type_check.expect(
                 b_type.dtype == x_type.dtype,
                 b_type.ndim == 1,

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -14,6 +14,7 @@ class LinearFunction(function_node.FunctionNode):
         n_in = in_types.size()
         type_check.expect(2 <= n_in, n_in <= 3)
         x_type, w_type = in_types[:2]
+        type_check.args((x_type, w_type), ('x', 'W'))
 
         type_check.expect(
             x_type.dtype.kind == 'f',
@@ -24,6 +25,7 @@ class LinearFunction(function_node.FunctionNode):
         )
         if type_check.eval(n_in) == 3:
             b_type = in_types[2]
+            type_check.args((b_type,), ('b',))
             type_check.expect(
                 b_type.dtype == x_type.dtype,
                 b_type.ndim == 1,

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -27,6 +27,8 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
         type_check.expect(in_types.size() == 2)
 
         x_type, t_type = in_types
+        type_check.name(x_type, 'x')
+        type_check.name(t_type, 't')
         type_check.expect(
             x_type.dtype == numpy.float32,
             t_type.dtype.kind == 'i',

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -24,7 +24,7 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
         self.count = None
 
     def check_type_forward(self, in_types):
-        type_check.args(in_types, ('x', 't'))
+        type_check.argname(in_types, ('x', 't'))
         x_type, t_type = in_types
 
         type_check.expect(

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -24,7 +24,7 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
         self.count = None
 
     def check_type_forward(self, in_types):
-        type_check.name(in_types, ('x', 't'))
+        type_check.args(in_types, ('x', 't'))
         x_type, t_type = in_types
 
         type_check.expect(

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -24,11 +24,9 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
         self.count = None
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
-
+        type_check.name(in_types, ('x', 't'))
         x_type, t_type = in_types
-        type_check.name(x_type, 'x')
-        type_check.name(t_type, 't')
+
         type_check.expect(
             x_type.dtype == numpy.float32,
             t_type.dtype.kind == 'i',

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -66,11 +66,9 @@ class SoftmaxCrossEntropy(function.Function):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.args(in_types, ('x', 't'))
         x_type, t_type = in_types
 
-        type_check.name(x_type, 'x')
-        type_check.name(t_type, 't')
         type_check.expect(
             x_type.dtype.kind == 'f',
             t_type.dtype.kind == 'i',

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -66,7 +66,7 @@ class SoftmaxCrossEntropy(function.Function):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.args(in_types, ('x', 't'))
+        type_check.argname(in_types, ('x', 't'))
         x_type, t_type = in_types
 
         type_check.expect(

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -69,6 +69,8 @@ class SoftmaxCrossEntropy(function.Function):
         type_check.expect(in_types.size() == 2)
         x_type, t_type = in_types
 
+        type_check.name(x_type, 'x')
+        type_check.name(t_type, 't')
         type_check.expect(
             x_type.dtype.kind == 'f',
             t_type.dtype.kind == 'i',

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -503,6 +503,12 @@ Invalid operation is performed in: {0} (Forward)
         self.actual = actual
 
 
+def name(in_type, name):
+    """Assigns the user friendly name for the input type."""
+    if isinstance(in_type, Variable):
+        in_type.name = name
+
+
 def expect(*bool_exprs):
     """Evaluates and tests all given expressions.
 

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -503,8 +503,8 @@ Invalid operation is performed in: {0} (Forward)
         self.actual = actual
 
 
-def args(in_types, names):
-    """Assigns the user friendly name for the input type.
+def argname(in_types, names):
+    """Assigns user friendly names for the input types.
 
     This function also asserts that lenghts of in_types and names are the
     same.

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -503,10 +503,16 @@ Invalid operation is performed in: {0} (Forward)
         self.actual = actual
 
 
-def name(in_type, name):
+def name(in_types, names):
     """Assigns the user friendly name for the input type."""
-    if isinstance(in_type, Variable):
-        in_type.name = name
+    if len(in_types) != len(names):
+        raise InvalidType(
+            '{} argument(s)'.format(str(len(names))),
+            '{} argument(s)'.format(str(len(in_types))),
+            'Invalid number of arguments')
+    for in_type, name in zip(in_types, names):
+        if isinstance(in_type, Variable):
+            in_type.name = name
 
 
 def expect(*bool_exprs):

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -503,8 +503,12 @@ Invalid operation is performed in: {0} (Forward)
         self.actual = actual
 
 
-def name(in_types, names):
-    """Assigns the user friendly name for the input type."""
+def args(in_types, names):
+    """Assigns the user friendly name for the input type.
+
+    This function also asserts that lenghts of in_types and names are the
+    same.
+    """
     if len(in_types) != len(names):
         raise InvalidType(
             '{} argument(s)'.format(str(len(names))),

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -508,6 +508,11 @@ def argname(in_types, names):
 
     This function also asserts that lenghts of in_types and names are the
     same.
+
+    Args:
+        in_types (tuple of TypeInfoTuple): Tuple of type information to assign
+            name to.
+        names (tuple of str): Human-readabel names of ``in_types``.
     """
     if len(in_types) != len(names):
         raise InvalidType(


### PR DESCRIPTION
Currently type check error report is difficult to understand for beginners, because:

* the name `in_types` is not intuitive
* the index `X` of `in_types[X]` in the error message is a X-th argument of the FunctionNode, so sometimes it does not match with the X-th argument of `F.xxx`.

This PR is a proposal of assigning a user-friendly name for each types.

Example output:

```
Invalid operation is performed in: SigmoidCrossEntropy (Forward)

Expect: x.shape == t.shape
Actual: (100, 1) != (100,)
```