### PR TITLE
Fix dataset path to support Windows

### DIFF
--- a/chainer/dataset/download.py
+++ b/chainer/dataset/download.py
@@ -9,8 +9,9 @@ from six.moves.urllib import request
 from chainer import utils
 
 
-_dataset_root = os.environ.get('CHAINER_DATASET_ROOT',
-                               os.path.expanduser('~/.chainer/dataset'))
+_dataset_root = os.environ.get(
+    'CHAINER_DATASET_ROOT',
+    os.path.join(os.path.expanduser('~'), '.chainer', 'dataset'))
 
 
 def get_dataset_root():


### PR DESCRIPTION
We have to use `os.path.join`.