### PR TITLE
Add upgrade guide for `Link.copyparams` changes

### DIFF
--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -10,13 +10,23 @@ Most changes are carefully designed not to break existing code; however changes 
 Chainer v5
 ==========
 
+Persistent Values are Copied in ``Link.copyparams``
+---------------------------------------------------
+
+:meth:`chainer.Link.copyparams` is a method to copy all parameters of the link to another link.
+This method can be used, for example, to copy parameters between two chains that partially share the same network structure to reuse pretrained weights.
+
+Prior to Chainer v5, only parameters are copied between links.
+In Chainer v5, in addition to parameters, persistent values (see :doc:`guides/serializers` for details) are also copied between links.
+This is especially beneficial when copying parameters of :class:`~chainer.links.BatchNormalization`, as it uses persistent values to record running statistics.
+
+You can skip copying persistent values by passing newly introduced ``copy_persistent=False`` option to :meth:`~chainer.Link.copyparams` so that it behaves as in Chainer v4.
+
 FuncionNodes as Implementation Details
 --------------------------------------
 
-When calling a Chainer function such as :func:`~chainer.functions.relu`, a corresponding :class:`~chainer.FunctionNode` is created internally, defining the forward and backward procedures. These classes are no longer a part of the public interface and you are encouraged not to instantiate these objects directly, as their interfaces may change.
-
-Chainer v5
-==========
+When calling a Chainer function such as :func:`~chainer.functions.relu`, a corresponding :class:`~chainer.FunctionNode` is created internally, defining the forward and backward procedures.
+These classes are no longer a part of the public interface and you are encouraged not to instantiate these objects directly, as their interfaces may change.
 
 Updaters Automatically Call ``Optimizer.new_epoch``
 ---------------------------------------------------


### PR DESCRIPTION
For #4997.

This PR also fixes broken heading. (duplicated "Chainer v5")