### PR TITLE
Copy persistent values in `Link.copyparams`

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -424,6 +424,35 @@ def copy(array, out=None, out_device=None, stream=None):
     return out
 
 
+def copyto(dst, src):
+    """Copies the elements of an ndarray to those of another one.
+
+    This function can copy the CPU/GPU arrays to the destination arrays on
+    another device.
+
+    Args:
+        dst (numpy.ndarray or cupy.ndarray): Destination array.
+        src (numpy.ndarray or cupy.ndarray): Source array.
+
+    """
+    if isinstance(dst, numpy.ndarray):
+        numpy.copyto(dst, to_cpu(src))
+    elif isinstance(dst, ndarray):
+        if isinstance(src, numpy.ndarray):
+            if dst.flags.c_contiguous or dst.flags.f_contiguous:
+                dst.set(src)
+            else:
+                cupy.copyto(dst, to_gpu(src, device=dst.device))
+        elif isinstance(src, ndarray):
+            cupy.copyto(dst, src)
+        else:
+            raise TypeError('cannot copy from non-array object of type {}'
+                            .format(type(src)))
+    else:
+        raise TypeError('cannot copy to non-array object of type {}'.format(
+            type(dst)))
+
+
 # ------------------------------------------------------------------------------
 # Function result memoization
 # ------------------------------------------------------------------------------

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -532,7 +532,7 @@ Assign a Parameter object directly to an attribute within a \
         for name in self._params:
             dst[name].copydata(src[name])
         if copy_persistent:
-            array_types = numpy.ndarray, cuda.ndarray
+            array_types = chainer.get_array_types()
             for name in self._persistent:
                 d = dst[name]
                 s = src[name]

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -850,14 +850,7 @@ Actual: {0}'''.format(type(data))
         elif dst is None:
             self.initialize(src.shape)
             dst = self.data
-        src_xp = cuda.get_array_module(src)
-        dst_xp = cuda.get_array_module(dst)
-        if dst_xp is src_xp:
-            dst_xp.copyto(dst, src)
-        elif dst_xp is numpy:
-            dst_xp.copyto(dst, src.get())
-        else:
-            dst.set(src)
+        cuda.copyto(dst, src)
 
     def addgrad(self, var):
         """Accumulates the gradient array from given source variable.

--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -23,6 +23,7 @@ CuPy array allocation and copy
    :nosignatures:
 
    chainer.backends.cuda.copy
+   chainer.backends.cuda.copyto
    chainer.backends.cuda.to_cpu
    chainer.backends.cuda.to_gpu
 

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -301,6 +301,56 @@ class TestToCPUScalar(unittest.TestCase):
         assert y == x
 
 
+class TestCopyTo(unittest.TestCase):
+
+    def test_cpu_to_cpu(self):
+        src = numpy.arange(1, 5, dtype=numpy.float32)
+        dst = numpy.zeros_like(src)
+        cuda.copyto(dst, src)
+        numpy.testing.assert_array_equal(dst, src)
+
+    @attr.gpu
+    def test_cpu_to_gpu(self):
+        src = numpy.arange(1, 5, dtype=numpy.float32)
+        dst = cuda.cupy.zeros_like(src)
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    @attr.gpu
+    def test_gpu_to_cpu(self):
+        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
+        dst = numpy.zeros_like(src.get())
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    @attr.gpu
+    def test_gpu_to_gpu(self):
+        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
+        dst = cuda.cupy.zeros_like(src)
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    @attr.multi_gpu(2)
+    def test_gpu_to_another_gpu(self):
+        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
+        with cuda.get_device_from_id(1):
+            dst = cuda.cupy.zeros_like(src)
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    def test_fail_on_invalid_src(self):
+        src = None
+        dst = numpy.zeros(1)
+        with self.assertRaises(TypeError):
+            cuda.copyto(dst, src)
+
+    def test_fail_on_invalid_dst(self):
+        src = numpy.zeros(1)
+        dst = None
+        with self.assertRaises(TypeError):
+            cuda.copyto(dst, src)
+
+
 @attr.cudnn
 class TestWorkspace(unittest.TestCase):
 

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -386,6 +386,7 @@ class TestLink(unittest.TestCase):
         l.u.grad.fill(7)
         l.v.data.fill(8)
         l.v.grad.fill(9)
+        l.add_persistent('p', numpy.full_like(self.link.p, 10))
 
         self.link.copyparams(l)
         numpy.testing.assert_array_equal(self.link.x.data, l.x.data)
@@ -396,6 +397,7 @@ class TestLink(unittest.TestCase):
         numpy.testing.assert_array_equal(self.link.u.grad, gu)
         numpy.testing.assert_array_equal(self.link.v.data, l.v.data)
         numpy.testing.assert_array_equal(self.link.v.grad, None)
+        numpy.testing.assert_array_equal(self.link.p, l.p)
 
     def test_cleargrads(self):
         self.link.cleargrads()

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -361,7 +361,7 @@ class TestLink(unittest.TestCase):
         self.assertEqual(pl[0][0], '/')
         self.assertIs(pl[0][1], self.link)
 
-    def test_copyparams(self):
+    def _setup_test_copyparams(self):
         self.link.x.grad.fill(0)
         self.link.y.grad.fill(1)
         self.link.u.initialize((2, 3))
@@ -388,7 +388,10 @@ class TestLink(unittest.TestCase):
         l.v.grad.fill(9)
         l.add_persistent('p', numpy.full_like(self.link.p, 10))
 
-        self.link.copyparams(l)
+        return l, (gx, gy, gu)
+
+    def _check_copyparams(self, l, gs):
+        gx, gy, gu = gs
         numpy.testing.assert_array_equal(self.link.x.data, l.x.data)
         numpy.testing.assert_array_equal(self.link.x.grad, gx)
         numpy.testing.assert_array_equal(self.link.y.data, l.y.data)
@@ -397,7 +400,22 @@ class TestLink(unittest.TestCase):
         numpy.testing.assert_array_equal(self.link.u.grad, gu)
         numpy.testing.assert_array_equal(self.link.v.data, l.v.data)
         numpy.testing.assert_array_equal(self.link.v.grad, None)
+
+    def test_copyparams(self):
+        l, gs = self._setup_test_copyparams()
+        self.link.copyparams(l)
+        self._check_copyparams(l, gs)
         numpy.testing.assert_array_equal(self.link.p, l.p)
+
+    def test_copyparams_no_copy_persistent(self):
+        orig_p = self.link.p.copy()
+
+        l, gs = self._setup_test_copyparams()
+        numpy.testing.assert_array_equal(False, orig_p == l)
+        self.link.copyparams(l, copy_persistent=False)
+
+        self._check_copyparams(l, gs)
+        numpy.testing.assert_array_equal(self.link.p, orig_p)
 
     def test_cleargrads(self):
         self.link.cleargrads()

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -411,7 +411,7 @@ class TestLink(unittest.TestCase):
         orig_p = self.link.p.copy()
 
         l, gs = self._setup_test_copyparams()
-        numpy.testing.assert_array_equal(False, orig_p == l)
+        numpy.testing.assert_array_equal(False, orig_p == l.p)
         self.link.copyparams(l, copy_persistent=False)
 
         self._check_copyparams(l, gs)


### PR DESCRIPTION
Fixes #4903. This change makes `Link.copyparams` also copies the persistent values, notably the `avg_mean`, `avg_var`, and `N` of `links.BatchNormalization`.

Note that this change is backward incompatible since the default behavior is changed. The original behavior is confusing, and the new behavior should be beneficial in most cases (including existing code). The original behavior can be reproduced by passing `copy_persistent=False`.