### PR TITLE
Initialize gradient of uninitialized parameter with default dtype when initializer is callable

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1331,7 +1331,7 @@ class Parameter(Variable):
             else:
                 # uninitialized parameter
                 super(Parameter, self).__init__(name=name)
-                dtype = getattr(initializer, 'dtype', numpy.float32)
+                dtype = getattr(initializer, 'dtype', None)
                 self._grad_initializer = constant.NaN(dtype)
         else:
             # parameter initialized with a given shape

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -987,6 +987,15 @@ class TestUninitializedParameter(unittest.TestCase):
         assert x.data.dtype == np.float64
         assert x.grad.dtype == np.float64
 
+    def test_initialize_by_callable_default_dtype(self):
+        def initializer(array):
+            array.fill(1.0)
+        x = chainer.Parameter(initializer=initializer)
+        with chainer.using_config('dtype', np.float16):
+            x.initialize((3, 2))
+        assert x.data.dtype == np.float16
+        assert x.grad.dtype == np.float16
+
     def test_initialize_node(self):
         initializer = initializers.Zero(np.float64)
         x = chainer.Parameter(initializer=initializer)


### PR DESCRIPTION
This PR follows up #4510.

The gradient of an uninitialized parameter was always initialized with NaN of `numpy.float32` when its initializer was a callable, in contrast to its data that was initialized with the default dtype. This caused mismatch of dtypes between the data and the gradient.

This PR fixes it to use the default dtype to initialize the gradient in such case so that the data and the gradient have the same dtype.
