### PR TITLE
Fix `GetItem.backward` for 0-dim boolean index

### DIFF
--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -61,11 +61,14 @@ class GetItemGrad(function_node.FunctionNode):
                 numpy.add.at(gx, self.slices, gy)
             except IndexError:
                 done = False
-                # In numpy<1.13, 0-dim boolean index is only supported by
-                # arr.__getitem__ for 0-dim arr.
+                # In numpy<1.13, 0-dim boolean index is not supported in
+                # numpy.add.at and it's supported for 0-dim arr in
+                # arr.__getitem__.
                 if not _numpy_supports_0d_bool_index and len(self.slices) == 1:
                     idx = numpy.asanyarray(self.slices[0])
                     if idx.dtype == numpy.dtype(bool):
+                        # Convert the array and the mask to 1-dim.
+                        # numpy.add.at with them is supported in older numpy.
                         numpy.add.at(gx[None], idx[None], gy)
                         done = True
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -124,13 +124,19 @@ class TestGetItem(unittest.TestCase):
     {'slices': numpy.array([False, False, False, False]),
         'sliced_shape': (0, 3, 2)},
     {'slices': (3, 2, Ellipsis, 1),
-     'sliced_shape': ()},
+        'sliced_shape': ()},
+    {'slices': (numpy.array(False)),
+        'input_shape': (), 'sliced_shape': (0,)},
+    {'slices': (numpy.array(True)),
+        'input_shape': (), 'sliced_shape': (1,)},
 )
 class TestGetItemAdvanced(unittest.TestCase):
 
+    input_shape = (4, 3, 2)
+
     def setUp(self):
         self.x_data = numpy.random.uniform(
-            -1, 1, (4, 3, 2)).astype(numpy.float32)
+            -1, 1, self.input_shape).astype(numpy.float32)
         self.gy_data = numpy.random.uniform(
             -1, 1, self.sliced_shape).astype(numpy.float32)
 


### PR DESCRIPTION
Fix #4957