### PR TITLE
Human readable representation of link and chain

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -163,6 +163,14 @@ class Link(object):
         if not self.__init_done:
             raise RuntimeError('Link.__init__() has not been called.')
 
+    def __str__(self):
+        specs = ', '.join(
+            '{}={}'.format(k, v) for k, v in self.printable_specs
+        )
+        return '{cls}({specs})'.format(
+            cls=self.__class__.__name__, specs=specs,
+        )
+
     @property
     def local_link_hooks(self):
         # type: () -> collections.OrderedDict[str, chainer.LinkHook]
@@ -197,6 +205,16 @@ class Link(object):
         if self._device.xp is cuda.cupy:
             return self._device.device.id
         return None
+
+    @property
+    def printable_specs(self):
+        """Generator of printable specs of this link.
+
+        Usually, this indicates the arguments passed to the :meth:`__init__`.
+
+        """
+        if 0:
+            yield
 
     @property
     def xp(self):
@@ -988,6 +1006,23 @@ class Chain(Link):
         for name, link in six.iteritems(links):
             self.add_link(name, link)
 
+    def __str__(self):
+        reps = []
+        for child in self.children():
+            rep = '({name}): {rep},'.format(
+                name=child.name, rep=str(child),
+            )
+            # Add indentation to each line.
+            for line in rep.splitlines():
+                reps.append('  {line}\n'.format(line=line))
+        reps = ''.join(reps)
+        if reps:  # No newline with no children.
+            reps = '\n' + reps
+
+        return '{cls}({children})'.format(
+            cls=self.__class__.__name__, children=reps,
+        )
+
     def __getitem__(self, name):
         # type: (str) -> tp.Any
         """Equivalent to getattr."""
@@ -1181,6 +1216,23 @@ class ChainList(Link, collections_abc.MutableSequence):
 
         for link in links:
             self.add_link(link)
+
+    def __str__(self):
+        reps = []
+        for index, child in enumerate(self._children):
+            rep = '({index}): {rep},'.format(
+                index=index, rep=str(child),
+            )
+            # Add indentation to each line.
+            for line in rep.splitlines():
+                reps.append('  {line}\n'.format(line=line))
+        reps = ''.join(reps)
+        if reps:  # No newline with no children.
+            reps = '\n' + reps
+
+        return '{cls}({children})'.format(
+            cls=self.__class__.__name__, children=reps,
+        )
 
     def __setattr__(self, name, value):
         # type: (str, tp.Any) -> None

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -210,8 +210,12 @@ class Link(object):
     def printable_specs(self):
         """Generator of printable specs of this link.
 
-        Usually, this indicates the arguments passed to the :meth:`__init__`.
-
+        Yields:
+            specs (tuple of str and object):
+                Basically, it returns the arguments (pair of keyword and value)
+                that are passed to the :meth:`__init__`. This pair of key and
+                value is used for representing this class or subclass with
+                :meth:`__str__`.
         """
         if 0:
             yield

--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -123,6 +123,7 @@ nobias=False, initialW=None, initial_bias=None, *, dilate=1, groups=1)
         self.stride = _pair(stride)
         self.pad = _pair(pad)
         self.dilate = _pair(dilate)
+        self.in_channels = in_channels
         self.out_channels = out_channels
         self.groups = int(groups)
 
@@ -139,6 +140,21 @@ nobias=False, initialW=None, initial_bias=None, *, dilate=1, groups=1)
                     initial_bias = 0
                 bias_initializer = initializers._get_initializer(initial_bias)
                 self.b = variable.Parameter(bias_initializer, out_channels)
+
+    @property
+    def printable_specs(self):
+        specs = [
+            ('in_channels', self.in_channels),
+            ('out_channels', self.out_channels),
+            ('ksize', self.ksize),
+            ('stride', self.stride),
+            ('pad', self.pad),
+            ('nobias', self.b is None),
+            ('dilate', self.dilate),
+            ('groups', self.groups),
+        ]
+        for spec in specs:
+            yield spec
 
     def _initialize_params(self, in_channels):
         kh, kw = _pair(self.ksize)

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -102,6 +102,7 @@ class Linear(link.Link):
 
         if out_size is None:
             in_size, out_size = None, in_size
+        self.in_size = in_size
         self.out_size = out_size
 
         with self.init_scope():
@@ -122,6 +123,16 @@ class Linear(link.Link):
         # type: (int) -> None
 
         self.W.initialize((self.out_size, in_size))  # type: ignore
