### PR TITLE
Fix invalid keyword arguments to `L.Linear` in ImageNet example

### DIFF
--- a/examples/imagenet/googlenetbn.py
+++ b/examples/imagenet/googlenetbn.py
@@ -147,19 +147,19 @@ class GoogLeNetBNFp16(GoogLeNetBN):
             self.inc5b = L.InceptionBN(
                 None, 352, 192, 320, 192, 224, 'max', 128,
                 conv_init=W, dtype=dtype)
-            self.out = L.Linear(None, 1000, initialW=W, bias=bias)
+            self.out = L.Linear(None, 1000, initialW=W, initial_bias=bias)
 
             self.conva = L.Convolution2D(None, 128, 1, initialW=W, nobias=True)
             self.norma = L.BatchNormalization(128, dtype=dtype)
             self.lina = L.Linear(None, 1024, initialW=W, nobias=True)
             self.norma2 = L.BatchNormalization(1024, dtype=dtype)
-            self.outa = L.Linear(None, 1000, initialW=W, bias=bias)
+            self.outa = L.Linear(None, 1000, initialW=W, initial_bias=bias)
 
             self.convb = L.Convolution2D(None, 128, 1, initialW=W, nobias=True)
             self.normb = L.BatchNormalization(128, dtype=dtype)
             self.linb = L.Linear(None, 1024, initialW=W, nobias=True)
             self.normb2 = L.BatchNormalization(1024, dtype=dtype)
-            self.outb = L.Linear(None, 1000, initialW=W, bias=bias)
+            self.outb = L.Linear(None, 1000, initialW=W, initial_bias=bias)
 
     def __call__(self, x, t):
         return GoogLeNetBN.__call__(self, F.cast(x, self.dtype), t)


### PR DESCRIPTION
This fixes the issue that `--arch googlenet_fp16` does not work.