### PR TITLE
Remove flake8 from AppVeyor test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,6 @@ build_script:
 test_script:
   # Run the project tests
   - "%CMD_IN_ENV% pip install -U -e .[appveyor]"
-  - "flake8"
   # Avoid interuption confirmation of cmd.exe
   - "echo SET CHAINER_TEST_GPU_LIMIT=0 > tmp.bat"
   - "echo python -m pytest --timeout=60 -m \"not cudnn and not ideep and not slow\" tests >> tmp.bat"

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ requirements = {
         'pillow',
     ],
     'appveyor': [
-        '-r stylecheck',
         '-r test',
         'pytest-timeout',
         'pytest-cov',


### PR DESCRIPTION
As style check is performed by Travis, we don't need to run it on AppVeyor.
This makes possible to quickly find errors specific on Windows even if the style error exists.