### PR TITLE
Update installation guide of numpy with openblas on macOS

### DIFF
--- a/chainer/_environment_check.py
+++ b/chainer/_environment_check.py
@@ -1,8 +1,5 @@
 import os
 import sys
-import warnings
-
-import numpy.distutils.system_info
 
 
 def _check_python_350():
@@ -18,20 +15,5 @@ def _check_python_350():
             raise Exception(msg)
 
 
-def _check_osx_numpy_backend():
-    if sys.platform != 'darwin':
-        return
-
-    blas_opt_info = numpy.distutils.system_info.get_info('blas_opt')
-    if blas_opt_info:
-        extra_link_args = blas_opt_info.get('extra_link_args')
-        if extra_link_args and '-Wl,Accelerate' in extra_link_args:
-            warnings.warn('''\
-Note that Chainer does not officially support Mac OS X.
-Please use it at your own risk.
-''')  # NOQA
-
-
 def check():
     _check_python_350()
-    _check_osx_numpy_backend()

--- a/chainer/_environment_check.py
+++ b/chainer/_environment_check.py
@@ -27,13 +27,7 @@ def _check_osx_numpy_backend():
         extra_link_args = blas_opt_info.get('extra_link_args')
         if extra_link_args and '-Wl,Accelerate' in extra_link_args:
             warnings.warn('''\
-Accelerate has been detected as a NumPy backend library.
-vecLib, which is a part of Accelerate, is known not to work correctly with Chainer.
-We recommend using other BLAS libraries such as OpenBLAS.
-For details of the issue, please see
-https://docs.chainer.org/en/stable/tips.html#mnist-example-does-not-converge-in-cpu-mode-on-mac-os-x.
-
-Also note that Chainer does not officially support Mac OS X.
+Note that Chainer does not officially support Mac OS X.
 Please use it at your own risk.
 ''')  # NOQA
 

--- a/chainer/_environment_check.py
+++ b/chainer/_environment_check.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import warnings
+
+import numpy.distutils.system_info
 
 
 def _check_python_350():
@@ -15,5 +18,25 @@ def _check_python_350():
             raise Exception(msg)
 
 
+def _check_osx_numpy_backend():
+    if sys.platform != 'darwin':
+        return
+
+    blas_opt_info = numpy.distutils.system_info.get_info('blas_opt')
+    if blas_opt_info:
+        extra_link_args = blas_opt_info.get('extra_link_args')
+        if extra_link_args and '-Wl,Accelerate' in extra_link_args:
+            warnings.warn('''\
+Accelerate has been detected as a NumPy backend library.
+vecLib, which is a part of Accelerate, is known not to work correctly with Chainer.
+We recommend using other BLAS libraries such as OpenBLAS.
+For details of the issue, please see
+https://docs.chainer.org/en/stable/tips.html#mnist-example-does-not-converge-in-cpu-mode-on-mac-os-x.
+
+Please be aware that Mac OS X is not an officially supported OS.
+''')  # NOQA
+
+
 def check():
     _check_python_350()
+    _check_osx_numpy_backend()

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -25,7 +25,7 @@ MNIST example does not converge in CPU mode on Mac OS X
 
 .. note::
 
-    Mac OS X is not an officially supported OS.
+   Mac OS X is not an officially supported OS.
 
 Many users have reported that MNIST example does not work correctly
 when using vecLib as NumPy backend on Mac OS X.
@@ -91,7 +91,7 @@ You should see the following information:
      runtime_library_dirs = ['/usr/local/opt/openblas/lib']
     ...
 
-Once this is done, you should be able to `import chainer` without OpenBLAS errors.
+Once this is done, you should be able to ``import chainer`` without OpenBLAS errors.
 
 For details of this problem, see `issue #704 <https://github.com/chainer/chainer/issues/704>`_.
 

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -34,18 +34,95 @@ vecLib is the default BLAS library installed on Mac OS X.
 We recommend using other BLAS libraries such as `OpenBLAS <http://www.openblas.net/>`_.
 
 To use an alternative BLAS library, it is necessary to reinstall NumPy.
-Here is an instruction to install NumPy with OpenBLAS using `Homebrew <https://brew.sh/>`_.
-
-For details of the issue, please see
-https://docs.chainer.org/en/stable/tips.html#mnist-example-does-not-converge-in-cpu-mode-on-mac-os-x.
+Here are instructions to install NumPy with OpenBLAS using `Conda <https://conda.io/docs/user-guide/install/index.html>`_.
 
 ::
 
