### PR TITLE
Remove deprecated imp.load_source in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ exec(open(os.path.join(here, 'chainer', '_version.py')).read())
 
 setup(
     name='chainer',
-    version=__version__, # NOQA
+    version=__version__,  # NOQA
     description='A flexible framework of neural networks',
     author='Seiya Tokui',
     author_email='tokui@preferred.jp',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import imp
 import os
 import pkg_resources
 import sys
@@ -125,7 +124,7 @@ exec(open(os.path.join(here, 'chainer', '_version.py')).read())
 
 setup(
     name='chainer',
-    version=__version__,
+    version=__version__, # NOQA
     description='A flexible framework of neural networks',
     author='Seiya Tokui',
     author_email='tokui@preferred.jp',

--- a/setup.py
+++ b/setup.py
@@ -119,8 +119,8 @@ else:
     print('No CuPy installation detected')
 
 here = os.path.abspath(os.path.dirname(__file__))
-__version__ = imp.load_source(
-    '_version', os.path.join(here, 'chainer', '_version.py')).__version__
+# Get __version__ variable
+exec(open(os.path.join(here, 'chainer', '_version.py')).read())
 
 
 setup(


### PR DESCRIPTION
I want to circumvent [imp.load_source](https://docs.python.org/3/library/imp.html), the deprecated module and undocumented function in Python3, via using exec, whereas such change may reduce code readability.
