### PR TITLE
Support default dtype in `L.StatefulMGU`

### DIFF
--- a/chainer/links/connection/mgu.py
+++ b/chainer/links/connection/mgu.py
@@ -61,8 +61,9 @@ class StatefulMGU(MGUBase):
     def __call__(self, x):
         if self.h is None:
             n_batch = x.shape[0]
+            dtype = chainer.get_dtype()
             h_data = self.xp.zeros(
-                (n_batch, self._state_size), dtype=numpy.float32)
+                (n_batch, self._state_size), dtype=dtype)
             h = chainer.Variable(h_data)
         else:
             h = self.h


### PR DESCRIPTION
This PR is a part of #4582, makes `L.StatefulMGU` use the default dtype to initialize its initial state `h`.
