### PR TITLE
Move `backends.cuda.copyto` to `backends.copyto` and make it work with iDeep

### DIFF
--- a/chainer/backends/__init__.py
+++ b/chainer/backends/__init__.py
@@ -1,6 +1,8 @@
 import numpy
 
+import chainer
 from chainer.backends import cuda
+from chainer.backends import intel64
 
 
 def copyto(dst, src):
@@ -15,9 +17,12 @@ def copyto(dst, src):
 
     """
     if isinstance(dst, numpy.ndarray):
-        numpy.copyto(dst, cuda.to_cpu(src))
+        numpy.copyto(dst, numpy.asarray(cuda.to_cpu(src)))
+    elif isinstance(dst, intel64.mdarray):
+        intel64.ideep.basic_copyto(dst, cuda.to_cpu(src))
     elif isinstance(dst, cuda.ndarray):
-        if isinstance(src, numpy.ndarray):
+        if isinstance(src, chainer.get_cpu_array_types()):
+            src = numpy.asarray(src)
             if dst.flags.c_contiguous or dst.flags.f_contiguous:
                 dst.set(src)
             else:

--- a/chainer/backends/__init__.py
+++ b/chainer/backends/__init__.py
@@ -1,0 +1,27 @@
+def copyto(dst, src):
+    """Copies the elements of an ndarray to those of another one.
+
+    This function can copy the CPU/GPU arrays to the destination arrays on
+    another device.
+
+    Args:
+        dst (numpy.ndarray or cupy.ndarray): Destination array.
+        src (numpy.ndarray or cupy.ndarray): Source array.
+
+    """
+    if isinstance(dst, numpy.ndarray):
+        numpy.copyto(dst, to_cpu(src))
+    elif isinstance(dst, ndarray):
+        if isinstance(src, numpy.ndarray):
+            if dst.flags.c_contiguous or dst.flags.f_contiguous:
+                dst.set(src)
+            else:
+                cupy.copyto(dst, to_gpu(src, device=dst.device))
+        elif isinstance(src, ndarray):
+            cupy.copyto(dst, src)
+        else:
+            raise TypeError('cannot copy from non-array object of type {}'
+                            .format(type(src)))
+    else:
+        raise TypeError('cannot copy to non-array object of type {}'.format(
+            type(dst)))

--- a/chainer/backends/__init__.py
+++ b/chainer/backends/__init__.py
@@ -12,10 +12,10 @@ def copyto(dst, src):
     another device.
 
     Args:
-        dst (:class:`numpy.ndarray`, :class:`cupy.ndarray` or
-             :class:`ideep4py.mdarray`): Destination array.
-        src (:class:`numpy.ndarray`, :class:`cupy.ndarray` or
-             :class:`ideep4py.mdarray`): Source array.
+        dst (`numpy.ndarray`, `cupy.ndarray` or `ideep4py.mdarray`):
+            Destination array.
+        src (`numpy.ndarray`, `cupy.ndarray` or `ideep4py.mdarray`):
+            Source array.
 
     """
     if isinstance(dst, numpy.ndarray):

--- a/chainer/backends/__init__.py
+++ b/chainer/backends/__init__.py
@@ -12,8 +12,10 @@ def copyto(dst, src):
     another device.
 
     Args:
-        dst (numpy.ndarray or cupy.ndarray): Destination array.
-        src (numpy.ndarray or cupy.ndarray): Source array.
+        dst (:class:`numpy.ndarray`, :class:`cupy.ndarray` or
+             :class:`ideep4py.mdarray`): Destination array.
+        src (:class:`numpy.ndarray`, :class:`cupy.ndarray` or
+             :class:`ideep4py.mdarray`): Source array.
 
     """
     if isinstance(dst, numpy.ndarray):

--- a/chainer/backends/__init__.py
+++ b/chainer/backends/__init__.py
@@ -1,3 +1,8 @@
+import numpy
+
+from chainer.backends import cuda
+
+
 def copyto(dst, src):
     """Copies the elements of an ndarray to those of another one.
 
