### PR TITLE
Better initializer support in `L.Maxout`

### DIFF
--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -1,3 +1,4 @@
+import functools
 import numpy
 
 from chainer.backends import cuda
@@ -63,22 +64,24 @@ class Maxout(link.Chain):
             initialW = initialW.reshape(linear_out_size, in_size)
         elif callable(initialW):
             def make_initialW_wrapper(initialW):
-                def f(array):
+                @functools.wraps(initialW)
+                def wrapper(array):
                     array.shape = (out_size, pool_size, in_size)
                     initialW(array)
                     array.shape = (linear_out_size, in_size)
-                return f
+                return wrapper
             initialW = make_initialW_wrapper(initialW)
 
         if isinstance(initial_bias, (numpy.ndarray, cuda.ndarray)):
             initial_bias = initial_bias.reshape(linear_out_size)
         elif callable(initial_bias):
             def make_initial_bias_wrapper(initial_bias):
-                def f(array):
+                @functools.wraps(initial_bias)
+                def wrapper(array):
                     array.shape = (out_size, pool_size)
                     initial_bias(array)
                     array.shape = linear_out_size,
-                return f
+                return wrapper
             initial_bias = make_initial_bias_wrapper(initial_bias)
 
         with self.init_scope():

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -60,9 +60,9 @@ class Maxout(link.Chain):
 
         linear_out_size = out_size * pool_size
 
-        if (initialW is None or
-            numpy.isscalar(initialW) or
-            isinstance(initialW, initializer.Initializer)):
+        if initialW is None or \
+           numpy.isscalar(initialW) or \
+           isinstance(initialW, initializer.Initializer):
             pass
         elif chainer.is_arrays_compatible([initialW]):
             if initialW.ndim != 3:
@@ -76,9 +76,9 @@ class Maxout(link.Chain):
                 initialW_orig(array)
                 array.shape = (linear_out_size, in_size)
 
-        if (initial_bias is None or
-            numpy.isscalar(initial_bias) or
-            isinstance(initial_bias, initializer.Initializer)):
+        if initial_bias is None or \
+           numpy.isscalar(initial_bias) or \
+           isinstance(initial_bias, initializer.Initializer):
             pass
         elif chainer.is_arrays_compatible([initial_bias]):
             if initial_bias.ndim != 2:

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -3,6 +3,7 @@ import numpy
 
 from chainer.backends import cuda
 from chainer.functions.activation import maxout
+from chainer import initializer
 from chainer import link
 from chainer.links.connection import linear
 
@@ -60,10 +61,14 @@ class Maxout(link.Chain):
 
         linear_out_size = out_size * pool_size
 
-        if isinstance(initialW, (numpy.ndarray, cuda.ndarray)):
+        if numpy.isscalar(initialW):
+            pass
+        elif isinstance(initialW, (numpy.ndarray, cuda.ndarray)):
             if initialW.ndim != 3:
                 raise ValueError('initialW.ndim should be 3')
             initialW = initialW.reshape(linear_out_size, in_size)
+        elif isinstance(initialW, initializer.Initializer):
+            pass
         elif callable(initialW):
             def make_initialW_wrapper(initialW):
                 @functools.wraps(initialW)
@@ -73,11 +78,17 @@ class Maxout(link.Chain):
                     array.shape = (linear_out_size, in_size)
                 return wrapper
             initialW = make_initialW_wrapper(initialW)
+        else:
+            pass
 
-        if isinstance(initial_bias, (numpy.ndarray, cuda.ndarray)):
+        if numpy.isscalar(initial_bias):
+            pass
+        elif isinstance(initial_bias, (numpy.ndarray, cuda.ndarray)):
             if initial_bias.ndim != 2:
                 raise ValueError('initial_bias.ndim should be 2')
             initial_bias = initial_bias.reshape(linear_out_size)
+        elif isinstance(initial_bias, initializer.Initializer):
+            pass
         elif callable(initial_bias):
             def make_initial_bias_wrapper(initial_bias):
                 @functools.wraps(initial_bias)
@@ -87,6 +98,8 @@ class Maxout(link.Chain):
                     array.shape = linear_out_size,
                 return wrapper
             initial_bias = make_initial_bias_wrapper(initial_bias)
