### PR TITLE
Fix dtype bug in F.normalize

### DIFF
--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -26,6 +26,7 @@ class NormalizeL2(function_node.FunctionNode):
         self.retain_inputs((0,))
         x, = inputs
         xp = cuda.get_array_module(x)
+        # keep x.ndim >= 1 to avoid casting to self.eps' type
         norm = xp.sqrt(xp.sum(
             xp.square(x), axis=self.axis, keepdims=True)) + self.eps
         return x / norm,

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -26,8 +26,7 @@ class NormalizeL2(function_node.FunctionNode):
         self.retain_inputs((0,))
         x, = inputs
         xp = cuda.get_array_module(x)
-        norm = xp.linalg.norm(x, axis=self.axis) + self.eps
-        norm = xp.expand_dims(norm, self.axis)
+        norm = xp.linalg.norm(x, axis=self.axis, keepdims=True) + self.eps
         return x / norm,
 
     def backward(self, indexes, grad_outputs):

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -12,6 +12,10 @@ class NormalizeL2(function_node.FunctionNode):
 
     def __init__(self, eps=1e-5, axis=1):
         self.eps = eps
+        if isinstance(axis, int):
+            axis = axis,
+        if len(axis) not in [1, 2]:
+            raise ValueError("Improper number of dimensions to norm.")
         self.axis = axis
 
     def check_type_forward(self, in_types):

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -14,7 +14,7 @@ class NormalizeL2(function_node.FunctionNode):
         self.eps = eps
         if isinstance(axis, int):
             axis = axis,
-        if len(axis) not in [1, 2]:
+        if len(axis) not in (1, 2):
             raise ValueError("Improper number of dimensions to norm.")
         self.axis = axis
 

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -34,14 +34,13 @@ class NormalizeL2(function_node.FunctionNode):
         gy, = grad_outputs
         F = chainer.functions
 
-        norm_noeps = F.sqrt(F.sum(F.square(x), axis=self.axis))
+        norm_noeps = F.sqrt(F.sum(F.square(x), axis=self.axis, keepdims=True))
         norm = norm_noeps + self.eps
-        norm = F.broadcast_to(F.expand_dims(norm, self.axis), gy.shape)
+        norm = F.broadcast_to(norm, gy.shape)
 
-        x_gy_reduced = F.sum((x * gy), axis=self.axis)
+        x_gy_reduced = F.sum((x * gy), axis=self.axis, keepdims=True)
         x_gy_reduced /= norm_noeps
-        x_gy_reduced = F.broadcast_to(
-            F.expand_dims(x_gy_reduced, self.axis), gy.shape)
+        x_gy_reduced = F.broadcast_to(x_gy_reduced, gy.shape)
         gx = gy * norm - x_gy_reduced * x
         gx = gx / norm ** 2
 

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -26,7 +26,8 @@ class NormalizeL2(function_node.FunctionNode):
         self.retain_inputs((0,))
         x, = inputs
         xp = cuda.get_array_module(x)
-        norm = xp.linalg.norm(x, axis=self.axis, keepdims=True) + self.eps
+        norm = xp.sqrt(xp.sum(
+            xp.square(x), axis=self.axis, keepdims=True)) + self.eps
         return x / norm,
 
     def backward(self, indexes, grad_outputs):

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -20,6 +20,7 @@ from chainer.testing import attr
         {'shape': (4, 3, 2, 5), 'axis': 1},
         {'shape': (4, 3, 2, 5), 'axis': 2},
         {'shape': (4, 3, 2, 5), 'axis': 3},
+        {'shape': (4, 3, 2), 'axis': (0, 1)},
     ],
     [
         {'eps': 1e-5},
@@ -45,8 +46,9 @@ class TestL2Normalization(unittest.TestCase):
         y_expect = numpy.empty_like(self.x)
         shape = self.x.shape
         indices = []
+        axis_tuple = axis if isinstance(axis, tuple) else (axis,)
         for i in six.moves.range(len(shape)):
-            if i != axis:
+            if i not in axis_tuple:
                 indices.append(six.moves.range(shape[i]))
             else:
                 indices.append([slice(None)])

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -15,6 +15,7 @@ from chainer.testing import attr
 @testing.parameterize(*testing.product([
     [
         {'shape': (4, 15), 'axis': 1},
+        {'shape': (4,), 'axis': 0},
         {'shape': (4, 3, 2, 5), 'axis': 0},
         {'shape': (4, 3, 2, 5), 'axis': 1},
         {'shape': (4, 3, 2, 5), 'axis': 2},


### PR DESCRIPTION
The test added in the first commit failed because the output dtype was `float64`.

After the refactoring, `F.normalize` supports Frobenius norm, which is equivalent to L2 norm of flattened vector.