+
+    @property
+    def printable_specs(self):
+        specs = [
+            ('in_size', self.in_size),
+            ('out_size', self.out_size),
+            ('nobias', self.b is None),
+        ]
+        for spec in specs:
+            yield spec
 
     def forward(self, x, n_batch_axes=1):
         # type: (variable.Variable, int) -> variable.Variable

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -192,10 +192,20 @@ class BatchNormalization(link.Link):
                  initial_avg_mean=None, initial_avg_var=None):
         super(BatchNormalization, self).__init__()
 
+        self._kwargs = [
+            ('size', size),
+            ('decay', decay),
+            ('eps', eps),
+            ('dtype', dtype),
+            ('use_gamma', use_gamma),
+            ('use_beta', use_beta),
+        ]
+
         if size is None and axis is None:
             raise RuntimeError('size or axis is required')
         self._initial_avg_mean = initial_avg_mean
         self._initial_avg_var = initial_avg_var
+
         self.N = 0
         self.register_persistent('N')
         self.decay = decay
@@ -241,6 +251,19 @@ class BatchNormalization(link.Link):
         initializer = initializers._get_initializer(initializer)
         return initializers.generate_array(
             initializer, size, self.xp, dtype=self._dtype, device=self.device)
+
+    @property
+    def printable_specs(self):
+        specs = [
+            ('size', self.avg_mean.shape[0]),
+            ('decay', self.decay),
+            ('eps', self.eps),
+            ('dtype', self.avg_mean.dtype),
+            ('use_gamma', hasattr(self, 'gamma')),
+            ('use_beta', hasattr(self, 'beta')),
+        ]
+        for spec in specs:
+            yield spec
 
     def forward(self, x, **kwargs):
         """forward(self, x, finetune=False)

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -192,15 +192,6 @@ class BatchNormalization(link.Link):
                  initial_avg_mean=None, initial_avg_var=None):
         super(BatchNormalization, self).__init__()
 
-        self._kwargs = [
-            ('size', size),
-            ('decay', decay),
-            ('eps', eps),
-            ('dtype', dtype),
-            ('use_gamma', use_gamma),
-            ('use_beta', use_beta),
-        ]
-
         if size is None and axis is None:
             raise RuntimeError('size or axis is required')
         self._initial_avg_mean = initial_avg_mean

--- a/chainer/sequential.py
+++ b/chainer/sequential.py
@@ -1,8 +1,6 @@
 import copy
-import functools
 import inspect
 
-from chainer import function
 from chainer import link as _link
 
 
@@ -233,40 +231,24 @@ class Sequential(_link.ChainList):
         return super(Sequential, self).__reduce__()
 
     def __str__(self):
-        ret = ''
-        for i, layer in enumerate(self):
-            if isinstance(layer, Sequential):
-                name = layer.__class__.__name__
-                name += '\twhich has {} layers'.format(len(layer))
-            elif isinstance(layer, _link.Chain):
-                name = layer.__class__.__name__
-                name += '\tThe structure behind a Chain is determined at '
-                name += 'runtime.'
-            elif isinstance(layer, _link.ChainList):
-                name = layer.__class__.__name__
-                name += '\tThe structure behind a ChainList is determined at '
-                name += 'runtime.'
-            elif isinstance(layer, _link.Link):
-                name = layer.__class__.__name__
-                param_info = '\t'
-                for param in sorted(layer.params(), key=lambda p: p.name):
-                    param_info += param.name
-                    if param._data[0] is not None:
-                        param_info += str(param._data[0].shape)
-                    else:
-                        param_info += '(None)'
-                    param_info += '\t'
-                name = name + param_info
-            elif isinstance(layer, function.Function):
-                name = layer.__class__.__name__
-            elif isinstance(layer, functools.partial):
-                name = repr(layer)
-            elif layer.__name__ == '<lambda>':
-                name = inspect.getsource(layer).strip()
+        reps = []
+        for index, layer in enumerate(self):
+            # Explore better representation by if-block.
+            if getattr(layer, '__name__', None) == '<lambda>':
+                rep = inspect.getsource(layer).strip().rstrip(',')
             else:
-                name = layer.__name__
-            ret += '{}\t{}\n'.format(i, name)
-        return ret
+                rep = str(layer)
+            # Add indentation to each line.
+            rep = '({index}): {rep},'.format(index=index, rep=rep)
+            for line in rep.splitlines():
+                reps.append('  {line}\n'.format(line=line))
+        reps = ''.join(reps)
+        if reps:  # No newline with no layers.
+            reps = '\n' + reps
+
+        return '{cls}({layers})'.format(
+            cls=self.__class__.__name__, layers=reps,
+        )
 
     def append(self, layer):
         self.insert(len(self), layer)

--- a/chainer/sequential.py
+++ b/chainer/sequential.py
@@ -82,12 +82,12 @@ class Sequential(_link.ChainList):
         You can check the structure of your model briefly using ``print``
         as following:
 
-        >>> print(model_C)  # doctest: +NORMALIZE_WHITESPACE
+        >>> print(model_C)  # doctest: +ELLIPSIS
         Sequential(
           (0): Linear(in_size=10, out_size=10, nobias=False),
-          (1): <function relu at 0x7f45b1d36510>,
+          (1): <function relu at 0x...>,
           (2): Linear(in_size=10, out_size=10, nobias=False),
-          (3): <function sigmoid at 0x7f45b1d3f510>,
+          (3): <function sigmoid at 0x...>,
         )
 
         .. note::

--- a/chainer/sequential.py
+++ b/chainer/sequential.py
@@ -83,10 +83,12 @@ class Sequential(_link.ChainList):
         as following:
 
         >>> print(model_C)  # doctest: +NORMALIZE_WHITESPACE
-        0       Linear  W(10, 10)       b(10,)
-        1       relu
-        2       Linear  W(10, 10)       b(10,)
-        3       sigmoid
+        Sequential(
+          (0): Linear(in_size=10, out_size=10, nobias=False),
+          (1): <function relu at 0x7f45b1d36510>,
+          (2): Linear(in_size=10, out_size=10, nobias=False),
+          (3): <function sigmoid at 0x7f45b1d3f510>,
+        )
 
         .. note::
 

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -115,6 +115,14 @@ class TestLink(LinkTestBase, unittest.TestCase):
         self.link.v.initialize((2, 3))
         self.check_param_init('v', (2, 3), 'f')
 
+    def test_str(self):
+        self.assertEqual(str(chainer.Link()), 'Link()')
+
+        class MyLink(chainer.Link):
+            pass  # won't override printable_specs
+
+        self.assertEqual(str(MyLink()), 'MyLink()')
+
     def test_assign_param_outside_of_init_scope(self):
         p = chainer.Parameter()
         self.link.p = p
@@ -875,6 +883,7 @@ class TestChain(ChainTestBase, unittest.TestCase):
         self.assertEqual(self.l3.name, 'l3')
 
     def test_str(self):
+        self.assertEqual(str(chainer.Chain()), 'Chain()')
         self.assertEqual(
             str(self.c2),
             '''\
@@ -1458,6 +1467,7 @@ class TestChainList(unittest.TestCase):
         self.assertEqual(self.c1.name, '0')
 
     def test_str(self):
+        self.assertEqual(str(chainer.ChainList()), 'ChainList()')
         self.assertEqual(
             str(self.c2),
             '''\

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -48,6 +48,32 @@ class LinkTestBase(object):
         if cuda.available:
             self.current_device_id = cuda.cupy.cuda.get_device_id()
 
+    def test_str(self):
+
+        class LinearForTest(chainer.Link):
+            def __init__(self, in_size, out_size, nobias=False):
+                self.in_size = in_size
+                self.out_size = out_size
+                self.nobias = nobias
+
+            @property
+            def printable_specs(self):
+                specs = [
+                    ('in_size', self.in_size),
+                    ('out_size', self.out_size),
+                    ('nobias', self.nobias)
+                ]
+                for spec in specs:
+                    yield spec
+
+            def __call__(self):
+                pass
+
+        self.assertEqual(
+            str(LinearForTest(10, 1)),
+            'LinearForTest(in_size=10, out_size=1, nobias=False)',
+        )
+
     def tearDown(self):
         if cuda.available \
                 and cuda.cupy.cuda.get_device_id() != self.current_device_id:
@@ -848,6 +874,19 @@ class TestChain(ChainTestBase, unittest.TestCase):
         self.assertIs(self.c2['l3'], self.l3)
         self.assertEqual(self.l3.name, 'l3')
 
+    def test_str(self):
+        self.assertEqual(
+            str(self.c2),
+            '''\
+Chain(
+  (c1): Chain(
+    (l1): Link(),
+    (l2): Link(),
+  ),
+  (l3): Link(),
+)''',
+        )
+
     def test_add_link(self):
         self.assertIs(self.c1.l2, self.l2)
         self.assertEqual(self.l2.name, 'l2')
@@ -1417,6 +1456,19 @@ class TestChainList(unittest.TestCase):
         self.assertEqual(self.l1.name, '0')
         self.assertIs(self.c2[0], self.c1)
         self.assertEqual(self.c1.name, '0')
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.c2),
+            '''\
+ChainList(
+  (0): ChainList(
+    (0): Link(),
+    (1): Link(),
+  ),
+  (1): Link(),
+)''',
+        )
 
     def test_add_link(self):
         self.assertIs(self.c1[1], self.l2)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -48,32 +48,6 @@ class LinkTestBase(object):
         if cuda.available:
             self.current_device_id = cuda.cupy.cuda.get_device_id()
 
-    def test_str(self):
-
-        class LinearForTest(chainer.Link):
-            def __init__(self, in_size, out_size, nobias=False):
-                self.in_size = in_size
-                self.out_size = out_size
-                self.nobias = nobias
-
-            @property
-            def printable_specs(self):
-                specs = [
-                    ('in_size', self.in_size),
-                    ('out_size', self.out_size),
-                    ('nobias', self.nobias)
-                ]
-                for spec in specs:
-                    yield spec
-
-            def __call__(self):
-                pass
-
-        self.assertEqual(
-            str(LinearForTest(10, 1)),
-            'LinearForTest(in_size=10, out_size=1, nobias=False)',
-        )
-
     def tearDown(self):
         if cuda.available \
                 and cuda.cupy.cuda.get_device_id() != self.current_device_id:
@@ -116,12 +90,39 @@ class TestLink(LinkTestBase, unittest.TestCase):
         self.check_param_init('v', (2, 3), 'f')
 
     def test_str(self):
+        # empty Link
         self.assertEqual(str(chainer.Link()), 'Link()')
 
         class MyLink(chainer.Link):
-            pass  # won't override printable_specs
+            pass
 
+        # Link without overriding printable_specs
         self.assertEqual(str(MyLink()), 'MyLink()')
+
+        class LinearForTest(chainer.Link):
+            def __init__(self, in_size, out_size, nobias=False):
+                self.in_size = in_size
+                self.out_size = out_size
+                self.nobias = nobias
+
+            @property
+            def printable_specs(self):
+                specs = [
+                    ('in_size', self.in_size),
+                    ('out_size', self.out_size),
+                    ('nobias', self.nobias)
+                ]
+                for spec in specs:
+                    yield spec
+
+            def __call__(self):
+                pass
+
+        # Link with overriding printable_specs
+        self.assertEqual(
+            str(LinearForTest(10, 1)),
+            'LinearForTest(in_size=10, out_size=1, nobias=False)',
+        )
 
     def test_assign_param_outside_of_init_scope(self):
         p = chainer.Parameter()

--- a/tests/chainer_tests/test_sequential.py
+++ b/tests/chainer_tests/test_sequential.py
@@ -489,6 +489,8 @@ class TestSequential(unittest.TestCase):
                 six.moves.cPickle.dump(self.s2, fp)
 
     def test_str(self):
+        self.assertEqual(str(chainer.Sequential()), 'Sequential()')
+
         expected = '''\
   (0): Sequential(
     (0): Linear(in_size=None, out_size=3, nobias=False),

--- a/tests/chainer_tests/test_sequential.py
+++ b/tests/chainer_tests/test_sequential.py
@@ -1,5 +1,5 @@
+import functools
 import os
-import platform
 import tempfile
 import unittest
 
@@ -488,13 +488,28 @@ class TestSequential(unittest.TestCase):
             with tempfile.TemporaryFile() as fp:
                 six.moves.cPickle.dump(self.s2, fp)
 
-    def test_repr(self):
-        bits, pl = platform.architecture()
-        self.assertEqual(
-            str(self.s1),
-            '0\tLinear\tW(None)\tb{}\t\n'
-            '1\tLinear\tW{}\tb{}\t\n'.format(
-                self.s1[0].b.shape, self.s1[1].W.shape, self.s1[1].b.shape))
+    def test_str(self):
+        expected = '''\
+  (0): Sequential(
+    (0): Linear(in_size=None, out_size=3, nobias=False),
+    (1): Linear(in_size=3, out_size=2, nobias=False),
+  ),
+  (1): Linear(in_size=2, out_size=3, nobias=False),
+  (2): lambda x: functions.leaky_relu(x, slope=0.2),
+'''
+        layers = [
+            self.s1,
+            self.l3,
+            lambda x: functions.leaky_relu(x, slope=0.2),
+        ]
+        if six.PY3:
+            # In Python2, it fails because of different id of the function.
+            layer = functools.partial(functions.leaky_relu, slope=0.2)
+            layers.append(layer)
+            expected += '  (3): %s,\n' % layer
+        expected = 'Sequential(\n%s)' % expected
+        s = chainer.Sequential(*layers)
+        self.assertEqual(str(s), expected)
 
     def test_repeat_with_init(self):
         # s2 ((l1 -> l2) -> l3) -> s2 ((l1 -> l2) -> l3)


### PR DESCRIPTION
## Why?

Currently, the representation of models implemented using Chain and ChainList is not so helpful to get to know about the model structure as follows.

```
% cat model_resnet.py
from chainer.links.model.vision.resnet import ResNet50Layers

model = ResNet50Layers(pretrained_model=None)
print(model)

% python model_resnet.py
<chainer.links.model.vision.resnet.ResNet50Layers object at 0x108fc4e48>
```

I think it is useful for users if registered links are printed, even though chainer has the define-by-run policy.

Below demonstrates the representation of ResNet50 with the pathces on this PR, and it seems better than before to understand its architecture.

```
ResNet50Layers(
  (bn1): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
  (conv1): Convolution2D(in_channels=3, out_channels=64, ksize=7, stride=2, pad=3, nobias=False, dilate=1, groups=1),
  (fc6): Linear(in_size=2048, out_size=1000, nobias=False),
  (res2): BuildingBlock(
    (a): BottleneckA(
      (bn1): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn4): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=64, out_channels=64, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=64, out_channels=64, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=64, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv4): Convolution2D(in_channels=64, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b1): BottleneckB(
      (bn1): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=256, out_channels=64, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=64, out_channels=64, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=64, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b2): BottleneckB(
      (bn1): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=64, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=256, out_channels=64, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=64, out_channels=64, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=64, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
  ),
  (res3): BuildingBlock(
    (a): BottleneckA(
      (bn1): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn4): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=256, out_channels=128, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=128, out_channels=128, ksize=3, stride=2, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=128, out_channels=512, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv4): Convolution2D(in_channels=256, out_channels=512, ksize=1, stride=2, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b1): BottleneckB(
      (bn1): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=512, out_channels=128, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=128, out_channels=128, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=128, out_channels=512, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b2): BottleneckB(
      (bn1): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=512, out_channels=128, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=128, out_channels=128, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=128, out_channels=512, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b3): BottleneckB(
      (bn1): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=128, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=512, out_channels=128, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=128, out_channels=128, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=128, out_channels=512, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
  ),
  (res4): BuildingBlock(
    (a): BottleneckA(
      (bn1): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=1024, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn4): BatchNormalization(size=1024, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=512, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=256, out_channels=256, ksize=3, stride=2, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=256, out_channels=1024, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv4): Convolution2D(in_channels=512, out_channels=1024, ksize=1, stride=2, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b1): BottleneckB(
      (bn1): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=1024, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=1024, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=256, out_channels=256, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=256, out_channels=1024, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b2): BottleneckB(
      (bn1): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=1024, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=1024, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=256, out_channels=256, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=256, out_channels=1024, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b3): BottleneckB(
      (bn1): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=1024, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=1024, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=256, out_channels=256, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=256, out_channels=1024, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b4): BottleneckB(
      (bn1): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=1024, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=1024, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=256, out_channels=256, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=256, out_channels=1024, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b5): BottleneckB(
      (bn1): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=256, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=1024, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=1024, out_channels=256, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=256, out_channels=256, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=256, out_channels=1024, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
  ),
  (res5): BuildingBlock(
    (a): BottleneckA(
      (bn1): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=2048, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn4): BatchNormalization(size=2048, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=1024, out_channels=512, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=512, out_channels=512, ksize=3, stride=2, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=512, out_channels=2048, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv4): Convolution2D(in_channels=1024, out_channels=2048, ksize=1, stride=2, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b1): BottleneckB(
      (bn1): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=2048, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=2048, out_channels=512, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=512, out_channels=512, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=512, out_channels=2048, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
    (b2): BottleneckB(
      (bn1): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn2): BatchNormalization(size=512, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (bn3): BatchNormalization(size=2048, decay=0.9, eps=2e-05, dtype=<class 'numpy.float32'>, use_gamma=True, use_beta=True),
      (conv1): Convolution2D(in_channels=2048, out_channels=512, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
      (conv2): Convolution2D(in_channels=512, out_channels=512, ksize=3, stride=1, pad=1, nobias=True, dilate=1, groups=1),
      (conv3): Convolution2D(in_channels=512, out_channels=2048, ksize=1, stride=1, pad=0, nobias=True, dilate=1, groups=1),
    ),
  ),
)
```

## Solution

Implement `__repr__` of `Link`, `Chain` and `ChainList`.
For `Link`, I add a new attribute `self._kwargs` which should be overwritten by child classes to represent the arguments for `__init__ `.
For example,  in `Linear` link, it adds `in_size`, `out_size`, and `nobias` to the `self._kwargs`.