### PR TITLE
Fix incorrect attributes and incorrect indentation in pooling tests

### DIFF
--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
@@ -154,7 +154,7 @@ class TestAveragePoolingND(unittest.TestCase):
         with chainer.using_config('use_cudnn', use_cudnn):
             func_nd = functions.AveragePoolingND(self.ndim, ksize,
                                                  stride=stride, pad=pad)
-        y_nd = func_nd.apply((x_nd,))[0]
+            y_nd = func_nd.apply((x_nd,))[0]
         y_nd.grad = gy_data
         y_nd.backward()
 
@@ -163,7 +163,7 @@ class TestAveragePoolingND(unittest.TestCase):
         with chainer.using_config('use_cudnn', use_cudnn):
             func_2d = functions.AveragePooling2D(ksize, stride=stride, pad=pad,
                                                  cover_all=False)
-        y_2d = func_2d.apply((x_2d,))[0]
+            y_2d = func_2d.apply((x_2d,))[0]
         y_2d.grad = gy_data
         y_2d.backward()
 
@@ -197,13 +197,13 @@ class TestAveragePoolingND(unittest.TestCase):
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx, 'never')
 
-    @attr.gpu
+    @attr.cudnn
     @condition.retry(10)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
 
-    @attr.gpu
+    @attr.cudnn
     @condition.retry(10)
     def test_double_backward_gpu_non_contiguous(self):
         self.check_double_backward(

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -184,7 +184,7 @@ class TestMaxPoolingND(unittest.TestCase):
         with chainer.using_config('use_cudnn', use_cudnn):
             func_nd = functions.MaxPoolingND(self.ndim, ksize, stride=stride,
                                              pad=pad, cover_all=self.cover_all)
-        y_nd = func_nd.apply((x_nd,))[0]
+            y_nd = func_nd.apply((x_nd,))[0]
         y_nd.grad = gy_data
         y_nd.backward()
 
@@ -193,7 +193,7 @@ class TestMaxPoolingND(unittest.TestCase):
         with chainer.using_config('use_cudnn', use_cudnn):
             func_2d = functions.MaxPooling2D(ksize, stride=stride, pad=pad,
                                              cover_all=self.cover_all)
-        y_2d = func_2d.apply((x_2d,))[0]
+            y_2d = func_2d.apply((x_2d,))[0]
         y_2d.grad = gy_data
         y_2d.backward()
 
@@ -240,12 +240,12 @@ class TestMaxPoolingND(unittest.TestCase):
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx, 'never')
 
-    @attr.gpu
+    @attr.cudnn
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
 
-    @attr.gpu
+    @attr.cudnn
     def test_double_backward_gpu_non_contiguous(self):
         self.check_double_backward(
             cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),


### PR DESCRIPTION
* Fix incorrect test attributes.
* `chainer.using_config('use_cudnn')` was not applied correctly.
