### PR TITLE
Fix `SigmoidCrossEntropy.backward`

### DIFF
--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -60,8 +60,9 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
     def backward(self, inputs, grad_outputs):
         x, t = self.get_retained_inputs()
         gy, = grad_outputs
-        return SigmoidCrossEntropyGrad(
+        gx, = SigmoidCrossEntropyGrad(
             self.reduce, self.count, self.ignore_mask, t.data).apply((x, gy))
+        return gx, None
 
 
 class SigmoidCrossEntropyGrad(function_node.FunctionNode):
@@ -88,10 +89,10 @@ class SigmoidCrossEntropyGrad(function_node.FunctionNode):
         else:
             gx = (gy * self.ignore_mask * (y - self.t)).astype(y.dtype)
 
-        return gx, None
+        return gx,
 
     def backward(self, indexes, grad_outputs):
-        ggx, _ = grad_outputs
+        ggx, = grad_outputs
         x, gy = self.get_retained_inputs()
         y = chainer.functions.sigmoid(x)
         yp = y * (1 - y)

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -616,6 +616,8 @@ def check_double_backward(func, x_data, y_grad, x_grad_grad, params=(),
     params_grad_grad = _as_tuple(params_grad_grad)
     n_x = len(x_data)
 
+    first_order_no_grads = [x.dtype.kind != 'f' for x in x_data]
+
     def first_order_grad(*inputs):
         xs = inputs[:n_x]
         gys = inputs[n_x:]
@@ -628,7 +630,19 @@ def check_double_backward(func, x_data, y_grad, x_grad_grad, params=(),
 
         y.backward(enable_double_backprop=True)
 
-        return tuple([x.grad_var for x in xs] + [p.grad_var for p in params])
+        gxs = []
+        for skip, x in six.moves.zip(first_order_no_grads, xs):
+            if skip:
+                if x.grad is not None:
+                    raise RuntimeError(
+                        'gradient of int variable must be None')
+            else:
+                if x.grad is None:
+                    raise RuntimeError(
+                        'gradients of some arguments are not calculated')
+                gxs.append(x.grad_var)
+
+        return tuple(gxs + [p.grad_var for p in params])
 
     inputs = x_data + y_grad
     grad_grad = x_grad_grad + params_grad_grad

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -190,7 +190,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
                 x, t, normalize=normalize, reduce=reduce)
 
         gradient_check.check_double_backward(
-            f, (x_data, t_data), y_grad, (gx_grad, None),
+            f, (x_data, t_data), y_grad, (gx_grad,),
             **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):


### PR DESCRIPTION
This fixes #4877, probably.
- [x] Fix backward
- [x] Fix tests
