### PR TITLE
Support default dtype in `L.GoogLeNet`

### DIFF
--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -349,7 +349,7 @@ class GoogLeNet(link.Chain):
         return y
 
 
-def prepare(image, size=(224, 224)):
+def prepare(image, size=(224, 224), dtype=None):
     """Converts the given image to the numpy array for GoogLeNet.
 
     Note that you have to call this method before ``__call__``
@@ -375,6 +375,7 @@ def prepare(image, size=(224, 224)):
         raise ImportError('PIL cannot be loaded. Install Pillow!\n'
                           'The actual import error is as follows:\n' +
                           str(_import_error))
+    dtype = chainer.get_dtype(dtype)
     if isinstance(image, numpy.ndarray):
         if image.ndim == 3:
             if image.shape[0] == 1:
@@ -385,9 +386,9 @@ def prepare(image, size=(224, 224)):
     image = image.convert('RGB')
     if size:
         image = image.resize(size)
-    image = numpy.asarray(image, dtype=numpy.float32)
+    image = numpy.asarray(image, dtype=dtype)
     image = image[:, :, ::-1]
-    image -= numpy.array([104.0, 117.0, 123.0], dtype=numpy.float32)  # BGR
+    image -= numpy.array([104.0, 117.0, 123.0], dtype=dtype)  # BGR
     image = image.transpose((2, 0, 1))
     return image
 

--- a/chainer/links/model/vision/googlenet.py
+++ b/chainer/links/model/vision/googlenet.py
@@ -349,7 +349,7 @@ class GoogLeNet(link.Chain):
         return y
 
 
-def prepare(image, size=(224, 224), dtype=None):
+def prepare(image, size=(224, 224)):
     """Converts the given image to the numpy array for GoogLeNet.
 
     Note that you have to call this method before ``__call__``
@@ -375,7 +375,7 @@ def prepare(image, size=(224, 224), dtype=None):
         raise ImportError('PIL cannot be loaded. Install Pillow!\n'
                           'The actual import error is as follows:\n' +
                           str(_import_error))
-    dtype = chainer.get_dtype(dtype)
+    dtype = chainer.get_dtype()
     if isinstance(image, numpy.ndarray):
         if image.ndim == 3:
             if image.shape[0] == 1:

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -358,7 +358,9 @@ class TestGoogLeNet(unittest.TestCase):
             self.assertEqual(y3.dtype, self.dtype)
 
     def test_extract_cpu(self):
-        self.check_extract()
+        err = 'ignore' if self.dtype == numpy.float16 else None
+        with numpy.errstate(over=err): # ignore FP16 overflow
+            self.check_extract()
 
     @attr.gpu
     def test_extract_gpu(self):
@@ -380,7 +382,9 @@ class TestGoogLeNet(unittest.TestCase):
             self.assertEqual(y.dtype, self.dtype)
 
     def test_predict_cpu(self):
-        self.check_predict()
+        err = 'ignore' if self.dtype == numpy.float16 else None
+        with numpy.errstate(over=err): # ignore FP16 overflow
+            self.check_predict()
 
     @attr.gpu
     def test_predict_gpu(self):

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -268,17 +268,12 @@ class TestVGG16Layers(unittest.TestCase):
 class TestGoogLeNet(unittest.TestCase):
 
     def setUp(self):
-        config = chainer.config
-        self._old_dtype = getattr(config._local, 'dtype', None)
-        config.dtype = self.dtype
+        self._config_user = chainer.using_config('dtype', self.dtype)
+        self._config_user.__enter__()
         self.link = googlenet.GoogLeNet(pretrained_model=None)
 
     def tearDown(self):
-        config = chainer.config
-        if self._old_dtype is None:
-            del config.dtype
-        else:
-            config.dtype = self._old_dtype
+        self._config_user.__exit__(None, None, None)
 
     def test_available_layers(self):
         result = self.link.available_layers

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -269,7 +269,7 @@ class TestGoogLeNet(unittest.TestCase):
 
     def setUp(self):
         config = chainer.config
