### PR TITLE
Fix `F.einsum` to support NumPy 1.15

### DIFF
--- a/chainer/functions/math/einsum.py
+++ b/chainer/functions/math/einsum.py
@@ -164,7 +164,7 @@ class DiagEinSum(EinSum):
                 diag_y.setflags(write=True)
             diag_y[...] = _einsum(
                 xp, dtype, self.in_subs, ''.join(direct_sub), *inputs
-            )[expander]
+            )[tuple(expander)]
         return y,
 
 


### PR DESCRIPTION
Fix #4644.

See also #4832.