### PR TITLE
Add LinkHook

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -13,6 +13,7 @@ from chainer import function_hooks  # NOQA
 from chainer import functions  # NOQA
 from chainer import initializers  # NOQA
 from chainer import iterators  # NOQA
+from chainer import link_hooks  # NOQA
 from chainer import links  # NOQA
 from chainer import optimizers  # NOQA
 from chainer import serializers  # NOQA
@@ -40,6 +41,7 @@ from chainer.initializer import Initializer  # NOQA
 from chainer.link import Chain  # NOQA
 from chainer.link import ChainList  # NOQA
 from chainer.link import Link  # NOQA
+from chainer.link_hook import LinkHook  # NOQA
 from chainer.optimizer import GradientMethod  # NOQA
 from chainer.optimizer import Optimizer  # NOQA
 from chainer.optimizer import UpdateRule  # NOQA
@@ -82,6 +84,15 @@ def get_function_hooks():
     except AttributeError:
         ret = collections.OrderedDict()
         _thread_local.function_hooks = ret
+    return ret
+
+
+def get_link_hooks():
+    try:
+        ret = _thread_local.link_hooks
+    except AttributeError:
+        ret = collections.OrderedDict()
+        _thread_local.link_hooks = ret
     return ret
 
 

--- a/chainer/link_hook.py
+++ b/chainer/link_hook.py
@@ -1,0 +1,139 @@
+import chainer
+
+
+class LinkHook(object):
+    """Base class of hooks for Links.
+
+    :class:`~chainer.LinkHook` is a callback object
+    that is registered to a :class:`~chainer.Link`.
+    Registered link hooks are invoked before calling
+    :meth:`forward` methodof each link.
+
+    Link hooks that derive :class:`LinkHook` are required
+    to implement two methods:
+    :meth:`~chainer.FunctionHook.forward_preprocess` and
+    :meth:`~chainer.FunctionHook.forward_postprocess`.
+    By default, these methods do nothing.
+
+    Specifically, when :meth:`~chainer.Link.__call__`
+    method of some function is invoked,
+    :meth:`~chainer.LinkHook.forward_preprocess`
+    (resp. :meth:`~chainer.LinkHook.forward_postprocess`)
+    of all function hooks registered to this function are called before
+    (resp. after) :meth:`forward` method of the link.
+
+    There are two ways to register :class:`~chainer.LinkHook`
+    objects to :class:`~chainer.Link` objects.
+
+    First one is to use ``with`` statement. Link hooks hooked
+    in this way are registered to all functions within ``with`` statement
+    and are unregistered at the end of ``with`` statement.
+
+    .. admonition:: Example
+
+        The following code is a simple example in which
+        we measure the elapsed time of a part of forward propagation procedure
+        with :class:`~chainer.link_hooks.TimerHook`, which is a subclass of
+        :class:`~chainer.LinkHook`.
+
+        >>> from chainer import link_hooks
+        >>> class Model(chainer.Chain):
+        ...   def __init__(self):
+        ...     super(Model, self).__init__()
+        ...     with self.init_scope():
+        ...       self.l = L.Linear(10, 10)
+        ...   def forward(self, x1):
+        ...     return F.exp(self.l(x1))
+        >>> model1 = Model()
+        >>> model2 = Model()
+        >>> x = chainer.Variable(np.zeros((1, 10), np.float32))
+        >>> with chainer.function_hooks.TimerHook() as m:
+        ...   _ = model1(x)
+        ...   y = model2(x)
+        ...   print("Total time : " + str(m.total_time()))
+        ...   model3 = Model()
+        ...   z = model3(y) # doctest:+ELLIPSIS
+        Total time : ...
+
+        In this example, we measure the elapsed times for each forward
+        propagation of all functions in ``model1`` and ``model2``
+        (specifically, :class:`~chainer.functions.LinearFunction` and
+        :class:`~chainer.functions.Exp` of ``model1`` and ``model2``).
+        Note that ``model3`` is not a target of measurement
+        as :class:`~chainer.function_hooks.TimerHook` is unregistered
+        before forward propagation of ``model3``.
+
+    .. note::
+
+       Chainer stores the dictionary of registered function hooks
+       as a thread local object. So, function hooks registered
+       are different depending on threads.
+
+    The other one is to register directly to
+    :class:`~chainer.FunctionNode` object with
+    :meth:`~chainer.Function.add_hook` method.
+    Function hooks registered in this way can be removed by
+    :meth:`~chainer.Function.delete_hook` method.
+    Contrary to former registration method, function hooks are registered
+    only to the function which :meth:`~chainer.FunctionNode.add_hook`
+    is called.
+
+    Args:
+        name(str): Name of this function hook.
+    """
+
+    name = 'LinkHook'
+
+    def __enter__(self):
+        link_hooks = chainer.get_link_hooks()
+        if self.name in link_hooks:
+            raise KeyError('hook %s already exists' % self.name)
+
+        link_hooks[self.name] = self
+        self.added()
+        return self
+
+    def __exit__(self, *_):
+        chainer.get_link_hooks()[self.name].deleted()
+        del chainer.get_link_hooks()[self.name]
+
+    def added(self, link=None):
+        """Callback function invoked when a link hook is added
+
+        Args:
+            link(~chainer.Link): Link object to which
+                the link hook is added.
+        """
+        pass
+
+    def deleted(self, link=None):
+        """Callback function invoked when a link hook is deleted
+
+        Args:
+            link(~chainer.Link): Link object to which
+                the link hook is deleted.
+        """
+        pass
+
+    # forward
+    def forward_preprocess(self, link, in_data):
+        """Callback function invoked before :meth:`forward`.
+
+        Args:
+            link(~chainer.Link): Link object to which
+                the link hook is registered.
+            in_data(tuple):
+               Input argument of :meth:`forward`.
+        """
+        pass
+
+    def forward_postprocess(self, link, in_data):
+        """Callback function invoked after link propagation.
+
+        Args:
+            link(~chainer.Link): Link object to which
+                the link hook is registered.
+            in_data(tuple):
+                Input argument of :meth:`forward`.
+        """
+        pass

--- a/chainer/link_hooks/__init__.py
+++ b/chainer/link_hooks/__init__.py
@@ -1,0 +1,2 @@
+# import classes and functions
+from chainer.link_hooks.timer import ForwardTimerHook  # NOQA

