### PR TITLE
[backport] Improve error message and exception type during `MultiprocessParallelUpdater` initialization

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -122,8 +122,8 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             raise Exception(
                 'NCCL is not enabled. MultiprocessParallelUpdater '
                 'requires NCCL.\n'
-                'Please reinstall chainer after you install NCCL.\n'
-                '(see https://github.com/chainer/chainer#installation).')
+                'Please reinstall CuPy after you install NCCL.\n'
+                '(see https://docs-cupy.chainer.org/en/latest/install.html)')
         try:
             cuda.cupy.cuda.driver.ctxGetCurrent()
             _cuda_initialized = True
@@ -131,7 +131,7 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             # The context is not initialized, it will be fine.
             _cuda_initialized = False
         if _cuda_initialized:
-            raise ValueError(
+            raise RuntimeError(
                 'The CUDA context has been already initialized. '
                 'MultiprocessParallelUpdater assumes the context is '
                 'uninitialized. Please do not call CUDA API before '

--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/cuda_init.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/cuda_init.py
@@ -1,0 +1,38 @@
+import numpy
+
+import chainer
+from chainer.backends import cuda
+import chainer.training.updaters.multiprocess_parallel_updater as mpu
+
+
+def test():
+    model = chainer.Link()
+    dataset = [((numpy.ones((2, 5, 5)) * i).astype(numpy.float32),
+                numpy.int32(0)) for i in range(100)]
+
+    batch_size = 5
+    devices = (0,)
+    iters = [chainer.iterators.SerialIterator(i, batch_size) for i in
+             chainer.datasets.split_dataset_n_random(
+                 dataset, len(devices))]
+    optimizer = chainer.optimizers.SGD(lr=1.0)
+    optimizer.setup(model)
+
+    # Initialize CUDA context.
+    cuda.cupy.cuda.runtime.runtimeGetVersion()
+
+    try:
+        mpu.MultiprocessParallelUpdater(iters, optimizer, devices=devices)
+    except RuntimeError as e:
+        assert 'CUDA context' in str(e)
+        return
+
+    assert False
+
+
+if __name__ == '__main__':
+    test()
+
+
+# This snippet is not a test code.
+# testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
@@ -179,4 +179,16 @@ class TestChildReporter(unittest.TestCase):
         self.check_with_gpus(2)
 
 
+class TestCUDAContext(unittest.TestCase):
+
+    @attr.gpu
+    @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
+                         'MultiprocessParallelUpdater is not available.')
+    def test_cuda_init(self):
+        ret, stdoutdata, stderrdata = _run_test_snippet('cuda_init.py')
+        assert ret == 0, (
+            '[stdout]:{!r}\n'
+            '[stderr]:{!r}'.format(stdoutdata, stderrdata))
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Backport of #4751