-        self._old_dtype = hasattr(config._local, 'dtype', None)
+        self._old_dtype = getattr(config._local, 'dtype', None)
         config.dtype = self.dtype
         self.link = googlenet.GoogLeNet(pretrained_model=None)
 

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -358,7 +358,7 @@ class TestGoogLeNet(unittest.TestCase):
             self.assertEqual(y3.dtype, self.dtype)
 
     def test_extract_cpu(self):
-        err = 'ignore' if self.dtype == numpy.float16 else None
+        err = 'ignore' if self.dtype is numpy.float16 else None
         with numpy.errstate(over=err): # ignore FP16 overflow
             self.check_extract()
 
@@ -382,7 +382,7 @@ class TestGoogLeNet(unittest.TestCase):
             self.assertEqual(y.dtype, self.dtype)
 
     def test_predict_cpu(self):
-        err = 'ignore' if self.dtype == numpy.float16 else None
+        err = 'ignore' if self.dtype is numpy.float16 else None
         with numpy.errstate(over=err): # ignore FP16 overflow
             self.check_predict()
 

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -268,10 +268,8 @@ class TestVGG16Layers(unittest.TestCase):
 class TestGoogLeNet(unittest.TestCase):
 
     def setUp(self):
-        self._old_dtype = None
         config = chainer.config
-        if hasattr(config._local, 'dtype'):
-            self._old_dtype = config.dtype
+        self._old_dtype = hasattr(config._local, 'dtype', None)
         config.dtype = self.dtype
         self.link = googlenet.GoogLeNet(pretrained_model=None)
 

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import chainer
 from chainer.backends import cuda
 from chainer.links.model.vision import googlenet
 from chainer.links.model.vision import resnet
@@ -259,12 +260,16 @@ class TestVGG16Layers(unittest.TestCase):
         self.check_copy()
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32],
+}))
 @unittest.skipUnless(googlenet.available, 'Pillow is required')
 @attr.slow
 class TestGoogLeNet(unittest.TestCase):
 
     def setUp(self):
-        self.link = googlenet.GoogLeNet(pretrained_model=None)
+        with chainer.using_config('dtype', self.dtype):
+            self.link = googlenet.GoogLeNet(pretrained_model=None)
 
     def test_available_layers(self):
         result = self.link.available_layers
@@ -275,7 +280,7 @@ class TestGoogLeNet(unittest.TestCase):
         xp = self.link.xp
 
         x = Variable(xp.asarray(numpy.random.uniform(
-            -1, 1, (1, 3, 224, 224)).astype(numpy.float32)))
+            -1, 1, (1, 3, 224, 224)).astype(self.dtype)))
         y = cuda.to_cpu(self.link(x)['prob'].data)
         self.assertEqual(y.shape, (1, 1000))
 
@@ -283,7 +288,7 @@ class TestGoogLeNet(unittest.TestCase):
         xp = self.link.xp
 
         x = Variable(xp.asarray(numpy.random.uniform(
-            -1, 1, (1, 3, 224, 224)).astype(numpy.float32)))
+            -1, 1, (1, 3, 224, 224)).astype(self.dtype)))
         y = cuda.to_cpu(self.link(x, ['loss1_fc2'])['loss1_fc2'].data)
         self.assertEqual(y.shape, (1, 1000))
 
@@ -291,7 +296,7 @@ class TestGoogLeNet(unittest.TestCase):
         xp = self.link.xp
 
         x = Variable(xp.asarray(numpy.random.uniform(
-            -1, 1, (1, 3, 224, 224)).astype(numpy.float32)))
+            -1, 1, (1, 3, 224, 224)).astype(self.dtype)))
         y = cuda.to_cpu(self.link(x, ['loss2_fc2'])['loss2_fc2'].data)
         self.assertEqual(y.shape, (1, 1000))
 