--- a/chainer/link_hooks/timer.py
+++ b/chainer/link_hooks/timer.py
@@ -1,0 +1,132 @@
+import sys
+import time
+
+import numpy
+
+from chainer.backends import cuda
+from chainer import link_hook
+
+
+class ForwardTimerHook(link_hook.LinkHook):
+    """Link hook for measuring elapsed time of :meth:`forward`.
+
+    Example:
+        Code example::
+
+            from chainer.link_hooks import ForwardTimerHook
+            hook = TimerHook()
+            with hook:
+                trainer.run()
+            hook.print_report()
+
+        Output example::
+
+                       LinkName  ElapsedTime  Occurrence
+                 LinearFunction      1.24sec        3900
+                           ReLU     593.05ms        2600
+            SoftmaxCrossEntropy     824.11ms        1300
+                       Accuracy     176.54ms         700
+
+        where *LinkName* is the name of link that calls the hook,
+        and *ElapsedTime* is the elapsed time the function consumed,
+        and *Occurrence* is the number of calls.
+
+    Attributes:
+        call_history: List of measurement results. It consists of pairs of
+            the name of the link that calls this hook and the elapsed time
+            the :meth:`forward` method of link consumes.
+
+    """
+
+    name = 'ForwardTimerHook'
+
+    def __init__(self):
+        self.call_history = []
+        self._running_stack = []
+        self._depth = 0
+        self._total_time = 0
+
+    def _preprocess(self):
+        if self.xp == numpy:
+            start = time.time()
+            self._running_stack.append(start)
+        else:
+            start = cuda.Event()
+            stop = cuda.Event()
+            start.record()
+            self._running_stack.append((start, stop))
+        self._depth += 1
+
+    def forward_preprocess(self, link, in_data):
+        self.xp = cuda.get_array_module(*in_data)
+        self._preprocess()
+
+    def _postprocess(self, function):
+        if self.xp == numpy:
+            start = self._running_stack.pop()
+            stop = time.time()
+            elapsed_time = stop - start
+        else:
+            start, stop = self._running_stack.pop()
+            stop.record()
+            stop.synchronize()
+            # Note that `get_elapsed_time` returns result in milliseconds
+            elapsed_time = cuda.cupy.cuda.get_elapsed_time(
+                start, stop) / 1000
+        self.call_history.append((function._impl_name, elapsed_time))
+
+        assert self._depth > 0
+        self._depth -= 1
+        if self._depth == 0:
+            self._total_time += elapsed_time
+
+    def forward_postprocess(self, function, in_data):
+        xp = cuda.get_array_module(*in_data)
+        assert xp == self.xp
+        self._postprocess(function)
+
+    def total_time(self):
+        """Returns total elapsed time in seconds."""
+        return self._total_time
+
+    def summary(self):
+        """Returns a summary of time profiling in functions.
+
+        Returns:
+            A summarized dictionary whose keys are function names and
+            values are dictionaries of `elapsed_time` and `occurrrence`.
+        """
+        summary = {}
+        for function_name, elapsed_time in self.call_history:
+            if function_name not in summary:
+                summary[function_name] = {'elapsed_time': 0, 'occurrence': 0}
+            record = summary[function_name]
+            record['elapsed_time'] += elapsed_time
+            record['occurrence'] += 1
+        return summary
+
+    def _humanized_time(self, second):
+        """Returns a human readable time."""
+        for unit in ['sec', 'ms', 'us']:
+            if second >= 1:
+                return '%3.2f%s' % (second, unit)
+            second *= 1000.0
+        return '%.2f%s' % (second, 'ns')
+
+    def print_report(self, file=sys.stdout):
+        """Prints a summary report of time profiling in functions."""
+        entries = [['FunctionName', 'ElapsedTime', 'Occurrence']]
+        for function_name, record in self.summary().items():
+            elapsed_time = self._humanized_time(record['elapsed_time'])
+            occurrence = str(record['occurrence'])
+            entries.append([function_name, elapsed_time, occurrence])
+        entry_widths = []
+        entry_widths.append(max(len(f) for f, _, _ in entries))
+        entry_widths.append(max(len(e) for _, e, _ in entries))
+        entry_widths.append(max(len(o) for _, _, o in entries))
+        template = '  '.join('{:>%d}' % w for w in entry_widths)
+        for function_name, elapsed_time, occurrence in entries:
+            line = template.format(function_name, elapsed_time, occurrence)
+            file.write(line)
+            file.write('\n')
+        file.flush()

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -80,7 +80,7 @@ class Maxout(link.Chain):
         self.out_size = out_size
         self.pool_size = pool_size
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the maxout layer.
 
         Args:

--- a/chainer/links/activation/prelu.py
+++ b/chainer/links/activation/prelu.py
@@ -27,7 +27,7 @@ class PReLU(link.Link):
         with self.init_scope():
             self.W = variable.Parameter(init, shape)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the parametric ReLU activation function.
 
         Args:

--- a/chainer/links/activation/simplified_dropconnect.py
+++ b/chainer/links/activation/simplified_dropconnect.py
@@ -71,7 +71,7 @@ class SimplifiedDropconnect(link.Link):
     def _initialize_params(self, in_size):
         self.W.initialize((self.out_size, in_size))
 
-    def __call__(self, x, train=True, mask=None, use_batchwise_mask=True):
+    def forward(self, x, train=True, mask=None, use_batchwise_mask=True):
         """Applies the simplified dropconnect layer.
 
         Args:

--- a/chainer/links/activation/swish.py
+++ b/chainer/links/activation/swish.py
@@ -35,7 +35,7 @@ class Swish(link.Link):
                     self.l2 = L.Linear(None, n_units)
                     self.l3 = L.Linear(None, n_out)
 
-            def __call__(self, x):
+            def forward(self, x):
                 h1 = F.relu(self.l1(x))
                 h2 = F.relu(self.l2(h1))
                 return self.l3(h2)
@@ -53,7 +53,7 @@ class Swish(link.Link):
                     self.s2 = L.Swish(None)
                     self.l3 = L.Linear(None, n_out)
 
-            def __call__(self, x):
+            def forward(self, x):
                 h1 = self.s1(self.l1(x))
                 h2 = self.s2(self.l2(h1))
                 return self.l3(h2)
@@ -77,7 +77,7 @@ class Swish(link.Link):
                 beta_init = initializers.Constant(beta_init)
                 self.beta = variable.Parameter(beta_init)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the Swish activation function.
 
         Args:

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -173,7 +173,7 @@ class CaffeFunction(link.Chain):
                         'Skip the layer "%s", since CaffeFunction does not'
                         'support it' % layer.name)
 
-    def __call__(self, inputs, outputs, disable=(), **kwargs):
+    def forward(self, inputs, outputs, disable=(), **kwargs):
         """__call__(self, inputs, outputs, disable=())
 
         Executes a sub-network of the network.

--- a/chainer/links/connection/bias.py
+++ b/chainer/links/connection/bias.py
@@ -17,7 +17,7 @@ class Bias(link.Link):
             input is applied.
         shape (tuple of ints): Shape of the learnable bias parameter. If
             ``None``, this link does not have learnable parameters so an
-            explicit bias needs to be given to its ``__call__`` method's second
+            explicit bias needs to be given to its ``forward`` method's second
             input.
 
     .. seealso:: See :func:`~chainer.functions.bias` for details.
@@ -38,7 +38,7 @@ class Bias(link.Link):
 
         self.axis = axis
 
-    def __call__(self, *xs):
+    def forward(self, *xs):
         """Applies broadcasted elementwise summation.
 
         Args:

--- a/chainer/links/connection/bilinear.py
+++ b/chainer/links/connection/bilinear.py
@@ -89,7 +89,7 @@ class Bilinear(link.Link):
                 self.V2 = variable.Parameter(initialV2, V2_shape)
                 self.b = variable.Parameter(initialb, b_shape)
 
-    def __call__(self, e1, e2):
+    def forward(self, e1, e2):
         """Applies the bilinear function to inputs and the internal parameters.
 
         Args:

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -154,7 +154,7 @@ class Convolution2D(link.Link):
         W_shape = (self.out_channels, int(in_channels / self.groups), kh, kw)
         self.W.initialize(W_shape)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the convolution layer.
 
         Args:

--- a/chainer/links/connection/convolution_nd.py
+++ b/chainer/links/connection/convolution_nd.py
@@ -74,7 +74,7 @@ class ConvolutionND(link.Link):
                 initial_bias = initializers._get_initializer(initial_bias)
                 self.b = variable.Parameter(initial_bias, out_channels)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies N-dimensional convolution layer.
 
         Args:

--- a/chainer/links/connection/deconvolution_2d.py
+++ b/chainer/links/connection/deconvolution_2d.py
@@ -176,7 +176,7 @@ class Deconvolution2D(link.Link):
         W_shape = (in_channels, int(self.out_channels / self.groups), kh, kw)
         self.W.initialize(W_shape)
 
