### PR TITLE
Add `StepShift` Extension.

### DIFF
--- a/chainer/training/extensions/__init__.py
+++ b/chainer/training/extensions/__init__.py
@@ -14,6 +14,7 @@ from chainer.training.extensions.plot_report import PlotReport  # NOQA
 from chainer.training.extensions.polynomial_shift import PolynomialShift  # NOQA
 from chainer.training.extensions.print_report import PrintReport  # NOQA
 from chainer.training.extensions.progress_bar import ProgressBar  # NOQA
+from chainer.training.extensions.step_shift import StepShift  # NOQA
 from chainer.training.extensions.value_observation import observe_lr  # NOQA
 from chainer.training.extensions.value_observation import observe_value  # NOQA
 from chainer.training.extensions.variable_statistics_plot import VariableStatisticsPlot  # NOQA

--- a/chainer/training/extensions/step_shift.py
+++ b/chainer/training/extensions/step_shift.py
@@ -10,7 +10,7 @@ class StepShift(extension.Extension):
     """Trainer extension to shift an optimizer attribute in "steps".
 
     This extension multiplies the specified attribute of the optimizer in
-    "steps". The typical use case is to scale the attribute at every ``k``th
+    "steps". The typical use case is to scale the attribute at every ``k``\ th
     iteration.
 
     For example, suppose that this extension is invoked at every iteration,

--- a/chainer/training/extensions/step_shift.py
+++ b/chainer/training/extensions/step_shift.py
@@ -1,0 +1,64 @@
+from __future__ import division
+
+import numpy
+
+from chainer.training import extension
+
+
+class StepShift(extension.Extension):
+
+    """Trainer extension to multiply an optimizer attribute by a fixed value
+    for every ``k`` iterations.
+
+    For example, suppose that this extension is called at every k iterations,
+    with a multiplier ``gamma`` and an initial value ``init``, then the
+    optimizer attribute will be set to ``init * gamma ^ (floor(iter / k))``.
+
+    This extension is also called before the training loop starts by default.
+
+    Args:
+        attr (str): Name of the optimizer attribute to adjust.
+        init (float): The initial value of the attribute.
+        gamma (float): The multiplier.
+        step (int): The number of iterations to do the multiplication, i.e.,
+            ``k``.
+        optimizer (~chainer.Optimizer): Target optimizer object. If it is None,
+            the main optimizer of the trainer is used.
+
+    """
+
+    def __init__(self, attr, init, gamma, step, optimizer=None):
+        self._attr = attr
+        self._init = init
+        self._gamma = gamma
+        self._step = step
+        self._optimizer = optimizer
+        self._t = 0
+        self._last_value = None
+
+    def initialize(self, trainer):
+        optimizer = self._get_optimizer(trainer)
+        if self._last_value is not None:
+            value = self._last_value
+        else:
+            value = self._init
+        self._update_value(optimizer, value)
+
+    def __call__(self, trainer):
+        self._t += 1
+        optimizer = self._get_optimizer(trainer)
+        value = self._init * self._gamma ** numpy.floor(self._t / self._step)
+        self._update_value(optimizer, value)
+
+    def serialize(self, serializer):
+        self._t = serializer('_t', self._t)
+        self._last_value = serializer('_last_value', self._last_value)
+        if isinstance(self._last_value, numpy.ndarray):
+            self._last_value = numpy.asscalar(self._last_value)
+
+    def _get_optimizer(self, trainer):
+        return self._optimizer or trainer.updater.get_optimizer('main')
+
+    def _update_value(self, optimizer, value):
+        setattr(optimizer, self._attr, value)
+        self._last_value = value

--- a/chainer/training/extensions/step_shift.py
+++ b/chainer/training/extensions/step_shift.py
@@ -7,12 +7,17 @@ from chainer.training import extension
 
 class StepShift(extension.Extension):
 
-    """Trainer extension to multiply an optimizer attribute by a fixed value
-    for every ``k`` iterations.
+    """Trainer extension to shift an optimizer attribute in "steps".
 
-    For example, given ``k``, a multiplier ``gamma`` and an initial value
+    This extension multiplies the specified attribute of the optimizer in
+    "steps". The typical use case is to scale the attribute at every ``k``th
+    iteration.
+
+    For example, suppose that this extension is invoked at every iteration,
+    then given ``k``, a multiplier ``gamma`` and an initial value
     ``init``, the optimizer attribute is set to
-    ``init * gamma ^ (floor(iter / k))``.
+    ``init * gamma ^ (floor(i / k))``, where ``i`` represents the index of the
+    current iteration.
 
     This extension is also called before the training loop starts by default.
 

--- a/chainer/training/extensions/step_shift.py
+++ b/chainer/training/extensions/step_shift.py
@@ -10,9 +10,9 @@ class StepShift(extension.Extension):
     """Trainer extension to multiply an optimizer attribute by a fixed value
     for every ``k`` iterations.
 
