### PR TITLE
[backport] Raise an error when `devices` argument given to `MultiprocessParallelUpdater` is not dict and list

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -157,6 +157,12 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             main = devices.pop('main')
             devices = list(six.itervalues(devices))
             devices = [main] + devices
+        elif isinstance(devices, (list, tuple)):
+            devices = list(devices)
+        else:
+            raise ValueError(
+                'devices argument should be either dict, list or tuple,'
+                ' but {} was given.'.format(type(devices)))
         if devices is None or any(device is None for device in devices):
             raise ValueError('must specify GPU devices')
 


### PR DESCRIPTION
Backport of #4716