### PR TITLE
Eliminate `no_grads` and squares in double backward tests

### DIFF
--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -188,6 +188,9 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
                 return _make_data_default(shape, dtype)[0:2]
             make_data = aux
 
+    if is_linear is not None:
+        warnings.warn('is_linear option is deprecated', DeprecationWarning)
+
     def f(klass):
         assert issubclass(klass, unittest.TestCase)
 
@@ -251,9 +254,6 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
 
         if is_new_style:
             def check_double_backward(self, x_data, y_grad, x_grad_grad):
-                if is_linear is not None:
-                    warnings.warn('is_linear option is deprecated',
-                                  DeprecationWarning)
                 gradient_check.check_double_backward(
                     func, x_data, y_grad,
                     x_grad_grad, **self.double_backward_options)

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -56,7 +56,7 @@ def _nonlinear(func):
 
 
 def unary_math_function_unittest(func, func_expected=None, label_expected=None,
-                                 make_data=None, is_linear=False,
+                                 make_data=None, is_linear=None,
                                  forward_options=None,
                                  backward_options=None,
                                  double_backward_options=None):
@@ -80,9 +80,11 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
             and returns a tuple of input, gradient and double gradient data. By
             default, uniform destribution ranged ``[-1, 1]`` is used for all of
             them.
-        is_linear(bool): Tells the decorator that ``func`` is a linear function
+        is_linear: Tells the decorator that ``func`` is a linear function
             so that it wraps ``func`` as a non-linear function to perform
-            double backward test. The default value is ``False``.
+            double backward test. This argument is left for backward
+            compatibility. Linear functions can be tested by default without
+            specifying ``is_linear`` in Chainer v5 or later.
         forward_options(dict): Options to be specified as an argument of
             :func:`chainer.testing.assert_allclose` function.
             If not given, preset tolerance values are automatically selected.
@@ -194,6 +196,9 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
             def aux(shape, dtype):
                 return _make_data_default(shape, dtype)[0:2]
             make_data = aux
+
+    if is_linear is not None:
+        warnings.warn('is_linear option is deprecated', DeprecationWarning)
 
     def f(klass):
         assert issubclass(klass, unittest.TestCase)

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 
@@ -48,15 +49,8 @@ def _make_data_default(shape, dtype):
     return x, gy, ggx
 
 
-def _nonlinear(func):
-    def aux(x):
-        y = func(x)
-        return y * y
-    return aux
-
-
 def unary_math_function_unittest(func, func_expected=None, label_expected=None,
-                                 make_data=None, is_linear=False,
+                                 make_data=None, is_linear=None,
                                  forward_options=None,
                                  backward_options=None,
                                  double_backward_options=None):
@@ -80,9 +74,8 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
             and returns a tuple of input, gradient and double gradient data. By
             default, uniform destribution ranged ``[-1, 1]`` is used for all of
             them.
-        is_linear(bool): Tells the decorator that ``func`` is a linear function
-            so that it wraps ``func`` as a non-linear function to perform
-            double backward test. The default value is ``False``.
+        is_linear: This argument has no effect. It is left for backward
+            compatibility.
         forward_options(dict): Options to be specified as an argument of
             :func:`chainer.testing.assert_allclose` function.
             If not given, preset tolerance values are automatically selected.
@@ -258,9 +251,11 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
 
         if is_new_style:
             def check_double_backward(self, x_data, y_grad, x_grad_grad):
-                func1 = _nonlinear(func) if is_linear else func
+                if is_linear is not None:
+                    warnings.warn('is_linear option is deprecated',
+                                  DeprecationWarning)
                 gradient_check.check_double_backward(
-                    func1, x_data, y_grad,
+                    func, x_data, y_grad,
                     x_grad_grad, **self.double_backward_options)
             setattr(klass, "check_double_backward", check_double_backward)
 

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -188,9 +188,6 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
                 return _make_data_default(shape, dtype)[0:2]
             make_data = aux
 
-    if is_linear is not None:
-        warnings.warn('is_linear option is deprecated', DeprecationWarning)
-
     def f(klass):
         assert issubclass(klass, unittest.TestCase)
 
@@ -254,6 +251,9 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
 
         if is_new_style:
             def check_double_backward(self, x_data, y_grad, x_grad_grad):
+                if is_linear is not None:
+                    warnings.warn('is_linear option is deprecated',
+                                  DeprecationWarning)
                 gradient_check.check_double_backward(
                     func, x_data, y_grad,
                     x_grad_grad, **self.double_backward_options)

--- a/chainer/testing/unary_math_function_test.py
+++ b/chainer/testing/unary_math_function_test.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import numpy
 
@@ -49,8 +48,15 @@ def _make_data_default(shape, dtype):
     return x, gy, ggx
 
 
+def _nonlinear(func):
+    def aux(x):
+        y = func(x)
+        return y * y
+    return aux
+
+
 def unary_math_function_unittest(func, func_expected=None, label_expected=None,
-                                 make_data=None, is_linear=None,
+                                 make_data=None, is_linear=False,
                                  forward_options=None,
                                  backward_options=None,
                                  double_backward_options=None):
@@ -74,8 +80,9 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
             and returns a tuple of input, gradient and double gradient data. By
             default, uniform destribution ranged ``[-1, 1]`` is used for all of
             them.
