### PR TITLE
Support default dtype in `L.Maxout`

### DIFF
--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -1,5 +1,6 @@
 import numpy
 
+import chainer
 from chainer.backends import cuda
 from chainer.functions.activation import maxout
 from chainer import link
@@ -63,8 +64,9 @@ class Maxout(link.Chain):
 
         if initial_bias is not None:
             if numpy.isscalar(initial_bias):
+                dtype = chainer.get_dtype()
                 initial_bias = numpy.full(
-                    (linear_out_size,), initial_bias, dtype=numpy.float32)
+                    (linear_out_size,), initial_bias, dtype=dtype)
             elif isinstance(initial_bias, (numpy.ndarray, cuda.ndarray)):
                 initial_bias = initial_bias.reshape(linear_out_size)
             else:

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -152,4 +152,15 @@ class TestInitialization(unittest.TestCase):
         self.check_param()
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float32, numpy.float16],
+}))
+class TestScalarInitialBias(unittest.TestCase):
+
+    def test_scalar_initial_bias(self):
+        with chainer.using_config('dtype', self.dtype):
+            link = links.Maxout(2, 3, 4, initial_bias=0)
+        assert link.linear.b.dtype == self.dtype
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR is a part of #4582, makes `L.Maxout` use the default dtype to initialize its initial bias when a scalar value is supplied for it.