### PR TITLE
Flush the output stream after PrintReport reports

### DIFF
--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -24,13 +24,18 @@ class PrintReport(extension.Extension):
     """
 
     def __init__(self, entries, log_report='LogReport', out=sys.stdout):
-        if not hasattr(out, "write") or not hasattr(out, "flush"):
+        if not hasattr(out, "write"):
             raise TypeError(
-                "Output stream should support `write' and `flush' method!")
+                "Output stream should support `write' method!")
 
         self._entries = entries
         self._log_report = log_report
         self._out = out
+
+        if hasattr(out, "flush"):
+            self._flush = lambda: out.flush()
+        else:
+            self._flush = lambda: None
 
         self._log_len = 0  # number of observations already printed
 
@@ -51,7 +56,6 @@ class PrintReport(extension.Extension):
 
         if self._header:
             out.write(self._header)
-            out.flush()
             self._header = None
 
         log_report = self._log_report
@@ -88,4 +92,4 @@ class PrintReport(extension.Extension):
             else:
                 out.write(empty)
         out.write('\n')
-        out.flush()
+        self._flush()

--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -24,6 +24,9 @@ class PrintReport(extension.Extension):
     """
 
     def __init__(self, entries, log_report='LogReport', out=sys.stdout):
+        if not hasattr(out, "write") or not hasattr(out, "flush"):
+            raise TypeError("Output stream should support `write' and `flush' method!")
+
         self._entries = entries
         self._log_report = log_report
         self._out = out

