### PR TITLE
Add abs to document of Variable

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -447,7 +447,7 @@ class Variable(object):
         * Floor Division: ``a // b`` (:meth:`__floordiv__`, \
                                       :meth:`__rfloordiv__`)
         * Exponentiation: ``a ** b`` (:meth:`__pow__`, :meth:`__rpow__`)
-        * Matirx Multiplication: ``a @ b`` (:meth:`__matmul__`, \
+        * Matrix Multiplication: ``a @ b`` (:meth:`__matmul__`, \
                                             :meth:`__rmatmul__`)
         * Negation (Arithmetic): ``- a`` (:meth:`__neg__`)
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -450,6 +450,7 @@ class Variable(object):
         * Matrix Multiplication: ``a @ b`` (:meth:`__matmul__`, \
                                             :meth:`__rmatmul__`)
         * Negation (Arithmetic): ``- a`` (:meth:`__neg__`)
+        * Absolute value: ``abs(a)`` (:meth:`__abs__`)
 
     .. warning::
 


### PR DESCRIPTION
I found several users, including me, search for the absolute function and find `chainer.functions.absolute`, while python's `abs` is available.  Add `abs` to the docstring of `Variable` even though it does not have a "-tion" form in English.