-        is_linear: This argument has no effect. It is left for backward
-            compatibility.
+        is_linear(bool): Tells the decorator that ``func`` is a linear function
+            so that it wraps ``func`` as a non-linear function to perform
+            double backward test. The default value is ``False``.
         forward_options(dict): Options to be specified as an argument of
             :func:`chainer.testing.assert_allclose` function.
             If not given, preset tolerance values are automatically selected.
@@ -251,11 +258,9 @@ def unary_math_function_unittest(func, func_expected=None, label_expected=None,
 
         if is_new_style:
             def check_double_backward(self, x_data, y_grad, x_grad_grad):
-                if is_linear is not None:
-                    warnings.warn('is_linear option is deprecated',
-                                  DeprecationWarning)
+                func1 = _nonlinear(func) if is_linear else func
                 gradient_check.check_double_backward(
-                    func, x_data, y_grad,
+                    func1, x_data, y_grad,
                     x_grad_grad, **self.double_backward_options)
             setattr(klass, "check_double_backward", check_double_backward)
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -84,8 +84,7 @@ class TestClippedReLU(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
         def f(x):
-            y = functions.clipped_relu(x, self.z)
-            return y * y
+            return functions.clipped_relu(x, self.z)
 
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/activation_tests/test_crelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_crelu.py
@@ -85,8 +85,7 @@ class TestCReLU(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = chainer.functions.crelu(x, self.axis)
-            return y * y
+            return chainer.functions.crelu(x, self.axis)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
@@ -68,8 +68,7 @@ class TestELU(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = functions.elu(x, alpha=self.alpha)
-            return y * y
+            return functions.elu(x, alpha=self.alpha)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/activation_tests/test_hard_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_hard_sigmoid.py
@@ -60,12 +60,9 @@ class TestHardSigmoid(unittest.TestCase):
                             cuda.to_gpu(self.gy))
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        def f(x):
-            y = functions.hard_sigmoid(x)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+            functions.hard_sigmoid, x_data, y_grad, x_grad_grad,
+            dtype=numpy.float64,
             **self.check_backward_option)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
@@ -67,8 +67,7 @@ class TestLeakyReLU(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = functions.leaky_relu(x, self.slope)
-            return y * y
+            return functions.leaky_relu(x, self.slope)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/activation_tests/test_prelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_prelu.py
@@ -73,12 +73,9 @@ class TestPReLU(unittest.TestCase):
 
     def check_double_backward(self, x_data, W_data, y_grad, x_grad_grad,
                               W_grad_grad):
-        def f(x, W):
-            y = functions.prelu(x, W)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, (x_data, W_data), y_grad, (x_grad_grad, W_grad_grad),
+            functions.prelu, (x_data, W_data), y_grad,
+            (x_grad_grad, W_grad_grad),
             **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -102,16 +102,12 @@ class TestReLU(unittest.TestCase):
             grad_outputs = _to_noncontiguous(grad_outputs)
             grad_grad_inputs = _to_noncontiguous(grad_grad_inputs)
 
-        def f(x):
-            x = functions.relu(x)
-            return x * x
-
         x, = inputs
         gy, = grad_outputs
         ggx, = grad_grad_inputs
         with backend_config:
             gradient_check.check_double_backward(
-                f, x, gy, ggx, dtype=numpy.float64,
+                functions.relu, x, gy, ggx, dtype=numpy.float64,
                 **self.check_double_backward_options)
 
     def test_double_backward(self, backend_config):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -80,13 +80,9 @@ class TestSigmoid(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
-        def f(x):
-            y = functions.sigmoid(x)
-            return y * y
-
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
-                f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+                functions.sigmoid, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
                 **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_sigmoid.py
@@ -82,7 +82,8 @@ class TestSigmoid(unittest.TestCase):
                               use_cudnn='always'):
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
-                functions.sigmoid, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+                functions.sigmoid, x_data, y_grad, x_grad_grad,
+                dtype=numpy.float64,
                 **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
@@ -61,8 +61,7 @@ class TestSoftplus(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
         def f(x):
-            y = functions.softplus(x, beta=self.beta)
-            return y * y
+            return functions.softplus(x, beta=self.beta)
 
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_broadcast.py
@@ -85,12 +85,8 @@ class TestBroadcast(unittest.TestCase):
         if len(data) == 1:
             return
 
-        def f(*xs):
-            ys = functions.broadcast(*xs)
-            return [y * y for y in ys]
-
         gradient_check.check_double_backward(
-            f, data, grads, gg, dtype=numpy.float64,
+            functions.broadcast, data, grads, gg, dtype=numpy.float64,
             **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_copy.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_copy.py
@@ -101,8 +101,7 @@ class TestCopy(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = functions.copy(x, -1)
-            return y * y
+            return functions.copy(x, -1)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/array_tests/test_depth_2_space.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_depth_2_space.py
@@ -87,8 +87,7 @@ class TestDepth2Space(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = functions.depth2space(x, self.r)
-            return y * y
+            return functions.depth2space(x, self.r)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/array_tests/test_diagonal.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_diagonal.py
@@ -59,8 +59,7 @@ class TestDiagonal(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            x = functions.diagonal(x, *self.args)
-            return x * x
+            return functions.diagonal(x, *self.args)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad,

--- a/tests/chainer_tests/functions_tests/array_tests/test_dstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_dstack.py
@@ -75,8 +75,7 @@ class TestDstack(unittest.TestCase):
 
     def check_double_backward(self, xs_data, y_grad, xs_grad_grad):
         def func(*xs):
-            y = functions.dstack(xs)
-            return y * y
+            return functions.dstack(xs)
 
         gradient_check.check_double_backward(
             func, xs_data, y_grad, xs_grad_grad, dtype='d',

--- a/tests/chainer_tests/functions_tests/array_tests/test_flip.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_flip.py
@@ -67,8 +67,7 @@ class TestFlip(unittest.TestCase):
 
     def check_double_backward(self, x_data, axis, y_grad, x_grad_grad):
         def f(x):
-            x = functions.flip(x, axis)
-            return x * x
+            return functions.flip(x, axis)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad,

--- a/tests/chainer_tests/functions_tests/array_tests/test_fliplr.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_fliplr.py
@@ -46,12 +46,8 @@ class TestFlipLR(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        def f(x):
-            y = functions.fliplr(x)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+            functions.fliplr, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
             atol=5e-4, rtol=5e-3)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_flipud.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_flipud.py
@@ -46,12 +46,8 @@ class TestFlipUD(unittest.TestCase):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        def f(x):
-            y = functions.flipud(x)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+            functions.flipud, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
             atol=5e-4, rtol=5e-3)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -80,8 +80,7 @@ class TestGetItem(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, ggx_data):
         def f(x):
-            y = functions.get_item(x, self.slices)
-            return y * y
+            return functions.get_item(x, self.slices)
 
         gradient_check.check_double_backward(
             f, (x_data,), y_grad, ggx_data, dtype='d')

--- a/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
@@ -76,8 +76,7 @@ class TestHstack(unittest.TestCase):
 
     def check_double_backward(self, xs_data, g_data, gg_data):
         def func(*xs):
-            y = functions.hstack(xs)
-            return y * y
+            return functions.hstack(xs)
 
         gradient_check.check_double_backward(
             func, xs_data, g_data, gg_data, dtype='d',

--- a/tests/chainer_tests/functions_tests/array_tests/test_im2col.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_im2col.py
@@ -148,10 +148,9 @@ class TestIm2Col(unittest.TestCase):
     def check_double_backward(self, x, ksize, stride, pad, cover_all, dilate,
                               gy, ggx):
         def f(x):
-            y = functions.im2col(
+            return functions.im2col(
                 x, ksize, stride=stride, pad=pad, cover_all=cover_all,
                 dilate=dilate)
-            return y * y
 
         gradient_check.check_double_backward(
             f, x, gy, ggx, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -83,8 +83,7 @@ class TestMoveaxis(unittest.TestCase):
 
     def check_double_backward(self, x_data, g_data, gg_data):
         def f(x):
-            y = functions.moveaxis(x, self.source, self.destination)
-            return y * y
+            return functions.moveaxis(x, self.source, self.destination)
 
         gradient_check.check_double_backward(
             f, x_data, g_data, gg_data, dtype='d',

--- a/tests/chainer_tests/functions_tests/array_tests/test_pad.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_pad.py
@@ -67,8 +67,7 @@ class TestPadDefault(unittest.TestCase):
 
     def check_double_backward(self, x_data, gy_data, ggx_data):
         def f(x):
-            y = functions.pad(x, pad_width=self.pad_width, mode=self.mode)
-            return y * y
+            return functions.pad(x, pad_width=self.pad_width, mode=self.mode)
 
         gradient_check.check_double_backward(
             f, x_data, gy_data, ggx_data, **self.check_backward_options)
@@ -145,10 +144,9 @@ class TestPad(unittest.TestCase):
 
     def check_double_backward(self, x_data, gy_data, ggx_data):
         def f(x):
-            y = functions.pad(
+            return functions.pad(
                 x, pad_width=self.pad_width, mode=self.mode,
                 constant_values=self.constant_values)
-            return y * y
 
         gradient_check.check_double_backward(
             f, x_data, gy_data, ggx_data, **self.check_backward_options)

--- a/tests/chainer_tests/functions_tests/array_tests/test_pad_sequence.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_pad_sequence.py
@@ -104,9 +104,8 @@ class TestPadSequence(unittest.TestCase):
             return
 
         def f(*xs):
-            y = functions.pad_sequence(
+            return functions.pad_sequence(
                 xs, length=self.length, padding=self.pad)
-            return y * y
 
         gradient_check.check_double_backward(
             f, xs, gy, ggxs, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -102,8 +102,7 @@ class TestRepeat(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = functions.repeat(x, self.repeats, self.axis)
-            return y * y
+            return functions.repeat(x, self.repeats, self.axis)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, **self.check_backward_options)

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -125,8 +125,7 @@ class TestResizeImagesBackward(unittest.TestCase):
 
     def check_double_backward(self, x, output_shape, gy, ggx):
         def f(x):
-            y = functions.resize_images(x, output_shape)
-            return y * y
+            return functions.resize_images(x, output_shape)
 
         gradient_check.check_double_backward(
             f, x, gy, ggx, atol=1e-2, rtol=1e-3)

--- a/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
@@ -63,8 +63,7 @@ class TestRollaxis(unittest.TestCase):
 
     def check_double_backward(self, x_data, g_data, gg_data):
         def f(x):
-            y = functions.rollaxis(x, self.axis, self.start)
-            return y * y
+            return functions.rollaxis(x, self.axis, self.start)
 
         gradient_check.check_double_backward(
             f, x_data, g_data, gg_data, dtype='d',

--- a/tests/chainer_tests/functions_tests/array_tests/test_scatter_add.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_scatter_add.py
@@ -74,8 +74,7 @@ class TestScatterAdd(unittest.TestCase):
     def check_double_backward(self, a_data, b_data, y_grad, a_grad_grad,
                               b_grad_grad):
         def f(a, b):
-            y = functions.scatter_add(a, self.slices, b)
-            return y * y
+            return functions.scatter_add(a, self.slices, b)
 
         gradient_check.check_double_backward(
             f, (a_data, b_data), y_grad, (a_grad_grad, b_grad_grad),

--- a/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_select_item.py
@@ -73,8 +73,7 @@ class TestSelectItem(unittest.TestCase):
 
     def check_double_backward(self, x_data, t_data, gy_data, ggx_data):
         def f(x):
-            y = functions.select_item(x, t_data)
-            return y * y
+            return functions.select_item(x, t_data)
 
         gradient_check.check_double_backward(
             f, x_data, gy_data, ggx_data, eps=0.01, dtype='d',

--- a/tests/chainer_tests/functions_tests/array_tests/test_space_2_depth.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_space_2_depth.py
@@ -87,8 +87,7 @@ class TestSpace2Depth(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = functions.space2depth(x, self.r)
-            return y * y
+            return functions.space2depth(x, self.r)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/array_tests/test_swapaxes.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_swapaxes.py
@@ -60,8 +60,7 @@ class TestSwapaxes(unittest.TestCase):
     @condition.retry(3)
     def check_double_backward(self, x_data, g_data, gg_data):
         def f(x):
-            y = functions.swapaxes(x, self.axis1, self.axis2)
-            return y * y
+            return functions.swapaxes(x, self.axis1, self.axis2)
 
         gradient_check.check_double_backward(
             f, x_data, g_data, gg_data, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/array_tests/test_tile.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_tile.py
@@ -60,8 +60,7 @@ class TestTile(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            y = functions.tile(x, self.reps)
-            return y * y
+            return functions.tile(x, self.reps)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, **self.check_backward_options)

--- a/tests/chainer_tests/functions_tests/array_tests/test_vstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_vstack.py
@@ -76,8 +76,7 @@ class TestVstack(unittest.TestCase):
 
     def check_double_backward(self, xs_data, y_grad, xs_grad_grad):
         def func(*xs):
-            y = functions.vstack(xs)
-            return y * y
+            return functions.vstack(xs)
 
         gradient_check.check_double_backward(
             func, xs_data, y_grad, xs_grad_grad, eps=2.0 ** -2, dtype='d',

--- a/tests/chainer_tests/functions_tests/connection_tests/test_bilinear.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_bilinear.py
@@ -129,24 +129,17 @@ class TestBilinearFunction(unittest.TestCase):
              cuda.to_gpu(self.ggW)), **self.check_backward_options)
 
     def test_full_double_backward_cpu(self):
-        def f(*inputs):
-            y = functions.bilinear(*inputs)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, (self.e1, self.e2, self.W, self.V1, self.V2, self.b),
+            functions.bilinear,
+            (self.e1, self.e2, self.W, self.V1, self.V2, self.b),
             self.gy,
             (self.gge1, self.gge2, self.ggW, self.ggV1, self.ggV2, self.ggb),
             **self.check_double_backward_options)
 
     @attr.gpu
     def test_full_double_backward_gpu(self):
-        def f(*inputs):
-            y = functions.bilinear(*inputs)
-            return y * y
-
         gradient_check.check_double_backward(
-            f,
+            functions.bilinear,
             (cuda.to_gpu(self.e1), cuda.to_gpu(self.e2), cuda.to_gpu(self.W),
              cuda.to_gpu(self.V1), cuda.to_gpu(self.V2), cuda.to_gpu(self.b)),
             cuda.to_gpu(self.gy),

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -205,10 +205,10 @@ class TestConvolution2DFunction(unittest.TestCase):
             grad_grads = grad_grads + (b_grad_grad,)
 
         def f(*args):
-            y = F.convolution_2d(*args, stride=self.stride, pad=self.pad,
-                                 cover_all=self.cover_all, dilate=self.dilate,
-                                 groups=self.groups)
-            return y * y  # make the function nonlinear
+            return F.convolution_2d(
+                *args, stride=self.stride, pad=self.pad,
+                cover_all=self.cover_all, dilate=self.dilate,
+                groups=self.groups)
 
         with backend_config:
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -240,10 +240,9 @@ class TestConvolutionND(unittest.TestCase):
             grad_grads += (b_grad_grad,)
 
         def f(*args):
-            y = F.convolution_nd(*args, stride=self.stride, pad=self.pad,
+            return F.convolution_nd(*args, stride=self.stride, pad=self.pad,
                                  cover_all=self.cover_all, dilate=self.dilate,
                                  groups=self.groups)
-            return y * y  # make the function nonlinear
 
         with chainer.using_config('use_cudnn', use_cudnn):
             with chainer.using_config('autotune', self.autotune):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -240,9 +240,10 @@ class TestConvolutionND(unittest.TestCase):
             grad_grads += (b_grad_grad,)
 
         def f(*args):
-            return F.convolution_nd(*args, stride=self.stride, pad=self.pad,
-                                 cover_all=self.cover_all, dilate=self.dilate,
-                                 groups=self.groups)
+            return F.convolution_nd(
+                *args, stride=self.stride, pad=self.pad,
+                cover_all=self.cover_all, dilate=self.dilate,
+                groups=self.groups)
 
         with chainer.using_config('use_cudnn', use_cudnn):
             with chainer.using_config('autotune', self.autotune):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -233,10 +233,9 @@ class TestDeconvolution2DFunction(unittest.TestCase):
             grad_grads = grad_grads + (b_grad_grad,)
 
         def f(*args):
-            y = F.deconvolution_2d(
+            return F.deconvolution_2d(
                 *args, stride=self.stride, pad=self.pad, outsize=self.outsize,
                 dilate=self.dilate, groups=self.groups)
-            return y * y  # make the function nonlinear
 
         with backend_config:
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -247,10 +247,9 @@ class TestDeconvolutionND(unittest.TestCase):
             grad_grads += (b_grad_grad,)
 
         def f(*args):
-            y = F.deconvolution_nd(
+            return F.deconvolution_nd(
                 *args, stride=self.stride, pad=self.pad, outsize=self.outsize,
                 dilate=self.dilate, groups=self.groups)
-            return y * y  # make the function nonlinear
 
         with chainer.using_config('use_cudnn', use_cudnn):
             with chainer.using_config('autotune', self.autotune):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_embed_id.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_embed_id.py
@@ -72,9 +72,8 @@ class TestEmbedID(unittest.TestCase):
 
     def check_double_backward(self, x_data, W_data, gy_data, ggW_data):
         def f(W):
-            y = chainer.functions.embed_id(
+            return chainer.functions.embed_id(
                 x_data, W, self.ignore_label)
-            return y * y
 
         gradient_check.check_double_backward(
             f,  W_data, gy_data, ggW_data,

--- a/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_linear.py
@@ -157,14 +157,9 @@ class TestNonparameterizedLinear(unittest.TestCase):
             inputs = inputs[:-1]
             grad_grad_inputs = grad_grad_inputs[:-1]
 
-        # non-linear function for testing
-        def nonlinear(*args):
-            y, = self.forward(*args)
-            return y * y
-
         with backend_config:
             gradient_check.check_double_backward(
-                nonlinear, inputs, grad_outputs, grad_grad_inputs,
+                self.forward, inputs, grad_outputs, grad_grad_inputs,
                 **self.check_double_backward_options)
 
     def test_double_backward(self, backend_config):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_absolute_error.py
@@ -67,12 +67,9 @@ class TestAbsoluteError(unittest.TestCase):
 
     def check_double_backward(self, x0_data, x1_data, y_grad,
                               gx0_grad, gx1_grad):
-        def f(x0, x1):
-            y = functions.absolute_error(x0, x1)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, (x0_data, x1_data), y_grad, (gx0_grad, gx1_grad), eps=1e-2)
+            functions.absolute_error, (x0_data, x1_data), y_grad,
+            (gx0_grad, gx1_grad), eps=1e-2)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -105,7 +105,8 @@ class TestContrastive(unittest.TestCase):
     def check_double_backward(
             self, x0_data, x1_data, t_data, gy_data, gx0_data, gx1_data):
         def f(x0, x1):
-            return functions.contrastive(x0, x1, t_data, self.margin, self.reduce)
+            return functions.contrastive(
+                x0, x1, t_data, self.margin, self.reduce)
 
         gradient_check.check_double_backward(
             f, (x0_data, x1_data), gy_data,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -105,8 +105,7 @@ class TestContrastive(unittest.TestCase):
     def check_double_backward(
             self, x0_data, x1_data, t_data, gy_data, gx0_data, gx1_data):
         def f(x0, x1):
-            y = functions.contrastive(x0, x1, t_data, self.margin, self.reduce)
-            return y * y
+            return functions.contrastive(x0, x1, t_data, self.margin, self.reduce)
 
         gradient_check.check_double_backward(
             f, (x0_data, x1_data), gy_data,

--- a/tests/chainer_tests/functions_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_crf1d.py
@@ -82,18 +82,12 @@ class TestCRF1d(unittest.TestCase):
             return functions.crf1d(cost, xs, ys, reduce=self.reduce)
 
         args = [cost_data] + xs_data + ys_data
-        if len(self.batches) == 1:
-            # When each sequence only contains one element, cost matrix
-            # is not used, and its gradient is not updated.
-            no_grads = [True] + [False] * len(xs_data) + [True] * len(ys_data)
-        else:
-            no_grads = None
         if self.reduce == 'mean':
             grad = None
         elif self.reduce == 'no':
             grad = g_data
         gradient_check.check_backward(
-            f, args, grad, no_grads=no_grads, rtol=1e-3, atol=1e-3)
+            f, args, grad, rtol=1e-3, atol=1e-3)
 
     def test_backward_cpu(self):
         self.check_backward(self.cost, self.xs, self.ys, self.g)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
@@ -59,12 +59,9 @@ class TestMeanAbsoluteError(unittest.TestCase):
 
     def check_double_backward(self, x0_data, x1_data, gy_data, ggx0_data,
                               ggx1_data):
-        def f(*xs):
-            y = chainer.functions.mean_absolute_error(*xs)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, (x0_data, x1_data), gy_data, (ggx0_data, ggx1_data), eps=1e-2)
+            chainer.functions.mean_absolute_error, (x0_data, x1_data),
+            gy_data, (ggx0_data, ggx1_data), eps=1e-2)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(

--- a/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
@@ -67,10 +67,6 @@ class TestSquaredError(unittest.TestCase):
 
     def check_double_backward(self, x0_data, x1_data, y_grad, ggx0_data,
                               ggx1_data):
-        def f(*xs):
-            y = functions.squared_error(*xs)
-            return y * y
-
         gradient_check.check_double_backward(
             functions.squared_error,
             (x0_data, x1_data), y_grad, (ggx0_data, ggx1_data), eps=1e-2)

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -199,12 +199,8 @@ class TestBinaryOp(unittest.TestCase):
             options = {'atol': 5e-3, 'rtol': 5e-2}
         options.update(args)
 
-        def _op(*xs):
-            y = op(*xs)
-            return y * y
-
         gradient_check.check_double_backward(
-            _op, (x1_data, x2_data), y_grad, (ggx1_data, ggx2_data),
+            op, (x1_data, x2_data), y_grad, (ggx1_data, ggx2_data),
             dtype=numpy.float64, **options)
 
     def double_backward_cpu(self, op, **options):
@@ -334,13 +330,9 @@ class TestMultipleAdd(unittest.TestCase):
             options = {'atol': 5e-3, 'rtol': 5e-2}
         options.update(args)
 
-        def _func(*xs):
-            y = func(*xs)
-            return y * y
-
         with backend_config:
             gradient_check.check_double_backward(
-                _func, (x1_data, x2_data, x3_data), y_grad,
+                func, (x1_data, x2_data, x3_data), y_grad,
                 (ggx1_data,
                  ggx2_data, ggx3_data),
                 dtype=numpy.float64, **options)
@@ -769,8 +761,7 @@ class TestVariableConstantOp(unittest.TestCase):
             options = {'atol': 5e-3, 'rtol': 5e-2}
 
         def _op(x):
-            y = op(x, self.value)
-            return y * y
+            return op(x, self.value)
 
         gradient_check.check_double_backward(
             _op, x_data, y_grad, x_grad_grad, dtype=numpy.float64, **options)
@@ -1006,8 +997,7 @@ class TestVariableConstantArrayOp(unittest.TestCase):
             options = {'atol': 5e-3, 'rtol': 5e-2}
 
         def _op(x):
-            y = op(x, value)
-            return y * y
+            return op(x, value)
 
         gradient_check.check_double_backward(
             _op, x_data, y_grad, x_grad_grad, dtype=numpy.float64, **options)

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1098,11 +1098,8 @@ class TestUnaryFunctions(unittest.TestCase):
         if self.dtype == numpy.float16:
             options = {'atol': 5e-3, 'rtol': 5e-2}
 
-        def f(x):
-            x = op(x)
-            return x * x
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64, **options)
+            op, x_data, y_grad, x_grad_grad, dtype=numpy.float64, **options)
 
     def double_backward_cpu(self, op):
         self.check_double_backward(op, self.x, self.gy, self.ggx)
@@ -1268,20 +1265,16 @@ class TestMatMul(unittest.TestCase):
             self, x_data, y_data, z_grad, x_grad_grad, y_grad_grad):
         if self.right_const:
             def op(x):
-                z = operator.matmul(x, y_data.astype(x.dtype))
-                return z * z
+                return operator.matmul(x, y_data.astype(x.dtype))
             data = x_data,
             grad_grad = x_grad_grad,
         elif self.left_const:
             def op(y):
-                z = operator.matmul(x_data.astype(y.dtype), y)
-                return z * z
+                return operator.matmul(x_data.astype(y.dtype), y)
             data = y_data,
             grad_grad = y_grad_grad,
         else:
-            def op(x, y):
-                z = operator.matmul(x, y)
-                return z * z
+            op = operator.matmul
             data = x_data, y_data
             grad_grad = x_grad_grad, y_grad_grad
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_clip.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_clip.py
@@ -67,8 +67,7 @@ class TestClip(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, gx_grad):
         def f(x):
-            y = functions.clip(x, self.x_min, self.x_max)
-            return y * y
+            return functions.clip(x, self.x_min, self.x_max)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, gx_grad, dtype=numpy.float64, atol=1e-3)

--- a/tests/chainer_tests/functions_tests/math_tests/test_cumsum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_cumsum.py
@@ -83,8 +83,7 @@ class TestCumsum(unittest.TestCase):
 
     def check_double_backward(self, x_data, axis, y_grad, x_grad_grad):
         def f(x):
-            y = functions.cumsum(x, axis)
-            return y * y
+            return functions.cumsum(x, axis)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/math_tests/test_floor.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_floor.py
@@ -48,11 +48,8 @@ class UnaryFunctionsTestBase(unittest.TestCase):
         self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
     def check_double_backward(self, op, x_data, y_grad, y_grad_grad):
-        def f(x):
-            x = op(x)
-            return x * x
         gradient_check.check_double_backward(
-            f, x_data, y_grad, y_grad_grad, dtype=numpy.float64,
+            op, x_data, y_grad, y_grad_grad, dtype=numpy.float64,
             atol=1e-7, rtol=1e-7)
 
     def check_double_backward_cpu(self, op):

--- a/tests/chainer_tests/functions_tests/math_tests/test_fmod.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_fmod.py
@@ -47,12 +47,8 @@ class UnaryFunctionsTestBase(unittest.TestCase):
             self.divisor), cuda.to_gpu(self.gy))
 
     def check_double_backward(self, op, x_data, divisor, y_grad, ggx, ggd):
-        def f(*args):
-            y = op(*args)
-            return y * y
-
         gradient_check.check_double_backward(
-            f, (x_data, divisor), y_grad, (ggx, ggd), dtype=numpy.float64,
+            op, (x_data, divisor), y_grad, (ggx, ggd), dtype=numpy.float64,
             atol=1e-3, rtol=1e-2)
 
     def check_double_backward_cpu(self, op):

--- a/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_maximum.py
@@ -79,16 +79,10 @@ class TestMaximum(unittest.TestCase):
         gy = cuda.to_gpu(self.gy)
         self.check_backward(x1, x2, gy)
 
-    def check_double_backward(
-            self, x1_data, x2_data, y_grad, x1_grad, x2_grad):
-        x = (x1_data, x2_data)
-        x_grad_grad = (x1_grad, x2_grad)
-
-        def func(x1, x2):
-            y = functions.maximum(x1, x2)
-            return y * y
+    def check_double_backward(self, x1, x2, gy, ggx1, ggx2):
         gradient_check.check_double_backward(
-            func, x, y_grad, x_grad_grad, **self.check_double_backward_options)
+            functions.maximum, (x1, x2), gy, (ggx1, ggx2),
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(

--- a/tests/chainer_tests/functions_tests/math_tests/test_minimum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minimum.py
@@ -81,7 +81,6 @@ class TestMinimum(unittest.TestCase):
     def check_double_backward(self, x1, x2, gy, ggx1, ggx2):
         gradient_check.check_double_backward(
             functions.minimum, (x1, x2), gy, (ggx1, ggx2),
-            no_grads=[True, True, False],
             **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_minmax.py
@@ -77,8 +77,7 @@ class TestMax(unittest.TestCase):
     def check_double_backward(
             self, x_data, y_grad, x_grad_grad):
         def f(x):
-            x = functions.max(x, self.axis, self.keepdims)
-            return x * x
+            return functions.max(x, self.axis, self.keepdims)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype='d',
@@ -181,8 +180,7 @@ class TestMin(unittest.TestCase):
     def check_double_backward(
             self, x_data, y_grad, x_grad_grad):
         def f(x):
-            x = functions.min(x, self.axis, self.keepdims)
-            return x * x
+            return functions.min(x, self.axis, self.keepdims)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, dtype='d',

--- a/tests/chainer_tests/functions_tests/math_tests/test_prod.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_prod.py
@@ -63,8 +63,7 @@ class TestProd(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         def f(x):
-            x = functions.prod(x, self.axis, self.keepdims)
-            return x * x
+            return functions.prod(x, self.axis, self.keepdims)
 
         gradient_check.check_double_backward(
             f, x_data, y_grad, x_grad_grad, atol=1e-3, dtype=numpy.float64)

--- a/tests/chainer_tests/functions_tests/math_tests/test_sign.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sign.py
@@ -20,7 +20,9 @@ class TestSign(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.ggx = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.no_grads = (True,)  # Always assert that gradients are `None`
+
+        # Avoid non-differentiable point
+        self.x[(abs(self.x) < 1e-2)] = 1
 
     def check_forward(self, x_data, xp):
         x = chainer.Variable(x_data)
@@ -53,9 +55,9 @@ class TestSign(unittest.TestCase):
     def test_forward_ndarray_gpu(self):
         self.check_forward_ndarray(cuda.to_gpu(self.x), cuda.cupy)
 
-    def check_backward(self, x_data, y_grad, no_grads):
+    def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            F.sign, x_data, y_grad, no_grads=no_grads)
+            F.sign, x_data, y_grad)
 
         # Explicitly check that gradients are `None`
         x = chainer.Variable(x_data)
@@ -63,12 +65,12 @@ class TestSign(unittest.TestCase):
         assert x.grad is None
 
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy, self.no_grads)
+        self.check_backward(self.x, self.gy)
 
     @attr.gpu
     def test_backward_gpu(self):
         self.check_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), self.no_grads)
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -104,8 +104,7 @@ class TestDropout(unittest.TestCase):
         dropout = functions.Dropout(self.ratio)
 
         def f(*inputs):
-            y, = dropout.apply(inputs)
-            return y * y,
+            return dropout.apply(inputs)
 
         with backend_config:
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
@@ -71,8 +71,7 @@ class TestGaussian(unittest.TestCase):
         gaussian = functions.Gaussian()
 
         def f(m, v):
-            y = gaussian.apply((m, v))[0]
-            return y * y
+            return gaussian.apply((m, v))
 
         gradient_check.check_double_backward(
             f, (m_data, v_data), y_grad, (m_grad_grad, v_grad_grad),

--- a/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_simplified_dropconnect.py
@@ -140,10 +140,9 @@ class TestSimplifiedDropconnect(unittest.TestCase):
         mask = xp.random.rand(*mask_shape) >= self.ratio
 
         def f(x, W, b=None):
-            y = functions.simplified_dropconnect(
+            return functions.simplified_dropconnect(
                 x, W, b, self.ratio, self.train, mask,
                 self.use_batchwise_mask)
-            return y * y
 
         gradient_check.check_double_backward(
             f, args, y_grad, grads, eps=1e-2,

--- a/tests/chainer_tests/functions_tests/noise_tests/test_zoneout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_zoneout.py
@@ -74,7 +74,7 @@ class TestZoneout(unittest.TestCase):
                     return_value=flag_x) as mock_rand:
                 y = functions.zoneout(h, x, self.ratio)
                 mock_rand.assert_called_once_with(*x.shape)
-            return y * y
+            return y
 
         gradient_check.check_double_backward(
             f, (h_data, x_data), y_grad, (h_grad_grad, x_grad_grad),

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -184,9 +184,8 @@ class TestBatchNormalization(unittest.TestCase):
             grad_grad_inputs = _to_fcontiguous(grad_grad_inputs)
 
         def f(*inputs):
-            y = functions.batch_normalization(
+            return functions.batch_normalization(
                 *inputs, **self.bn_options)
-            return y * y,  # make nonlinear against beta
 
         with backend_config:
             gradient_check.check_double_backward(
@@ -313,8 +312,7 @@ class TestFixedBatchNormalization(unittest.TestCase):
             grad_grad_inputs = _to_fcontiguous(grad_grad_inputs)
 
         def f(*inputs):
-            y = functions.fixed_batch_normalization(*inputs, eps=self.eps)
-            return y * y,  # make nonlinear against beta
+            return functions.fixed_batch_normalization(*inputs, eps=self.eps)
 
         with backend_config:
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
@@ -99,9 +99,8 @@ class TestGroupNormalization(unittest.TestCase):
 
     def check_double_backward(self, args, y_grad, x_grad_grad):
         def func(*args_):
-            y = functions.group_normalization(
+            return functions.group_normalization(
                 *[args_[0], self.groups, args_[1], args_[2]])
-            return y * y
 
         gradient_check.check_double_backward(
             func, args, y_grad, x_grad_grad,

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_layer_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_layer_normalization.py
@@ -82,8 +82,7 @@ class TestLayerNormalization(unittest.TestCase):
 
     def check_double_backward(self, args, y_grad, x_grad_grad):
         def func(*args_):
-            y = functions.layer_normalization(*args_, eps=self.eps)
-            return y * y
+            return functions.layer_normalization(*args_, eps=self.eps)
 
         gradient_check.check_double_backward(
             func, args, y_grad, x_grad_grad,

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -118,8 +118,7 @@ class TestAveragePooling2D(unittest.TestCase):
             grad_grad_inputs = _to_fcontiguous(grad_grad_inputs)
 
         def f(x):
-            y = functions.average_pooling_2d(x, 3, 2, 1)
-            return y * y
+            return functions.average_pooling_2d(x, 3, 2, 1)
 
         with backend_config:
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
@@ -202,9 +202,8 @@ class TestAveragePoolingND(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
         def f(x):
-            y = functions.average_pooling_nd(
+            return functions.average_pooling_nd(
                 x, self.ksize, stride=self.stride, pad=self.pad)
-            return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
                 f, x_data, y_grad, x_grad_grad, **self.check_backward_options)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -172,9 +172,8 @@ class TestMaxPooling2D(unittest.TestCase):
             grad_grad_inputs = _to_fcontiguous(grad_grad_inputs)
 
         def f(x):
-            y = functions.max_pooling_2d(
+            return functions.max_pooling_2d(
                 x, 3, stride=2, pad=1, cover_all=self.cover_all)
-            return y * y
 
         with backend_config:
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -227,10 +227,9 @@ class TestMaxPoolingND(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
         def f(x):
-            y = functions.max_pooling_nd(
+            return functions.max_pooling_nd(
                 x, self.ksize, stride=self.stride, pad=self.pad,
                 cover_all=self.cover_all)
-            return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
                 f, x_data, y_grad, x_grad_grad,

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_spatial_pyramid_pooling_2d.py
@@ -116,12 +116,9 @@ class TestSpatialPyramidPooling2D(unittest.TestCase):
 
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
-        def f(x):
-            y = self.func(x)
-            return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
-                f, x_data, y_grad, x_grad_grad,
+                self.func, x_data, y_grad, x_grad_grad,
                 dtype=numpy.float64, atol=5e-3, rtol=5e-3)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
@@ -112,9 +112,8 @@ class TestUnpooling2D(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
         def f(x):
-            y = functions.unpooling_2d(x, self.ksize, outsize=self.outsize,
+            return functions.unpooling_2d(x, self.ksize, outsize=self.outsize,
                                        cover_all=self.cover_all)
-            return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
                 f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
@@ -113,7 +113,7 @@ class TestUnpooling2D(unittest.TestCase):
                               use_cudnn='always'):
         def f(x):
             return functions.unpooling_2d(x, self.ksize, outsize=self.outsize,
-                                       cover_all=self.cover_all)
+                                          cover_all=self.cover_all)
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
                 f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_nd.py
@@ -206,10 +206,9 @@ class TestUnpoolingND(unittest.TestCase):
                               use_cudnn='always'):
         def f(x):
             outs = self.gy.shape[2:]
-            y = functions.unpooling_nd(
+            return functions.unpooling_nd(
                 x, self.ksize, stride=self.stride, pad=self.pad,
                 outsize=outs, cover_all=self.cover_all)
-            return y * y
 
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_upsampling_2d.py
@@ -79,11 +79,10 @@ class TestUpsampling2D(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad,
                               use_cudnn='always'):
         def f(x):
-            y = F.upsampling_2d(
+            return F.upsampling_2d(
                 x, self.p.indexes, ksize=(self.p.kh, self.p.kw),
                 stride=(self.p.sy, self.p.sx), pad=(self.p.ph, self.p.pw),
                 outsize=self.in_shape[2:], cover_all=self.p.cover_all)
-            return y * y
         with chainer.using_config('use_cudnn', use_cudnn):
             gradient_check.check_double_backward(
                 f, x_data, y_grad, x_grad_grad, dtype='d',


### PR DESCRIPTION
Use #4654 and stop squaring outputs of affine functions.

This PR also fixes #4656.