-   $ brew tap homebrew/science
-   $ brew install openblas
-   $ brew install numpy --with-openblas
+   $ conda install -c conda-forge numpy
 
-If you want to install NumPy with pip, use `site.cfg <https://github.com/numpy/numpy/blob/master/site.cfg.example>`_ file.
+Otherwise, to install NumPy without Conda, you may need to install NumPy from source.
+
+Use `Homebrew <https://brew.sh/>`_ to install OpenBLAS.
+
+::
+
+   $ brew install openblas
+
+Uninstall existing NumPy installation
+
+::
+
+   $ pip uninstall numpy
+
+Install NumPy from the source code
+
+::
+
+   $ git clone https://github.com/numpy/numpy
+   $ cd numpy
+   $ git checkout refs/tags/v1.13.3
+   $ cp site.cfg.example site.cfg
+
+You'll need to edit the site.cfg file around line 128 to set the library to OpenBLAS by removing the comment #s.
+
+::
+
+   [openblas]
+   libraries = openblas
+   library_dirs = /usr/local/opt/openblas/lib
+   include_dirs = /usr/local/opt/openblas/include
+   runtime_library_dirs = /usr/local/opt/openblas/lib
+
+Check the setup config file.
+
+::
+
+   $ python setup.py config
+
+If you see these settings in the log, it should be ok:
+
+::
+
+    openblas_info:
+      FOUND:
+        libraries = ['openblas', 'openblas']
+        library_dirs = ['/usr/local/opt/openblas/lib']
+        language = c
+        define_macros = [('HAVE_CBLAS', None)]
+        runtime_library_dirs = ['/usr/local/opt/openblas/lib']
+
+Continue with the build. This takes a few minutes.
+
+::
+
+   $ python setup.py build
+   $ python setup.py install
+
+Confirm NumPy has been installed with OpenBLAS by running this command:
+
+::
+
+   $ python -c "import numpy; print(numpy.show_config())"
+
+You should see the following information:
+
+::
+
+   blas_mkl_info:
+     NOT AVAILABLE
+   blis_info:
+     NOT AVAILABLE
+   openblas_info:
+     libraries = ['openblas', 'openblas']
+     library_dirs = ['/usr/local/opt/openblas/lib']
+     language = c
+     define_macros = [('HAVE_CBLAS', None)]
+     runtime_library_dirs = ['/usr/local/opt/openblas/lib']
+    ...
+
+Once this is done, you should be able to `import chainer` without OpenBLAS errors.
+
+Thanks for this guide to the Japanese site, `kumilog.net <https://www.kumilog.net/entry/openblas-numpy>`_.
 
 For details of this problem, see `issue #704 <https://github.com/chainer/chainer/issues/704>`_.
 

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -20,34 +20,6 @@ If your home directory is not suited to caching the kernels (e.g. in case that i
 See `CuPy Overview <https://docs-cupy.chainer.org/en/stable/overview.html>`_ for more details.
 
 
-MNIST example does not converge in CPU mode on Mac OS X
--------------------------------------------------------
-
-.. note::
-
-   Mac OS X is not officially supported.
-   Please use it at your own risk.
-
-Many users have reported that MNIST example does not work correctly
-when using vecLib as NumPy backend on Mac OS X.
-vecLib is the default BLAS library installed on Mac OS X.
-
-We recommend using other BLAS libraries such as `OpenBLAS <http://www.openblas.net/>`_.
-
-To use an alternative BLAS library, it is necessary to reinstall NumPy.
-Here is an instruction to install NumPy with OpenBLAS using `Homebrew <https://brew.sh/>`_.
-
-::
-
-   $ brew tap homebrew/science
-   $ brew install openblas
-   $ brew install numpy --with-openblas
-
-If you want to install NumPy with pip, use `site.cfg <https://github.com/numpy/numpy/blob/master/site.cfg.example>`_ file.
-
-For details of this problem, see `issue #704 <https://github.com/chainer/chainer/issues/704>`_.
-
-
 How do I fix InvalidType error?
 -------------------------------
 

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -23,6 +23,10 @@ See `CuPy Overview <https://docs-cupy.chainer.org/en/stable/overview.html>`_ for
 MNIST example does not converge in CPU mode on Mac OS X
 -------------------------------------------------------
 
+.. note::
+
+    Mac OS X is not an officially supported OS.
+
 Many users have reported that MNIST example does not work correctly
 when using vecLib as NumPy backend on Mac OS X.
 vecLib is the default BLAS library installed on Mac OS X.
@@ -31,6 +35,9 @@ We recommend using other BLAS libraries such as `OpenBLAS <http://www.openblas.n
 
 To use an alternative BLAS library, it is necessary to reinstall NumPy.
 Here is an instruction to install NumPy with OpenBLAS using `Homebrew <https://brew.sh/>`_.
+
+For details of the issue, please see
+https://docs.chainer.org/en/stable/tips.html#mnist-example-does-not-converge-in-cpu-mode-on-mac-os-x.
 
 ::
 

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -54,16 +54,7 @@ Uninstall existing NumPy installation
 
    $ pip uninstall numpy
 
-Install NumPy from the source code
-
-::
-
-   $ git clone https://github.com/numpy/numpy
-   $ cd numpy
-   $ git checkout refs/tags/v1.13.3
-   $ cp site.cfg.example site.cfg
-
-You'll need to edit the site.cfg file around line 128 to set the library to OpenBLAS by removing the comment #s.
+You'll to create a file called `.numpy-site.cfg` in your home (~/) directory with the following:
 
 ::
 
@@ -71,32 +62,12 @@ You'll need to edit the site.cfg file around line 128 to set the library to Open
    libraries = openblas
    library_dirs = /usr/local/opt/openblas/lib
    include_dirs = /usr/local/opt/openblas/include
-   runtime_library_dirs = /usr/local/opt/openblas/lib
 
-Check the setup config file.
-
-::
-
-   $ python setup.py config
-
-If you see these settings in the log, it should be ok:
+Install NumPy from the source code
 
 ::
 
-    openblas_info:
-      FOUND:
-        libraries = ['openblas', 'openblas']
-        library_dirs = ['/usr/local/opt/openblas/lib']
-        language = c
-        define_macros = [('HAVE_CBLAS', None)]
-        runtime_library_dirs = ['/usr/local/opt/openblas/lib']
-
-Continue with the build. This takes a few minutes.
-
-::
-
-   $ python setup.py build
-   $ python setup.py install
+   pip install --no-binary :all: numpy
 
 Confirm NumPy has been installed with OpenBLAS by running this command:
 
@@ -121,8 +92,6 @@ You should see the following information:
     ...
 
 Once this is done, you should be able to `import chainer` without OpenBLAS errors.
-
-Thanks for this guide to the Japanese site, `kumilog.net <https://www.kumilog.net/entry/openblas-numpy>`_.
 
 For details of this problem, see `issue #704 <https://github.com/chainer/chainer/issues/704>`_.
 

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -20,6 +20,29 @@ If your home directory is not suited to caching the kernels (e.g. in case that i
 See `CuPy Overview <https://docs-cupy.chainer.org/en/stable/overview.html>`_ for more details.
 
 
+MNIST example does not converge in CPU mode on Mac OS X
+-------------------------------------------------------
+
+Many users have reported that MNIST example does not work correctly
+when using vecLib as NumPy backend on Mac OS X.
+vecLib is the default BLAS library installed on Mac OS X.
+
+We recommend using other BLAS libraries such as `OpenBLAS <http://www.openblas.net/>`_.
+
+To use an alternative BLAS library, it is necessary to reinstall NumPy.
+Here is an instruction to install NumPy with OpenBLAS using `Homebrew <https://brew.sh/>`_.
+
+::
+
+   $ brew tap homebrew/science
+   $ brew install openblas
+   $ brew install numpy --with-openblas
+
+If you want to install NumPy with pip, use `site.cfg <https://github.com/numpy/numpy/blob/master/site.cfg.example>`_ file.
+
+For details of this problem, see `issue #704 <https://github.com/chainer/chainer/issues/704>`_.
+
+
 How do I fix InvalidType error?
 -------------------------------
 


### PR DESCRIPTION
Addressing Issue #4904 

Since vecLib appears to are fixed for MNIST, removing the ReadTheDocs references to work arounds for MacOS NumPy.