### PR TITLE
Fix test warning filter for Theano 1.0.2 which triggers DeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ filterwarnings= ignore::FutureWarning
                 error::DeprecationWarning
                 # theano 0.8 causes DeprecationWarnings. It is fixed in 0.9
                 ignore::DeprecationWarning:theano.configparser
+                # theano 1.0.2 pass deprecated argument to distutils.
+                ignore::DeprecationWarning:theano.gof.cmodule
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,14 @@ exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 [tool:pytest]
 filterwarnings= ignore::FutureWarning
                 error::DeprecationWarning
-                # theano 0.8 causes DeprecationWarnings. It is fixed in 0.9
+                # Theano 0.8 causes DeprecationWarnings. It is fixed in 0.9.
                 ignore::DeprecationWarning:theano.configparser
-                # theano 1.0.2 pass deprecated argument to distutils.
+                # Theano 1.0.2 passes a deprecated argument to distutils during
+                # importing ``theano.gof`` module.
+                # Without this configuration, the DeprecationWarning would be
+                # treated as an exception, and therefore the import would fail,
+                # causing AttributeError in the subsequent uses of
+                # ``theano.gof``. (#4810)
                 ignore::DeprecationWarning:theano.gof.cmodule
 testpaths = tests docs
 python_files = test_*.py


### PR DESCRIPTION
Theano 1.0.2 (released on May 23rd) calls ``distutils`` with deprecated arguments ("SO").
To workaround this issue, set warningfilter for this module.

https://github.com/Theano/Theano/blob/rel-1.0.2/theano/gof/cmodule.py#L274
https://github.com/python/cpython/blob/v3.6.5/Lib/distutils/sysconfig.py#L524-L532