### PR TITLE
Fix hacking version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements = {
     ],
     'stylecheck': [
         'autopep8',
-        'hacking',
+        'hacking==1.0.0',
     ],
     'test': [
         'pytest',


### PR DESCRIPTION
Our code is currently not compatible with `hacking` 1.1 released on May 9.

https://pypi.org/project/hacking/#history

This is a temporary fix to use old `hacking` for tests.