### PR TITLE
[backport] Fix import failure when matplotlib 1.x is installed

### DIFF
--- a/chainer/training/extensions/variable_statistics_plot.py
+++ b/chainer/training/extensions/variable_statistics_plot.py
@@ -13,13 +13,21 @@ from chainer.training import trigger as trigger_module
 
 try:
     import matplotlib
-    _plot_color = matplotlib.colors.to_rgba('#1f77b4')  # C0 color
-    _plot_color_trans = _plot_color[:3] + (0.2,)  # apply alpha
-    _plot_common_kwargs = {
-        'alpha': 0.2, 'linewidth': 0, 'color': _plot_color_trans}
     _available = True
 except ImportError:
     _available = False
+
+
+if _available:
+    if hasattr(matplotlib.colors, 'to_rgba'):
+        _to_rgba = matplotlib.colors.to_rgba
+    else:
+        # For matplotlib 1.x
+        _to_rgba = matplotlib.colors.ColorConverter().to_rgba
+    _plot_color = _to_rgba('#1f77b4')  # C0 color
+    _plot_color_trans = _plot_color[:3] + (0.2,)  # apply alpha
+    _plot_common_kwargs = {
+        'alpha': 0.2, 'linewidth': 0, 'color': _plot_color_trans}
 
 
 def _check_available():


### PR DESCRIPTION
Backport of #4681