### PR TITLE
Add NumPy-compatible namespace

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -14,6 +14,7 @@ from chainer import functions  # NOQA
 from chainer import initializers  # NOQA
 from chainer import iterators  # NOQA
 from chainer import links  # NOQA
+from chainer import np  # NOQA
 from chainer import optimizers  # NOQA
 from chainer import serializers  # NOQA
 from chainer import training  # NOQA
@@ -142,6 +143,8 @@ global_config.autotune = False
 global_config.use_ideep = os.environ.get('CHAINER_USE_IDEEP', 'never')
 global_config.lazy_grad_sum = bool(int(
     os.environ.get('CHAINER_LAZY_GRAD_SUM', '0')))
+global_config.default_device = np.get_device(
+    os.environ.get('CHAINER_DEVICE', 'native'))
 
 
 def is_debug():

--- a/chainer/np/__init__.py
+++ b/chainer/np/__init__.py
@@ -1,0 +1,212 @@
+# This is a NumPy/CuPy-compatible namespace of Chainer. All the functions act
+# on chainer.Variable instead of ndarrays. Function names are coming from
+# NumPy, so sometimes the terminology is different from Chainer's one. For
+# example, "array" in this namespace means "variable" in Chainer.
+
+# =============================================================================
+# NumPy/CuPy-compatible APIs
+# =============================================================================
+
+# ======== Dtypes (borrowed from NumPy) ========
+
+# NOTE: Dtypes that are commented out are currently not supported by Chainer.
+
+# Generic types
+# from numpy import complexfloating  # NOQA
+from numpy import floating  # NOQA
+from numpy import generic  # NOQA
+from numpy import inexact  # NOQA
+from numpy import integer  # NOQA
+from numpy import number  # NOQA
+from numpy import signedinteger  # NOQA
+# from numpy import unsignedinteger
+
+# Bool
+from numpy import bool8  # NOQA
+from numpy import bool_  # NOQA
+
+# Integers
+# from numpy import byte
+# from numpy import int8
+# from numpy import int16
+from numpy import int32  # NOQA
+from numpy import int_  # NOQA
+from numpy import intc  # NOQA
+from numpy import intp  # NOQA
+from numpy import longlong  # NOQA
+# from numpy import short
+
+# Unsigned integers
+# from numpy import ubyte
+# from numpy import ushort
+# from numpy import uintc
+# from numpy import uint
+# from numpy import ulonglong
+# from numpy import uintp
+# from numpy import uint8
+# from numpy import uint16
+# from numpy import uint32
+# from numpy import uint64
+
+# Floating-point numbers
+from numpy import double  # NOQA
+from numpy import float16  # NOQA
+from numpy import float32  # NOQA
+from numpy import float64  # NOQA
+from numpy import float_  # NOQA
+# from numpy import float96
+# from numpy import float128
+from numpy import half  # NOQA
+# from numpy import longfloat
+from numpy import single  # NOQA
+
+# Complex floating-point numbers
+# from numpy import csingle
+# from numpy import complex64
+# from numpy import complex128
+# from numpy import complex192
+# from numpy import complex256
+# from numpy import complex_
+# from numpy import clongfloat
+
+# Built-in Python types
+from numpy import bool  # NOQA
+from numpy import float  # NOQA
+from numpy import int  # NOQA
+
+# ======== Routines ========
+
+# Variable creation routines
+from chainer.np.creation import empty  # NOQA
+from chainer.np.creation import empty_like  # NOQA
+from chainer.np.creation import eye  # NOQA
+from chainer.np.creation import full  # NOQA
+from chainer.np.creation import full_like  # NOQA
+from chainer.np.creation import identity  # NOQA
+from chainer.np.creation import ones  # NOQA
+from chainer.np.creation import ones_like  # NOQA
+from chainer.np.creation import zeros  # NOQA
+from chainer.np.creation import zeros_like  # NOQA
+
+# Manipulation routines
+from chainer.functions import reshape  # NOQA
+
+from chainer.functions import moveaxis  # NOQA
+from chainer.functions import rollaxis  # NOQA
+from chainer.functions import swapaxes  # NOQA
+from chainer.functions import transpose  # NOQA
+
+from chainer.functions import broadcast_to  # NOQA
+from chainer.functions import expand_dims  # NOQA
+from chainer.functions import squeeze  # NOQA
+
+from chainer.functions import dstack  # NOQA
+from chainer.functions import hstack  # NOQA
+from chainer.functions import stack  # NOQA
+from chainer.functions import vstack  # NOQA
+
+from chainer.functions import repeat  # NOQA
+from chainer.functions import tile  # NOQA
+
+from chainer.functions import flip  # NOQA
+from chainer.functions import fliplr  # NOQA
+from chainer.functions import flipud  # NOQA
+
+# Data type routines (borrowed from NumPy)
+from numpy import can_cast  # NOQA
+from numpy import common_type  # NOQA
+from numpy import min_scalar_type  # NOQA
+from numpy import obj2sctype  # NOQA
+from numpy import promote_types  # NOQA
+from numpy import result_type  # NOQA
+
+from numpy import dtype  # NOQA
+from numpy import format_parser  # NOQA
+
+from numpy import finfo  # NOQA
+from numpy import iinfo  # NOQA
+from numpy import MachAr  # NOQA
+
+from numpy import find_common_type  # NOQA
+from numpy import issctype  # NOQA
+from numpy import issubclass_  # NOQA
+from numpy import issubdtype  # NOQA
+from numpy import issubsctype  # NOQA
+
+from numpy import mintypecode  # NOQA
+from numpy import sctype2char  # NOQA
+from numpy import typename  # NOQA
+
+# Linear algebra
+from chainer.functions import matmul  # NOQA
+from chainer.functions import tensordot  # NOQA
+
+# Mathematical functions
+from chainer.functions import arccos  # NOQA
+from chainer.functions import arcsin  # NOQA
+from chainer.functions import arctan  # NOQA
+from chainer.functions import arctan2  # NOQA
+from chainer.functions import cos  # NOQA
+from chainer.functions import sin  # NOQA
+from chainer.functions import tan  # NOQA
+
+from chainer.functions import cosh  # NOQA
+from chainer.functions import sinh  # NOQA
+from chainer.functions import tanh  # NOQA
+
+from chainer.functions import ceil  # NOQA
+from chainer.functions import fix  # NOQA
+from chainer.functions import floor  # NOQA
+
+from chainer.functions import cumsum  # NOQA
+from chainer.functions import prod  # NOQA
+from chainer.functions import sum  # NOQA
+
+from chainer.functions import exp  # NOQA
+from chainer.functions import expm1  # NOQA
+from chainer.functions import log  # NOQA
+from chainer.functions import log10  # NOQA
+from chainer.functions import log1p  # NOQA
+from chainer.functions import log2  # NOQA
+
+from chainer.functions import add  # NOQA
+from chainer.functions import fmod  # NOQA
+
+from chainer.functions import absolute as abs  # NOQA
+from chainer.functions import absolute  # NOQA
+from chainer.functions import clip  # NOQA
+from chainer.functions import maximum  # NOQA
+from chainer.functions import minimum  # NOQA
+from chainer.functions import sign  # NOQA
+from chainer.functions import sqrt  # NOQA
+from chainer.functions import square  # NOQA
+
+# Padding
+from chainer.functions import pad  # NOQA
+
+# Sorting, searching, and counting
+from chainer.functions import argmax  # NOQA
+from chainer.functions import argmin  # NOQA
+from chainer.functions import where  # NOQA
+
+# Statistics
+from chainer.functions import max  # NOQA
+from chainer.functions import max as amax  # NOQA
+from chainer.functions import min  # NOQA
+from chainer.functions import min as amin  # NOQA
+
+from chainer.functions import average  # NOQA
+from chainer.functions import mean  # NOQA
+
+# Testing
+from chainer.np import testing  # NOQA
+
+# =============================================================================
+# Chainer-specific APIs
+# =============================================================================
+
+# Device
+from chainer.np.device import Device  # NOQA
+from chainer.np.device import get_default_device  # NOQA
+from chainer.np.device import get_device  # NOQA
+from chainer.np.device import set_default_device  # NOQA

