### PR TITLE
Support all float dtypes in `F.mean_squared_error`

### DIFF
--- a/chainer/functions/loss/mean_squared_error.py
+++ b/chainer/functions/loss/mean_squared_error.py
@@ -12,8 +12,8 @@ class MeanSquaredError(function_node.FunctionNode):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
-            in_types[0].dtype == numpy.float32,
-            in_types[1].dtype == numpy.float32,
+            in_types[0].dtype.kind == 'f',
+            in_types[0].dtype == in_types[1].dtype,
             in_types[0].shape == in_types[1].shape
         )
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
@@ -9,23 +9,35 @@ from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
+from chainer.utils import type_check
 
 
+@testing.parameterize(
+    {'dtype': numpy.float32,
+     'places': 5,
+     'backward_tols': {'atol': 1e-5, 'rtol': 1e-4},
+     'double_backward_tols': {'atol': 1e-5, 'rtol': 1e-4}},
+    {'dtype': numpy.float16,
+     'places': 3,
+     'backward_tols': {'atol': 5e-2, 'rtol': 5e-1},
+     'double_backward_tols': {'atol': 5e-2, 'rtol': 5e-1}},
+)
 class TestMeanSquaredError(unittest.TestCase):
 
     def setUp(self):
-        self.x0 = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
-        self.x1 = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)
-        self.ggx0 = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
-        self.ggx1 = numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32)
+        dtype = self.dtype
+        self.x0 = numpy.random.uniform(-1, 1, (4, 3)).astype(dtype)
+        self.x1 = numpy.random.uniform(-1, 1, (4, 3)).astype(dtype)
+        self.gy = numpy.random.uniform(-1, 1, ()).astype(dtype)
+        self.ggx0 = numpy.random.uniform(-1, 1, (4, 3)).astype(dtype)
+        self.ggx1 = numpy.random.uniform(-1, 1, (4, 3)).astype(dtype)
 
     def check_forward(self, x0_data, x1_data):
         x0 = chainer.Variable(x0_data)
         x1 = chainer.Variable(x1_data)
         loss = functions.mean_squared_error(x0, x1)
         loss_value = cuda.to_cpu(loss.data)
-        self.assertEqual(loss_value.dtype, numpy.float32)
+        self.assertEqual(loss_value.dtype, self.dtype)
         self.assertEqual(loss_value.shape, ())
 
         # Compute expected value
@@ -34,7 +46,7 @@ class TestMeanSquaredError(unittest.TestCase):
             loss_expect += (self.x0[i] - self.x1[i]) ** 2
         loss_expect /= self.x0.size
 
-        self.assertAlmostEqual(loss_expect, loss_value, places=5)
+        self.assertAlmostEqual(loss_expect, loss_value, places=self.places)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -46,9 +58,11 @@ class TestMeanSquaredError(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
 
     def check_backward(self, x0_data, x1_data):
+        atol = self.backward_tols['atol']
+        rtol = self.backward_tols['rtol']
         gradient_check.check_backward(
             functions.mean_squared_error,
-            (x0_data, x1_data), None, eps=1e-2)
+            (x0_data, x1_data), None, eps=1e-2, atol=atol, rtol=rtol)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -61,10 +75,11 @@ class TestMeanSquaredError(unittest.TestCase):
 
     def check_double_backward(self, x0_data, x1_data, gy_data,
                               ggx0_data, ggx1_data):
-
+        atol = self.double_backward_tols['atol']
+        rtol = self.double_backward_tols['rtol']
         gradient_check.check_double_backward(
             functions.mean_squared_error, (x0_data, x1_data), gy_data,
-            (ggx0_data, ggx1_data), eps=1e-2)
+            (ggx0_data, ggx1_data), eps=1e-2, atol=atol, rtol=rtol)
 
     @condition.retry(3)
     def test_double_backward_cpu(self):
@@ -78,6 +93,25 @@ class TestMeanSquaredError(unittest.TestCase):
             cuda.to_gpu(self.x0), cuda.to_gpu(self.x1),
             cuda.to_gpu(self.gy),
             cuda.to_gpu(self.ggx0), cuda.to_gpu(self.ggx1))
+
+
+class TestMeanSquaredErrorTypeCheck(unittest.TestCase):
+
+    def test_invalid_dtype1(self):
+        x0 = chainer.Variable(
+            numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.int32))
+        x1 = chainer.Variable(
+            numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.int32))
+        with self.assertRaises(type_check.InvalidType):
+            functions.mean_squared_error(x0, x1)
+
+    def test_invalid_dtype2(self):
+        x0 = chainer.Variable(
+            numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float32))
+        x1 = chainer.Variable(
+            numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float16))
+        with self.assertRaises(type_check.InvalidType):
+            functions.mean_squared_error(x0, x1)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_squared_error.py
@@ -58,11 +58,9 @@ class TestMeanSquaredError(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x0), cuda.to_gpu(self.x1))
 
     def check_backward(self, x0_data, x1_data):
-        atol = self.backward_tols['atol']
-        rtol = self.backward_tols['rtol']
         gradient_check.check_backward(
             functions.mean_squared_error,
-            (x0_data, x1_data), None, eps=1e-2, atol=atol, rtol=rtol)
+            (x0_data, x1_data), None, eps=1e-2, **self.backward_tols)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -75,11 +73,9 @@ class TestMeanSquaredError(unittest.TestCase):
 
     def check_double_backward(self, x0_data, x1_data, gy_data,
                               ggx0_data, ggx1_data):
-        atol = self.double_backward_tols['atol']
-        rtol = self.double_backward_tols['rtol']
         gradient_check.check_double_backward(
             functions.mean_squared_error, (x0_data, x1_data), gy_data,
-            (ggx0_data, ggx1_data), eps=1e-2, atol=atol, rtol=rtol)
+            (ggx0_data, ggx1_data), eps=1e-2, **self.double_backward_tols)
 
     @condition.retry(3)
     def test_double_backward_cpu(self):


### PR DESCRIPTION
This PR is a part of #4582 and generalizes `F.mean_squared_error` to support all float dtypes other than `float32`, with loosing the condition of inputs.
