### PR TITLE
Run gradient clipping on GPU, if possible

### DIFF
--- a/chainer/optimizer_hooks/gradient_clipping.py
+++ b/chainer/optimizer_hooks/gradient_clipping.py
@@ -50,8 +50,8 @@ class GradientClipping(object):
 
     def __call__(self, opt):
         sqnorm = _sum_sqnorm([p.grad for p in opt.target.params(False)])
-        norm = cuda.get_array_module(sqnorm).sqrt(sqnorm)
-        with cuda.get_device_from_array(norm) as dev:
+        with cuda.get_device_from_array(sqnorm) as dev:
+            norm = cuda.get_array_module(sqnorm).sqrt(sqnorm)
             rate = self.threshold / norm
             # When no clipping is needed, skip the clipping on CPU and
             # multiply 1.0 on the device otherwise.

--- a/chainer/optimizer_hooks/gradient_clipping.py
+++ b/chainer/optimizer_hooks/gradient_clipping.py
@@ -1,6 +1,5 @@
 import collections
 
-import numpy
 import six
 
 from chainer import cuda
@@ -13,7 +12,12 @@ def _sum_sqnorm(arr):
             x = x.ravel()
             s = x.dot(x)
             sq_sum[int(dev)] += s
-    return sum([float(i) for i in six.itervalues(sq_sum)])
+    # If only a single device is used, aggregate square norms on it.
+    if len(sq_sum) == 1:
+        with cuda.get_device_from_array(arr[0]):
+            return sum(six.itervalues(sq_sum))
+    else:
+        return sum([float(i) for i in six.itervalues(sq_sum)])
 
 
 class GradientClipping(object):
@@ -45,11 +49,18 @@ class GradientClipping(object):
         self.threshold = threshold
 
     def __call__(self, opt):
-        norm = numpy.sqrt(_sum_sqnorm(
-            [p.grad for p in opt.target.params(False)]))
-        rate = self.threshold / norm
-        if rate < 1:
-            for param in opt.target.params(False):
-                grad = param.grad
-                with cuda.get_device_from_array(grad):
-                    grad *= rate
+        sqnorm = _sum_sqnorm([p.grad for p in opt.target.params(False)])
+        norm = cuda.get_array_module(sqnorm).sqrt(sqnorm)
+        with cuda.get_device_from_array(norm) as dev:
+            rate = self.threshold / norm
+            # When no clipping is needed, skip the clipping on CPU and
+            # multiply 1.0 on the device otherwise.
+            if int(dev) == -1:
+                if rate >= 1:
+                    return
+            else:
+                rate = rate.clip(None, 1)
+        for param in opt.target.params(False):
+            grad = param.grad
+            with cuda.get_device_from_array(grad):
+                grad *= rate


### PR DESCRIPTION
~20% speed up (~6.0 iters/sec => ~7.3 iters/sec) was observed
with train_ptb.py on my GPU.

Probably, it'd be better to aggregate square norms on a GPU even
on multi-GPUs, but I haven't done it because I don't have multi-GPU
environment.

Tested by:

```
> $ CHAINER_TEST_GPU_LIMIT=1 python3 -m pytest \
   tests/chainer_tests/optimizer_hooks_tests/test_gradient_clipping.py
```
