### PR TITLE
Remove experimental warning

### DIFF
--- a/chainer/exporters/caffe.py
+++ b/chainer/exporters/caffe.py
@@ -9,7 +9,6 @@ import chainer
 from chainer import function
 from chainer import function_node
 from chainer.links.caffe.protobuf3 import caffe_pb2 as caffe_pb
-from chainer import utils
 from chainer import variable
 
 
@@ -434,7 +433,6 @@ def export(model, args, directory=None,
 
     """
 
-    utils.experimental('chainer.exporters.caffe.export')
     assert isinstance(args, (tuple, list))
     if len(args) != 1:
         raise NotImplementedError()

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -11,7 +11,6 @@ from chainer import _backprop_utils
 from chainer.backends import cuda
 from chainer import configuration
 from chainer import function_hook
-from chainer.utils import experimental
 from chainer.utils import type_check
 from chainer import variable
 
@@ -308,8 +307,6 @@ Use apply() method instead.\
                 self._retained_output_data = tuple(retained_data)
 
             self.lazy_grad_sum = configuration.config.lazy_grad_sum
-            if self.lazy_grad_sum:
-                experimental('config.lazy_grad_sum')
 
         return ret
 

--- a/chainer/functions/pooling/average_pooling_nd.py
+++ b/chainer/functions/pooling/average_pooling_nd.py
@@ -9,7 +9,6 @@ from chainer.backends import cuda
 from chainer import function_node
 from chainer.functions.pooling import average_pooling_nd_kernel
 from chainer.functions.pooling import pooling_nd
-from chainer import utils
 from chainer.utils import conv
 from chainer.utils import conv_nd
 
@@ -48,7 +47,6 @@ class AveragePoolingND(pooling_nd._PoolingND):
             raise ValueError(
                 'pad_value must be either 0 or None, not {}.'.format(
                     pad_value))
-        utils.experimental('chainer.functions.pooling.AveragePoolingND')
 
         # TODO(takagi) Support cover_all mode.
         if cover_all is True:

--- a/chainer/functions/pooling/max_pooling_nd.py
+++ b/chainer/functions/pooling/max_pooling_nd.py
@@ -9,7 +9,6 @@ from chainer.backends import cuda
 from chainer import function_node
 from chainer.functions.pooling import max_pooling_nd_kernel
 from chainer.functions.pooling import pooling_nd
-from chainer import utils
 from chainer.utils import conv_nd
 
 
@@ -24,7 +23,6 @@ class MaxPoolingND(pooling_nd._PoolingND):
     """
 
     def __init__(self, ndim, ksize, stride=None, pad=0, cover_all=True):
-        utils.experimental('chainer.functions.pooling.MaxPoolingND')
         super(MaxPoolingND, self).__init__(
             ndim, ksize, stride=stride, pad=pad, cover_all=cover_all)
 

--- a/chainer/functions/pooling/unpooling_nd.py
+++ b/chainer/functions/pooling/unpooling_nd.py
@@ -4,7 +4,6 @@ import six
 from chainer.backends import cuda
 from chainer import function_node
 from chainer.functions.pooling import pooling_nd
-from chainer import utils
 from chainer.utils import conv
 from chainer.utils import conv_nd
 from chainer.utils import type_check
@@ -23,7 +22,6 @@ class UnpoolingND(pooling_nd._PoolingND):
                  cover_all=True):
         super(UnpoolingND, self).__init__(ndim, ksize, stride, pad, cover_all)
         self.outs = None if outsize is None else outsize
-        utils.experimental('chainer.functions.pooling.UnpoolingND')
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()

--- a/chainer/functions/theano/theano_function.py
+++ b/chainer/functions/theano/theano_function.py
@@ -3,14 +3,12 @@ import six
 
 from chainer.backends import cuda
 from chainer import function
-from chainer import utils
 from chainer.utils import type_check
 
 
 class TheanoFunction(function.Function):
 
     def __init__(self, forward_func, backward_func):
-        utils.experimental('chainer.functions.TheanoFunction')
         self.forward_func = forward_func
         self.backward_func = backward_func
 

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -5,7 +5,6 @@ from chainer.functions.array import concat
 from chainer.functions.array import split_axis
 from chainer import link
 from chainer.links.connection import linear
-from chainer import utils
 
 
 class ChildSumTreeLSTM(link.Chain):
@@ -61,7 +60,6 @@ class ChildSumTreeLSTM(link.Chain):
 
         self.in_size = in_size
         self.state_size = out_size
-        utils.experimental('chainer.links.tree_lstm.py')
 
     def __call__(self, *cshsx):
         """Returns new cell state and output of Child-Sum TreeLSTM.
@@ -199,7 +197,6 @@ class NaryTreeLSTM(link.Chain):
         self.in_size = in_size
         self.state_size = out_size
         self.n_ary = n_ary
-        utils.experimental('chainer.links.tree_lstm.py')
 
     def __call__(self, *cshsx):
         """Returns new cell state and output of N-ary TreeLSTM.

--- a/chainer/links/normalization/layer_normalization.py
+++ b/chainer/links/normalization/layer_normalization.py
@@ -3,7 +3,6 @@ import operator
 
 from chainer.functions.normalization import layer_normalization
 from chainer import link
-from chainer import utils
 from chainer import variable
 
 
@@ -60,9 +59,6 @@ class LayerNormalization(link.Link):
 
         if size is not None:
             self._initialize_params(size)
-
-        utils.experimental(
-            'chainer.links.normalization.layer_normalization.py')
 
     def _initialize_params(self, size):
         self.gamma.initialize(size)

--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -2,7 +2,6 @@ import collections
 
 from chainer.functions.theano import theano_function
 from chainer import link
-from chainer import utils
 
 
 def _to_var_tuple(vs):
@@ -67,7 +66,6 @@ class TheanoFunction(link.Link):
     """
 
     def __init__(self, inputs, outputs):
-        utils.experimental('chainer.links.TheanoFunction')
         try:
             # When Theano library is imported, it executes a lot of
             # initialization process. To minimize its side effect,


### PR DESCRIPTION
We have changed the policy so that we no longer use the warning to
indicate that a feature is experimental, and instead we should write
the status in the documentation.
