### PR TITLE
[backport] Delete redundant `no_grads` from test

### DIFF
--- a/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_simplified_dropconnect.py
@@ -95,7 +95,7 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         gradient_check.check_backward(
             self.link_wrapper, (x_data, mask), y_grad,
             (self.link.W, self.link.b),
-            no_grads=(False, True), dtype='d', **self.check_backward_options)
+            dtype='d', **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy, self.mask)
@@ -161,7 +161,7 @@ class TestSimplifiedDropconnectParameterShapePlaceholder(unittest.TestCase):
     def check_backward(self, x_data, y_grad, mask):
         gradient_check.check_backward(
             self.link_wrapper, (x_data, mask), y_grad,
-            (self.link.W, self.link.b), dtype='d', no_grads=(False, True),
+            (self.link.W, self.link.b), dtype='d',
             atol=1e-4, rtol=1e-3)
 
     def test_backward_cpu(self):


### PR DESCRIPTION
Backport of #4914