@@ -10,15 +15,15 @@ def copyto(dst, src):
 
     """
     if isinstance(dst, numpy.ndarray):
-        numpy.copyto(dst, to_cpu(src))
-    elif isinstance(dst, ndarray):
+        numpy.copyto(dst, cuda.to_cpu(src))
+    elif isinstance(dst, cuda.ndarray):
         if isinstance(src, numpy.ndarray):
             if dst.flags.c_contiguous or dst.flags.f_contiguous:
                 dst.set(src)
             else:
-                cupy.copyto(dst, to_gpu(src, device=dst.device))
-        elif isinstance(src, ndarray):
-            cupy.copyto(dst, src)
+                cuda.cupy.copyto(dst, cuda.to_gpu(src, device=dst.device))
+        elif isinstance(src, cuda.ndarray):
+            cuda.cupy.copyto(dst, src)
         else:
             raise TypeError('cannot copy from non-array object of type {}'
                             .format(type(src)))

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -427,35 +427,6 @@ def copy(array, out=None, out_device=None, stream=None):
     return out
 
 
-def copyto(dst, src):
-    """Copies the elements of an ndarray to those of another one.
-
-    This function can copy the CPU/GPU arrays to the destination arrays on
-    another device.
-
-    Args:
-        dst (numpy.ndarray or cupy.ndarray): Destination array.
-        src (numpy.ndarray or cupy.ndarray): Source array.
-
-    """
-    if isinstance(dst, numpy.ndarray):
-        numpy.copyto(dst, to_cpu(src))
-    elif isinstance(dst, ndarray):
-        if isinstance(src, numpy.ndarray):
-            if dst.flags.c_contiguous or dst.flags.f_contiguous:
-                dst.set(src)
-            else:
-                cupy.copyto(dst, to_gpu(src, device=dst.device))
-        elif isinstance(src, ndarray):
-            cupy.copyto(dst, src)
-        else:
-            raise TypeError('cannot copy from non-array object of type {}'
-                            .format(type(src)))
-    else:
-        raise TypeError('cannot copy to non-array object of type {}'.format(
-            type(dst)))
-
-
 # ------------------------------------------------------------------------------
 # Function result memoization
 # ------------------------------------------------------------------------------

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -7,6 +7,7 @@ import numpy
 import six
 
 import chainer
+from chainer import backends
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import initializers
@@ -536,7 +537,7 @@ Assign a Parameter object directly to an attribute within a \
                 d = dst[name]
                 s = src[name]
                 if isinstance(d, array_types) and isinstance(s, array_types):
-                    cuda.copyto(d, s)
+                    backends.copyto(d, s)
                 else:
                     dst[name] = copy.deepcopy(s)
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -9,6 +9,7 @@ import numpy
 
 import chainer
 from chainer import _backprop_utils
+from chainer import backends
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import initializers
@@ -850,7 +851,7 @@ Actual: {0}'''.format(type(data))
         elif dst is None:
             self.initialize(src.shape)
             dst = self.data
-        cuda.copyto(dst, src)
+        backends.copyto(dst, src)
 
     def addgrad(self, var):
         """Accumulates the gradient array from given source variable.

--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -2,6 +2,13 @@ CUDA and Backend Utilities
 ==========================
 
 .. module:: chainer.backends
+.. currentmodule:: /
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.backends.copyto
 
 CUDA
 ----
@@ -28,7 +35,6 @@ CuPy array allocation and copy
    :toctree: generated/
    :nosignatures:
 
-   chainer.backends.copyto
    chainer.backends.cuda.copy
    chainer.backends.cuda.to_cpu
    chainer.backends.cuda.to_gpu

--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -28,8 +28,8 @@ CuPy array allocation and copy
    :toctree: generated/
    :nosignatures:
 
+   chainer.backends.copyto
    chainer.backends.cuda.copy
-   chainer.backends.cuda.copyto
    chainer.backends.cuda.to_cpu
    chainer.backends.cuda.to_gpu
 

