### PR TITLE
Stop using freeze_running_statistics in TestFixedBatchRenormalization

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -153,13 +153,13 @@ class TestFixedBatchRenormalization(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
 
-    def _pure_forward(self, *args):
+    def _forward(self, *args):
         return batch_renormalization.fixed_batch_renormalization(
             *args, eps=self.eps)
 
     def check_forward(self, args):
         with chainer.using_config('train',  self.train):
-            y = self._pure_forward(*args)
+            y = self._forward(*args)
         self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_renormalization(
@@ -182,7 +182,7 @@ class TestFixedBatchRenormalization(unittest.TestCase):
     def check_backward(self, args, y_grad):
         with chainer.using_config('train',  self.train):
             gradient_check.check_backward(
-                self._pure_forward,
+                self._forward,
                 args, y_grad, **self.check_backward_options)
 
     @condition.retry(3)


### PR DESCRIPTION
Avoid directly using `FunctionNode`.
