### PR TITLE
Fix operations in ChainList

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -990,12 +990,12 @@ class ChainList(Link, collections.MutableSequence):
 
     def __setitem__(self, index, value):
         if isinstance(index, int):
-            self._children[index].name = None
             value.name = str(index)
             self._children[index] = value
         elif isinstance(index, slice):
-            for i, j in enumerate(range(*index.indices(len(self._children)))):
-                self[j] = value[i]
+            self._children[index] = value
+            for i, c in enumerate(self._children):
+                c.name = str(i)
         else:
             raise TypeError(
                 'ChainList indices must be integers or slices, not %s' %
@@ -1014,8 +1014,9 @@ class ChainList(Link, collections.MutableSequence):
         return self._children[index]
 
     def __delitem__(self, index):
-        self._children[index].name = None
         del self._children[index]
+        for i, c in enumerate(self._children):
+            c.name = str(i)
 
     def insert(self, index, link):
         """Insert a child link at the given index.
@@ -1026,9 +1027,13 @@ class ChainList(Link, collections.MutableSequence):
             link (Link): The link to be inserted.
 
         """
-        self._children.insert(index, link)
-        for i in range(index, len(self._children)):
-            self._children[i].name = str(i)
+        if index == len(self._children):
+            self._children.append(link)
+            link.name = str(index)
+        else:
+            self._children.insert(index, link)
+            for i, c in enumerate(self._children):
+                c.name = str(i)
 
     def __iter__(self):
         return iter(self._children)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -1117,6 +1117,7 @@ class TestChainList(unittest.TestCase):
             self.l3.x = chainer.Parameter(shape=3)
         self.l4 = chainer.Link()
         self.l5 = chainer.Link()
+        self.l6 = chainer.Link()
         self.c1 = chainer.ChainList(self.l1)
         self.c1.add_link(self.l2)
         self.c2 = chainer.ChainList(self.c1)
@@ -1139,7 +1140,6 @@ class TestChainList(unittest.TestCase):
 
     def test_setitem(self):
         self.c1[1] = self.l3
-        self.assertIs(self.l2.name, None)
         self.assertEqual(self.l3.name, '1')
 
     def test_setitem_slice(self):
@@ -1147,10 +1147,24 @@ class TestChainList(unittest.TestCase):
         self.c1[3:0:-1] = [self.l4, self.l5]  # l1 l5 l4
         self.assertEqual(len(self.c1), 3)
         self.assertEqual(self.l1.name, '0')
-        self.assertIs(self.l2.name, None)
-        self.assertIs(self.l3.name, None)
         self.assertEqual(self.l4.name, '2')
         self.assertEqual(self.l5.name, '1')
+
+    def test_setitem_slice_short(self):
+        self.c1.append(self.l3)  # l1 l2 l3
+        self.c1[1:3] = [self.l4]  # l1 l4
+        self.assertEqual(len(self.c1), 2)
+        self.assertEqual(self.l1.name, '0')
+        self.assertEqual(self.l4.name, '1')
+
+    def test_setitem_slice_long(self):
+        self.c1.append(self.l3)  # l1 l2 l3
+        self.c1[1:3] = [self.l4, self.l5, self.l6]  # l1 l4 l5 l6
+        self.assertEqual(len(self.c1), 4)
+        self.assertEqual(self.l1.name, '0')
+        self.assertEqual(self.l4.name, '1')
+        self.assertEqual(self.l5.name, '2')
+        self.assertEqual(self.l6.name, '3')
 
     def test_iadd(self):
         self.c2 += self.c3
@@ -1159,9 +1173,8 @@ class TestChainList(unittest.TestCase):
 
     def test_delete_item(self):
         del self.c2[0]
-        self.assertIs(self.c1.name, None)
         self.assertEqual(len(self.c2), 1)
-        self.assertEqual(self.l3.name, '1')
+        self.assertEqual(self.l3.name, '0')
 
     def test_assign_param_in_init_scope(self):
         p = chainer.Parameter()


### PR DESCRIPTION
This PR fix `ChainList` that is related to #4659 and #4660

- Support array assignment of different length arrays. 
- Set correct name.