### PR TITLE
[backport] Warn only if the BN input tensor is 2-dimensional

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 import six
+import warnings
 
 import chainer
 from chainer.backends import cuda
@@ -361,6 +362,41 @@ class TestBatchNormalizationCudnnEps(unittest.TestCase):
     def test_invalid(self):
         with self.assertRaises(RuntimeError):
             functions.batch_normalization(*self.args, eps=2e-6)
+
+
+class TestBatchNormalizationWarning(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def create_batch(self, param_shape, x_shape):
+        dtype = numpy.float32
+        gamma = numpy.random.uniform(.5, 1, param_shape).astype(dtype)
+        beta = numpy.random.uniform(-1, 1, param_shape).astype(dtype)
+        x = numpy.random.uniform(-1, 1, x_shape).astype(dtype)
+        args = [x, gamma, beta]
+        return args
+
+    def test_invalid_batch(self):
+        args = self.create_batch((3,), (1, 3))
+        with testing.assert_warns(UserWarning):
+            functions.batch_normalization(*args)
+
+    def test_invalid_batch_no_batch_axis(self):
+        args = self.create_batch((1, 3,), (1, 3, 1))
+        with testing.assert_warns(UserWarning):
+            functions.batch_normalization(*args, axis=2)
+
+    def test_valid_batch(self):
+        args = self.create_batch((3,), (1, 3, 2, 2))
+        with warnings.catch_warnings(record=True) as w:
+            functions.batch_normalization(*args)
+            assert len(w) == 0
+
+    def test_valid_batch_no_batch_axis(self):
+        args = self.create_batch((1, 3,), (1, 3, 2))
+        with warnings.catch_warnings(record=True) as w:
+            functions.batch_normalization(*args, axis=2)
+            assert len(w) == 0
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Backport of #4663