### PR TITLE
Support NumPy 1.14 in docs

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,7 +25,7 @@ You need to have the following components to use Chainer.
 * `Python <https://python.org/>`_
     * Supported Versions: 2.7.6+, 3.4.3+, 3.5.1+ and 3.6.0+.
 * `NumPy <http://www.numpy.org/>`_
-    * Supported Versions: 1.9, 1.10, 1.11, 1.12 and 1.13.
+    * Supported Versions: 1.9, 1.10, 1.11, 1.12, 1.13 and 1.14.
     * NumPy will be installed automatically during the installation of Chainer.
 
 Before installing Chainer, we recommend you to upgrade ``setuptools`` and ``pip``::


### PR DESCRIPTION
We started to support NumPy 1.14 in Chainer v5.0.0b2 / v4.2.0 (as the corresponding CuPy started to support it), but was not documented.