@@ -310,45 +315,47 @@ class TestGoogLeNet(unittest.TestCase):
     def test_prepare(self):
         x1 = numpy.random.uniform(0, 255, (320, 240, 3)).astype(numpy.uint8)
         x2 = numpy.random.uniform(0, 255, (320, 240)).astype(numpy.uint8)
-        x3 = numpy.random.uniform(0, 255, (160, 120, 3)).astype(numpy.float32)
-        x4 = numpy.random.uniform(0, 255, (1, 160, 120)).astype(numpy.float32)
+        x3 = numpy.random.uniform(0, 255, (160, 120, 3)).astype(self.dtype)
+        x4 = numpy.random.uniform(0, 255, (1, 160, 120)).astype(self.dtype)
         x5 = numpy.random.uniform(0, 255, (3, 160, 120)).astype(numpy.uint8)
 
-        y1 = googlenet.prepare(x1)
-        self.assertEqual(y1.shape, (3, 224, 224))
-        self.assertEqual(y1.dtype, numpy.float32)
-        y2 = googlenet.prepare(x2)
-        self.assertEqual(y2.shape, (3, 224, 224))
-        self.assertEqual(y2.dtype, numpy.float32)
-        y3 = googlenet.prepare(x3, size=None)
-        self.assertEqual(y3.shape, (3, 160, 120))
-        self.assertEqual(y3.dtype, numpy.float32)
-        y4 = googlenet.prepare(x4)
-        self.assertEqual(y4.shape, (3, 224, 224))
-        self.assertEqual(y4.dtype, numpy.float32)
-        y5 = googlenet.prepare(x5, size=None)
-        self.assertEqual(y5.shape, (3, 160, 120))
-        self.assertEqual(y5.dtype, numpy.float32)
+        with chainer.using_config('dtype', self.dtype):
+            y1 = googlenet.prepare(x1)
+            self.assertEqual(y1.shape, (3, 224, 224))
+            self.assertEqual(y1.dtype, self.dtype)
+            y2 = googlenet.prepare(x2)
+            self.assertEqual(y2.shape, (3, 224, 224))
+            self.assertEqual(y2.dtype, self.dtype)
+            y3 = googlenet.prepare(x3, size=None)
+            self.assertEqual(y3.shape, (3, 160, 120))
+            self.assertEqual(y3.dtype, self.dtype)
+            y4 = googlenet.prepare(x4)
+            self.assertEqual(y4.shape, (3, 224, 224))
+            self.assertEqual(y4.dtype, self.dtype)
+            y5 = googlenet.prepare(x5, size=None)
+            self.assertEqual(y5.shape, (3, 160, 120))
+            self.assertEqual(y5.dtype, self.dtype)
 
     def check_extract(self):
         x1 = numpy.random.uniform(0, 255, (320, 240, 3)).astype(numpy.uint8)
         x2 = numpy.random.uniform(0, 255, (320, 240)).astype(numpy.uint8)
 
-        result = self.link.extract([x1, x2], layers=['pool5', 'loss3_fc'])
-        self.assertEqual(len(result), 2)
-        y1 = cuda.to_cpu(result['pool5'].data)
-        self.assertEqual(y1.shape, (2, 1024, 1, 1))
-        self.assertEqual(y1.dtype, numpy.float32)
-        y2 = cuda.to_cpu(result['loss3_fc'].data)
-        self.assertEqual(y2.shape, (2, 1000))
-        self.assertEqual(y2.dtype, numpy.float32)
+        with chainer.using_config('dtype', self.dtype):
+            result = self.link.extract([x1, x2], layers=['pool5', 'loss3_fc'])
+            self.assertEqual(len(result), 2)
+            y1 = cuda.to_cpu(result['pool5'].data)
+            self.assertEqual(y1.shape, (2, 1024, 1, 1))
+            self.assertEqual(y1.dtype, self.dtype)
+            y2 = cuda.to_cpu(result['loss3_fc'].data)
+            self.assertEqual(y2.shape, (2, 1000))
+            self.assertEqual(y2.dtype, self.dtype)
 
