### PR TITLE
[backport] Fix exception not raised when unsupported format is specified when dumping computational graph

### DIFF
--- a/chainer/computational_graph.py
+++ b/chainer/computational_graph.py
@@ -162,8 +162,7 @@ class ComputationalGraph(object):
         """
         if format == 'dot':
             return self._to_dot()
-        else:
-            NotImplementedError('Currently, only dot format is supported.')
+        raise NotImplementedError('Currently, only dot format is supported.')
 
 
 def _skip_variable(nodes, edges):

--- a/tests/chainer_tests/test_computational_graph.py
+++ b/tests/chainer_tests/test_computational_graph.py
@@ -212,6 +212,10 @@ class TestGraphBuilderStylization(unittest.TestCase):
             for key, value in style.items():
                 self.assertIn('{0}="{1}"'.format(key, value), dotfile_content)
 
+    def test_unsupported_format(self):
+        with self.assertRaises(NotImplementedError):
+            self.g.dump('graphml')
+
 
 class TestGraphBuilderShowName(unittest.TestCase):
 


### PR DESCRIPTION
Backport of #4971