### PR TITLE
Revert "Tentatively restrict pytest-timeout version to <1.3.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,7 @@ requirements = {
     'travis': [
         '-r stylecheck',
         '-r test',
-        # pytest-timeout>=1.3.0 requires pytest>=3.6.
-        # TODO(niboshi): Consider upgrading pytest to >=3.6
-        'pytest-timeout<1.3.0',
+        'pytest-timeout',
         'pytest-cov',
         'theano',
         'h5py',
@@ -62,9 +60,7 @@ requirements = {
     ],
     'appveyor': [
         '-r test',
-        # pytest-timeout>=1.3.0 requires pytest>=3.6.
-        # TODO(niboshi): Consider upgrading pytest to >=3.6
-        'pytest-timeout<1.3.0',
+        'pytest-timeout',
         'pytest-cov',
     ],
 }


### PR DESCRIPTION
Reverts chainer/chainer#4918

I cleared [Travis cache](https://travis-ci.org/chainer/chainer/caches). Check if it resolves the issue.