-    def __call__(self, x):
+    def forward(self, x):
         if self.W.data is None:
             self._initialize_params(x.shape[1])
         return deconvolution_2d.deconvolution_2d(

--- a/chainer/links/connection/deconvolution_nd.py
+++ b/chainer/links/connection/deconvolution_nd.py
@@ -71,7 +71,7 @@ class DeconvolutionND(link.Link):
                 initial_bias = initializers._get_initializer(initial_bias)
                 self.b = variable.Parameter(initial_bias, out_channels)
 
-    def __call__(self, x):
+    def forward(self, x):
         return deconvolution_nd.deconvolution_nd(
             x, self.W, b=self.b, stride=self.stride, pad=self.pad,
             outsize=self.outsize)

--- a/chainer/links/connection/depthwise_convolution_2d.py
+++ b/chainer/links/connection/depthwise_convolution_2d.py
@@ -76,7 +76,7 @@ class DepthwiseConvolution2D(link.Link):
         if self.b is not None:
             self.b.initialize(self.channel_multiplier * in_channels)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the depthwise convolution layer.
 
         Args:

--- a/chainer/links/connection/dilated_convolution_2d.py
+++ b/chainer/links/connection/dilated_convolution_2d.py
@@ -118,7 +118,7 @@ reshape(1, 3, 10, 10)
         W_shape = (self.out_channels, in_channels, kh, kw)
         self.W.initialize(W_shape)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the convolution layer.
 
         Args:

--- a/chainer/links/connection/embed_id.py
+++ b/chainer/links/connection/embed_id.py
@@ -57,7 +57,7 @@ class EmbedID(link.Link):
                 initialW = normal.Normal(1.0)
             self.W = variable.Parameter(initialW, (in_size, out_size))
 
-    def __call__(self, x):
+    def forward(self, x):
         """Extracts the word embedding of given IDs.
 
         Args:

--- a/chainer/links/connection/gru.py
+++ b/chainer/links/connection/gru.py
@@ -105,7 +105,7 @@ class StatelessGRU(GRUBase):
 
     """
 
-    def __call__(self, h, x):
+    def forward(self, h, x):
         r = sigmoid.sigmoid(self.W_r(x) + self.U_r(h))
         z = sigmoid.sigmoid(self.W_z(x) + self.U_z(h))
         h_bar = tanh.tanh(self.W(x) + self.U(r * h))
@@ -223,7 +223,7 @@ class StatefulGRU(GRUBase):
     def reset_state(self):
         self.h = None
 
-    def __call__(self, x):
+    def forward(self, x):
         z = self.W_z(x)
         h_bar = self.W(x)
         if self.h is not None:
@@ -261,15 +261,15 @@ class GRU(StatefulGRU):
 
     """
 
-    def __call__(self, *args):
-        """__call__(self, x)
+    def forward(self, *args):
+        """forward(self, x)
 
         Does forward propagation.
 
         """
 
         n_args = len(args)
-        msg = ("Invalid argument. The length of GRU.__call__ must be 1. "
+        msg = ("Invalid argument. The length of GRU.forward must be 1. "
                "But %d is given. " % n_args)
 
         if n_args == 0 or n_args >= 3:
@@ -281,4 +281,4 @@ class GRU(StatefulGRU):
                     "Use chainer.links.StatelessGRU instead.")
             raise ValueError(msg)
 
-        return super(GRU, self).__call__(args[0])
+        return super(GRU, self).forward(args[0])

--- a/chainer/links/connection/highway.py
+++ b/chainer/links/connection/highway.py
@@ -60,7 +60,7 @@ class Highway(link.Chain):
                 in_out_size, in_out_size, nobias=nobias,
                 initialW=init_Wt, initial_bias=init_bt)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Computes the output of the Highway module.
 
         Args:

--- a/chainer/links/connection/inception.py
+++ b/chainer/links/connection/inception.py
@@ -61,7 +61,7 @@ class Inception(link.Chain):
                 in_channels, proj_pool, 1, initialW=conv_init,
                 initial_bias=bias_init)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Computes the output of the Inception module.
 
         Args:

--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -92,7 +92,7 @@ class InceptionBN(link.Chain):
                 self.poolpn = batch_normalization.BatchNormalization(
                     proj_pool, dtype=dtype)
 
-    def __call__(self, x):
+    def forward(self, x):
         outs = []
 
         if self.out1 > 0:

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -113,7 +113,7 @@ class Linear(link.Link):
     def _initialize_params(self, in_size):
         self.W.initialize((self.out_size, in_size))
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the linear layer.
 
         Args:

--- a/chainer/links/connection/local_convolution_2d.py
+++ b/chainer/links/connection/local_convolution_2d.py
@@ -87,7 +87,7 @@ class LocalConvolution2D(link.Link):
         if not self.nobias:
             self.b.initialize(bias_shape)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Applies the local convolution layer.
 
         Args:

--- a/chainer/links/connection/lstm.py
+++ b/chainer/links/connection/lstm.py
@@ -117,7 +117,7 @@ class StatelessLSTM(LSTMBase):
 
     """
 
-    def __call__(self, c, h, x):
+    def forward(self, c, h, x):
         """Returns new cell state and updated output of LSTM.
 
         Args:
@@ -289,7 +289,7 @@ class LSTM(LSTMBase):
         """
         self.c = self.h = None
 
-    def __call__(self, x):
+    def forward(self, x):
         """Updates the internal state and returns the LSTM outputs.
 
         Args:

--- a/chainer/links/connection/mgu.py
+++ b/chainer/links/connection/mgu.py
@@ -26,7 +26,7 @@ class MGUBase(link.Chain):
 
 class StatelessMGU(MGUBase):
 
-    __call__ = MGUBase._call_mgu
+    forward = MGUBase._call_mgu
 
 
 class StatefulMGU(MGUBase):
@@ -58,7 +58,7 @@ class StatefulMGU(MGUBase):
     def reset_state(self):
         self.h = None
 
