### PR TITLE
 Clarifications for L.Linear

### DIFF
--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -15,21 +15,26 @@ class Linear(link.Link):
     and holds a weight matrix ``W`` and optionally a bias vector ``b`` as
     parameters.
 
-    The weight matrix ``W`` is initialized with i.i.d. Gaussian samples, each
-    of which has zero mean and deviation :math:`\\sqrt{1/\\text{in_size}}`. The
-    bias vector ``b`` is of size ``out_size``. Each element is initialized with
-    the ``bias`` value. If ``nobias`` argument is set to ``True``, then this
-    link does not hold a bias vector.
+    If ``initialW`` is left to the default value of ``None``, the weight matrix
+    ``W`` is initialized with i.i.d. Gaussian samples, each of which has zero
+    mean and deviation :math:`\\sqrt{1/\\text{in_size}}`. The bias vector ``b``
+    is of size ``out_size``. If the ``initial_bias`` is to left the default
+    value of ``None``, each element is initialized as zero.  If the ``nobias``
+    argument is set to ``True``, then this link does not hold a bias vector.
 
     Args:
-        in_size (int or None): Dimension of input vectors. If ``None``,
-            parameter initialization will be deferred until the first forward
-            data pass at which time the size will be determined.
-        out_size (int): Dimension of output vectors.
+        in_size (int or None): Dimension of input vectors. If unspecified or
+            ``None``, parameter initialization will be deferred until the
+            first forward data pass at which time the size will be determined.
+        out_size (int): Dimension of output vectors. If only one value is
+            passed for ``in_size`` and ``out_size``, that value will be used
+            for the ``out_size`` dimension.
         nobias (bool): If ``True``, then this function does not use the bias.
         initialW (:ref:`initializer <initializer>`): Initializer to initialize
             the weight. When it is :class:`numpy.ndarray`,
-            its ``ndim`` should be 2.
+            its ``ndim`` should be 2. If ``initialW`` is ``None``, then the
+            weights are initialized with i.i.d. Gaussian samples, each of which
+            has zero mean and deviation :math:`\\sqrt{1/\\text{in_size}}`.
         initial_bias (:ref:`initializer <initializer>`): Initializer to
             initialize the bias. If ``None``, the bias will be initialized to
             zero. When it is :class:`numpy.ndarray`, its ``ndim`` should be 1.


### PR DESCRIPTION
Adressing Issue #4115 

These items are done:

- Explanation on how W and b are initialized ignores initialW and initial_bias
- There's no explanation on how out_size=None works (except in the example section)
- There's no explanation on how initialW=None works

@muupan Can you provide clarification on what you mean by this?
> The `bias` parameter doesn't exist

Also, can you give a link to the specific compatibility policy or example of the format you're looking for for this?
> shapes and dtypes of `W` and `b` should be documented

Thanks, 