### PR TITLE
Fix hang on exceptions when MultiprocessParallelUpdater is used

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -32,7 +32,7 @@ def _sigchld_handler(signo, stk):
         sys.stderr.write("******************************************\n")
         sys.stderr.write("\n\n")
         sys.stderr.flush()
-        exit(-1)
+        sys.exit(-1)
 
 class _Worker(multiprocessing.Process):
 

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -21,14 +21,18 @@ import numpy
 
 def _sigchld_handler(signo, stk):
     import sys
-    sys.stderr.write("******************************************\n")
-    sys.stderr.write("Chainer multiprocess parallel updater: \n")
-    sys.stderr.write("   It seems that an uncaught exception in a worker process\n")
-    sys.stderr.write("******************************************\n")
-    sys.stderr.write("\n\n")
-    sys.stderr.flush()
-    sys.exit(1)
+    import os
 
+    pid, stat = os.waitpid(-1, os.WNOHANG)
+
+    if stat != 0:
+        sys.stderr.write("******************************************\n")
+        sys.stderr.write("Chainer multiprocess parallel updater: \n")
+        sys.stderr.write("   It seems that an uncaught exception in a worker process\n")
+        sys.stderr.write("******************************************\n")
+        sys.stderr.write("\n\n")
+        sys.stderr.flush()
+        exit(-1)
 
 class _Worker(multiprocessing.Process):
 


### PR DESCRIPTION
This is a PR to fix #4709.

## The problem
When `MultiprocessParallelUpdater` is used and a worker process exists before or during a training process unexpectedly, the master process is not aware of the fail and still tries to communicate using NCCL. As a result, the whole processes hang and the worker process becomes a zombie.

## The solution
This PR adds a `SIGCHLD` signal handler in the master process of `MultiprocessParallelUpdater`. The handler checks if the child process exits abnormally and shut down the master process if necessary to avoid deadlock.

## Restriction
This PR uses `os.waitpid()` function, which behaves differently on Unix and Windows platforms. As of now, this PR only works on Unix. 
