### PR TITLE
[backport] Fix dead link to ``numpy.dtype.kind`` in Tips

### DIFF
--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -74,7 +74,7 @@ Here are some examples of ``InvalidType`` errors:
    Expect: in_types[0].dtype.kind == f
    Actual: i != f
 
-In this case, :class:`~numpy.dtype.kind` of ``in_types[0]`` (which means the first input to the function, ``x``) is expected to be ``f`` (floating-point), whereas the input was ``i`` (signed integer).
+In this case, :attr:`~numpy.dtype.kind` of ``in_types[0]`` (which means the first input to the function, ``x``) is expected to be ``f`` (floating-point), whereas the input was ``i`` (signed integer).
 You need to cast the input appropriately before passing to the function (e.g., ``x.astype(np.float32)``).
 
 .. testcode::


### PR DESCRIPTION
Backport of #5051