--- a/chainer/np/creation.py
+++ b/chainer/np/creation.py
@@ -1,0 +1,52 @@
+import chainer
+from chainer import np
+
+
+def empty(shape, dtype=float, order='C', device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.empty(shape, dtype, order))
+
+
+def empty_like(a, dtype=None, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.empty_like(a, dtype))
+
+
+def eye(N, M=None, k=0, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.eye(N, M, k, dtype))
+
+
+def identity(n, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.identity(n, dtype))
+
+
+def ones(shape, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.ones(shape, dtype))
+
+
+def ones_like(a, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.ones_like(a, dtype))
+
+
+def zeros(shape, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.zeros(shape, dtype))
+
+
+def zeros_like(a, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.zeros_like(a, dtype))
+
+
+def full(shape, fill_value, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.full(shape, fill_value, dtype))
+
+
+def full_like(a, fill_value, dtype=float, device=None):
+    with np.get_device(device) as dev:
+        return chainer.as_variable(dev.xp.full_like(a, fill_value, dtype))

--- a/chainer/np/device.py
+++ b/chainer/np/device.py
@@ -1,0 +1,144 @@
+import numpy
+
+import chainer
+from chainer.backends import cuda
+
+
+class Device(object):
+
+    """Object that represents a device.
+
+    A device object is specified by the backend name and the device index.
+    The backend name is either ``'native'`` or ``'cuda'``.
+    The index is used to indentify the individual device handled by the
+    backend.
+
+    The device is identified by the pair of the backend name and the device
+    index, or the concatenation of them separated by ``':'``. For example,
+    the second device of CUDA backend is specified by ``('cuda', 1)`` or
+    ``'cuda:1'`` (note that the device index is zero-originated).
+
+    Note: it is not recommended to directly create an instance of this class.
+    Use :func:`~chainer.np.get_device` instead.
+
+    Attributes:
+        backend (str): Name of the backend.
+        index (int): Index of the device.
+        xp: NumPy-compatible module for the device.
+        underlying_device: Backend-specific underlying device object. It
+            supports ``use()`` method and the context management protocol
+            (``__enter__`` and ``__exit__``) to temporarily make the device
+            current for the backend-specific APIs.
+
+    """
+
+    def __init__(self, backend, index, xp, underlying_device):
+        self.backend = backend
+        self.index = index
+        self.xp = xp
+        self.underlying_device = underlying_device
+        self._device_stack = []
+
+    def __str__(self):
+        return '%s:%d' % (self.backend, self.index)
+
+    def __repr__(self):
+        return 'Device("%s", %d)' % (self.backend, self.index)
+
+    def __enter__(self):
+        self._device_stack.append(chainer.config.default_device)
+        chainer.config.default_device = self
+
+        self.underlying_device.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.underlying_device.__exit__(*exc_info)
+        chainer.config.default_device = self._device_stack.pop()
+
+    def use(self):
+        chainer.config.default_device = self
+        self.underlying_device.use()
+
+
+_devices = {}
+
+
+def get_device(name=None, index=None):
+    """Returns the device object specified by the name and index.
+
+    Args:
+        name (str or chainer.np.Device or None): Device or backend name. If it
+            is ``None``, the default device is returned. If it is already a
+            ``Device`` object, this argument is returned as is.
+        index (int or None): Index of the device. If ``name`` also contains the
+            index in its name (specified in the form
+            ``'<backend name>:<index>'``), this argument can be omitted.
+            If ``name`` only represents the backend name and still this
+            argument is omitted, ``0`` is used.
+
+    Returns:
+        chainer.np.Device: Device object for the specified backend name and
+            index.
+
+    """
+    if name is None:
+        return chainer.config.default_device
+    if isinstance(name, Device):
+        return name
+
+    pair = _resolve_device_name(name, index)
+    if pair in _devices:
+        return _devices[pair]
+
+    backend, index = pair
+    if backend == 'native':
+        device = Device('native', index, numpy, cuda.DummyDeviceType())
+    elif backend == 'cuda':
+        device = Device('cuda', index, cuda.cupy, cuda.Device(index))
+    else:
+        raise ValueError('invalid backend name: "{}"'.format(backend))
+
+    _devices[pair] = device
+    return device
+
+
+def get_default_device():
+    """Returns the default device of the current thread."""
+    return chainer.config.default_device
+
+
+def set_default_device(name, index=None):
+    """Sets the default device for the current thread.
+
+    Args:
+        name (str or chainer.np.Device): The device to set. It can be either
+            a backend name, device name, or a :class:`Device` object.
+            If it is a backend name, ``index`` is used for the device index.
+        index (int or None): The device index. If it is omitted and ``name``
+            does not specify the index, ``0`` is used.
+
+    """
+    get_device(name, index).use()
+
+
+def _resolve_device_name(name, index=None):
+    parts = name.split(':')
+    if len(parts) == 0:
+        raise ValueError('device name is empty')
+
+    if len(parts) == 1:
+        if index is None:
+            index = 0
+        return parts[0], index
+
+    try:
+        n, i = parts
+    except ValueError:
+        raise ValueError('invalid device name: "{}"'.format(name))
+
+    if index is not None:
+        raise ValueError(
+            'device id is duplicated: backend={}, index={}'.format(
+                name, index))
+    return n, int(i)

