### PR TITLE
Support copying 1-dim array to ideep

### DIFF
--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -87,7 +87,7 @@ def should_use_ideep(level):
 
 
 def inputs_all_ready(inputs, supported_ndim=(2, 4)):
-    """Checks if input arrays are supported for ideep optimization.
+    """Checks if input arrays are supported for the iDeep primitive.
 
     Information to be checked includes array types, dimesions and data types.
     The function checks ``inputs`` info and ``supported_ndim``.
@@ -96,8 +96,7 @@ def inputs_all_ready(inputs, supported_ndim=(2, 4)):
         inputs (sequence of arrays or variables``):
             Inputs to be checked.
         supported_ndim (tuple of ints):
-            Supported ndim values.
-            iDeep supports array dimension in either 2 or 4 only.
+            Supported ndim values for the iDeep primitive.
 
     Returns:
         bool: ``True`` if all conditions meet.

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -87,18 +87,18 @@ def should_use_ideep(level):
 
 
 def inputs_all_ready(inputs, supported_ndim=(2, 4)):
-    """Checks if input arrays are supported for the iDeep primitive.
+    """Checks if input arrays are supported for an iDeep primitive.
 
-    Before calling iDeep primitives (e.g., ``ideep4py.linear.Forward``), you
+    Before calling an iDeep primitive (e.g., ``ideep4py.linear.Forward``), you
     need to make sure that all input arrays are ready for the primitive by
     calling this function.
     Information to be checked includes array types, dimesions and data types.
     The function checks ``inputs`` info and ``supported_ndim``.
 
     Inputs to be tested can be any of ``Variable``, ``numpy.ndarray`` or
-    ``ideep4py.mdarray``. However, all inputs to the iDeep primitive must be
-    ``ideep4py.mdarray``. Callers of iDeep primitives are responsible to
-    convert all inputs as ``ideep4py.mdarray``.
+    ``ideep4py.mdarray``. However, all inputs to iDeep primitives must be
+    ``ideep4py.mdarray``. Callers of iDeep primitives are responsible of
+    converting all inputs to ``ideep4py.mdarray``.
 
     Args:
         inputs (sequence of arrays or variables):

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -93,7 +93,7 @@ def inputs_all_ready(inputs, supported_ndim=(2, 4)):
     The function checks ``inputs`` info and ``supported_ndim``.
 
     Args:
-        inputs (sequence of arrays or variables``):
+        inputs (sequence of arrays or variables):
             Inputs to be checked.
         supported_ndim (tuple of ints):
             Supported ndim values for the iDeep primitive.

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -89,8 +89,16 @@ def should_use_ideep(level):
 def inputs_all_ready(inputs, supported_ndim=(2, 4)):
     """Checks if input arrays are supported for the iDeep primitive.
 
+    Before calling iDeep primitives (e.g., ``ideep4py.linear.Forward``), you
+    need to make sure that all input arrays are ready for the primitive by
+    calling this function.
     Information to be checked includes array types, dimesions and data types.
     The function checks ``inputs`` info and ``supported_ndim``.
+
+    Inputs to be tested can be any of ``Variable``, ``numpy.ndarray`` or
+    ``ideep4py.mdarray``. However, all inputs to the iDeep primitive must be
+    ``ideep4py.mdarray``. Callers of iDeep primitives are responsible to
+    convert all inputs as ``ideep4py.mdarray``.
 
     Args:
         inputs (sequence of arrays or variables):

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -417,6 +417,7 @@ Assign a Parameter object directly to an attribute within a \
             if isinstance(value, cuda.ndarray):
                 value = value.get()  # to numpy.ndarray
             if (isinstance(value, numpy.ndarray) and value.ndim in (1, 2, 4)):
+                # TODO(kmaehashi): Remove ndim validation once iDeep has fixed.
                 # Currently iDeep only supports (1, 2, 4)-dim arrays.
                 # Note that array returned from `ideep.array` may not be an
                 # iDeep mdarray, e.g., when the dtype is not float32.

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -416,8 +416,10 @@ Assign a Parameter object directly to an attribute within a \
             value = d[name]
             if isinstance(value, cuda.ndarray):
                 value = value.get()  # to numpy.ndarray
-            if (isinstance(value, numpy.ndarray) and
-                    intel64.inputs_all_ready((value,))):
+            if (isinstance(value, numpy.ndarray) and value.ndim in (1, 2, 4)):
+                # Currently iDeep only supports (1, 2, 4)-dim arrays.
+                # Note that array returned from `ideep.array` may not be an
+                # iDeep mdarray, e.g., when the dtype is not float32.
                 value = intel64.ideep.array(
                     value, itype=intel64.ideep.wgt_array)
             d[name] = value

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -780,6 +780,7 @@ Actual: {0}'''.format(type(data))
                 # cupy.ndarray to numpy.ndarray
                 data = data.get()
             if (isinstance(data, numpy.ndarray) and data.ndim in (1, 2, 4)):
+                # TODO(kmaehashi): Remove ndim validation once iDeep has fixed.
                 # Currently iDeep only supports (1, 2, 4)-dim arrays.
                 # Note that array returned from `ideep.array` may not be an
                 # iDeep mdarray, e.g., when the dtype is not float32.

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -779,9 +779,10 @@ Actual: {0}'''.format(type(data))
             if isinstance(data, cuda.ndarray):
                 # cupy.ndarray to numpy.ndarray
                 data = data.get()
-            if (isinstance(data, numpy.ndarray) and
-                    intel64.inputs_all_ready((data,))):
-                # numpy.ndarray to ideep.mdarray
+            if (isinstance(data, numpy.ndarray) and data.ndim in (1, 2, 4)):
+                # Currently iDeep only supports (1, 2, 4)-dim arrays.
+                # Note that array returned from `ideep.array` may not be an
+                # iDeep mdarray, e.g., when the dtype is not float32.
                 data = intel64.ideep.array(
                     data, itype=intel64.ideep.wgt_array)
             self._data = [data]

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1714,7 +1714,7 @@ class TestLossScale(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(3, 2), (2, 3, 4, 3)],
+    'shape': [(0,), (1,), (3, 2), (2, 3, 4, 3)],
     'dtype': [
         np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32,
         np.uint64, np.float16, np.float32, np.float64],
@@ -1791,7 +1791,7 @@ class TestIntel64(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(), (0,), (3, 2, 3), (4, 4, 3, 2, 3)],
+    'shape': [(), (3, 2, 3), (4, 4, 3, 2, 3)],
     'dtype': [
         np.int8, np.int16, np.int32, np.int64,
         np.uint8, np.uint16, np.uint32, np.uint64,


### PR DESCRIPTION
Currently `to_intel64` does not copy 1-dim arrays to iDeep.
As a result, bias parameter of the Linear layer is not copied to iDeep.
This causes memory copy overhead every time Linear layer is evaluated.

`mnist.mnist.MLPPredict.time_predict` benchmark results over this PR is as follows:
https://github.com/chainer/chainer-benchmark/blob/master/benchmarks/mnist/mnist.py#L92

Before applying this PR:

```
=========== ========== ============
--             units / batchsize   
----------- -----------------------
  backend    1000 / 1   1000 / 100 
=========== ========== ============
 cpu-ideep   971.01μs     1.40ms   
=========== ========== ============
```

After applying this PR:

```
=========== ========== ============
--             units / batchsize   
----------- -----------------------
  backend    1000 / 1   1000 / 100 
=========== ========== ============
 cpu-ideep   830.86μs     1.29ms   
=========== ========== ============
```