+        else:
+            pass
 
         with self.init_scope():
             self.linear = linear.Linear(

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -61,6 +61,8 @@ class Maxout(link.Chain):
         linear_out_size = out_size * pool_size
 
         if isinstance(initialW, (numpy.ndarray, cuda.ndarray)):
+            if initialW.ndim != 3:
+                raise ValueError('initialW.ndim should be 3')
             initialW = initialW.reshape(linear_out_size, in_size)
         elif callable(initialW):
             def make_initialW_wrapper(initialW):
@@ -73,6 +75,8 @@ class Maxout(link.Chain):
             initialW = make_initialW_wrapper(initialW)
 
         if isinstance(initial_bias, (numpy.ndarray, cuda.ndarray)):
+            if initial_bias.ndim != 2:
+                raise ValueError('initial_bias.ndim should be 2')
             initial_bias = initial_bias.reshape(linear_out_size)
         elif callable(initial_bias):
             def make_initial_bias_wrapper(initial_bias):

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -1,4 +1,3 @@
-import functools
 import numpy
 
 from chainer.backends import cuda
@@ -70,16 +69,12 @@ class Maxout(link.Chain):
         elif isinstance(initialW, initializer.Initializer):
             pass
         elif callable(initialW):
-            def make_initialW_wrapper(initialW):
-                @functools.wraps(initialW)
-                def wrapper(array):
-                    array.shape = (out_size, pool_size, in_size)
-                    initialW(array)
-                    array.shape = (linear_out_size, in_size)
-                return wrapper
-            initialW = make_initialW_wrapper(initialW)
-        else:
-            pass
+            initialW_orig = initialW
+
+            def initialW(array):
+                array.shape = (out_size, pool_size, in_size)
+                initialW_orig(array)
+                array.shape = (linear_out_size, in_size)
 
         if numpy.isscalar(initial_bias):
             pass
@@ -90,16 +85,12 @@ class Maxout(link.Chain):
         elif isinstance(initial_bias, initializer.Initializer):
             pass
         elif callable(initial_bias):
-            def make_initial_bias_wrapper(initial_bias):
-                @functools.wraps(initial_bias)
-                def wrapper(array):
-                    array.shape = (out_size, pool_size)
-                    initial_bias(array)
-                    array.shape = linear_out_size,
-                return wrapper
-            initial_bias = make_initial_bias_wrapper(initial_bias)
-        else:
-            pass
+            initial_bias_orig = initial_bias
+
+            def initial_bias(array):
+                array.shape = (out_size, pool_size)
+                initial_bias_orig(array)
+                array.shape = linear_out_size,
 
         with self.init_scope():
             self.linear = linear.Linear(

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -60,14 +60,14 @@ class Maxout(link.Chain):
 
         linear_out_size = out_size * pool_size
 
-        if numpy.isscalar(initialW):
+        if (initialW is None or
+            numpy.isscalar(initialW) or
+            isinstance(initialW, initializer.Initializer)):
             pass
-        elif initialW is not None and chainer.is_arrays_compatible([initialW]):
+        elif chainer.is_arrays_compatible([initialW]):
             if initialW.ndim != 3:
                 raise ValueError('initialW.ndim should be 3')
             initialW = initialW.reshape(linear_out_size, in_size)
-        elif isinstance(initialW, initializer.Initializer):
-            pass
         elif callable(initialW):
             initialW_orig = initialW
 
@@ -76,15 +76,14 @@ class Maxout(link.Chain):
                 initialW_orig(array)
                 array.shape = (linear_out_size, in_size)
 
-        if numpy.isscalar(initial_bias):
+        if (initial_bias is None or
+            numpy.isscalar(initial_bias) or
+            isinstance(initial_bias, initializer.Initializer)):
             pass
-        elif (initial_bias is not None and
-              chainer.is_arrays_compatible([initial_bias])):
+        elif chainer.is_arrays_compatible([initial_bias]):
             if initial_bias.ndim != 2:
                 raise ValueError('initial_bias.ndim should be 2')
             initial_bias = initial_bias.reshape(linear_out_size)
-        elif isinstance(initial_bias, initializer.Initializer):
-            pass
         elif callable(initial_bias):
             initial_bias_orig = initial_bias
 

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer.backends import cuda
+import chainer
 from chainer.functions.activation import maxout
 from chainer import initializer
 from chainer import link
@@ -62,7 +62,7 @@ class Maxout(link.Chain):
 
         if numpy.isscalar(initialW):
             pass
-        elif isinstance(initialW, (numpy.ndarray, cuda.ndarray)):
+        elif chainer.is_arrays_compatible([initialW]):
             if initialW.ndim != 3:
                 raise ValueError('initialW.ndim should be 3')
             initialW = initialW.reshape(linear_out_size, in_size)
@@ -78,7 +78,7 @@ class Maxout(link.Chain):
 
         if numpy.isscalar(initial_bias):
             pass
-        elif isinstance(initial_bias, (numpy.ndarray, cuda.ndarray)):
+        elif chainer.is_arrays_compatible([initial_bias]):
             if initial_bias.ndim != 2:
                 raise ValueError('initial_bias.ndim should be 2')
             initial_bias = initial_bias.reshape(linear_out_size)

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -62,7 +62,7 @@ class Maxout(link.Chain):
 
         if numpy.isscalar(initialW):
             pass
-        elif chainer.is_arrays_compatible([initialW]):
+        elif initialW is not None and chainer.is_arrays_compatible([initialW]):
             if initialW.ndim != 3:
                 raise ValueError('initialW.ndim should be 3')
             initialW = initialW.reshape(linear_out_size, in_size)
@@ -78,7 +78,8 @@ class Maxout(link.Chain):
 
         if numpy.isscalar(initial_bias):
             pass
-        elif chainer.is_arrays_compatible([initial_bias]):
+        elif (initial_bias is not None and
+              chainer.is_arrays_compatible([initial_bias])):
             if initial_bias.ndim != 2:
                 raise ValueError('initial_bias.ndim should be 2')
             initial_bias = initial_bias.reshape(linear_out_size)

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -6,6 +6,7 @@ import six
 import chainer
 from chainer.backends import cuda
 from chainer import gradient_check
+from chainer.initializers import constant
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
@@ -120,28 +121,78 @@ class TestInvalidMaxout(unittest.TestCase):
             self.link(chainer.Variable(self.x))
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'initializer': ['Initializer', 'scalar', 'ndarray', 'callable'],
+}))
 class TestInitialization(unittest.TestCase):
 
     def setUp(self):
         self.in_size = 2
         self.out_size = 3
         self.pool_size = 4
