### PR TITLE
Support importing Caffe Reshape layer

### DIFF
--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -351,6 +351,15 @@ class CaffeFunction(link.Chain):
         self.forwards[layer.name] = fw
         self._add_layer(layer)
 
+    @_layer('Reshape', None)
+    def _setup_reshape(self, layer):
+        shape = layer.reshape_param.shape.dim
+
+        fw = _SingleArgumentFunction(functions.reshape, shape=shape)
+
+        self.forwards[layer.name] = fw
+        self._add_layer(layer)
+
     @_layer('BatchNorm', None)
     def _setup_batchnorm(self, layer):
         # Get layer parameters.

--- a/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
+++ b/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
@@ -573,6 +573,35 @@ class TestLeakyReLU(TestCaffeFunctionBaseMock):
         self.mock.assert_called_once_with(self.inputs[0], slope=0.5)
 
 
+class TestReshape(TestCaffeFunctionBaseMock):
+
+    func_name = 'chainer.functions.reshape'
+    in_shapes = [(3, 2, 3)]
+    out_shapes = [(3, 6)]
+
+    data = {
+        'layer': [
+            {
+                'name': 'l1',
+                'type': 'Reshape',
+                'bottom': ['x'],
+                'top': ['y'],
+                'reshape_param': {
+                    'shape': {
+                        'dim': [3, 6]
+                    }
+                }
+            }
+        ]
+    }
+
+    def test_reshape(self):
+        self.init_func()
+        self.assertEqual(len(self.func.layers), 1)
+        self.call(['x'], ['y'])
+        self.mock.assert_called_once_with(self.inputs[0], shape=[3, 6])
+
+
 class TestBatchNorm(TestCaffeFunctionBaseMock):
 
     func_name = 'chainer.links.BatchNormalization.__call__'


### PR DESCRIPTION
Motivation behind this PR: #4884 (Some functions like `F.linear` exports `Reshape` layer)