### PR TITLE
Improve Batch Renormalization tests

### DIFF
--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -35,7 +35,7 @@ class BatchRenormalization(BatchNormalization):
     def __init__(self, size, rmax=1, dmax=0, decay=0.9, eps=2e-5,
                  dtype=numpy.float32, use_gamma=True, use_beta=True,
                  initial_gamma=None, initial_beta=None,
-                 freeze_running_statistics=False):
+                 ):
         super(BatchRenormalization, self).__init__(size, decay, eps, dtype,
                                                    use_gamma, use_beta,
                                                    initial_gamma, initial_beta)
@@ -43,7 +43,6 @@ class BatchRenormalization(BatchNormalization):
         self.dmax = dmax  # maximum allowed correction of mean
         self.r = None
         self.d = None
-        self.freeze_running_statistics = freeze_running_statistics
 
     def __call__(self, x, finetune=False):
         if self.gamma is not None:
@@ -69,14 +68,8 @@ class BatchRenormalization(BatchNormalization):
 
             func = batch_renormalization.BatchRenormalizationFunction(
                 self.eps, self.avg_mean, self.avg_var, decay,
-                self.rmax, self.dmax, self.freeze_running_statistics)
-            if self.freeze_running_statistics:
-                func.r = self.r
-                func.d = self.d
+                self.rmax, self.dmax)
             ret = func(x, gamma, beta)
-            if self.freeze_running_statistics and self.r is None:
-                self.r = func.r
-                self.d = func.d
 
             self.avg_mean[:] = func.running_mean
             self.avg_var[:] = func.running_var

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -34,8 +34,7 @@ class BatchRenormalization(BatchNormalization):
 
     def __init__(self, size, rmax=1, dmax=0, decay=0.9, eps=2e-5,
                  dtype=numpy.float32, use_gamma=True, use_beta=True,
-                 initial_gamma=None, initial_beta=None,
-                 ):
+                 initial_gamma=None, initial_beta=None):
         super(BatchRenormalization, self).__init__(size, decay, eps, dtype,
                                                    use_gamma, use_beta,
                                                    initial_gamma, initial_beta)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -124,31 +124,6 @@ class TestBatchRenormalization(unittest.TestCase):
     def test_forward_gpu(self):
         self.check_forward([cuda.to_gpu(i) for i in self.args])
 
-    def check_backward(self, args, y_grad):
-        with chainer.using_config('train',  self.train):
-            # Freezing the update of running statistics is needed in order to
-            # make gradient check work, since the parameters r and d in batch
-            # renormalization are calculated from the input, but should be
-            # treated as constants during gradient computation, as stated in
-            # the paper.
-            gradient_check.check_backward(
-                batch_renormalization.BatchRenormalizationFunction(
-                    mean=self.running_mean, var=self.running_var,
-                    decay=self.decay, eps=self.eps, rmax=self.rmax,
-                    dmax=self.dmax,
-                    freeze_running_statistics=True), args, y_grad,
-                **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.args, self.gy)
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.check_backward(
-            [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))
-
     def check_compare_naive(self, args, y_grad):
         def compute(f):
             x, gamma, beta = [chainer.Variable(v.copy()) for v in args]

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -89,11 +89,10 @@ class TestBatchRenormalization(unittest.TestCase):
 
         self.train = True
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'dtype': numpy.float64}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, args):
         with chainer.using_config('train',  self.train):
@@ -153,7 +152,6 @@ class TestBatchRenormalization(unittest.TestCase):
             tested[0], expected[0], **self.check_forward_options)
 
         # test backward
-        self.check_backward_options.pop('dtype')
         for g, g_expected in zip(tested[1:], expected[1:]):
             testing.assert_allclose(
                 g, g_expected, **self.check_backward_options)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -33,7 +33,6 @@ def _naive_batch_renormalization(
     avg_std = avg_std.reshape(stat_shape)
 
     mean = chainer.functions.mean(x, axis=axis, keepdims=True)
-    _, gamma, beta, mean = chainer.functions.broadcast(x, gamma, beta, mean)
     std = chainer.functions.sqrt(
         eps +
         chainer.functions.mean(
@@ -41,7 +40,6 @@ def _naive_batch_renormalization(
             axis=axis, keepdims=True))
     r = (std.array / avg_std).clip(1./rmax, rmax)
     d = ((mean.array - avg_mean) / avg_std).clip(-dmax, dmax)
-    _, std, r, d = chainer.functions.broadcast(x, std, r, d)
     xhat = ((x - mean) / std) * r + d
     return gamma * xhat + beta
 


### PR DESCRIPTION
Replace the backward tests of Batch Renormalization by comparisons with its naive implementation, which uses several `FunctionNode`s.

Batch Renormalization uses "partial gradient". The current tests in Chainer use `check_backward` so that they check gradients w.r.t. a modified forward computation.  This PR removes `freeze_running_statistics` option, which has been introduced just for these tests.

Merge #4869 first.