### PR TITLE
[backport] Raise an error when CUDA has been initialized before MultiprocessParallelUpdater is initialized

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -124,6 +124,18 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
                 'requires NCCL.\n'
                 'Please reinstall chainer after you install NCCL.\n'
                 '(see https://github.com/chainer/chainer#installation).')
+        try:
+            cuda.cupy.cuda.driver.ctxGetCurrent()
+            _cuda_initialized = True
+        except cuda.cupy.cuda.driver.CUDADriverError:
+            # The context is not initialized, it will be fine.
+            _cuda_initialized = False
+        if _cuda_initialized:
+            raise ValueError(
+                'The CUDA context has been already initialized. '
+                'MultiprocessParallelUpdater assumes the context is '
+                'uninitialized. Please do not call CUDA API before '
+                'MultiprocessParallelUpdater creates processes.')
 
         assert len(iterators) == len(devices)
         for iterator in iterators[1:]:


### PR DESCRIPTION
Backport of #4717