### PR TITLE
Fix verb error in chainer.functions.fft docstring

### DIFF
--- a/chainer/functions/math/fft.py
+++ b/chainer/functions/math/fft.py
@@ -54,7 +54,7 @@ def fft(x):
         the result and ``ri`` is the imaginary part of the result.
 
     .. note::
-       Currently this function supports a tuple as input. It will supports a
+       Currently this function supports a tuple as input. It will support a
        complex numbers directly in the future.
 
     """
@@ -76,7 +76,7 @@ def ifft(x):
         the result and ``ri`` is the imaginary part of the result.
 
     .. note::
-       Currently this function supports a tuple as input. It will supports a
+       Currently this function supports a tuple as input. It will support a
        complex numbers directly in the future.
 
     """


### PR DESCRIPTION
I found a minor grammatical error in the docstring of chainer.functions.fft
https://github.com/chainer/chainer/blob/4bd5237f45f384a05490e92aa6c58bd0d7e134e6/chainer/functions/math/fft.py#L57