### PR TITLE
[backport] Stop using freeze_running_statistics in TestFixedBatchRenormalization

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -153,11 +153,13 @@ class TestFixedBatchRenormalization(unittest.TestCase):
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
 
+    def _forward(self, *args):
+        return batch_renormalization.fixed_batch_renormalization(
+            *args, eps=self.eps)
+
     def check_forward(self, args):
         with chainer.using_config('train',  self.train):
-            y = batch_renormalization.fixed_batch_renormalization(
-                *[chainer.Variable(i) for i in args],
-                eps=self.eps)
+            y = self._forward(*args)
         self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _batch_renormalization(
@@ -180,11 +182,7 @@ class TestFixedBatchRenormalization(unittest.TestCase):
     def check_backward(self, args, y_grad):
         with chainer.using_config('train',  self.train):
             gradient_check.check_backward(
-                batch_renormalization.BatchRenormalizationFunction(
-                    mean=None, var=None,
-                    decay=self.decay, eps=self.eps,
-                    rmax=self.rmax, dmax=self.dmax,
-                    freeze_running_statistics=True),
+                self._forward,
                 args, y_grad, **self.check_backward_options)
 
     @condition.retry(3)


### PR DESCRIPTION
Backport of #4868