--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -24,10 +24,6 @@ class PrintReport(extension.Extension):
     """
 
     def __init__(self, entries, log_report='LogReport', out=sys.stdout):
-        if not hasattr(out, "write"):
-            raise TypeError(
-                "Output stream should support `write' method!")
-
         self._entries = entries
         self._log_report = log_report
         self._out = out

--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -83,5 +83,5 @@ class PrintReport(extension.Extension):
             else:
                 out.write(empty)
         out.write('\n')
-        if hasattr(out, "flush"):
+        if hasattr(out, 'flush'):
             out.flush()

--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -47,6 +47,7 @@ class PrintReport(extension.Extension):
 
         if self._header:
             out.write(self._header)
+            out.flush()
             self._header = None
 
         log_report = self._log_report
@@ -83,3 +84,4 @@ class PrintReport(extension.Extension):
             else:
                 out.write(empty)
         out.write('\n')
+        out.flush()

--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -25,7 +25,8 @@ class PrintReport(extension.Extension):
 
     def __init__(self, entries, log_report='LogReport', out=sys.stdout):
         if not hasattr(out, "write") or not hasattr(out, "flush"):
-            raise TypeError("Output stream should support `write' and `flush' method!")
+            raise TypeError(
+                "Output stream should support `write' and `flush' method!")
 
         self._entries = entries
         self._log_report = log_report

--- a/chainer/training/extensions/print_report.py
+++ b/chainer/training/extensions/print_report.py
@@ -32,11 +32,6 @@ class PrintReport(extension.Extension):
         self._log_report = log_report
         self._out = out
 
-        if hasattr(out, "flush"):
-            self._flush = lambda: out.flush()
-        else:
-            self._flush = lambda: None
-
         self._log_len = 0  # number of observations already printed
 
         # format information
@@ -92,4 +87,5 @@ class PrintReport(extension.Extension):
             else:
                 out.write(empty)
         out.write('\n')
-        self._flush()
+        if hasattr(out, "flush"):
+            out.flush()

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -27,7 +27,7 @@ class TestPrintReport(unittest.TestCase):
         self.assertTrue(hasattr(self.stream, 'flush'))
         self.stream.flush.assert_not_called()
         self.report(self.trainer)
-        self.stream.flush.assert_called_once_with()
+        self.stream.flush.assert_called_with()
 
     def test_stream_without_flush_raises_no_exception(self):
         self._setup(delete_flush=True)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,6 +1,6 @@
 import sys
 import unittest
-from unittest.mock import MagicMock
+from mock import MagicMock
 
 from chainer import testing
 from chainer.training import extensions

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,17 +1,18 @@
 import sys
 import unittest
 
+import mock
+
 from chainer import testing
 from chainer.training import extensions
-from mock import MagicMock
 
 
 class TestPrintReport(unittest.TestCase):
     def _setup(self, stream=None, delete_flush=False):
-        self.logreport = MagicMock(spec=extensions.LogReport(
+        self.logreport = mock.MagicMock(spec=extensions.LogReport(
             ['epoch'], trigger=(1, 'iteration'), log_name=None))
         if stream is None:
-            self.stream = MagicMock()
+            self.stream = mock.MagicMock()
             if delete_flush:
                 del self.stream.flush
         else:

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,18 +1,60 @@
 import sys
 import unittest
+from unittest.mock import MagicMock
 
 from chainer import testing
 from chainer.training import extensions
 
 
-class TestPrintReport(unittest.TestCase):
-
-    def test_stream_typecheck(self):
-        report = extensions.PrintReport(['epoch'], out=sys.stderr)
+class TestPrintReportInitialization(unittest.TestCase):
+    def test_stream_as_out_passes(self):
+        stream = MagicMock(spec=sys.stdout)
+        report = extensions.PrintReport(['epoch'], out=stream)
         self.assertIsInstance(report, extensions.PrintReport)
 
+    def test_object_without_write_as_out_does_not_pass(self):
+        stream = MagicMock()
+        del stream.write
         with self.assertRaises(TypeError):
-            report = extensions.PrintReport(['epoch'], out=False)
+            extensions.PrintReport(['epoch'], out=stream)
+
+    def test_stream_without_flush_as_out_passes(self):
+        stream = MagicMock(spec=sys.stderr)
+        del stream.flush
+        report = extensions.PrintReport(['epoch'], out=stream)
+        self.assertIsInstance(report, extensions.PrintReport)
+
+
+class TestPrintReport(unittest.TestCase):
+    def _setup(self, delete_flush=False):
+        self.logreport = MagicMock(spec=extensions.LogReport(
+            ['epoch'], trigger=(1, 'iteration'), log_name=None))
+        self.stream = MagicMock()
+        if delete_flush:
+            del self.stream.flush
+        self.report = extensions.PrintReport(
+            ['epoch'], log_report=self.logreport, out=self.stream)
+
+        self.trainer = testing.get_trainer_with_mock_updater(
+            stop_trigger=(1, 'iteration'))
+        self.trainer.extend(self.logreport)
+        self.trainer.extend(self.report)
+        self.logreport.log = [{'epoch': 0}]
+
+    def test_stream_with_flush_is_flushed(self):
+        self._setup(delete_flush=False)
+        self.assertTrue(hasattr(self.stream, 'flush'))
+        self.stream.flush.assert_not_called()
+        self.report(self.trainer)
+        self.stream.flush.assert_called_once_with()
+
+    def test_stream_without_flush_is_not_flushed(self):
+        self._setup(delete_flush=True)
+        self.assertFalse(hasattr(self.stream, 'flush'))
+        self.stream.flush = MagicMock()
+        self.stream.flush.assert_not_called()
+        self.report(self.trainer)
+        self.stream.flush.assert_not_called()
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,4 +1,3 @@
-import sys
 import tempfile
 import unittest
 

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -6,13 +6,17 @@ from mock import MagicMock
 from chainer import testing
 from chainer.training import extensions
 
+
 class TestPrintReport(unittest.TestCase):
-    def _setup(self, delete_flush=False):
+    def _setup(self, stream=None, delete_flush=False):
         self.logreport = MagicMock(spec=extensions.LogReport(
             ['epoch'], trigger=(1, 'iteration'), log_name=None))
-        self.stream = MagicMock()
-        if delete_flush:
-            del self.stream.flush
+        if stream is None:
+            self.stream = MagicMock()
+            if delete_flush:
+                del self.stream.flush
+        else:
+            self.stream = stream
         self.report = extensions.PrintReport(
             ['epoch'], log_report=self.logreport, out=self.stream)
 
@@ -32,6 +36,10 @@ class TestPrintReport(unittest.TestCase):
     def test_stream_without_flush_raises_no_exception(self):
         self._setup(delete_flush=True)
         self.assertFalse(hasattr(self.stream, 'flush'))
+        self.report(self.trainer)
+
+    def test_real_stream_raises_no_exception(self):
+        self._setup(stream=sys.stderr)
         self.report(self.trainer)
 
 

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -32,10 +32,7 @@ class TestPrintReport(unittest.TestCase):
     def test_stream_without_flush_raises_no_exception(self):
         self._setup(delete_flush=True)
         self.assertFalse(hasattr(self.stream, 'flush'))
-        try:
-            self.report(self.trainer)
-        except Exception as e:
-            self.fail("Unexpected exception: %s `%s'" % (type(e), e))
+        self.report(self.trainer)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,4 +1,5 @@
 import sys
+import tempfile
 import unittest
 
 import mock
@@ -39,8 +40,9 @@ class TestPrintReport(unittest.TestCase):
         self.report(self.trainer)
 
     def test_real_stream_raises_no_exception(self):
-        self._setup(stream=sys.stderr)
-        self.report(self.trainer)
+        with tempfile.TemporaryFile(mode='w') as stream:
+            self._setup(stream=stream)
+            self.report(self.trainer)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,0 +1,18 @@
+import sys
+import unittest
+
+from chainer import testing
+from chainer.training import extensions
+
+
+class TestPrintReport(unittest.TestCase):
+
+    def test_stream_typecheck(self):
+        report = extensions.PrintReport(['epoch'], out=sys.stderr)
+        self.assertIsInstance(report, extensions.PrintReport)
+
+        with self.assertRaises(TypeError):
+            report = extensions.PrintReport(['epoch'], out=False)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -49,13 +49,13 @@ class TestPrintReport(unittest.TestCase):
         self.report(self.trainer)
         self.stream.flush.assert_called_once_with()
 
-    def test_stream_without_flush_is_not_flushed(self):
+    def test_stream_without_flush_raises_no_exception(self):
         self._setup(delete_flush=True)
         self.assertFalse(hasattr(self.stream, 'flush'))
-        self.stream.flush = MagicMock()
-        self.stream.flush.assert_not_called()
-        self.report(self.trainer)
-        self.stream.flush.assert_not_called()
+        try:
+            self.report(self.trainer)
+        except Exception as e:
+            self.fail("Unexpected exception: %s `%s'" % (type(e), e))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -6,26 +6,6 @@ from mock import MagicMock
 from chainer import testing
 from chainer.training import extensions
 
-
-class TestPrintReportInitialization(unittest.TestCase):
-    def test_stream_as_out_passes(self):
-        stream = MagicMock(spec=sys.stdout)
-        report = extensions.PrintReport(['epoch'], out=stream)
-        self.assertIsInstance(report, extensions.PrintReport)
-
-    def test_object_without_write_as_out_does_not_pass(self):
-        stream = MagicMock()
-        del stream.write
-        with self.assertRaises(TypeError):
-            extensions.PrintReport(['epoch'], out=stream)
-
-    def test_stream_without_flush_as_out_passes(self):
-        stream = MagicMock(spec=sys.stderr)
-        del stream.flush
-        report = extensions.PrintReport(['epoch'], out=stream)
-        self.assertIsInstance(report, extensions.PrintReport)
-
-
 class TestPrintReport(unittest.TestCase):
     def _setup(self, delete_flush=False):
         self.logreport = MagicMock(spec=extensions.LogReport(

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,10 +1,9 @@
 import sys
 import unittest
 
-from mock import MagicMock
-
 from chainer import testing
 from chainer.training import extensions
+from mock import MagicMock
 
 
 class TestPrintReport(unittest.TestCase):

--- a/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_print_report.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+
 from mock import MagicMock
 
 from chainer import testing


### PR DESCRIPTION
PrintReport extension now seems not flushing the output stream at all, and output comes after a significant delay unless ProgressBar or something is used together.

This patch would fix that, but I can't provide a test because I don't know how I can test the stream is flushed properly.