### PR TITLE
[backport] Tentatively restrict pytest-timeout version to <1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,9 @@ requirements = {
     'travis': [
         '-r stylecheck',
         '-r test',
-        'pytest-timeout',
+        # pytest-timeout>=1.3.0 requires pytest>=3.6.
+        # TODO(niboshi): Consider upgrading pytest to >=3.6
+        'pytest-timeout<1.3.0',
         'pytest-cov',
         'theano',
         'h5py',
@@ -60,7 +62,9 @@ requirements = {
     ],
     'appveyor': [
         '-r test',
-        'pytest-timeout',
+        # pytest-timeout>=1.3.0 requires pytest>=3.6.
+        # TODO(niboshi): Consider upgrading pytest to >=3.6
+        'pytest-timeout<1.3.0',
         'pytest-cov',
     ],
 }


### PR DESCRIPTION
Backport of #4918