### PR TITLE
Fix `F.rollaxis` backward when `axis=0` and `start=0`

### DIFF
--- a/chainer/functions/array/rollaxis.py
+++ b/chainer/functions/array/rollaxis.py
@@ -48,7 +48,7 @@ class Rollaxis(function_node.FunctionNode):
 
         if axis > start:
             axis += 1
-        else:
+        elif axis < start:
             start -= 1
 
         return Rollaxis(start, axis).apply(gy)

--- a/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
@@ -20,6 +20,7 @@ from chainer.utils import type_check
     {'axis': -2, 'start': -2, 'out_shape': (2, 3, 4)},
     {'axis': 0, 'start': 3, 'out_shape': (3, 4, 2)},
     {'axis': 2, 'start': -3, 'out_shape': (4, 2, 3)},
+    {'axis': 0, 'start': 0, 'out_shape': (2, 3, 4)},
 )
 class TestRollaxis(unittest.TestCase):
 


### PR DESCRIPTION
Backward should nothing in such a case, but unexpectedly it rolled the last axis of the gradient. Note: I keep the change small for this bug fix, but ideally `F.rollaxis` should do nothing when `axis == start` (I mean, it should just return `chainer.as_variable(x)` without creating a new node).