### PR TITLE
[RFC] Add `params` and `xp` to `Distribution`

### DIFF
--- a/chainer/distribution.py
+++ b/chainer/distribution.py
@@ -1,5 +1,7 @@
 import copy
 
+from chainer.backends import cuda
+
 
 class Distribution(object):
 
@@ -328,6 +330,15 @@ class Distribution(object):
 
         """
         raise NotImplementedError
+
+    @property
+    def xp(self):
+        """Array module for the distribution.
+
+        Depending on which of CPU/GPU this distribution is on, this property
+        returns :mod:`numpy` or :mod:`cupy`.
+        """
+        return cuda.get_array_module(*self.params.values())
 
 
 _KLDIVERGENCE = {}

--- a/chainer/distribution.py
+++ b/chainer/distribution.py
@@ -203,6 +203,16 @@ class Distribution(object):
         """
         raise NotImplementedError
 
+    @property
+    def params(self):
+        """Returns the parameters of the distribution.
+
+        Returns:
+            dict: The parameters of the distribution.
+
+        """
+        raise NotImplementedError
+
     def perplexity(self, x):
         """Evaluates the perplexity function at the given points.
 

--- a/chainer/distributions/normal.py
+++ b/chainer/distributions/normal.py
@@ -88,6 +88,10 @@ class Normal(distribution.Distribution):
     def mean(self):
         return self.loc
 
+    @property
+    def params(self):
+        return {'loc': self.loc, 'scale': self.scale}
+
     def prob(self, x):
         return PROBC / broadcast.broadcast_to(self.scale, x.shape) * \
             exponential.exp(


### PR DESCRIPTION
I'd like to have `Distribution.params` to get all the parameters (in the statistics' sense) in a tuple or a dict.  This name can be confusing because `Link` has `params` method with different meaning.
In ChainerRL, `params` method returns a tuple of `Variable`s.

`params` can be used to give the default implementation of `Distribution.xp`.