### PR TITLE
Fix broken notations in `F.linear` docs

### DIFF
--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -201,21 +201,21 @@ def linear(x, W, b=None, n_batch_axes=1):
             ..., s_n)`-shaped float array. Its first ``n_batch_axes``
             dimensions are handled as *minibatch dimensions*. The
             other dimensions are handled as concatenated one dimension whose
-            size must be :math:`(s_{\\rm n_batch_axes} * ... * s_n = N)`.
+            size must be :math:`(s_{\\rm n\_batch\_axes} * ... * s_n = N)`.
         W (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`): Weight variable of shape :math:`(M, N)`,
-            where :math:`(N = s_{\\rm n_batch_axes} * ... * s_n)`.
+            where :math:`(N = s_{\\rm n\_batch\_axes} * ... * s_n)`.
         b (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`): Bias variable (optional) of shape
             :math:`(M,)`.
         n_batch_axes (int): The number of batch axes. The default is 1. The
             input variable is reshaped into
-            :math:`{\\rm n_batch_axes} + 1`-dimensional tensor.
+            (:math:`{\\rm n\_batch\_axes} + 1`)-dimensional tensor.
             This should be greater than 0.
 
     Returns:
         ~chainer.Variable: Output variable. A float array with shape
-        of :math:`(s_1, ..., s_{\\rm n_batch_axes}, M)`.
+        of :math:`(s_1, ..., s_{\\rm n\_batch\_axes}, M)`.
 
     .. seealso:: :class:`~chainer.links.Linear`
 


### PR DESCRIPTION
Fix <img width="69" alt="screen shot 2018-06-26 at 20 44 22" src="https://user-images.githubusercontent.com/939877/41909350-c5b7dde2-7981-11e8-9a50-79a5475552db.png">
https://docs.chainer.org/en/latest/reference/generated/chainer.functions.linear.html