-        x3 = numpy.random.uniform(0, 255, (80, 60)).astype(numpy.uint8)
-        result = self.link.extract([x3], layers=['pool1'], size=None)
-        self.assertEqual(len(result), 1)
-        y3 = cuda.to_cpu(result['pool1'].data)
-        self.assertEqual(y3.shape, (1, 64, 20, 15))
-        self.assertEqual(y3.dtype, numpy.float32)
+            x3 = numpy.random.uniform(0, 255, (80, 60)).astype(numpy.uint8)
+            result = self.link.extract([x3], layers=['pool1'], size=None)
+            self.assertEqual(len(result), 1)
+            y3 = cuda.to_cpu(result['pool1'].data)
+            self.assertEqual(y3.shape, (1, 64, 20, 15))
+            self.assertEqual(y3.dtype, self.dtype)
 
     def test_extract_cpu(self):
         self.check_extract()
@@ -362,14 +369,15 @@ class TestGoogLeNet(unittest.TestCase):
         x1 = numpy.random.uniform(0, 255, (320, 240, 3)).astype(numpy.uint8)
         x2 = numpy.random.uniform(0, 255, (320, 240)).astype(numpy.uint8)
 
-        result = self.link.predict([x1, x2], oversample=False)
-        y = cuda.to_cpu(result.data)
-        self.assertEqual(y.shape, (2, 1000))
-        self.assertEqual(y.dtype, numpy.float32)
-        result = self.link.predict([x1, x2], oversample=True)
-        y = cuda.to_cpu(result.data)
-        self.assertEqual(y.shape, (2, 1000))
-        self.assertEqual(y.dtype, numpy.float32)
+        with chainer.using_config('dtype', self.dtype):
+            result = self.link.predict([x1, x2], oversample=False)
+            y = cuda.to_cpu(result.data)
+            self.assertEqual(y.shape, (2, 1000))
+            self.assertEqual(y.dtype, self.dtype)
+            result = self.link.predict([x1, x2], oversample=True)
+            y = cuda.to_cpu(result.data)
+            self.assertEqual(y.shape, (2, 1000))
+            self.assertEqual(y.dtype, self.dtype)
 
     def test_predict_cpu(self):
         self.check_predict()

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -359,7 +359,7 @@ class TestGoogLeNet(unittest.TestCase):
 
     def test_extract_cpu(self):
         err = 'ignore' if self.dtype is numpy.float16 else None
-        with numpy.errstate(over=err): # ignore FP16 overflow
+        with numpy.errstate(over=err):  # ignore FP16 overflow
             self.check_extract()
 
     @attr.gpu
@@ -383,7 +383,7 @@ class TestGoogLeNet(unittest.TestCase):
 
     def test_predict_cpu(self):
         err = 'ignore' if self.dtype is numpy.float16 else None
-        with numpy.errstate(over=err): # ignore FP16 overflow
+        with numpy.errstate(over=err):  # ignore FP16 overflow
             self.check_predict()
 
     @attr.gpu

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -271,16 +271,16 @@ class TestGoogLeNet(unittest.TestCase):
         self._old_dtype = None
         config = chainer.config
         if hasattr(config._local, 'dtype'):
-            self._old_dtype = getattr(config, 'dtype')
-        setattr(config, 'dtype', self.dtype)
+            self._old_dtype = config.dtype
+        config.dtype = self.dtype
         self.link = googlenet.GoogLeNet(pretrained_model=None)
 
     def tearDown(self):
         config = chainer.config
         if self._old_dtype is None:
-            delattr(config, 'dtype')
+            del config.dtype
         else:
-            setattr(config, 'dtype', self._old_dtype)
+            config.dtype = self._old_dtype
 
     def test_available_layers(self):
         result = self.link.available_layers


### PR DESCRIPTION
This PR is a part of #4582, makes `L.GoogLeNet` use the default dtype in its methods.