-    def __call__(self, x):
+    def forward(self, x):
         if self.h is None:
             n_batch = x.shape[0]
             h_data = self.xp.zeros(

--- a/chainer/links/connection/mlp_convolution_2d.py
+++ b/chainer/links/connection/mlp_convolution_2d.py
@@ -84,7 +84,7 @@ class MLPConvolution2D(link.ChainList):
         super(MLPConvolution2D, self).__init__(*convs)
         self.activation = activation
 
-    def __call__(self, x):
+    def forward(self, x):
         """Computes the output of the mlpconv layer.
 
         Args:

--- a/chainer/links/connection/n_step_lstm.py
+++ b/chainer/links/connection/n_step_lstm.py
@@ -31,8 +31,8 @@ class NStepLSTMBase(n_step_rnn.NStepRNNBase):
 
     n_weights = 8
 
-    def __call__(self, hx, cx, xs, **kwargs):
-        """__call__(self, hx, cx, xs)
+    def forward(self, hx, cx, xs, **kwargs):
+        """forward(self, hx, cx, xs)
 
         Calculate all hidden states and cell states.
 

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -124,8 +124,8 @@ class NStepRNNBase(link.ChainList):
         """
         return NotImplementedError
 
-    def __call__(self, hx, xs, **kwargs):
-        """__call__(self, hx, xs)
+    def forward(self, hx, xs, **kwargs):
+        """forward(self, hx, xs)
 
         Calculate all hidden states and cell states.
 

--- a/chainer/links/connection/parameter.py
+++ b/chainer/links/connection/parameter.py
@@ -26,7 +26,7 @@ class Parameter(link.Link):
         if isinstance(array, cuda.ndarray):
             self.to_gpu(cuda.get_device_from_array(array))
 
-    def __call__(self, volatile='off'):
+    def forward(self, volatile='off'):
         """Returns the parameter variable.
 
         Args:

--- a/chainer/links/connection/peephole.py
+++ b/chainer/links/connection/peephole.py
@@ -85,7 +85,7 @@ class StatefulPeepholeLSTM(link.Chain):
         """
         self.c = self.h = None
 
-    def __call__(self, x):
+    def forward(self, x):
         """Updates the internal state and returns the LSTM outputs.
 
         Args:

--- a/chainer/links/connection/scale.py
+++ b/chainer/links/connection/scale.py
@@ -18,7 +18,7 @@ class Scale(link.Chain):
             input is applied.
         W_shape (tuple of ints): Shape of learnable weight parameter. If
             ``None``, this link does not have learnable weight parameter so an
-            explicit weight needs to be given to its ``__call__`` method's
+            explicit weight needs to be given to its ``forward`` method's
             second input.
         bias_term (bool): Whether to also learn a bias (equivalent to Scale
             link + Bias link).
@@ -55,7 +55,7 @@ class Scale(link.Chain):
                             'learnt parameter and bias_term is True.')
                     self.bias = bias.Bias(axis, bias_shape)
 
-    def __call__(self, *xs):
+    def forward(self, *xs):
         """Applies broadcasted elementwise product.
 
         Args:

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -63,7 +63,7 @@ class ChildSumTreeLSTM(link.Chain):
         self.state_size = out_size
         utils.experimental('chainer.links.tree_lstm.py')
 
-    def __call__(self, *cshsx):
+    def forward(self, *cshsx):
         """Returns new cell state and output of Child-Sum TreeLSTM.
 
         Args:
@@ -201,7 +201,7 @@ class NaryTreeLSTM(link.Chain):
         self.n_ary = n_ary
         utils.experimental('chainer.links.tree_lstm.py')
 
-    def __call__(self, *cshsx):
+    def forward(self, *cshsx):
         """Returns new cell state and output of N-ary TreeLSTM.
 
         Args:

--- a/chainer/links/connection/zoneoutlstm.py
+++ b/chainer/links/connection/zoneoutlstm.py
@@ -75,7 +75,7 @@ class StatefulZoneoutLSTM(link.Chain):
         """
         self.c = self.h = None
 
-    def __call__(self, x):
+    def forward(self, x):
         """Updates the internal state and returns the LSTM outputs.
 
         Args:

--- a/chainer/links/loss/black_out.py
+++ b/chainer/links/loss/black_out.py
@@ -44,7 +44,7 @@ class BlackOut(link.Link):
             super(BlackOut, self).to_gpu()
             self.sampler.to_gpu()
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         """Computes the loss value for given input and ground truth labels.
 
         Args:

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -24,7 +24,7 @@ class CRF1d(link.Link):
         with self.init_scope():
             self.cost = variable.Parameter(0, (n_label, n_label))
 
-    def __call__(self, xs, ys, reduce='mean'):
+    def forward(self, xs, ys, reduce='mean'):
         return crf1d.crf1d(self.cost, xs, ys, reduce)
 
     def argmax(self, xs):

--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -349,7 +349,7 @@ class BinaryHierarchicalSoftmax(link.Link):
 
         return q.get()[2]
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         """Computes the loss value for given input and ground truth labels.
 
         Args:

--- a/chainer/links/loss/negative_sampling.py
+++ b/chainer/links/loss/negative_sampling.py
@@ -49,7 +49,7 @@ class NegativeSampling(link.Link):
             super(NegativeSampling, self).to_gpu()
             self.sampler.to_gpu()
 
-    def __call__(self, x, t, reduce='sum'):
+    def forward(self, x, t, reduce='sum'):
         """Computes the loss value for given input and ground truth labels.
 
         Args:

--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -70,7 +70,7 @@ class Classifier(link.Chain):
         with self.init_scope():
             self.predictor = predictor
 
-    def __call__(self, *args, **kwargs):
+    def forward(self, *args, **kwargs):
         """Computes the loss value for an input and label pair.
 
         It also computes accuracy and stores it to the attribute.

--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -84,7 +84,7 @@ class GoogLeNet(link.Chain):
 
     Attributes:
         ~GoogLeNet.available_layers (list of str): The list of available layer
-            names used by ``__call__`` and ``extract`` methods.
+            names used by ``forward`` and ``extract`` methods.
 
     """
 
@@ -182,8 +182,8 @@ class GoogLeNet(link.Chain):
         _transfer_googlenet(caffemodel, chainermodel)
         npz.save_npz(path_npz, chainermodel, compression=False)
 
-    def __call__(self, x, layers=None, **kwargs):
-        """__call__(self, x, layers=['prob'])
+    def forward(self, x, layers=None, **kwargs):
+        """forward(self, x, layers=['prob'])
 
         Computes all the feature maps specified by ``layers``.
 
@@ -245,11 +245,11 @@ class GoogLeNet(link.Chain):
 
         Extracts all the feature maps of given images.
 
-        The difference of directly executing ``__call__`` is that
+        The difference of directly executing ``forward`` is that
         it directly accepts images as an input and automatically
         transforms them to a proper variable. That is,
         it is also interpreted as a shortcut method that implicitly calls
-        ``prepare`` and ``__call__`` functions.
+        ``prepare`` and ``forward`` functions.
 
         .. warning::
 
@@ -326,7 +326,7 @@ class GoogLeNet(link.Chain):
 def prepare(image, size=(224, 224)):
     """Converts the given image to the numpy array for GoogLeNet.
 
-    Note that you have to call this method before ``__call__``
+    Note that you have to call this method before ``forward``
     because the pre-trained GoogLeNet model requires to resize the given
     image, covert the RGB to the BGR, subtract the mean,
     and permute the dimensions before calling.

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -73,7 +73,7 @@ class ResNetLayers(link.Chain):
 
     Attributes:
         ~ResNetLayers.available_layers (list of str): The list of available
-            layer names used by ``__call__`` and ``extract`` methods.
+            layer names used by ``forward`` and ``extract`` methods.
 
     """
 
@@ -156,8 +156,8 @@ class ResNetLayers(link.Chain):
                              ' or 152, but {} was given.'.format(n_layers))
         npz.save_npz(path_npz, chainermodel, compression=False)
 
-    def __call__(self, x, layers=None, **kwargs):
-        """__call__(self, x, layers=['prob'])
+    def forward(self, x, layers=None, **kwargs):
+        """forward(self, x, layers=['prob'])
 
         Computes all the feature maps specified by ``layers``.
 
@@ -205,11 +205,11 @@ class ResNetLayers(link.Chain):
 
         Extracts all the feature maps of given images.
 
-        The difference of directly executing ``__call__`` is that
+        The difference of directly executing ``forward`` is that
         it directly accepts images as an input and automatically
         transforms them to a proper variable. That is,
         it is also interpreted as a shortcut method that implicitly calls
-        ``prepare`` and ``__call__`` functions.
+        ``prepare`` and ``forward`` functions.
 
         .. warning::
 
@@ -330,7 +330,7 @@ class ResNet50Layers(ResNetLayers):
 
     Attributes:
         ~ResNet50Layers.available_layers (list of str): The list of available
-            layer names used by ``__call__`` and ``extract`` methods.
+            layer names used by ``forward`` and ``extract`` methods.
 
     """
 
@@ -383,7 +383,7 @@ class ResNet101Layers(ResNetLayers):
 
     Attributes:
         ~ResNet101Layers.available_layers (list of str): The list of available
-            layer names used by ``__call__`` and ``extract`` methods.
+            layer names used by ``forward`` and ``extract`` methods.
 
     """
 
@@ -435,7 +435,7 @@ class ResNet152Layers(ResNetLayers):
 
     Attributes:
         ~ResNet152Layers.available_layers (list of str): The list of available
-            layer names used by ``__call__`` and ``extract`` methods.
+            layer names used by ``forward`` and ``extract`` methods.
 
     """
 
@@ -448,7 +448,7 @@ class ResNet152Layers(ResNetLayers):
 def prepare(image, size=(224, 224)):
     """Converts the given image to the numpy array for ResNets.
 
-    Note that you have to call this method before ``__call__``
+    Note that you have to call this method before ``forward``
     because the pre-trained resnet model requires to resize the given
     image, covert the RGB to the BGR, subtract the mean,
     and permute the dimensions before calling.
@@ -520,7 +520,7 @@ class BuildingBlock(link.Chain):
                 setattr(self, name, bottleneck)
                 self._forward.append(name)
 
-    def __call__(self, x):
+    def forward(self, x):
         for name in self._forward:
             l = getattr(self, name)
             x = l(x)
@@ -565,7 +565,7 @@ class BottleneckA(link.Chain):
                 nobias=True)
             self.bn4 = BatchNormalization(out_channels)
 
-    def __call__(self, x):
+    def forward(self, x):
         h1 = relu(self.bn1(self.conv1(x)))
         h1 = relu(self.bn2(self.conv2(h1)))
         h1 = self.bn3(self.conv3(h1))
@@ -600,7 +600,7 @@ class BottleneckB(link.Chain):
                 nobias=True)
             self.bn3 = BatchNormalization(in_channels)
 
-    def __call__(self, x):
+    def forward(self, x):
         h = relu(self.bn1(self.conv1(x)))
         h = relu(self.bn2(self.conv2(h)))
         h = self.bn3(self.conv3(h))

--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -68,7 +68,7 @@ class VGG16Layers(link.Chain):
 
     Attributes:
         ~VGG16Layers.available_layers (list of str): The list of available
-            layer names used by ``__call__`` and ``extract`` methods.
+            layer names used by ``forward`` and ``extract`` methods.
 
     """
 
@@ -159,8 +159,8 @@ class VGG16Layers(link.Chain):
         caffemodel = CaffeFunction(path_caffemodel)
         npz.save_npz(path_npz, caffemodel, compression=False)
 
-    def __call__(self, x, layers=None, **kwargs):
-        """__call__(self, x, layers=['prob'])
+    def forward(self, x, layers=None, **kwargs):
+        """forward(self, x, layers=['prob'])
 
         Computes all the feature maps specified by ``layers``.
 
@@ -208,11 +208,11 @@ class VGG16Layers(link.Chain):
 
         Extracts all the feature maps of given images.
 
-        The difference of directly executing ``__call__`` is that
+        The difference of directly executing ``forward`` is that
         it directly accepts images as an input and automatically
         transforms them to a proper variable. That is,
         it is also interpreted as a shortcut method that implicitly calls
-        ``prepare`` and ``__call__`` functions.
+        ``prepare`` and ``forward`` functions.
 
         .. warning::
 
@@ -289,7 +289,7 @@ class VGG16Layers(link.Chain):
 def prepare(image, size=(224, 224)):
     """Converts the given image to the numpy array for VGG models.
 
-    Note that you have to call this method before ``__call__``
+    Note that you have to call this method before ``forward``
     because the pre-trained vgg model requires to resize the given image,
     covert the RGB to the BGR, subtract the mean,
     and permute the dimensions before calling.

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -98,8 +98,8 @@ class BatchNormalization(link.Link):
                 initial_beta.dtype = dtype
                 self.beta = variable.Parameter(initial_beta, size)
 
-    def __call__(self, x, **kwargs):
-        """__call__(self, x, finetune=False)
+    def forward(self, x, **kwargs):
+        """forward(self, x, finetune=False)
 
         Invokes the forward propagation of BatchNormalization.
 

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -44,7 +44,7 @@ class BatchRenormalization(BatchNormalization):
         self.d = None
         self.freeze_running_statistics = freeze_running_statistics
 
-    def __call__(self, x, finetune=False):
+    def forward(self, x, finetune=False):
         if self.gamma is not None:
             gamma = self.gamma
         else:

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -68,7 +68,7 @@ class LayerNormalization(link.Link):
         self.gamma.initialize(size)
         self.beta.initialize(size)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Apply layer normalization to given input.
 
         Args:

--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -99,6 +99,6 @@ Please install theano to activate theano function.
             outputs=grad,
             on_unused_input='ignore')
 
-    def __call__(self, *args):
+    def forward(self, *args):
         return theano_function.theano_function(
             self.forward_func, self.backward_func, *args)

--- a/docs/source/examples/cnn.rst
+++ b/docs/source/examples/cnn.rst
@@ -59,7 +59,7 @@ digit images in 1998. In Chainer, the model can be written as follows:
                 self.fc4 = L.Linear(None, 84)
                 self.fc5 = L.Linear(84, 10)
 
-        def __call__(self, x):
+        def forward(self, x):
             h = F.sigmoid(self.conv1(x))
             h = F.max_pooling_2d(h, 2, 2)
             h = F.sigmoid(self.conv2(h))
@@ -128,7 +128,7 @@ can also write the model like in this way:
                         setattr(self, n[0], n[1])
             self.forward = net
 
-        def __call__(self, x):
+        def forward(self, x):
             for n, f in self.forward:
                 if not n.startswith('_'):
                     x = getattr(self, n)(x)
@@ -231,7 +231,7 @@ useful. First, let's see how to write a VGG16 [Simonyan14]_ model.
                 VGGBlock(512, 3),
                 VGGBlock(512, 3, True))
 
-        def __call__(self, x):
+        def forward(self, x):
             for f in self.children():
                 x = f(x)
             if chainer.config.train:
@@ -258,7 +258,7 @@ useful. First, let's see how to write a VGG16 [Simonyan14]_ model.
             self.n_convs = n_convs
             self.fc = fc
 
-        def __call__(self, x):
+        def forward(self, x):
             h = F.relu(self.conv1(x))
             h = F.relu(self.conv2(h))
             if self.n_convs == 3:
@@ -306,7 +306,7 @@ In the other words, it's easy. One possible way to write ResNet-152 is:
                 self.res5 = ResBlock(n_blocks[3], 1024, 512, 2048)
                 self.fc6 = L.Linear(2048, 1000)
 
-        def __call__(self, x):
+        def forward(self, x):
             h = self.bn1(self.conv1(x))
             h = F.max_pooling_2d(F.relu(h), 2, 2)
             h = self.res2(h)
@@ -327,7 +327,7 @@ In the other words, it's easy. One possible way to write ResNet-152 is:
             for _ in range(n_layers - 1):
                 self.add_link(BottleNeck(n_out, n_mid, n_out))
 
-        def __call__(self, x):
+        def forward(self, x):
             for f in self.children():
                 x = f(x)
             return x
@@ -353,7 +353,7 @@ In the other words, it's easy. One possible way to write ResNet-152 is:
                     self.bn_r = L.BatchNormalization(n_out)
             self.proj = proj
 
-        def __call__(self, x):
+        def forward(self, x):
             h = F.relu(self.bn_a(self.conv1x1a(x)))
             h = F.relu(self.bn_b(self.conv3x3b(h)))
             h = self.bn_c(self.conv1x1c(h))

--- a/docs/source/examples/mnist.rst
+++ b/docs/source/examples/mnist.rst
@@ -64,7 +64,7 @@ Here, we are going to use the same model as the one defined in :doc:`train_loop`
                 self.l2 = L.Linear(None, n_mid_units)
                 self.l3 = L.Linear(None, n_out)
 
-        def __call__(self, x):
+        def forward(self, x):
             h1 = F.relu(self.l1(x))
             h2 = F.relu(self.l2(h1))
             return self.l3(h2)

--- a/docs/source/examples/rnn.rst
+++ b/docs/source/examples/rnn.rst
@@ -72,7 +72,7 @@ Based on this LSTM link, let's write our recurrent network as a new chain:
        def reset_state(self):
            self.mid.reset_state()
 
-       def __call__(self, cur_word):
+       def forward(self, cur_word):
            # Given the current word ID, predict the next word.
            x = self.embed(cur_word)
            h = self.mid(x)

--- a/docs/source/examples/train_loop.rst
+++ b/docs/source/examples/train_loop.rst
@@ -143,7 +143,7 @@ The main steps are twofold:
                     self.l2 = L.Linear(n_mid_units, n_mid_units)
                     self.l3 = L.Linear(n_mid_units, n_out)
 
-            def __call__(self, x):
+            def forward(self, x):
                 h = F.relu(self.l1(x))
                 h = F.relu(self.l2(h))
                 return self.l3(h)
@@ -177,7 +177,7 @@ You can easily try out other optimizers as well. Please test and observe the res
                 self.l2 = L.Linear(n_mid_units, n_mid_units)
                 self.l3 = L.Linear(n_mid_units, n_out)
 
-        def __call__(self, x):
+        def forward(self, x):
             h = F.relu(self.l1(x))
             h = F.relu(self.l2(h))
             return self.l3(h)

--- a/docs/source/guides/functions.rst
+++ b/docs/source/guides/functions.rst
@@ -454,7 +454,7 @@ It can be defined as follows:
            with self.init_scope():
                self.W = chainer.Parameter(initializers.Normal(scale=1.), shape)
 
-       def __call__(self, x):
+       def forward(self, x):
            return self.W * x
 
 For another example, assume we want to define a simple linear layer.
@@ -496,7 +496,7 @@ In order to make a convenient module, let's wrap it into a link:
                    (out_size, in_size))
                self.b = chainer.Parameter(0, (out_size,))
 
-       def __call__(self, x):
+       def forward(self, x):
            return linear(x, self.W, self.b)
 
 This link hides the parameters of the linear layer.

--- a/docs/source/guides/gpu.rst
+++ b/docs/source/guides/gpu.rst
@@ -177,7 +177,7 @@ A :class:`Link` object can be transferred to the specified GPU using the :meth:`
                self.l2 = L.Linear(None, n_units)
                self.l3 = L.Linear(None, n_out)
 
-       def __call__(self, x):
+       def forward(self, x):
            h1 = F.relu(self.l1(x))
            h2 = F.relu(self.l2(h1))
            y = self.l3(h2)
@@ -282,7 +282,7 @@ Let's write a link for the whole network.
                self.mlp2_gpu0 = MLP(1000, 10).to_gpu(0)
                self.mlp2_gpu1 = MLP(1000, 10).to_gpu(1)
 
-       def __call__(self, x):
+       def forward(self, x):
            # assume x is on GPU 0
            z0 = self.mlp1_gpu0(x)
            z1 = self.mlp1_gpu1(F.copy(x, 1))

--- a/docs/source/guides/models.rst
+++ b/docs/source/guides/models.rst
@@ -27,7 +27,7 @@ More Pythonic way is combining the links and procedures into a class:
    ...         self.l1 = L.Linear(4, 3)
    ...         self.l2 = L.Linear(3, 2)
    ...
-   ...     def forward(self, x):
+   ...     def __call__(self, x):
    ...         h = self.l1(x)
    ...         return self.l2(h)
 
@@ -44,7 +44,7 @@ Then, what we have to do here is just define the above class as a subclass of Ch
    ...             self.l1 = L.Linear(4, 3)
    ...             self.l2 = L.Linear(3, 2)
    ...
-   ...     def __call__(self, x):
+   ...     def forward(self, x):
    ...         h = self.l1(x)
    ...         return self.l2(h)
 
@@ -78,7 +78,7 @@ Another way to define a chain is using the :class:`ChainList` class, which behav
    ...             L.Linear(3, 2),
    ...         )
    ...
-   ...     def __call__(self, x):
+   ...     def forward(self, x):
    ...         h = self[0](x)
    ...         return self[1](h)
 

--- a/docs/source/guides/optimizers.rst
+++ b/docs/source/guides/optimizers.rst
@@ -14,7 +14,7 @@ From the previous guide on :doc:`models`, let's use the ``MyChain`` class:
    ...             self.l1 = L.Linear(4, 3)
    ...             self.l2 = L.Linear(3, 2)
    ...
-   ...     def __call__(self, x):
+   ...     def forward(self, x):
    ...         h = self.l1(x)
    ...         return self.l2(h)
 

--- a/docs/source/guides/report.rst
+++ b/docs/source/guides/report.rst
@@ -81,7 +81,7 @@ See the following example:
     ...         with self.init_scope():
     ...             self.predictor = predictor
     ...
-    ...     def __call__(self, x, t):
+    ...     def forward(self, x, t):
     ...         y = self.predictor(x)
     ...         loss = F.softmax_cross_entropy(y, t)
     ...         accuracy = F.accuracy(y, t)
@@ -124,7 +124,7 @@ See the following example:
     ...             self.l2 = L.Linear(None, n_units)  # n_units -> n_units
     ...             self.l3 = L.Linear(None, n_out)    # n_units -> n_out
     ...
-    ...     def __call__(self, x):
+    ...     def forward(self, x):
     ...         h1 = F.relu(self.l1(x))
     ...         h2 = F.relu(self.l2(h1))
     ...         y = self.l3(h2)

--- a/examples/caffe_export/export.py
+++ b/examples/caffe_export/export.py
@@ -25,7 +25,7 @@ class DumpModel(chainer.Chain):
         with self.init_scope():
             self.base_model = archs[arch_name]()
 
-    def __call__(self, img):
+    def forward(self, img):
         return self.base_model(img, layers=['prob'])['prob']
 
 

--- a/examples/cifar/models/VGG.py
+++ b/examples/cifar/models/VGG.py
@@ -27,7 +27,7 @@ class Block(chainer.Chain):
                                         nobias=True)
             self.bn = L.BatchNormalization(out_channels)
 
-    def __call__(self, x):
+    def forward(self, x):
         h = self.conv(x)
         h = self.bn(h)
         return F.relu(h)
@@ -77,7 +77,7 @@ class VGG(chainer.Chain):
             self.bn_fc1 = L.BatchNormalization(512)
             self.fc2 = L.Linear(None, class_labels, nobias=True)
 
-    def __call__(self, x):
+    def forward(self, x):
         # 64 channel blocks:
         h = self.block1_1(x)
         h = F.dropout(h, ratio=0.3)

--- a/examples/dcgan/net.py
+++ b/examples/dcgan/net.py
@@ -40,7 +40,7 @@ class Generator(chainer.Chain):
         return numpy.random.uniform(-1, 1, (batchsize, self.n_hidden, 1, 1))\
             .astype(numpy.float32)
 
-    def __call__(self, z):
+    def forward(self, z):
         h = F.reshape(F.relu(self.bn0(self.l0(z))),
                       (len(z), self.ch, self.bottom_width, self.bottom_width))
         h = F.relu(self.bn1(self.dc1(h)))
@@ -71,7 +71,7 @@ class Discriminator(chainer.Chain):
             self.bn2_1 = L.BatchNormalization(ch // 1, use_gamma=False)
             self.bn3_0 = L.BatchNormalization(ch // 1, use_gamma=False)
 
-    def __call__(self, x):
+    def forward(self, x):
         h = add_noise(x)
         h = F.leaky_relu(add_noise(self.c0_0(h)))
         h = F.leaky_relu(add_noise(self.bn0_1(self.c0_1(h))))

--- a/examples/image_captioning/model.py
+++ b/examples/image_captioning/model.py
@@ -36,7 +36,7 @@ class ImageCaptionModel(chainer.Chain):
         """Single image to resized and normalized image."""
         return self.feat_extractor.prepare(img)
 
-    def __call__(self, imgs, captions):
+    def forward(self, imgs, captions):
         """Batch of images to a single loss."""
         imgs = Variable(imgs)
         if self.finetune_feat_extractor:

--- a/examples/imagenet/alex.py
+++ b/examples/imagenet/alex.py
@@ -24,7 +24,7 @@ class Alex(chainer.Chain):
             self.fc7 = L.Linear(None, 4096)
             self.fc8 = L.Linear(None, 1000)
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         h = F.max_pooling_2d(F.local_response_normalization(
             F.relu(self.conv1(x))), 3, stride=2)
         h = F.max_pooling_2d(F.local_response_normalization(
@@ -68,5 +68,5 @@ class AlexFp16(Alex):
             self.fc7 = L.Linear(None, 4096, initialW=W, initial_bias=bias)
             self.fc8 = L.Linear(None, 1000, initialW=W, initial_bias=bias)
 
-    def __call__(self, x, t):
-        return Alex.__call__(self, F.cast(x, self.dtype), t)
+    def forward(self, x, t):
+        return Alex.forward(self, F.cast(x, self.dtype), t)

--- a/examples/imagenet/googlenet.py
+++ b/examples/imagenet/googlenet.py
@@ -32,7 +32,7 @@ class GoogLeNet(chainer.Chain):
             self.loss2_fc1 = L.Linear(None, 1024)
             self.loss2_fc2 = L.Linear(None, 1000)
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         h = F.relu(self.conv1(x))
         h = F.local_response_normalization(
             F.max_pooling_2d(h, 3, stride=2), n=5)

--- a/examples/imagenet/googlenetbn.py
+++ b/examples/imagenet/googlenetbn.py
@@ -54,7 +54,7 @@ class GoogLeNetBN(chainer.Chain):
             self.normb2 = L.BatchNormalization(1024)
             self.outb = L.Linear(None, 1000)
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         h = F.max_pooling_2d(
             F.relu(self.norm1(self.conv1(x))),  3, stride=2, pad=1)
         h = F.max_pooling_2d(
@@ -161,5 +161,5 @@ class GoogLeNetBNFp16(GoogLeNetBN):
             self.normb2 = L.BatchNormalization(1024, dtype=dtype)
             self.outb = L.Linear(None, 1000, initialW=W, bias=bias)
 
-    def __call__(self, x, t):
-        return GoogLeNetBN.__call__(self, F.cast(x, self.dtype), t)
+    def forward(self, x, t):
+        return GoogLeNetBN.forward(self, F.cast(x, self.dtype), t)

--- a/examples/imagenet/nin.py
+++ b/examples/imagenet/nin.py
@@ -24,7 +24,7 @@ class NIN(chainer.Chain):
             self.mlpconv4 = L.MLPConvolution2D(
                 None, (1024, 1024, 1000), 3, pad=1, conv_init=conv_init)
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         h = F.max_pooling_2d(F.relu(self.mlpconv1(x)), 3, stride=2)
         h = F.max_pooling_2d(F.relu(self.mlpconv2(h)), 3, stride=2)
         h = F.max_pooling_2d(F.relu(self.mlpconv3(h)), 3, stride=2)

--- a/examples/imagenet/resnet50.py
+++ b/examples/imagenet/resnet50.py
@@ -30,7 +30,7 @@ class BottleNeckA(chainer.Chain):
                 initialW=initialW, nobias=True)
             self.bn4 = L.BatchNormalization(out_size)
 
-    def __call__(self, x):
+    def forward(self, x):
         h1 = F.relu(self.bn1(self.conv1(x)))
         h1 = F.relu(self.bn2(self.conv2(h1)))
         h1 = self.bn3(self.conv3(h1))
@@ -57,7 +57,7 @@ class BottleNeckB(chainer.Chain):
                 ch, in_size, 1, 1, 0, initialW=initialW, nobias=True)
             self.bn3 = L.BatchNormalization(in_size)
 
-    def __call__(self, x):
+    def forward(self, x):
         h = F.relu(self.bn1(self.conv1(x)))
         h = F.relu(self.bn2(self.conv2(h)))
         h = self.bn3(self.conv3(h))
@@ -73,7 +73,7 @@ class Block(chainer.ChainList):
         for i in range(layer - 1):
             self.add_link(BottleNeckB(out_size, ch, groups))
 
-    def __call__(self, x):
+    def forward(self, x):
         for f in self.children():
             x = f(x)
         return x
@@ -95,7 +95,7 @@ class ResNet50(chainer.Chain):
             self.res5 = Block(3, 1024, 512, 2048)
             self.fc = L.Linear(2048, 1000)
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         h = self.bn1(self.conv1(x))
         h = F.max_pooling_2d(F.relu(h), 3, stride=2)
         h = self.res2(h)

--- a/examples/memnn/memnn.py
+++ b/examples/memnn/memnn.py
@@ -171,7 +171,7 @@ class MemNN(chainer.Chain):
         a = self.W(u)
         return a
 
-    def __call__(self, sentences, question):
+    def forward(self, sentences, question):
         self.register_all(sentences)
         a = self.query(question)
         return a

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -19,7 +19,7 @@ class MLP(chainer.Chain):
             self.l2 = L.Linear(None, n_units)  # n_units -> n_units
             self.l3 = L.Linear(None, n_out)  # n_units -> n_out
 
-    def __call__(self, x):
+    def forward(self, x):
         h1 = F.relu(self.l1(x))
         h2 = F.relu(self.l2(h1))
         return self.l3(h2)

--- a/examples/mnist/train_mnist_model_parallel.py
+++ b/examples/mnist/train_mnist_model_parallel.py
@@ -27,7 +27,7 @@ class ParallelMLP(chainer.Chain):
             self.second0 = train_mnist.MLP(n_units // 2, n_out).to_gpu(gpu0)
             self.second1 = train_mnist.MLP(n_units // 2, n_out).to_gpu(gpu1)
 
-    def __call__(self, x):
+    def forward(self, x):
         # assume x is on gpu0
         x1 = F.copy(x, self.gpu1)
 

--- a/examples/pos/postagging.py
+++ b/examples/pos/postagging.py
@@ -22,7 +22,7 @@ class CRF(chainer.Chain):
             self.feature = L.EmbedID(n_vocab, n_pos)
             self.crf = L.CRF1d(n_pos)
 
-    def __call__(self, xs, ys):
+    def forward(self, xs, ys):
         # Before making a transpose, you need to sort two lists in descending
         # order of length.
         inds = numpy.argsort([-len(x) for x in xs]).astype(numpy.int32)

--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -35,7 +35,7 @@ class RNNForLM(chainer.Chain):
         self.l1.reset_state()
         self.l2.reset_state()
 
-    def __call__(self, x):
+    def forward(self, x):
         h0 = self.embed(x)
         h1 = self.l1(F.dropout(h0))
         h2 = self.l2(F.dropout(h1))

--- a/examples/reinforcement_learning/ddpg_pendulum.py
+++ b/examples/reinforcement_learning/ddpg_pendulum.py
@@ -29,7 +29,7 @@ class QFunction(chainer.Chain):
             self.l2 = L.Linear(n_units, 1,
                                initialW=chainer.initializers.HeNormal(1e-3))
 
-    def __call__(self, obs, action):
+    def forward(self, obs, action):
         """Compute Q-values for given state-action pairs."""
         x = F.concat((obs, action), axis=1)
         h = F.relu(self.l0(x))
@@ -58,7 +58,7 @@ class Policy(chainer.Chain):
             self.l2 = L.Linear(n_units, action_size,
                                initialW=chainer.initializers.HeNormal(1e-3))
 
-    def __call__(self, x):
+    def forward(self, x):
         """Compute actions for given observations."""
         h = F.relu(self.l0(x))
         h = F.relu(self.l1(h))

--- a/examples/reinforcement_learning/dqn_cartpole.py
+++ b/examples/reinforcement_learning/dqn_cartpole.py
@@ -29,7 +29,7 @@ class QFunction(chainer.Chain):
             self.l1 = L.Linear(n_units, n_units)
             self.l2 = L.Linear(n_units, n_actions)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Compute Q-values of actions for given observations."""
         h = F.relu(self.l0(x))
         h = F.relu(self.l1(h))

--- a/examples/sentiment/train_recursive_minibatch.py
+++ b/examples/sentiment/train_recursive_minibatch.py
@@ -119,7 +119,7 @@ class ThinStackRecursiveNet(chainer.Chain):
     def label(self, v):
         return self.w(v)
 
-    def __call__(self, *inputs):
+    def forward(self, *inputs):
         batch = len(inputs) // 6
         lefts = inputs[0: batch]
         rights = inputs[batch: batch * 2]

--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -41,7 +41,7 @@ class Seq2seq(chainer.Chain):
         self.n_layers = n_layers
         self.n_units = n_units
 
-    def __call__(self, xs, ys):
+    def forward(self, xs, ys):
         xs = [x[::-1] for x in xs]
 
         eos = self.xp.array([EOS], numpy.int32)

--- a/examples/text_classification/nets.py
+++ b/examples/text_classification/nets.py
@@ -86,7 +86,7 @@ class TextClassifier(chainer.Chain):
             self.output = L.Linear(encoder.out_units, n_class)
         self.dropout = dropout
 
-    def __call__(self, xs, ys):
+    def forward(self, xs, ys):
         concat_outputs = self.predict(xs)
         concat_truths = F.concat(ys, axis=0)
 
@@ -132,7 +132,7 @@ class RNNEncoder(chainer.Chain):
         self.out_units = n_units
         self.dropout = dropout
 
-    def __call__(self, xs):
+    def forward(self, xs):
         exs = sequence_embed(self.embed, xs, self.dropout)
         last_h, last_c, ys = self.encoder(None, None, exs)
         assert(last_h.shape == (self.n_layers, len(xs), self.out_units))
@@ -177,7 +177,7 @@ class CNNEncoder(chainer.Chain):
         self.out_units = out_units * 3
         self.dropout = dropout
 
-    def __call__(self, xs):
+    def forward(self, xs):
         x_block = chainer.dataset.convert.concat_examples(xs, padding=-1)
         ex_block = block_embed(self.embed, x_block, self.dropout)
         h_w3 = F.max(self.cnn_w3(ex_block), axis=2)
@@ -208,7 +208,7 @@ class MLP(chainer.ChainList):
         self.dropout = dropout
         self.out_units = n_units
 
-    def __call__(self, x):
+    def forward(self, x):
         for i, link in enumerate(self.children()):
             x = F.dropout(x, ratio=self.dropout)
             x = F.relu(link(x))
@@ -237,7 +237,7 @@ class BOWEncoder(chainer.Chain):
         self.out_units = n_units
         self.dropout = dropout
 
-    def __call__(self, xs):
+    def forward(self, xs):
         x_block = chainer.dataset.convert.concat_examples(xs, padding=-1)
         ex_block = block_embed(self.embed, x_block)
         x_len = self.xp.array([len(x) for x in xs], numpy.int32)[:, None, None]
@@ -268,7 +268,7 @@ class BOWMLPEncoder(chainer.Chain):
 
         self.out_units = n_units
 
-    def __call__(self, xs):
+    def forward(self, xs):
         h = self.bow_encoder(xs)
         h = self.mlp_encoder(h)
         return h

--- a/examples/vae/net.py
+++ b/examples/vae/net.py
@@ -20,7 +20,7 @@ class VAE(chainer.Chain):
             self.ld1 = L.Linear(n_latent, n_h)
             self.ld2 = L.Linear(n_h, n_in)
 
-    def __call__(self, x, sigmoid=True):
+    def forward(self, x, sigmoid=True):
         """AutoEncoder"""
         return self.decode(self.encode(x)[0], sigmoid)
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -31,7 +31,7 @@ class ContinuousBoW(chainer.Chain):
                 n_vocab, n_units, initialW=I.Uniform(1. / n_units))
             self.loss_func = loss_func
 
