### PR TITLE
Support all float dtypes in `F.mean_absolute_error`

### DIFF
--- a/chainer/functions/loss/mean_absolute_error.py
+++ b/chainer/functions/loss/mean_absolute_error.py
@@ -13,8 +13,8 @@ class MeanAbsoluteError(function_node.FunctionNode):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
-            in_types[0].dtype == numpy.float32,
-            in_types[1].dtype == numpy.float32,
+            in_types[0].dtype.kind == 'f',
+            in_types[0].dtype == in_types[1].dtype,
             in_types[0].shape == in_types[1].shape
         )
 


### PR DESCRIPTION
This PR is a part of #4582 and generalizes `F.mean_absolute_error` to support all float dtypes other than `float32`, with losing the condition of inputs.