--- a/tests/chainer_tests/backends_test/test_init.py
+++ b/tests/chainer_tests/backends_test/test_init.py
@@ -77,3 +77,6 @@ class TestCopyToError(unittest.TestCase):
         dst = None
         with self.assertRaises(TypeError):
             backends.copyto(dst, src)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_test/test_init.py
+++ b/tests/chainer_tests/backends_test/test_init.py
@@ -1,0 +1,48 @@
+class TestCopyTo(unittest.TestCase):
+
+    def test_cpu_to_cpu(self):
+        src = numpy.arange(1, 5, dtype=numpy.float32)
+        dst = numpy.zeros_like(src)
+        cuda.copyto(dst, src)
+        numpy.testing.assert_array_equal(dst, src)
+
+    @attr.gpu
+    def test_cpu_to_gpu(self):
+        src = numpy.arange(1, 5, dtype=numpy.float32)
+        dst = cuda.cupy.zeros_like(src)
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    @attr.gpu
+    def test_gpu_to_cpu(self):
+        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
+        dst = numpy.zeros_like(src.get())
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    @attr.gpu
+    def test_gpu_to_gpu(self):
+        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
+        dst = cuda.cupy.zeros_like(src)
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    @attr.multi_gpu(2)
+    def test_gpu_to_another_gpu(self):
+        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
+        with cuda.get_device_from_id(1):
+            dst = cuda.cupy.zeros_like(src)
+        cuda.copyto(dst, src)
+        cuda.cupy.testing.assert_array_equal(dst, src)
+
+    def test_fail_on_invalid_src(self):
+        src = None
+        dst = numpy.zeros(1)
+        with self.assertRaises(TypeError):
+            cuda.copyto(dst, src)
+
+    def test_fail_on_invalid_dst(self):
+        src = numpy.zeros(1)
+        dst = None
+        with self.assertRaises(TypeError):
+            cuda.copyto(dst, src)

--- a/tests/chainer_tests/backends_test/test_init.py
+++ b/tests/chainer_tests/backends_test/test_init.py
@@ -5,6 +5,7 @@ import numpy
 from chainer import backends
 from chainer.backends import cuda
 from chainer.backends import intel64
+from chainer import testing
 from chainer.testing import attr
 
 

--- a/tests/chainer_tests/backends_test/test_init.py
+++ b/tests/chainer_tests/backends_test/test_init.py
@@ -1,30 +1,39 @@
+import unittest
+
+import numpy
+
+from chainer import backends
+from chainer.backends import cuda
+from chainer.testing import attr
+
+
 class TestCopyTo(unittest.TestCase):
 
     def test_cpu_to_cpu(self):
         src = numpy.arange(1, 5, dtype=numpy.float32)
         dst = numpy.zeros_like(src)
-        cuda.copyto(dst, src)
+        backends.copyto(dst, src)
         numpy.testing.assert_array_equal(dst, src)
 
     @attr.gpu
     def test_cpu_to_gpu(self):
         src = numpy.arange(1, 5, dtype=numpy.float32)
         dst = cuda.cupy.zeros_like(src)
-        cuda.copyto(dst, src)
+        backends.copyto(dst, src)
         cuda.cupy.testing.assert_array_equal(dst, src)
 
     @attr.gpu
     def test_gpu_to_cpu(self):
         src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
         dst = numpy.zeros_like(src.get())
-        cuda.copyto(dst, src)
+        backends.copyto(dst, src)
         cuda.cupy.testing.assert_array_equal(dst, src)
 
     @attr.gpu
     def test_gpu_to_gpu(self):
         src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
         dst = cuda.cupy.zeros_like(src)
-        cuda.copyto(dst, src)
+        backends.copyto(dst, src)
         cuda.cupy.testing.assert_array_equal(dst, src)
 
     @attr.multi_gpu(2)
@@ -32,17 +41,17 @@ class TestCopyTo(unittest.TestCase):
         src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
         with cuda.get_device_from_id(1):
             dst = cuda.cupy.zeros_like(src)
