### PR TITLE
Allow more than 2 axis in `F.normalize`

### DIFF
--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -57,17 +57,17 @@ def normalize(x, eps=1e-5, axis=1):
     This function implements L2 normalization on a vector along the given axis.
     No reduction is done along the normalization axis.
 
-    This function computes an output vector :math:`y` by the following
-    equation:
+    In the case when :obj:`axis=1` and :math:`\\mathbf{x}` is a matrix of
+    dimension :math:`(N, K)`, where :math:`N` and :math:`K` denote mini-batch
+    size and the dimension of the input vectors, this function computes an
+    output matrix :math:`\\mathbf{y}` of dimension :math:`(N, K)` by the
+    following equation:
 
     .. math::
-       y_{i,j} = {x_{i,j} \\over \\| x_{i,*} \\|_2 + \\epsilon}
+       \\mathbf{y}_i = {\\mathbf{x}_i \\over \\| \\mathbf{x}_i \\|_2 + \\epsilon}
 
-    where :math:`j` is an index over the normalization axis and :math:`i` is an
-    index over the remaining axis.
-
-    :obj:`eps` is used to avoid division by zero when norm of :math:`x` along
-    the given axis is zero.
+    :obj:`eps` is used to avoid division by zero when norm of
+    :math:`\\mathbf{x}` along the given axis is zero.
 
     The default value of :obj:`axis` is determined for backward compatibility.
 

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -14,8 +14,6 @@ class NormalizeL2(function_node.FunctionNode):
         self.eps = eps
         if isinstance(axis, int):
             axis = axis,
-        if len(axis) not in (1, 2):
-            raise ValueError("Improper number of dimensions to norm.")
         self.axis = axis
 
     def check_type_forward(self, in_types):
@@ -59,13 +57,14 @@ def normalize(x, eps=1e-5, axis=1):
     This function implements L2 normalization on a vector along the given axis.
     No reduction is done along the normalization axis.
 
-    In the case when :obj:`axis=1` and :math:`x` is a vector of dimension
-    :math:`(N, K)`, where :math:`N` and :math:`K` denote mini-batch size and
-    the dimension of the input variable, this function computes an output
-    vector :math:`y` by the following equation:
+    This function computes an output vector :math:`y` by the following
+    equation:
 
     .. math::
-       y_i = {x_i \\over \\| x_i \\|_2 + \\epsilon}
+       y_{i,j} = {x_{i,j} \\over \\| x_{i,*} \\|_2 + \\epsilon}
+
+    where :math:`j` is an index over the normalization axis and :math:`i` is an
+    index over the remaining axis.
 
     :obj:`eps` is used to avoid division by zero when norm of :math:`x` along
     the given axis is zero.
@@ -76,7 +75,7 @@ def normalize(x, eps=1e-5, axis=1):
         x (~chainer.Variable): Two dimensional output variable. The first
             dimension is assumed to be the mini-batch dimension.
         eps (float): Epsilon value for numerical stability.
-        axis (int): Axis along which to normalize.
+        axis (int or tuple of ints): Axis along which to normalize.
 
     Returns:
         ~chainer.Variable: The output variable which has the same shape

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -3,6 +3,7 @@ import numpy
 from chainer.backends import cuda
 from chainer import function_node
 import chainer.functions
+from chainer import utils
 from chainer.utils import type_check
 
 
@@ -28,10 +29,9 @@ class NormalizeL2(function_node.FunctionNode):
         self.retain_inputs((0,))
         x, = inputs
         xp = cuda.get_array_module(x)
-        # keep x.ndim >= 1 to avoid casting to self.eps' type
-        norm = xp.sqrt(xp.sum(
-            xp.square(x), axis=self.axis, keepdims=True)) + self.eps
-        return x / norm,
+        norm = (xp.sqrt(xp.sum(xp.square(x), axis=self.axis, keepdims=True))
+                + x.dtype.type(self.eps))
+        return utils.force_array(x / norm),
 
     def backward(self, indexes, grad_outputs):
         x, = self.get_retained_inputs()

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -64,7 +64,8 @@ def normalize(x, eps=1e-5, axis=1):
     following equation:
 
     .. math::
-       \\mathbf{y}_i = {\\mathbf{x}_i \\over \\| \\mathbf{x}_i \\|_2 + \\epsilon}
+       \\mathbf{y}_i =
+           {\\mathbf{x}_i \\over \\| \\mathbf{x}_i \\|_2 + \\epsilon}
 
     :obj:`eps` is used to avoid division by zero when norm of
     :math:`\\mathbf{x}` along the given axis is zero.

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -23,6 +23,7 @@ from chainer.testing import attr
         {'shape': (4, 3, 2), 'axis': (0, 1)},
         {'shape': (4, 3, 2, 4, 3, 2, 2), 'axis': (1, 4, 3, 6)},
         {'shape': (0, 2), 'axis': 1},
+        {'shape': (), 'axis': ()},
     ],
     [
         {'eps': 1e-5},

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -21,6 +21,8 @@ from chainer.testing import attr
         {'shape': (4, 3, 2, 5), 'axis': 2},
         {'shape': (4, 3, 2, 5), 'axis': 3},
         {'shape': (4, 3, 2), 'axis': (0, 1)},
+        {'shape': (4, 3, 2, 4, 3, 2, 2), 'axis': (1, 4, 3, 6)},
+        {'shape': (0, 2), 'axis': 1},
     ],
     [
         {'eps': 1e-5},


### PR DESCRIPTION
As the use of `np.linalg.norm` has been eliminated in #4763, we no longer have to limit the number of axis in `F.normalize`.