### PR TITLE
Add hacking 1.1.0 style check to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,5 +66,6 @@ test_script:
   # Run the project tests
   - "%CMD_IN_ENV% pip install -U -e .[appveyor]"
   # Avoid interuption confirmation of cmd.exe
-  - "echo python -m pytest --timeout=60 -m \"not gpu and not cudnn and not ideep and not slow\" tests > tmp.bat"
+  - "echo python -m flake8 . > tmp.bat"
+  - "echo python -m pytest --timeout=60 -m \"not gpu and not cudnn and not ideep and not slow\" tests >> tmp.bat"
   - "call tmp.bat < nul"

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ requirements = {
         'pillow',
     ],
     'appveyor': [
+        'hacking==1.1.0',
         '-r test',
         # pytest-timeout>=1.3.0 requires pytest>=3.6.
         # TODO(niboshi): Consider upgrading pytest to >=3.6


### PR DESCRIPTION
After #4864, we will have to check OpenStack style manually.

It seemed Chainer was incompatible with hacking==1.1.0, but it seems not.  The compatibility problem between the style checkers would be solved by installing either one to each of environments.
