### PR TITLE
[backport] Remove unused parameter from `TestBatchRenormalization`

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -20,12 +20,10 @@ def _batch_renormalization(expander, gamma, beta, x, mean, var, r, d):
 
 
 @testing.parameterize(*(testing.product({
-    'param_shape': [(3, 4), (3, 2, 3)],
     'ndim': [0, 1, 2],
     'eps': [2e-5, 1e-1],
     'dtype': [numpy.float32],
 }) + testing.product({
-    'param_shape': [(3,)],
     'ndim': [1],
     'eps': [2e-5, 1e-1],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],


### PR DESCRIPTION
Backport of #5016