### PR TITLE
Support skipping tests decorated by condition or parametize

### DIFF
--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -62,7 +62,13 @@ def repeat_with_success_at_least(times, min_success):
                         tearDown=ins.tearDown))
 
                 result = QuietTestRunner().run(suite)
-                if result.wasSuccessful():
+                if len(result.skipped) == 1:
+                    # "Skipped" is a special case of "Successful".
+                    # When the test has been skipped, immedeately quit the
+                    # test regardleess of `times` and `min_success` by raising
+                    # SkipTest exception using the original reason.
+                    instance.skipTest(result.skipped[0][1])
+                elif result.wasSuccessful():
                     success_counter += 1
                 else:
                     results.append(result)

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -41,6 +41,8 @@ def _gen_case(base, module, i, param):
         def wrap(*args, **kwargs):
             try:
                 return method(*args, **kwargs)
+            except unittest.SkipTest:
+                raise
             except Exception as e:
                 s = six.StringIO()
                 s.write('Parameterized test failed.\n\n')

--- a/tests/chainer_tests/testing_tests/test_condition.py
+++ b/tests/chainer_tests/testing_tests/test_condition.py
@@ -4,12 +4,16 @@ from chainer import testing
 from chainer.testing import condition
 
 
+SKIP_REASON = 'test skip reason'
+
+
 # The test fixtures of this TestCase is used to be decorated by
 # decorator in test. So we do not run them alone.
 class MockUnitTest(unittest.TestCase):
 
     failure_case_counter = 0
     success_case_counter = 0
+    skip_case_counter = 0
     probabilistic_case_counter = 0
     probabilistic_case_success_counter = 0
     probabilistic_case_failure_counter = 0
@@ -18,6 +22,7 @@ class MockUnitTest(unittest.TestCase):
     def clear_counter():
         MockUnitTest.failure_case_counter = 0
         MockUnitTest.success_case_counter = 0
+        MockUnitTest.skip_case_counter = 0
         MockUnitTest.probabilistic_case_counter = 0
         MockUnitTest.probabilistic_case_success_counter = 0
         MockUnitTest.probabilistic_case_failure_counter = 0
@@ -29,6 +34,10 @@ class MockUnitTest(unittest.TestCase):
     def success_case(self):
         MockUnitTest.success_case_counter += 1
         self.assertTrue(True)
+
+    def skip_case(self):
+        MockUnitTest.skip_case_counter += 1
+        self.skipTest(SKIP_REASON)
 
     def error_case(self):
         raise Exception()
@@ -58,6 +67,15 @@ def _should_fail(self, f):
 
 def _should_pass(self, f):
     f(self.unit_test)
+
+
+def _should_skip(self, f):
+    try:
+        f(self.unit_test)
+        self.fail(
+            'SkipTest is expected to be raised, but none is raised')
+    except unittest.SkipTest as e:
+        self.assertIn(SKIP_REASON, str(e))
 
 
 class TestRepeatWithSuccessAtLeast(unittest.TestCase):
@@ -132,6 +150,11 @@ class TestRepeat(unittest.TestCase):
         _should_pass(self, f)
         self.assertEqual(self.unit_test.success_case_counter, 10)
 
+    def test_skip_case(self):
+        f = self._decorate(MockUnitTest.skip_case, 10)
+        _should_skip(self, f)
+        self.assertEqual(self.unit_test.skip_case_counter, 1)
+
     def test_probabilistic_case(self):
         f = self._decorate(MockUnitTest.probabilistic_case, 10)
         _should_fail(self, f)
@@ -159,6 +182,11 @@ class TestRetry(unittest.TestCase):
         f = self._decorate(MockUnitTest.success_case, 10)
         _should_pass(self, f)
         self.assertLessEqual(self.unit_test.success_case_counter, 10)
+
+    def test_skip_case(self):
+        f = self._decorate(MockUnitTest.skip_case, 10)
+        _should_skip(self, f)
+        self.assertEqual(self.unit_test.skip_case_counter, 1)
 
     def test_probabilistic_case(self):
         f = self._decorate(MockUnitTest.probabilistic_case, 10)

--- a/tests/chainer_tests/testing_tests/test_parameterized.py
+++ b/tests/chainer_tests/testing_tests/test_parameterized.py
@@ -59,5 +59,9 @@ class TestParameterize(unittest.TestCase):
         y = self.callable(1)
         self.assertEqual(y, 1)
 
+    def test_skip(self):
+        # Skipping the test case should not report error.
+        self.skipTest('skip')
+
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Allow individual test cases to be skipped by `self.skipTest`.
Related to #4272.