### PR TITLE
Add support for importing and exporting Caffe Deconvolution layer

### DIFF
--- a/chainer/exporters/caffe.py
+++ b/chainer/exporters/caffe.py
@@ -193,6 +193,7 @@ class _RetrieveAsCaffeModel(object):
                 params['type'] = 'Convolution'
             else:
                 params['type'] = 'Deconvolution'
+                convolution_param['num_output'] = n_in
             params['convolution_param'] = convolution_param
 
             if net is not None:

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -10,6 +10,7 @@ from chainer import initializer
 from chainer import link
 from chainer.links.caffe.protobuf3 import caffe_pb2 as caffe_pb
 from chainer.links.connection import convolution_2d
+from chainer.links.connection import deconvolution_2d
 from chainer.links.connection import linear
 from chainer.links.connection import scale
 from chainer.links.normalization import batch_normalization
@@ -259,6 +260,30 @@ class CaffeFunction(link.Chain):
         n_out = num
 
         func = convolution_2d.Convolution2D(
+            n_in, n_out, ksize, stride, pad, nobias=not bias_term,
+            initialW=_ConvolutionBlob(blobs[0], param.group),
+            initial_bias=_Blob(blobs[1]) if bias_term else None)
+
+        with self.init_scope():
+            setattr(self, layer.name, func)
+        self.forwards[layer.name] = _CallChildLink(self, layer.name)
+        self._add_layer(layer)
+
+    @_layer('Deconvolution', 'DECONVOLUTION')
+    def _setup_deconvolution(self, layer):
+        blobs = layer.blobs
+        param = layer.convolution_param
+        ksize = _get_ksize(param)
+        stride = _get_stride(param)
+        pad = _get_pad(param)
+        num = _get_num(blobs[0])
+        channels = _get_channels(blobs[0])
+        bias_term = param.bias_term
+
+        n_in = num
+        n_out = channels * param.group
+
+        func = deconvolution_2d.Deconvolution2D(
             n_in, n_out, ksize, stride, pad, nobias=not bias_term,
             initialW=_ConvolutionBlob(blobs[0], param.group),
             initial_bias=_Blob(blobs[1]) if bias_term else None)

--- a/tests/chainer_tests/exporters_tests/test_caffe.py
+++ b/tests/chainer_tests/exporters_tests/test_caffe.py
@@ -35,12 +35,14 @@ class TestCaffeExport(unittest.TestCase):
                 with self.init_scope():
                     self.l1 = L.Convolution2D(None, 1, 1, 1, 0)
                     self.b2 = L.BatchNormalization(1, eps=1e-2)
-                    self.l3 = L.Linear(None, 1)
+                    self.l3 = L.Deconvolution2D(None, 1, 1, 1, 0)
+                    self.l4 = L.Linear(None, 1)
 
             def __call__(self, x):
                 h = F.relu(self.l1(x))
                 h = self.b2(h)
-                return self.l3(h)
+                h = self.l3(h)
+                return self.l4(h)
 
         assert_export_import_match(Model(), self.x)
 


### PR DESCRIPTION
I fixed Caffe Deconvolution layer to export properly `num_output` param. Also, I added support for importing the layer. I tested these features with [waifu2x-chainer](https://github.com/tsurumeso/waifu2x-chainer) that contains Deconvolution layer and I confirmed that it works correctly.