--- a/chainer/np/testing/__init__.py
+++ b/chainer/np/testing/__init__.py
@@ -1,0 +1,1 @@
+from chainer.np.testing.helper import numpy_chainer_array_equal  # NOQA

--- a/chainer/np/testing/helper.py
+++ b/chainer/np/testing/helper.py
@@ -1,0 +1,92 @@
+import functools
+import traceback
+
+import numpy
+
+import chainer
+from chainer import np
+
+
+def _call_func(self, impl, args, kw):
+    try:
+        return impl(self, *args, **kw), None, None
+    except Exception as e:
+        return None, e, traceback.format_exc()
+
+
+def _check_chainer_numpy_error(self, chainer_error, chainer_tb, numpy_error,
+                               numpy_tb, accept_error):
+    # TODO(oktua): expected_regexp like numpy.testing.assert_raises_regex
+    if chainer_error is None and numpy_error is None:
+        self.fail('Both chainer.np and numpy are expected to raise errors, '
+                  'but not')
+    elif chainer_error is None:
+        self.fail('Only numpy raises error\n\n' + numpy_tb)
+    elif numpy_error is None:
+        self.fail('Only chainer.np raises error\n\n' + chainer_tb)
+    elif not isinstance(chainer_error, type(numpy_error)):
+        # Chainer errors should be at least as explicit as the NumPy errors,
+        # i.e. allow Chainer errors to derive from NumPy errors but not the
+        # opposite. This ensures that try/except blocks that catch NumPy errors
+        # also catch Chainer errors.
+        msg = '''Different types of errors occurred
+
+chainer.np
+%s
+numpy
+%s
+''' % (chainer_tb, numpy_tb)
+        self.fail(msg)
+    elif not (isinstance(chainer_error, accept_error) and
+              isinstance(numpy_error, accept_error)):
+        msg = '''Both cupy and numpy raise exceptions
+
+chainer.np
+%s
+numpy
+%s
+''' % (chainer_tb, numpy_tb)
+        self.fail(msg)
+
+
+def _make_decorator(check_func, name, type_check, accept_error):
+    def decorator(impl):
+        @functools.wraps(impl)
+        def test_func(self, *args, **kw):
+            kw[name] = np
+            with np.get_device('native'):
+                ch_result, ch_error, ch_tb = _call_func(self, impl, args, kw)
+
+            # TODO(beam2d): Test CUDA device, too.
+
+            kw[name] = numpy
+            np_result, np_error, np_tb = _call_func(self, impl, args, kw)
+
+            if ch_error or np_error:
+                _check_chainer_numpy_error(self, ch_error, ch_tb,
+                                           np_error, np_tb,
+                                           accept_error=accept_error)
+                return
+
+            self.assertIsNotNone(ch_result)
+            self.assertIsNotNone(np_result)
+
+            self.assertEqual(ch_result.shape, np_result.shape)
+
+            if type_check:
+                self.assertEqual(ch_result.dtype, np_result.dtype,
+                                 'cupy dtype is not equal to numpy dtype')
+            self.assertIsInstance(ch_result, chainer.Variable)
+            check_func(ch_result, np_result)
+
+        return test_func
+    return decorator
+
+
+def numpy_chainer_array_equal(err_msg='', verbose=True, name='np',
+                              type_check=True, accept_error=()):
+    def check_func(ch_result, np_result):
+        numpy.testing.assert_array_equal(ch_result.array, np_result, err_msg,
+                                         verbose)
+
+    return _make_decorator(check_func, name, type_check, accept_error)

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,8 @@ setup(
               'chainer.links.model.vision',
               'chainer.links.normalization',
               'chainer.links.theano',
+              'chainer.np',
+              'chainer.np.testing',
               'chainer.optimizers',
               'chainer.optimizer_hooks',
               'chainer.serializers',

--- a/tests/chainer_tests/np_tests/test_creation.py
+++ b/tests/chainer_tests/np_tests/test_creation.py
@@ -1,0 +1,56 @@
+import unittest
+
+import chainer
+from chainer import np
+from chainer import testing
+
+
+class TestCreationRoutines(unittest.TestCase):
+
+    def test_empty(self):
+        a = np.empty((2, 3), dtype=np.float32)
+        assert isinstance(a, chainer.Variable)
+        assert a.shape == (2, 3)
+        assert a.dtype == np.float32
+
+    def test_empty_like(self):
+        a = np.empty((2, 3), dtype=np.float32)
+        b = np.empty_like(a, dtype=np.float16)
+        assert isinstance(b, chainer.Variable)
+        assert b.shape == a.shape
+        assert b.dtype == np.float16
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_eye(self, np):
+        return np.eye(5, 4, 2, np.float32)
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_full(self, np):
+        return np.full((2, 3), 3, np.float32)
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_full_like(self, np):
+        return np.full_like(np.empty((2, 3), np.float32), 3, np.float16)
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_identity(self, np):
+        return np.identity(3, np.float64)
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_ones(self, np):
+        return np.ones((2, 3), np.float32)
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_ones_like(self, np):
+        return np.ones_like(np.empty((2, 3), np.float32), np.float16)
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_zeros(self, np):
+        return np.zeros((2, 3), np.float32)
+
+    @np.testing.numpy_chainer_array_equal()
+    def test_zeros_like(self, np):
+        return np.zeros_like(np.empty((2, 3), np.float32), np.float16)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/np_tests/test_device.py
+++ b/tests/chainer_tests/np_tests/test_device.py
@@ -1,0 +1,72 @@
+import mock
+import numpy
+import unittest
+
+import chainer
+from chainer.backends import cuda
+from chainer import np
+from chainer import testing
+from chainer.testing import attr
+
+
+class TestDevice(unittest.TestCase):
+
+    def setUp(self):
+        self.orig_device = chainer.config.default_device
+
+    def tearDown(self):
+        chainer.config.default_device = self.orig_device
+
+    @mock.patch.object(np.Device, '__exit__')
+    @mock.patch.object(np.Device, '__enter__')
+    def test_device_init(self, enter_mock, exit_mock):
+        index = 1
+        if self.orig_device.backend == 'native':
+            index = 1 if self.orig_device.index == 0 else 0
+
+        device = np.Device('mydevice', index, numpy, cuda.DummyDeviceType())
+        assert str(device) == 'mydevice:1'
+        assert repr(device) == 'Device("mydevice", 1)'
+
+        with device:
+            assert chainer.config.default_device is device
+            enter_mock.assert_called_once()
+
+        assert chainer.config.default_device is self.orig_device
+        exit_mock.assert_called_once()
+
+
+class TestGetDevice(unittest.TestCase):
+
+    def check_device(self, device, backend, index, xp):
+        assert device.backend == backend
+        assert device.index == index
+        assert device.xp is xp
+        assert device is np.get_device(backend, index)
+
+    def test_native(self):
+        self.check_device(np.get_device('native'), 'native', 0, numpy)
+
+    def test_native_2(self):
+        self.check_device(np.get_device('native:1'), 'native', 1, numpy)
+
+    @attr.gpu
+    def test_cuda(self):
+        self.check_device(np.get_device('cuda'), 'cuda', 0, cuda.cupy)
+
+    @attr.multi_gpu(2)
+    def test_cuda_2(self):
+        self.check_device(np.get_device('cuda:1'), 'cuda', 1, cuda.cupy)
+
+    def test_invalid_device(self):
+        with self.assertRaises(ValueError):
+            np.get_device('')
+        with self.assertRaises(ValueError):
+            np.get_device('foo')
+        with self.assertRaises(ValueError):
+            np.get_device('native:0', 1)
+        with self.assertRaises(ValueError):
+            np.get_device('native:0:')
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This change adds the `chainer.np` module. It has the following properties:

- The interface follows NumPy (`chainer.np` works as a replacement of `numpy`).
- The interface is device-agnostic. Array creation routines (e.g. `empty`) allocate a new array on the "default device", which can be specified by the device API (`CHAINER_DEVICE` and `set_default_device`).
- Functions are differentiable.

This PR is not the complete realization of NumPy-compatible interface for Chainer. It only includes:

- Array creation routines
- Routines that are covered by `chainer.functions` (just importing symbols from it)
- Dtypes and related symbols (just importing them from `numpy`)
- Device-agnostic coding support
  - It currently only supports the native (CPU) and CUDA backends.
- Testing utilities