### PR TITLE
v4: fix required version of CuPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ set CHAINER_PYTHON_350_FORCE environment variable to 1."""
 
 
 def cupy_requirement(pkg):
-    return '{}==4.1.0'.format(pkg)
+    return '{} >=4.1.0, <5.0.0'.format(pkg)
 
 
 requirements = {


### PR DESCRIPTION
This PR is for stable (v4) branch.

Fix #4084.