### PR TITLE
Correct docs of batch_{re}normalization about running averages

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -728,12 +728,12 @@ def batch_normalization(x, gamma, beta, **kwargs):
     which is referred to as the channel shape. This channel shape corresponds
     to the dimensions in the input which are not averaged over. Since the
     first dimension of the input corresponds to the batch size, the second
-    dimension of `x` will correspond to the first dimension of the channel
-    shape, the third dimension of `x` will correspond to the second channel
+    dimension of ``x`` will correspond to the first dimension of the channel
+    shape, the third dimension of ``x`` will correspond to the second channel
     dimension (if it exists) and so on. Therefore, the dimensionality of the
     input must be at least one plus the number of channel dimensions. The
     total effective "batch size" will then be considered to be the product of
-    all dimensions in `x` except for the channel dimensions.
+    all dimensions in ``x`` except for the channel dimensions.
 
     As an example, if the input is four dimensional and the parameter
     variables are one dimensional, then it is assumed that the first
@@ -743,14 +743,6 @@ def batch_normalization(x, gamma, beta, **kwargs):
     batch size in the batch normalization computations. That is,
     the total batch size will be considered to be the product of all
     input dimensions except the second dimension.
-
-    Note: If this function is called, it will not be possible to access the
-    updated running mean and variance statistics, because they are members
-    of the function object, which cannot be accessed by the caller.
-    If it is desired to access the updated running statistics, it is necessary
-    to get a new instance of the function object, call the object, and then
-    access the running_mean and/or running_var attributes. See the
-    corresponding Link class for an example of how to do this.
 
     .. warning::
 
@@ -764,17 +756,19 @@ def batch_normalization(x, gamma, beta, **kwargs):
         beta (Variable): Shifting parameter of scaled normalized data.
         eps (float): Epsilon value for numerical stability.
         running_mean (numpy.ndarray or cupy.ndarray):
-            Running average of the mean. This is a
-            running average of the mean over several mini-batches using
-            the decay parameter. If ``None``, the running average is not
-            computed. If this is ``None``, then ``runnng_var`` must also
-            be ``None``.
+            Running average of the mean. This is a running average of
+            the mean over several mini-batches using the decay parameter.
+            The function takes a previous running average, and updates
+            the array in-place by the new running average.
+            If ``None``, the running average is not computed. If this is
+            ``None``, then ``runnng_var`` must also be ``None``.
         running_var (numpy.ndarray or cupy.ndarray):
-            Running average of the variance. This is a
-            running average of the variance over several mini-batches using
-            the decay parameter. If ``None``, the running average is not
-            computed. If this is ``None``, then ``running_mean`` must also
-            be ``None``.
+            Running average of the variance. This is a running average of
+            the variance over several mini-batches using the decay parameter.
+            The function takes a previous running average, and updates
+            the array in-place by the new running average.
+            If ``None``, the running average is not computed. If this is
+            ``None``, then ``running_mean`` must also be ``None``.
         decay (float): Decay rate of moving average. It is used during
             training.
         axis (int, tuple of int or None): Axis over which normalization is
@@ -789,7 +783,7 @@ def batch_normalization(x, gamma, beta, **kwargs):
     See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
           Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_
 
-    .. seealso:: :class:`links.BatchNormalization`
+    .. seealso:: :class:`~chainer.links.BatchNormalization`
 
     """  # NOQA
 
@@ -829,8 +823,8 @@ def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5, axis=None):
             order. For example, (0, 2) is OK, but (2, 0) is not.
 
     .. seealso::
-       :func:`functions.batch_normalization`,
-       :class:`links.BatchNormalization`
+       :func:`~chainer.functions.batch_normalization`,
+       :class:`~chainer.links.BatchNormalization`
 
     """
     return FixedBatchNormalization(eps, axis).apply((x, gamma, beta, mean,

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -207,6 +207,17 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
     training and inference models generate the same outputs that depend on
     individual examples rather than the entire minibatch.
 
+    Note: This function does not perform in-place update to
+    ``running_mean`` and ``running_var``, contrary to
+    :func:`~chainer.functions.batch_normalization`.
+    If the function is called, it will not be possible to access the
+    updated running mean and variance statistics, because they are members
+    of the function object, which cannot be accessed by the caller.
+    If it is desired to access the updated running statistics, it is necessary
+    to get a new instance of the function object, call the object, and then
+    access the ``running_mean`` and/or ``running_var`` attributes. See the
+    corresponding Link class for an example of how to do this.
+
     See: `Batch Renormalization: Towards Reducing Minibatch Dependence in \
           Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_
 


### PR DESCRIPTION
Current document is quite misleading. The link `chainer.links.BatchNormalization` does not access to `running_mean` and/or `running_var`; instead it relies on in-place updates. But another link `chainer.links.BatchRenormalization` indeed accesses to the attributes.