### PR TITLE
Refactor sentiment example

### DIFF
--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -69,10 +69,10 @@ class RecursiveNet(chainer.Chain):
     def label(self, v):
         return self.w(v)
 
-    def _traverse(self, node, evaluate=None):
+    def _traverse(self, node, evaluate):
         if isinstance(node['node'], int):
             # leaf node
-            word = xp.array([node['node']], np.int32)
+            word = self.xp.array([node['node']], np.int32)
             loss = 0
             v = self.leaf(word)
         else:
@@ -85,15 +85,14 @@ class RecursiveNet(chainer.Chain):
 
         y = self.label(v)
 
-        label = xp.array([node['label']], np.int32)
+        label = self.xp.array([node['label']], np.int32)
         t = chainer.Variable(label)
         loss += F.softmax_cross_entropy(y, t)
 
-        if evaluate is not None:
-            predict = cuda.to_cpu(y.data.argmax(1))
-            if predict[0] == node['label']:
-                evaluate['correct'] += 1
-            evaluate['total'] += 1
+        predict = cuda.to_cpu(y.data.argmax(1))
+        if predict[0] == node['label']:
+            evaluate['correct'] += 1
+        evaluate['total'] += 1
 
         return loss, v
 
@@ -121,12 +120,6 @@ def main():
     batchsize = args.batchsize      # minibatch size
     n_label = args.label         # number of labels
     epoch_per_eval = args.epocheval  # number of epochs per evaluation
-
-    if args.gpu >= 0:
-        chainer.cuda.get_device(args.gpu).use()
-        xp = cuda.cupy
-    else:
-        xp = np
 
     if args.test:
         max_size = 10

--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -155,6 +155,8 @@ def main():
                        for tree in data.read_corpus('trees/dev.txt', max_size)]
     validation_iter = chainer.iterators.SerialIterator(
         validation_data, batchsize, repeat=False, shuffle=False)
+    test_data = [convert_tree(vocab, tree)
+                 for tree in data.read_corpus('trees/test.txt', max_size)]
 
     model = RecursiveNet(len(vocab), n_units, n_label)
 
@@ -193,8 +195,6 @@ def main():
     trainer.run()
 
     print('Test evaluation')
-    test_data = [convert_tree(vocab, tree)
-                 for tree in data.read_corpus('trees/test.txt', max_size)]
     evaluate(model, test_data)
 
 


### PR DESCRIPTION
To make the sentiment example run with trainer because I want to compare ``train_sentiment.py`` and ``train_recursive_minibatch.py`` easily.

```
$ ./train_sentiment.py --test           
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           1690.33                           0.15991                                  1.26023       
2           572.783     453.789               0.5            0.477564                  1.88768       
3           408.466                           0.689189                                 2.39682       
4           365.993     544.563               0.736486       0.496795                  3.01825       
5           342.518                           0.754505                                 3.567         
6           281.222     466.595               0.844595       0.49359                   4.19773       
7           184.178                           0.912162                                 4.70343       
8           139.351     506.42                0.957207       0.503205                  5.32209       
9           108.956                           0.977477                                 5.8469        
10          86.4477     538.983               0.981982       0.503205                  6.48094
```