### PR TITLE
separate MultiprocessParallelUpdater tests

### DIFF
--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/child_reporter.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/child_reporter.py
@@ -66,3 +66,7 @@ if __name__ == '__main__':
     trainer = trainer.Trainer(updater, (1, 'iteration'), '/tmp')
     trainer.run()
     assert model.call_called == 1
+
+
+# This snippet is not a test code.
+# testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/child_reporter.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/child_reporter.py
@@ -1,0 +1,68 @@
+import sys
+
+import numpy
+
+import chainer
+from chainer.training import trainer
+import chainer.training.updaters.multiprocess_parallel_updater as mpu
+
+
+class SimpleNetChild(chainer.Chain):
+
+    def __init__(self):
+        super(SimpleNetChild, self).__init__()
+        with self.init_scope():
+            self.conv = chainer.links.Convolution2D(2, 2, 3)
+
+    def __call__(self, x):
+
+        h = chainer.functions.relu(self.conv(x))
+
+        chainer.reporter.report({
+            'h_max': chainer.functions.math.minmax.max(h)}, self)
+
+        return h
+
+
+class SimpleNetChildReporter(chainer.Chain):
+
+    def __init__(self):
+        super(SimpleNetChildReporter, self).__init__()
+        with self.init_scope():
+            self.c1 = SimpleNetChild()
+            self.fc = chainer.links.Linear(18, 2)
+        self.call_called = 0
+
+    def clear(self):
+        self.loss = None
+
+    def __call__(self, x, t):
+
+        self.call_called += 1
+
+        h = chainer.functions.relu(self.c1(x))
+        y = self.fc(h)
+
+        self.loss = chainer.functions.softmax_cross_entropy(y, t)
+        chainer.reporter.report({'loss': self.loss}, self)
+
+        return self.loss
+
+
+if __name__ == '__main__':
+    model = SimpleNetChildReporter()
+    dataset = [(numpy.full((2, 5, 5), i, numpy.float32),
+                numpy.int32(0)) for i in range(100)]
+
+    batch_size = 5
+    devices = tuple([int(x) for x in sys.argv[1].split(',')])
+    iters = [chainer.iterators.SerialIterator(i, batch_size) for i in
+             chainer.datasets.split_dataset_n_random(
+                 dataset, len(devices))]
+    optimizer = chainer.optimizers.SGD(lr=1.0)
+    optimizer.setup(model)
+    updater = mpu.MultiprocessParallelUpdater(
+        iters, optimizer, devices=devices)
+    trainer = trainer.Trainer(updater, (1, 'iteration'), '/tmp')
+    trainer.run()
+    assert model.call_called == 1

--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/raw_array.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/raw_array.py
@@ -1,0 +1,60 @@
+import numpy
+
+import chainer
+from chainer import testing
+import chainer.training.updaters.multiprocess_parallel_updater as mpu
+
+
+class SimpleNetRawArray(chainer.Chain):
+
+    def __init__(self):
+        super(SimpleNetRawArray, self).__init__()
+        with self.init_scope():
+            self.conv = chainer.links.Convolution2D(2, 2, 3)
+            self.fc = chainer.links.Linear(18, 2)
+
+        self.train = True
+        self.call_called = 0
+
+    def clear(self):
+        self.loss = None
+        self.accuracy = None
+
+    def __call__(self, x, t):
+        assert not isinstance(x, chainer.Variable)
+        assert not isinstance(t, chainer.Variable)
+
+        self.call_called += 1
+
+        h = chainer.functions.relu(self.conv(x))
+        y = self.fc(h)
+
+        self.loss = chainer.functions.softmax_cross_entropy(y, t)
+        self.accuracy = chainer.functions.accuracy(y, t)
+
+        return self.loss
+
+
+def test():
+    model = SimpleNetRawArray()
+    dataset = [((numpy.ones((2, 5, 5)) * i).astype(numpy.float32),
+                numpy.int32(0)) for i in range(100)]
+
+    batch_size = 5
+    devices = (0,)
+    iters = [chainer.iterators.SerialIterator(i, batch_size) for i in
+             chainer.datasets.split_dataset_n_random(
+                 dataset, len(devices))]
+    optimizer = chainer.optimizers.SGD(lr=1.0)
+    optimizer.setup(model)
+
+    with testing.assert_warns(UserWarning):
+        updater = mpu.MultiprocessParallelUpdater(
+            iters, optimizer, devices=devices)
+    updater.update()
+
+    assert model.call_called == 1
+
+
+if __name__ == '__main__':
+    test()

--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/raw_array.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/raw_array.py
@@ -58,3 +58,7 @@ def test():
 
 if __name__ == '__main__':
     test()
+
+
+# This snippet is not a test code.
+# testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
@@ -1,8 +1,6 @@
 import os
