### PR TITLE
Update packaging for iDeep 2.0

### DIFF
--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -6,6 +6,7 @@ import six
 
 import chainer
 from chainer.backends import cuda
+from chainer.backends import intel64
 
 
 class _RuntimeInfo(object):
@@ -13,6 +14,7 @@ class _RuntimeInfo(object):
     chainer_version = None
     numpy_version = None
     cuda_info = None
+    ideep_version = None
 
     def __init__(self):
         self.chainer_version = chainer.__version__
@@ -22,6 +24,10 @@ class _RuntimeInfo(object):
             self.cuda_info = cuda.cupyx.get_runtime_info()
         else:
             self.cuda_info = None
+        if intel64.is_ideep_available():
+            self.ideep_version = intel64.ideep.__version__
+        else:
+            self.ideep_version = None
 
     def __str__(self):
         s = six.StringIO()
@@ -34,6 +40,10 @@ class _RuntimeInfo(object):
             s.write('''CuPy:\n''')
             for line in str(self.cuda_info).splitlines():
                 s.write('''  {}\n'''.format(line))
+        if self.ideep_version is None:
+            s.write('''iDeep: Not Available\n''')
+        else:
+            s.write('''iDeep: {}\n'''.format(self.ideep_version))
         return s.getvalue()
 
 

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -111,13 +111,17 @@ Install Chainer Backend for Intel Architecture
 The following environments are recommended by `Chainer Backend for Intel Architecture <https://github.com/intel/ideep>`_.
 
 * Ubuntu 14.04 / 16.04 LTS (64-bit) and CentOS 7 (64-bit)
-* Python 2.7.5+, 3.5.2+, and 3.6.0+
+* Python 2.7.6+, 3.5.2+, and 3.6.0+
 
 On recommended systems, you can install Chainer Backend for Intel Architecture wheel (binary distribution) by:
 
 .. code-block:: console
 
     $ pip install 'ideep4py<2.1'
+
+.. note::
+
+    ``ideep4py`` v1.0.x is incompatible with v2.0.x, and is not supported in Chainer v4.4.0 or later.
 
 Enable Chainer Backend for Intel Architecture Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -121,7 +121,7 @@ On recommended systems, you can install Chainer Backend for Intel Architecture w
 
 .. note::
 
-    ``ideep4py`` v1.0.x is incompatible with v2.0.x, and is not supported in Chainer v4.4.0 or later.
+    ``ideep4py`` v1.0.x is incompatible with v2.0.x, and is not supported in Chainer v5.0 or later.
 
 Enable Chainer Backend for Intel Architecture Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See #5049

This PR includes:
* ~Fix #4948. This also improves the message during installation by displaying detected package path of CuPy. This intends to make it easy for users to understand why and where cupy/ideep4py was detected.~ iDeep requirements will be checked at runtime (#5425)
* Update docs for iDeep 2.0.
* Detect version of iDeep.
* Show iDeep version information in `chianer.print_runtime_info()`.