### PR TITLE
[backport] Remove wrong-length check from `GetItem.check_type_forward`

### DIFF
--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -32,9 +32,6 @@ class GetItem(function_node.FunctionNode):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 1)
-        n_nones = len([item for item in self.slices if item is None])
-        valid_slice = len(self.slices) - n_nones
-        type_check.expect(in_types[0].ndim >= valid_slice)
 
     def forward(self, xs):
         return utils.force_array(xs[0][self.slices]),

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -9,7 +9,6 @@ from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import parameterize
-from chainer.utils import type_check
 
 
 @parameterize(
@@ -124,6 +123,8 @@ class TestGetItem(unittest.TestCase):
         'sliced_shape': (4, 2, 2)},
     {'slices': numpy.array([False, False, False, False]),
         'sliced_shape': (0, 3, 2)},
+    {'slices': (3, 2, Ellipsis, 1),
+     'sliced_shape': ()},
 )
 class TestGetItemAdvanced(unittest.TestCase):
 
@@ -234,10 +235,6 @@ class TestInvalidGetItem(unittest.TestCase):
     def test_multiple_ellipsis(self):
         with self.assertRaises(ValueError):
             functions.get_item(self.x_data, (Ellipsis, Ellipsis))
-
-    def test_too_many_indices(self):
-        with self.assertRaises(type_check.InvalidType):
-            functions.get_item(self.x_data, (0, 0, 0, 0))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Backport of #4845