-    def __call__(self, x, contexts):
+    def forward(self, x, contexts):
         e = self.embed(contexts)
         h = F.sum(e, axis=1) * (1. / contexts.shape[1])
         loss = self.loss_func(h, x)
@@ -50,7 +50,7 @@ class SkipGram(chainer.Chain):
                 n_vocab, n_units, initialW=I.Uniform(1. / n_units))
             self.loss_func = loss_func
 
-    def __call__(self, x, contexts):
+    def forward(self, x, contexts):
         e = self.embed(contexts)
         batch_size, n_context, n_units = e.shape
         x = F.broadcast_to(x[:, None], (batch_size, n_context))
@@ -71,7 +71,7 @@ class SoftmaxCrossEntropyLoss(chainer.Chain):
         with self.init_scope():
             self.out = L.Linear(n_in, n_out, initialW=0)
 
-    def __call__(self, x, t):
+    def forward(self, x, t):
         return F.softmax_cross_entropy(self.out(x), t)
 
 

--- a/tests/chainer_tests/test_link_hook.py
+++ b/tests/chainer_tests/test_link_hook.py
@@ -1,0 +1,50 @@
+import unittest
+
+import mock
+import numpy
+
+import chainer
+from chainer import testing
+
+
+class TestLinkHook(unittest.TestCase):
+
+    def setUp(self):
+        self.h = chainer.LinkHook()
+
+        class Model(chainer.Chain):
+            def __init__(self):
+                super(Model, self).__init__()
+                with self.init_scope():
+                    self.l1 = chainer.links.Linear(3, 2)
+            
+            def forward(self, x):
+                return self.l1(x)
+        
+        self.model = Model()
+
+    def test_name(self):
+        self.assertEqual(self.h.name, 'LinkHook')
+
+    def test_forward_preprocess(self):
+        self.assertTrue(hasattr(self.h, 'forward_preprocess'))
+
+    def test_forward_postprocess(self):
+        self.assertTrue(hasattr(self.h, 'forward_postprocess'))
+
+    def check_hook_methods_called(self, x):
+        def check_method_called(name):
+            with mock.patch.object(self.h, name) as patched:
+                with self.h:
+                    self.model(x)
+                patched.assert_called()
+
+        check_method_called('forward_preprocess')
+        check_method_called('forward_postprocess')
+
+    def test_all_called(self):
+        x = chainer.Variable(numpy.random.rand(2, 3).astype(numpy.float32))
+        self.check_hook_methods_called(x)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds `LinkHook` which enables to add `forward_preprocess` and `forward_postprocess` hooks to `chainer.Link`s. To enable this, all the `__call__` methods of provided `Link`s in Chainer are renamed to `forward`. `Link.__call__` is still available and it calls `forward_preprocess` first, then call `Link.forward`, then call `forward_postprocess`. Almost all design is come from `FunctionHook`.