### PR TITLE
[WIP] Add initialW and initial_bias to NStep links

### DIFF
--- a/chainer/links/connection/n_step_gru.py
+++ b/chainer/links/connection/n_step_gru.py
@@ -1,4 +1,8 @@
+import numpy
+
 from chainer.functions.connection import n_step_gru as rnn
+from chainer import initializers
+from chainer.initializers import normal
 from chainer.links.connection import n_step_rnn
 
 
@@ -32,6 +36,12 @@ class NStepGRUBase(n_step_rnn.NStepRNNBase):
     """
 
     n_weights = 6
+
+    def _get_weight_initializer(self, initialW, w_in):
+        if initialW is None:
+            return normal.Normal(numpy.sqrt(1. / w_in))
+        else:
+            return initializers._get_initializer(initialW)
 
 
 class NStepGRU(NStepGRUBase):

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -64,7 +64,7 @@ class NStepRNNBase(link.ChainList):
     """  # NOQA
 
     def __init__(self, n_layers, in_size, out_size, dropout,
-                 initialW, initial_bias, **kwargs):
+                 initialW=None, initial_bias=None, **kwargs):
         if kwargs:
             argument.check_unexpected_kwargs(
                 kwargs,


### PR DESCRIPTION
This PR adds `initialW` and `initial_bias` to `__init__` of the following links: 

- `NStepRNNTanh`
- `NStepRNNReLU`
- `NStepGRU`
- `NStepBiGRU`
- `NStepLSTM`
- `NStepBiLSTM`

As reported in #4755, `NStepLSTM` and `NStepBiLSTM` once had these arguments but has been unintentionally removed. So, this PR fixes #4755.