-        cuda.copyto(dst, src)
+        backends.copyto(dst, src)
         cuda.cupy.testing.assert_array_equal(dst, src)
 
     def test_fail_on_invalid_src(self):
         src = None
         dst = numpy.zeros(1)
         with self.assertRaises(TypeError):
-            cuda.copyto(dst, src)
+            backends.copyto(dst, src)
 
     def test_fail_on_invalid_dst(self):
         src = numpy.zeros(1)
         dst = None
         with self.assertRaises(TypeError):
-            cuda.copyto(dst, src)
+            backends.copyto(dst, src)

--- a/tests/chainer_tests/test_cuda.py
+++ b/tests/chainer_tests/test_cuda.py
@@ -299,56 +299,6 @@ class TestToCPUScalar(unittest.TestCase):
         assert y == x
 
 
-class TestCopyTo(unittest.TestCase):
-
-    def test_cpu_to_cpu(self):
-        src = numpy.arange(1, 5, dtype=numpy.float32)
-        dst = numpy.zeros_like(src)
-        cuda.copyto(dst, src)
-        numpy.testing.assert_array_equal(dst, src)
-
-    @attr.gpu
-    def test_cpu_to_gpu(self):
-        src = numpy.arange(1, 5, dtype=numpy.float32)
-        dst = cuda.cupy.zeros_like(src)
-        cuda.copyto(dst, src)
-        cuda.cupy.testing.assert_array_equal(dst, src)
-
-    @attr.gpu
-    def test_gpu_to_cpu(self):
-        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
-        dst = numpy.zeros_like(src.get())
-        cuda.copyto(dst, src)
-        cuda.cupy.testing.assert_array_equal(dst, src)
-
-    @attr.gpu
-    def test_gpu_to_gpu(self):
-        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
-        dst = cuda.cupy.zeros_like(src)
-        cuda.copyto(dst, src)
-        cuda.cupy.testing.assert_array_equal(dst, src)
-
-    @attr.multi_gpu(2)
-    def test_gpu_to_another_gpu(self):
-        src = cuda.cupy.arange(1, 5, dtype=numpy.float32)
-        with cuda.get_device_from_id(1):
-            dst = cuda.cupy.zeros_like(src)
-        cuda.copyto(dst, src)
-        cuda.cupy.testing.assert_array_equal(dst, src)
-
-    def test_fail_on_invalid_src(self):
-        src = None
-        dst = numpy.zeros(1)
-        with self.assertRaises(TypeError):
-            cuda.copyto(dst, src)
-
-    def test_fail_on_invalid_dst(self):
-        src = numpy.zeros(1)
-        dst = None
-        with self.assertRaises(TypeError):
-            cuda.copyto(dst, src)
-
-
 @attr.cudnn
 class TestWorkspace(unittest.TestCase):
 

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -640,6 +640,12 @@ class TestVariable(unittest.TestCase):
                             np.ones(3, dtype=np.float32),
                             cp.ones(3, dtype=np.float32))
 
+    @attr.ideep
+    def test_copydata_cpu_to_ideep(self):
+        self.check_copydata(intel64.ideep.array(np.zeros(3, dtype=np.float32)),
+                            np.ones(3, dtype=np.float32),
+                            np.ones(3, dtype=np.float32))
+
     @attr.gpu
     def test_copydata_gpu_to_gpu(self):
         cp = cuda.cupy
@@ -652,6 +658,12 @@ class TestVariable(unittest.TestCase):
         cp = cuda.cupy
         self.check_copydata(np.zeros(3, dtype=np.float32),
                             cp.ones(3, dtype=np.float32),
+                            np.ones(3, dtype=np.float32))
+
+    @attr.ideep
+    def test_copydata_ideep_to_cpu(self):
+        self.check_copydata(np.zeros(3, dtype=np.float32),
+                            intel64.ideep.array(np.ones(3, dtype=np.float32)),
                             np.ones(3, dtype=np.float32))
 
     @attr.multi_gpu(2)


### PR DESCRIPTION
This fixes #5009.
This is not to-be-backported as `backends.cuda.copyto` is introduced in #4997.