-        self.initialW = numpy.random.uniform(
-            -1, 1, (self.out_size, self.pool_size, self.in_size)
-        ).astype(numpy.float32)
-        self.initial_bias = numpy.random.uniform(
-            -1, 1, (self.out_size, self.pool_size)
-        ).astype(numpy.float32)
-        self.link = links.Maxout(
-            self.in_size, self.out_size, self.pool_size,
-            initialW=self.initialW, initial_bias=self.initial_bias)
+
+        if self.initializer == 'Initializer':
+            self.initialW = constant.Constant(1.0)
+            self.initial_bias = constant.Constant(2.0)
+        elif self.initializer == 'scalar':
+            self.initialW = 1.0
+            self.initial_bias = 2.0
+        elif self.initializer == 'ndarray':
+            self.initialW = numpy.random.uniform(
+                -1, 1, (self.out_size, self.pool_size, self.in_size)
+            ).astype(self.dtype)
+            self.initial_bias = numpy.random.uniform(
+                -1, 1, (self.out_size, self.pool_size)
+            ).astype(self.dtype)
+        elif self.initializer == 'callable':
+            def callable_initialW(array):
+                assert array.dtype == self.dtype
+                assert array.shape == (
+                    self.out_size, self.pool_size, self.in_size)
+                array.fill(1.0)
+            self.initialW = callable_initialW
+            def callable_initial_bias(array):
+                assert array.dtype == self.dtype
+                assert array.shape == (self.out_size, self.pool_size)
+                array.fill(2.0)
+            self.initial_bias = callable_initial_bias
+        else:
+            raise ValueError('invalid parameter')
+
+        with chainer.using_config('dtype', self.dtype):
+            self.link = links.Maxout(
+                self.in_size, self.out_size, self.pool_size,
+                initialW=self.initialW, initial_bias=self.initial_bias)
 
     def check_param(self):
+        dtype = self.dtype
+        link = self.link
+
+        assert link.linear.W.dtype == dtype
+        assert link.linear.b.dtype == dtype
+
         linear_out_size = self.out_size * self.pool_size
