### PR TITLE
Suggest users to use iDeep4py v1 for now

### DIFF
--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -117,7 +117,7 @@ On recommended systems, you can install iDeep wheel (binary distribution) by:
 
 .. code-block:: console
 
-    $ pip install ideep4py
+    $ pip install 'ideep4py<2'
 
 Enable iDeep Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Refs #4933.

iDeep4py v2 seems to have different API than v1, and it also has a separate package for AVX2 environment and AVX512 environment.