### PR TITLE
Raise an error when `devices` argument given to `MultiprocessParallelUpdater` is not dict and list

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -157,6 +157,12 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             main = devices.pop('main')
             devices = list(six.itervalues(devices))
             devices = [main] + devices
+        elif isinstance(devices, list):
+            pass
+        else:
+            raise ValueError(
+                'device argument should be either dict or list, '
+                'but {} wad given.'.format(type(devices)))
         if devices is None or any(device is None for device in devices):
             raise ValueError('must specify GPU devices')
 

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -161,7 +161,7 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             pass
         else:
             raise ValueError(
-                'device argument should be either dict or list, '
+                'devices argument should be either dict or list, '
                 'but {} wad given.'.format(type(devices)))
         if devices is None or any(device is None for device in devices):
             raise ValueError('must specify GPU devices')

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -162,7 +162,7 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
         else:
             raise ValueError(
                 'devices argument should be either dict or list, '
-                'but {} wad given.'.format(type(devices)))
+                'but {} was given.'.format(type(devices)))
         if devices is None or any(device is None for device in devices):
             raise ValueError('must specify GPU devices')
 

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -157,8 +157,8 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             main = devices.pop('main')
             devices = list(six.itervalues(devices))
             devices = [main] + devices
-        elif isinstance(devices, list):
-            pass
+        elif isinstance(devices, (list, tuple)):
+            devices = list(devices)
         else:
             raise ValueError(
                 'devices argument should be either dict or list, '

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -161,8 +161,8 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             devices = list(devices)
         else:
             raise ValueError(
-                'devices argument should be either dict or list, '
-                'but {} was given.'.format(type(devices)))
+                'devices argument should be either dict, list or tuple,'
+                ' but {} was given.'.format(type(devices)))
         if devices is None or any(device is None for device in devices):
             raise ValueError('must specify GPU devices')
 


### PR DESCRIPTION
This PR related to #4709 , but doesn't resolve it.