### PR TITLE
[backport] Fix `GetItem.backward` for 0-dim boolean index

### DIFF
--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -8,6 +8,10 @@ from chainer.utils import type_check
 from chainer import variable
 
 
+_numpy_supports_0d_bool_index = \
+    numpy.lib.NumpyVersion(numpy.__version__) >= '1.13.0'
+
+
 class GetItem(function_node.FunctionNode):
 
     """Function that slices array and extract elements."""
@@ -49,10 +53,35 @@ class GetItemGrad(function_node.FunctionNode):
         self._in_dtype = in_dtype
 
     def forward(self, inputs):
+        gy, = inputs
         xp = cuda.get_array_module(*inputs)
         gx = xp.zeros(self._in_shape, self._in_dtype)
         if xp is numpy:
-            numpy.add.at(gx, self.slices, inputs[0])
+            try:
+                numpy.add.at(gx, self.slices, gy)
+            except IndexError:
+                done = False
+                # In numpy<1.13, 0-dim boolean index is not supported in
+                # numpy.add.at and it's supported for 0-dim arr in
+                # arr.__getitem__.
+                if not _numpy_supports_0d_bool_index and len(self.slices) == 1:
+                    idx = numpy.asanyarray(self.slices[0])
+                    if idx.dtype == numpy.dtype(bool):
+                        # Convert the array and the mask to 1-dim.
+                        # numpy.add.at with them is supported in older numpy.
+                        numpy.add.at(gx[None], idx[None], gy)
+                        done = True
+
+                if not done:
+                    msg = '''
+GetItem does not support backward for this slices. The slices argument is not
+supported by numpy.add.at, while it is supported by numpy.ndarray.__getitem__.
+
+Please report this error to the issue tracker with the stack trace,
+the information of your environment, and your script:
+https://github.com/chainer/chainer/issues/new.
+'''
+                    raise IndexError(msg)
         else:
             gx.scatter_add(self.slices, inputs[0])
         return gx,

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -123,13 +123,19 @@ class TestGetItem(unittest.TestCase):
     {'slices': numpy.array([False, False, False, False]),
         'sliced_shape': (0, 3, 2)},
     {'slices': (3, 2, Ellipsis, 1),
-     'sliced_shape': ()},
+        'sliced_shape': ()},
+    {'slices': (numpy.array(False)),
+        'input_shape': (), 'sliced_shape': (0,)},
+    {'slices': (numpy.array(True)),
+        'input_shape': (), 'sliced_shape': (1,)},
 )
 class TestGetItemAdvanced(unittest.TestCase):
 
+    input_shape = (4, 3, 2)
+
     def setUp(self):
         self.x_data = numpy.random.uniform(
-            -1, 1, (4, 3, 2)).astype(numpy.float32)
+            -1, 1, self.input_shape).astype(numpy.float32)
         self.gy_data = numpy.random.uniform(
             -1, 1, self.sliced_shape).astype(numpy.float32)
 


### PR DESCRIPTION
Backport of #4958