### PR TITLE
[backport] Document `call_for_each_param` attribute in optimizer hooks

### DIFF
--- a/chainer/optimizer_hooks/gradient_hard_clipping.py
+++ b/chainer/optimizer_hooks/gradient_hard_clipping.py
@@ -22,6 +22,12 @@ class GradientHardClipping(object):
                          Optimizer/UpdateRule. Valid values are 'pre'
                          (before any updates) and 'post'
                          (after any updates).
+        ~optimizer_hooks.GradientHardClipping.call_for_each_param (bool): \
+                         Specifies if this hook is called for each parameter
+                         (``True``) or only once (``False``) by an optimizer to
+                         which this hook is registered. This function does
+                         not expect users to switch the value from default one,
+                         which is `True`.
 
     .. versionadded:: 4.0.0
        The *timing* parameter.

--- a/chainer/optimizer_hooks/gradient_lars.py
+++ b/chainer/optimizer_hooks/gradient_lars.py
@@ -60,6 +60,12 @@ class GradientLARS(object):
                          when this hook should be called by the
                          Optimizer/UpdateRule. Valid values are 'pre'
                          (before any updates) and 'post' (after any updates).
+        ~optimizer_hooks.GradientLARS.call_for_each_param (bool): Specifies
+                         if this hook is called for each parameter (``True``)
+                         or only once (``False``) by an optimizer to
+                         which this hook is registered. This function does
+                         not expect users to switch the value from default one,
+                         which is `True`.
 
     """
     name = 'GradientLARS'

--- a/chainer/optimizer_hooks/gradient_noise.py
+++ b/chainer/optimizer_hooks/gradient_noise.py
@@ -47,6 +47,12 @@ class GradientNoise(object):
                          Optimizer/UpdateRule. Valid values are
                          'pre' (before any updates) and 'post' (after any
                          updates).
+        ~optimizer_hooks.GradientNoise.call_for_each_param (bool): Specifies
+                         if this hook is called for each parameter (``True``)
+                         or only once (``False``) by an optimizer to
+                         which this hook is registered. This function does
+                         not expect users to switch the value from default one,
+                         which is `True`.
 
     .. versionadded:: 4.0.0
        The *timing* parameter.

--- a/chainer/optimizer_hooks/lasso.py
+++ b/chainer/optimizer_hooks/lasso.py
@@ -16,6 +16,12 @@ class Lasso(object):
                          when this hook should be called by
                          the Optimizer/UpdateRule. Valid values are 'pre'
                          (before any updates) and 'post' (after any updates).
+        ~optimizer_hooks.Lasso.call_for_each_param (bool): Specifies
+                         if this hook is called for each parameter (``True``)
+                         or only once (``False``) by an optimizer to
+                         which this hook is registered. This function does
+                         not expect users to switch the value from default one,
+                         which is `True`.
 
     .. versionadded:: 4.0.0
        The *timing* parameter.

--- a/chainer/optimizer_hooks/weight_decay.py
+++ b/chainer/optimizer_hooks/weight_decay.py
@@ -18,6 +18,12 @@ class WeightDecay(object):
                          when this hook should be called by the
                          Optimizer/UpdateRule. Valid values are 'pre'
                          (before any updates) and 'post' (after any updates).
+        ~optimizer_hooks.WeightDecay.call_for_each_param (bool): Specifies
+                         if this hook is called for each parameter (``True``)
+                         or only once (``False``) by an optimizer to
+                         which this hook is registered. This function does
+                         not expect users to switch the value from default one,
+                         which is `True`.
 
     .. versionadded:: 4.0.0
        The *timing* parameter.


### PR DESCRIPTION
Backport of #4849