-        initialW = self.initialW.reshape((linear_out_size, -1))
-        testing.assert_allclose(initialW, self.link.linear.W.data)
-        initial_bias = self.initial_bias.reshape((linear_out_size,))
-        testing.assert_allclose(initial_bias, self.link.linear.b.data)
+        if self.initializer == 'Initializer' or self.initializer == 'callable':
+            W = numpy.empty(
+                (self.out_size, self.pool_size, self.in_size), dtype=dtype)
+            self.initialW(W)
+            bias = numpy.empty((self.out_size, self.pool_size), dtype=dtype)
+            self.initial_bias(bias)
+        elif self.initializer == 'scalar':
+            W = numpy.full((self.out_size, self.pool_size, self.in_size),
+                           self.initialW, dtype=dtype)
+            bias = numpy.full((self.out_size, self.pool_size),
+                              self.initial_bias, dtype=dtype)
+        elif self.initializer == 'ndarray':
+            W = self.initialW
+            bias = self.initial_bias
+        else:
+            raise ValueError('invalid parameter')
+        W = W.reshape(linear_out_size, self.in_size)
+        bias = bias.reshape(linear_out_size)
+        testing.assert_allclose(W, link.linear.W.data)
+        testing.assert_allclose(bias, link.linear.b.data)
 
     def test_param_cpu(self):
         self.check_param()
@@ -150,17 +201,6 @@ class TestInitialization(unittest.TestCase):
     def test_param_gpu(self):
         self.link.to_gpu()
         self.check_param()
-
-
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float32, numpy.float16],
-}))
-class TestScalarInitialBias(unittest.TestCase):
-
-    def test_scalar_initial_bias(self):
-        with chainer.using_config('dtype', self.dtype):
-            link = links.Maxout(2, 3, 4, initial_bias=0)
-        assert link.linear.b.dtype == self.dtype
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -207,4 +207,30 @@ class TestInitialization(unittest.TestCase):
         self.check_param()
 
 
+class TestInvalidInitialization(unittest.TestCase):
+
+    def setUp(self):
+        self.in_size = 2
+        self.out_size = 3
+        self.pool_size = 4
+
+    def test_invalid_initialW_ndarray(self):
+        invalid_dim = 1
+        initialW = numpy.random.uniform(
+            -1, 1, (self.out_size, self.pool_size, self.in_size, invalid_dim)
+        ).astype(numpy.float32)
+        with self.assertRaises(ValueError):
+            links.Maxout(
+                self.in_size, self.out_size, self.pool_size, initialW=initialW)
+
+    def test_invalid_initial_bias_ndarray(self):
+        invalid_dim = 1
+        initial_bias = self.initial_bias = numpy.random.uniform(
+            -1, 1, (self.out_size, self.pool_size, invalid_dim)
+        ).astype(numpy.float32)
+        with self.assertRaises(ValueError):
+            links.Maxout(self.in_size, self.out_size, self.pool_size,
+                         initial_bias=initial_bias)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -152,6 +152,7 @@ class TestInitialization(unittest.TestCase):
                     self.out_size, self.pool_size, self.in_size)
                 array.fill(1.0)
             self.initialW = callable_initialW
+
             def callable_initial_bias(array):
                 assert array.dtype == self.dtype
                 assert array.shape == (self.out_size, self.pool_size)

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -168,11 +168,6 @@ class TestInitialization(unittest.TestCase):
 
     def check_param(self):
         link = self.link
-        if self.initializer == 'callable':
-            linear = link.linear
-            assert linear.W.initializer.__name__ == 'callable_initialW'
-            assert linear.b.initializer.__name__ == 'callable_initial_bias'
-
         dtype = self.dtype
         assert link.linear.W.dtype == dtype
         assert link.linear.b.dtype == dtype

--- a/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/links_tests/activation_tests/test_maxout.py
@@ -166,9 +166,13 @@ class TestInitialization(unittest.TestCase):
                 initialW=self.initialW, initial_bias=self.initial_bias)
 
     def check_param(self):
-        dtype = self.dtype
         link = self.link
+        if self.initializer == 'callable':
+            linear = link.linear
+            assert linear.W.initializer.__name__ == 'callable_initialW'
+            assert linear.b.initializer.__name__ == 'callable_initial_bias'
 
+        dtype = self.dtype
         assert link.linear.W.dtype == dtype
         assert link.linear.b.dtype == dtype
 


### PR DESCRIPTION
Merge #5058 and #5064 first.

The documentation of `L.Maxout` says that `initialW` and `initial_bias` can be initializers, but its implementation actually looks assuming that they are scalars or ndarrays.

This PR fixes `L.Maxout` to support general initializers including `Initializer` instances and callables.

Note that callables are wrapped to destructively reshape arrays to initialize into appropreate shapes for L.Maxout.