### PR TITLE
Add maxtasksperchild parameter for MultiprocessIterator

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -345,7 +345,8 @@ class _PrefetchLoop(object):
         self._pool = multiprocessing.Pool(
             processes=self.n_processes,
             initializer=_fetch_setup,
-            initargs=(self.dataset, self.mem_size, self.mem_bulk))
+            initargs=(self.dataset, self.mem_size, self.mem_bulk),
+            maxtasksperchild=10)
         if self._interruption_testing:
             pids = self._pool.map(_report_pid, range(self.n_processes))
             print(' '.join(map(str, pids)))

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -56,6 +56,7 @@ class DummyDeserializer(serializer.Deserializer):
     'shared_mem': [None, 1000000],
     'order_sampler': [
         None, lambda order, _: numpy.random.permutation(len(order))],
+    'maxtasksperchild': [None, 1, 10],
 }))
 class TestMultiprocessIterator(unittest.TestCase):
 
@@ -63,7 +64,8 @@ class TestMultiprocessIterator(unittest.TestCase):
         self.n_processes = 2
         self.options = {'n_processes': self.n_processes,
                         'n_prefetch': self.n_prefetch,
-                        'shared_mem': self.shared_mem}
+                        'shared_mem': self.shared_mem,
+                        'maxtasksperchild': self.maxtasksperchild}
         if self.order_sampler is not None:
             self.options.update(
                 {'order_sampler': self.order_sampler})


### PR DESCRIPTION
fixes https://github.com/chainer/chainer/issues/4946

In `_PrefetchLoop` class, `multiprocess.Pool` is used but `maxtasksperchild` is set to `None` as default.
As original document noted ( https://docs.python.org/3.6/library/multiprocessing.html#multiprocessing.pool.Pool ), it was recommended to clean processes by setting `maxtasksperchild`. 

May I suggest to add `maxtasksperchild` parameter to `MultiprocessIterator`?