### PR TITLE
[WIP] Fix hang on exception in MultiprocessUpdator

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -42,6 +42,28 @@ class _Worker(multiprocessing.Process):
                                     self.model.namedlinks(skipself=True))
 
     def run(self):
+        try:
+            self._run()
+        except:
+            import os
+            import signal
+            import sys
+            # Send SIGKILL to the master process to avoid deadlock.
+            sys.stderr.write("\n")
+            sys.stderr.write("******************************************\n")
+            sys.stderr.write("\n")
+            sys.stderr.write("Chainer multiprocess parallel updater: \n")
+            sys.stderr.write("   Uncaught exception in a worker process (PID {}).\n".format(os.getpid()))
+            sys.stderr.write("To avoid deadlock, sending SIGKILL to the master process (PID {})\n".format(os.getppid()))
+            sys.stderr.write("\n")
+            sys.stderr.write("******************************************\n")
+            sys.stderr.write("\n\n")
+            sys.stderr.flush()
+            os.kill(os.getppid(), signal.SIGKILL)
+
+            raise
+
+    def _run(self):
         dev = cuda.Device(self.device)
         dev.use()
         self.setup()

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -44,7 +44,7 @@ class _Worker(multiprocessing.Process):
     def run(self):
         try:
             self._run()
-        except:
+        except Exception:
             import os
             import signal
             import sys
@@ -53,8 +53,10 @@ class _Worker(multiprocessing.Process):
             sys.stderr.write("******************************************\n")
             sys.stderr.write("\n")
             sys.stderr.write("Chainer multiprocess parallel updater: \n")
-            sys.stderr.write("   Uncaught exception in a worker process (PID {}).\n".format(os.getpid()))
-            sys.stderr.write("To avoid deadlock, sending SIGKILL to the master process (PID {})\n".format(os.getppid()))
+            sys.stderr.write("   Uncaught exception in a worker process "
+                             "(PID {}).\n".format(os.getpid()))
+            sys.stderr.write("To avoid deadlock, sending SIGKILL to the "
+                             "master process (PID {})\n".format(os.getppid()))
             sys.stderr.write("\n")
             sys.stderr.write("******************************************\n")
             sys.stderr.write("\n\n")


### PR DESCRIPTION
This is a WIP PR to fix #4709.

## The problem
When `MultiprocessParallelUpdater` is used and an uncaught exception happens in a worker process, Python's `multiprocessing` module catch the exception and exit the process, while the master process is not aware of the fail and tries to exchange the gradients using NCCL. As a result, the whole processes hang and the worker process becomes a zombie.

## Solution
To fix this, this PR wraps the `_Worker.run` function by a `try`-`catch` clause and send `SIGKILL` to the parent (master) process. We need more discussion on how to terminate the parent process, though.
