### PR TITLE
Remove obsolete codes form batch (re)normalization

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -747,9 +747,12 @@ def batch_normalization(x, gamma, beta, **kwargs):
        See :func:`chainer.using_config`.
 
     Args:
-        x (Variable): Input variable.
-        gamma (Variable): Scaling parameter of normalized data.
-        beta (Variable): Shifting parameter of scaled normalized data.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Input variable.
+        gamma (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Scaling parameter of normalized data.
+        beta (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Shifting parameter of scaled normalized data.
         eps (float): Epsilon value for numerical stability.
         running_mean (numpy.ndarray or cupy.ndarray):
             Running average of the mean. This is a running average of
@@ -802,11 +805,16 @@ def fixed_batch_normalization(x, gamma, beta, mean, var, eps=2e-5, axis=None):
     statistics cannot be used for prediction consistency.
 
     Args:
-        x (Variable): Input variable.
-        gamma (Variable): Scaling parameter of normalized data.
-        beta (Variable): Shifting parameter of scaled normalized data.
-        mean (Variable): Shifting parameter of input.
-        var (Variable): Square of scaling parameter of input.
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Input variable.
+        gamma (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Scaling parameter of normalized data.
+        beta (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Shifting parameter of scaled normalized data.
+        mean (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Shifting parameter of input.
+        var (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray`): Square of scaling parameter of input.
         eps (float): Epsilon value for numerical stability.
         axis (int, tuple of int or None): Axis over which normalization is
             performed. When axis is ``None``, it is determined from input

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -60,49 +60,43 @@ class BatchRenormalizationFunction(function.Function):
         # Note: we must be in train mode.
         assert configuration.config.train
 
-        if configuration.config.train:
-            if self.running_mean is None:
-                self.running_mean = xp.zeros_like(gamma)
-                self.running_var = xp.zeros_like(gamma)
-            else:
-                self.running_mean = xp.array(self.running_mean)
-                self.running_var = xp.array(self.running_var)
+        if self.running_mean is None:
+            self.running_mean = xp.zeros_like(gamma)
+            self.running_var = xp.zeros_like(gamma)
+        else:
+            self.running_mean = xp.array(self.running_mean)
+            self.running_var = xp.array(self.running_var)
 
         head_ndim = gamma.ndim + 1
         expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
 
         # NOTE(tommi): cuDNN is not used since it does not support
         # batch renormalization
-        if configuration.config.train:
-            axis = (0,) + tuple(range(head_ndim, x.ndim))
-            mean = x.mean(axis=axis)
-            var = x.var(axis=axis) + self.eps
+        axis = (0,) + tuple(range(head_ndim, x.ndim))
+        mean = x.mean(axis=axis)
+        var = x.var(axis=axis) + self.eps
         self.std = xp.sqrt(var, dtype=var.dtype)
 
-        if configuration.config.train:
-            running_sigma = xp.sqrt(self.running_var + self.eps,
-                                    dtype=self.running_mean.dtype)
-            self.r = xp.clip(self.std / running_sigma,
-                             1.0 / self.rmax, self.rmax)
-            self.d = xp.clip((mean - self.running_mean) / running_sigma,
-                             -self.dmax, self.dmax)
+        running_sigma = xp.sqrt(self.running_var + self.eps,
+                                dtype=self.running_mean.dtype)
+        self.r = xp.clip(self.std / running_sigma,
+                         1.0 / self.rmax, self.rmax)
+        self.d = xp.clip((mean - self.running_mean) / running_sigma,
+                         -self.dmax, self.dmax)
 
-            # Update running statistics:
-            m = x.size // gamma[expander].size
-            self.running_mean *= self.decay
-            adjust = m / max(m - 1., 1.)  # unbiased estimation
-            temp_ar = xp.array(mean)
-            temp_ar *= (1 - self.decay)
-            self.running_mean += temp_ar
-            del temp_ar
-            self.running_var *= self.decay
-            temp_ar = xp.array(var)
-            temp_ar *= (1 - self.decay) * adjust
-            self.running_var += temp_ar
-            del temp_ar
-        else:
-            self.r = xp.ones_like(gamma)
-            self.d = xp.zeros_like(gamma)
+        # Update running statistics:
+        m = x.size // gamma[expander].size
+        self.running_mean *= self.decay
+        adjust = m / max(m - 1., 1.)  # unbiased estimation
+        temp_ar = xp.array(mean)
+        temp_ar *= (1 - self.decay)
+        self.running_mean += temp_ar
+        del temp_ar
+        self.running_var *= self.decay
+        temp_ar = xp.array(var)
+        temp_ar *= (1 - self.decay) * adjust
+        self.running_var += temp_ar
+        del temp_ar
 
         gamma = gamma[expander]
         beta = beta[expander]

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -247,15 +247,15 @@ class BatchNormalization(link.Link):
             gamma = self.gamma
         else:
             with cuda.get_device_from_id(self._device_id):
-                gamma = variable.Variable(self.xp.ones(
-                    self.avg_mean.shape, dtype=x.dtype))
+                gamma = self.xp.ones(
+                    self.avg_mean.shape, dtype=x.dtype)
 
         if hasattr(self, 'beta'):
             beta = self.beta
         else:
             with cuda.get_device_from_id(self._device_id):
-                beta = variable.Variable(self.xp.zeros(
-                    self.avg_mean.shape, dtype=x.dtype))
+                beta = self.xp.zeros(
+                    self.avg_mean.shape, dtype=x.dtype)
 
         if configuration.config.train:
             if finetune:
@@ -269,8 +269,8 @@ class BatchNormalization(link.Link):
                 running_var=self.avg_var, decay=decay, axis=self.axis)
         else:
             # Use running average statistics or fine-tuned statistics.
-            mean = variable.Variable(self.avg_mean)
-            var = variable.Variable(self.avg_var)
+            mean = self.avg_mean
+            var = self.avg_var
             ret = functions.fixed_batch_normalization(
                 x, gamma, beta, mean, var, self.eps, axis=self.axis)
         return ret

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -48,15 +48,15 @@ class BatchRenormalization(BatchNormalization):
             gamma = self.gamma
         else:
             with cuda.get_device_from_id(self._device_id):
-                gamma = variable.Variable(self.xp.ones(
-                    self.avg_mean.shape, dtype=x.dtype))
+                gamma = self.xp.ones(
+                    self.avg_mean.shape, dtype=x.dtype)
 
         if self.beta is not None:
             beta = self.beta
         else:
             with cuda.get_device_from_id(self._device_id):
-                beta = variable.Variable(self.xp.zeros(
-                    self.avg_mean.shape, dtype=x.dtype))
+                beta = self.xp.zeros(
+                    self.avg_mean.shape, dtype=x.dtype)
 
         if configuration.config.train:
             if finetune:
@@ -74,8 +74,8 @@ class BatchRenormalization(BatchNormalization):
             self.avg_var[:] = func.running_var
         else:
             # Use running average statistics or fine-tuned statistics.
-            mean = variable.Variable(self.avg_mean)
-            var = variable.Variable(self.avg_var)
+            mean = self.avg_mean
+            var = self.avg_var
             ret = batch_normalization.fixed_batch_normalization(
                 x, gamma, beta, mean, var, self.eps)
         return ret

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -5,7 +5,6 @@ from chainer import configuration
 from chainer.functions.normalization import batch_normalization
 from chainer.functions.normalization import batch_renormalization
 from chainer.links.normalization.batch_normalization import BatchNormalization
-from chainer import variable
 
 
 class BatchRenormalization(BatchNormalization):


### PR DESCRIPTION
- `BatchRenormalizationFunction` no longer has to support `F.fixed_batch_renormalization` (#4869).
- Stop manually wrapping `ndarray` by `Variable`.