-    For example, suppose that this extension is called at every k iterations,
-    with a multiplier ``gamma`` and an initial value ``init``, then the
-    optimizer attribute will be set to ``init * gamma ^ (floor(iter / k))``.
+    For example, given ``k``, a multiplier ``gamma`` and an initial value
+    ``init``, the optimizer attribute is set to
+    ``init * gamma ^ (floor(iter / k))``.
 
     This extension is also called before the training loop starts by default.
 
@@ -20,8 +20,7 @@ class StepShift(extension.Extension):
         attr (str): Name of the optimizer attribute to adjust.
         init (float): The initial value of the attribute.
         gamma (float): The multiplier.
-        step (int): The number of iterations to do the multiplication, i.e.,
-            ``k``.
+        step (int): The interval for the multiplication, i.e., ``k``.
         optimizer (~chainer.Optimizer): Target optimizer object. If it is None,
             the main optimizer of the trainer is used.
 

--- a/docs/source/reference/training.rst
+++ b/docs/source/reference/training.rst
@@ -102,6 +102,7 @@ The typical use case is to change the learning rate of the optimizer over time.
    chainer.training.extensions.InverseShift
    chainer.training.extensions.LinearShift
    chainer.training.extensions.PolynomialShift
+   chainer.training.extensions.StepShift
 
 Reporting
 ~~~~~~~~~

--- a/tests/chainer_tests/training_tests/extensions_tests/test_step_shift.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_step_shift.py
@@ -1,0 +1,72 @@
+import unittest
+
+import mock
+
+from chainer import testing
+from chainer import training
+from chainer.training import extensions
+
+
+class TestStepShift(unittest.TestCase):
+
+    init = 1.0
+    gamma = 2.0
+    step = 2
+    expect = [1.0, 1.0, 2.0, 2.0, 4.0, 4.0, 8.0, 8.0, 16.0, 16.0]
+
+    def setUp(self):
+        self.optimizer = mock.MagicMock()
+        self.extension = extensions.StepShift(
+            'x', self.init, self.gamma, self.step)
+
+        self.interval = 1
+        self.trigger = training.get_trigger((self.interval, 'iteration'))
+
+        self.trainer = testing.get_trainer_with_mock_updater(self.trigger)
+        self.trainer.updater.get_optimizer.return_value = self.optimizer
+
+    def _run_trainer(self, extension, expect, optimizer=None):
+        if optimizer is None:
+            optimizer = self.optimizer
+        extension.initialize(self.trainer)
+
+        actual = []
+        for _ in expect:
+            self.trainer.updater.update()
+            actual.append(optimizer.x)
+            if self.trigger(self.trainer):
+                extension(self.trainer)
+
+        self.assertEqual(actual, expect)
+
+    def test_basic(self):
+        self.optimizer.x = 0
+        extension = extensions.StepShift(
+            'x', self.init, self.gamma, self.step)
+        self._run_trainer(extension, self.expect)
+
+    def test_with_optimizer(self):
+        optimizer = mock.Mock()
+        optimizer.x = 0
+        extension = extensions.StepShift(
+            'x', self.init, self.gamma, self.step, optimizer)
+        self._run_trainer(extension, self.expect, optimizer)
+
+    def test_resume(self):
+        new_optimizer = mock.Mock()
+        new_extension = extensions.StepShift(
+            'x', self.init, self.gamma, self.step, new_optimizer)
+
+        self.trainer.extend(self.extension)
+        self.trainer.run()
+
+        new_trainer = testing.get_trainer_with_mock_updater((5, 'iteration'))
+        new_trainer.extend(new_extension)
+        testing.save_and_load_npz(self.trainer, new_trainer)
+
+        new_extension.initialize(new_trainer)
+        self.assertEqual(new_optimizer.x, self.optimizer.x)
+        self.assertIsInstance(new_optimizer.x, float)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds StepShift Extension to `Trainer`.

For example, given ``k``, a multiplier ``gamma`` and an initial value ``init``, the optimizer attribute is set to ``init * gamma ^ (floor(iter / k))``.

Docs and simple unittests are added.