### PR TITLE
Fix ValueError in caffe exporter on Windows with Python 2.7

### DIFF
--- a/chainer/exporters/caffe.py
+++ b/chainer/exporters/caffe.py
@@ -116,10 +116,10 @@ class _RetrieveAsCaffeModel(object):
             s += ' ' * (depth * indent)
             s += '}\n'
             return s
-        elif isinstance(layer_params, (int, float)):
-            return '{}: {}\n'.format(name, layer_params)
         elif isinstance(layer_params, bool):
             return '{}: {}\n'.format(name, 'true' if layer_params else 'false')
+        elif isinstance(layer_params, six.integer_types + (float,)):
+            return '{}: {}\n'.format(name, layer_params)
         elif isinstance(layer_params, str):
             return '{}: "{}"\n'.format(name, layer_params)
         elif isinstance(layer_params, list):


### PR DESCRIPTION
This fixes type mismatch error on Windows 64-bit w/ Python 2.7. Fixes #4927.

https://ci.appveyor.com/project/pfnet/chainer/build/10765/job/9m4yuq02f3426yv8

(will remove WIP after I confirmed AppVeyor test pass)