-import shutil
 import subprocess
 import sys
-import tempfile
 import unittest
 
 import numpy
@@ -162,6 +160,18 @@ class SimpleNetRawArray(chainer.Chain):
         return self.loss
 
 
+def _run_test_snippet(name, *args):
+    script_path = os.path.join(
+        os.path.dirname(__file__), 'snippets/{}'.format(name))
+    proc = subprocess.Popen(
+        (sys.executable, script_path) + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    stdoutdata, stderrdata = proc.communicate()
+    ret = proc.returncode
+    return (ret, stdoutdata, stderrdata)
+
+
 class TestRawArray(unittest.TestCase):
 
     def setUp(self):
@@ -192,105 +202,25 @@ class TestRawArray(unittest.TestCase):
 
 class TestChildReporter(unittest.TestCase):
 
-    def check_update_uses_raw_array(self, n_devices):
-        device_ids_tuple = 'tuple([{}])'.format(
-            ', '.join([str(n) for n in range(n_devices)]))
-        code = '''
-import numpy
-import chainer
-from chainer.training import trainer
-import chainer.training.updaters.multiprocess_parallel_updater as mpu
-class SimpleNetChild(chainer.Chain):
-
-    def __init__(self):
-        super(SimpleNetChild, self).__init__()
-        with self.init_scope():
-            self.conv = chainer.links.Convolution2D(2, 2, 3)
-
-    def __call__(self, x):
-
-        h = chainer.functions.relu(self.conv(x))
-
-        chainer.reporter.report({
-            'h_max': chainer.functions.math.minmax.max(h)}, self)
-
-        return h
-
-
-class SimpleNetChildReporter(chainer.Chain):
-
-    def __init__(self):
-        super(SimpleNetChildReporter, self).__init__()
-        with self.init_scope():
-            self.c1 = SimpleNetChild()
-            self.fc = chainer.links.Linear(18, 2)
-        self.call_called = 0
-
-    def clear(self):
-        self.loss = None
-
-    def __call__(self, x, t):
-
-        self.call_called += 1
-
-        h = chainer.functions.relu(self.c1(x))
-        y = self.fc(h)
-
-        self.loss = chainer.functions.softmax_cross_entropy(y, t)
-        chainer.reporter.report({'loss': self.loss}, self)
-
-        return self.loss
-
-if __name__ == '__main__':
-    model = SimpleNetChildReporter()
-    dataset = [(numpy.full((2, 5, 5), i, numpy.float32),
-                numpy.int32(0)) for i in range(100)]
-
-    batch_size = 5
-    devices = {{{device_ids_tuple}}}
-    iters = [chainer.iterators.SerialIterator(i, batch_size) for i in
-             chainer.datasets.split_dataset_n_random(
-                 dataset, len(devices))]
-    optimizer = chainer.optimizers.SGD(lr=1.0)
-    optimizer.setup(model)
-    updater = mpu.MultiprocessParallelUpdater(
-        iters, optimizer, devices=devices)
-    trainer = trainer.Trainer(updater, (1, 'iteration'), '/tmp')
-    trainer.run()
-    assert model.call_called == 1
-'''.replace('{{{device_ids_tuple}}}', device_ids_tuple)
-
-        temp_dir = tempfile.mkdtemp()
-        try:
-            script_path = os.path.join(temp_dir, 'script.py')
-            with open(script_path, 'w') as f:
-                f.write(code)
-            proc = subprocess.Popen(
-                [sys.executable, script_path],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
-            stdoutdata, stderrdata = proc.communicate()
-        finally:
-            shutil.rmtree(temp_dir, ignore_errors=True)
-        ret = proc.returncode
+    def check_with_gpus(self, n_devices):
+        device_ids_str = ','.join([str(n) for n in range(n_devices)])
+        ret, stdoutdata, stderrdata = _run_test_snippet(
+            'child_reporter.py', device_ids_str)
         assert ret == 0, (
-            'Import test failed.\n'
-            '[code]:\n{}\n'
             '[stdout]:{!r}\n'
-            '[stderr]:{!r}'.format(
-                code, stdoutdata, stderrdata))
+            '[stderr]:{!r}'.format(stdoutdata, stderrdata))
 
     @attr.gpu
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
     def test_single_device(self):
-        self.check_update_uses_raw_array(1)
+        self.check_with_gpus(1)
 
     @attr.multi_gpu(2)
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
     def test_multi_device(self):
-        self.check_update_uses_raw_array(2)
+        self.check_with_gpus(2)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fix in #4717 changed MPU to raise an error when CUDA is used in the parent process.
This PR changes the MPU tests to run in separate process to avoid test failure when #4717  got merged.

(discussion regarding this change: https://github.com/chainer/chainer/pull/4368#issuecomment-366934262)