### PR TITLE
Support default dtype in `L.ResNetLayers`

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -501,7 +501,7 @@ class ResNet152Layers(ResNetLayers):
             pretrained_model, 152, downsample_fb)
 
 
-def prepare(image, size=(224, 224), dtype=None):
+def prepare(image, size=(224, 224)):
     """Converts the given image to the numpy array for ResNets.
 
     Note that you have to call this method before ``__call__``
@@ -517,8 +517,6 @@ def prepare(image, size=(224, 224), dtype=None):
             the order of the channels must be RGB.
         size (pair of ints): Size of converted images.
             If ``None``, the given image is not resized.
-        dtype (numpy.dtype): Dtype of the output array. If ``None``, the
-            default dtype is used.
 
     Returns:
         numpy.ndarray: The converted output array.

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -527,7 +527,7 @@ def prepare(image, size=(224, 224)):
         raise ImportError('PIL cannot be loaded. Install Pillow!\n'
                           'The actual import error is as follows:\n' +
                           str(_import_error))
-    dtype = chainer.get_dtype(dtype)
+    dtype = chainer.get_dtype()
     if isinstance(image, numpy.ndarray):
         if image.ndim == 3:
             if image.shape[0] == 1:

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -501,7 +501,7 @@ class ResNet152Layers(ResNetLayers):
             pretrained_model, 152, downsample_fb)
 
 
-def prepare(image, size=(224, 224)):
+def prepare(image, size=(224, 224), dtype=None):
     """Converts the given image to the numpy array for ResNets.
 
     Note that you have to call this method before ``__call__``
@@ -517,6 +517,8 @@ def prepare(image, size=(224, 224)):
             the order of the channels must be RGB.
         size (pair of ints): Size of converted images.
             If ``None``, the given image is not resized.
+        dtype (numpy.dtype): Dtype of the output array. If ``None``, the
+            default dtype is used.
 
     Returns:
         numpy.ndarray: The converted output array.
@@ -527,6 +529,7 @@ def prepare(image, size=(224, 224)):
         raise ImportError('PIL cannot be loaded. Install Pillow!\n'
                           'The actual import error is as follows:\n' +
                           str(_import_error))
+    dtype = chainer.get_dtype(dtype)
     if isinstance(image, numpy.ndarray):
         if image.ndim == 3:
             if image.shape[0] == 1:
@@ -537,14 +540,14 @@ def prepare(image, size=(224, 224)):
     image = image.convert('RGB')
     if size:
         image = image.resize(size)
-    image = numpy.asarray(image, dtype=numpy.float32)
+    image = numpy.asarray(image, dtype=dtype)
     image = image[:, :, ::-1]
     # NOTE: in the original paper they subtract a fixed mean image,
     #       however, in order to support arbitrary size we instead use the
     #       mean pixel (rather than mean image) as with VGG team. The mean
     #       value used in ResNet is slightly different from that of VGG16.
     image -= numpy.array(
-        [103.063,  115.903,  123.152], dtype=numpy.float32)
+        [103.063,  115.903,  123.152], dtype=dtype)
     image = image.transpose((2, 0, 1))
     return image
 

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import chainer
 from chainer.backends import cuda
 from chainer.links.model.vision import googlenet
 from chainer.links.model.vision import resnet
@@ -12,23 +13,29 @@ from chainer.variable import Variable
 
 
 @testing.parameterize(*testing.product({
+    'dtype': [numpy.float32],
     'n_layers': [50, 101, 152],
     'downsample_fb': [True, False],
-}))
+}) + [{
+    'dtype': numpy.float16,
+    'n_layers': 50,
+    'downsample_fb': False,
+}])
 @unittest.skipUnless(resnet.available, 'Pillow is required')
 @attr.slow
 class TestResNetLayers(unittest.TestCase):
 
     def setUp(self):
-        if self.n_layers == 50:
-            self.link = resnet.ResNet50Layers(
-                pretrained_model=None, downsample_fb=self.downsample_fb)
-        elif self.n_layers == 101:
-            self.link = resnet.ResNet101Layers(
-                pretrained_model=None, downsample_fb=self.downsample_fb)
-        elif self.n_layers == 152:
-            self.link = resnet.ResNet152Layers(
-                pretrained_model=None, downsample_fb=self.downsample_fb)
+        with chainer.using_config('dtype', self.dtype):
+            if self.n_layers == 50:
+                self.link = resnet.ResNet50Layers(
+                    pretrained_model=None, downsample_fb=self.downsample_fb)
+            elif self.n_layers == 101:
+                self.link = resnet.ResNet101Layers(
+                    pretrained_model=None, downsample_fb=self.downsample_fb)
+            elif self.n_layers == 152:
+                self.link = resnet.ResNet152Layers(
+                    pretrained_model=None, downsample_fb=self.downsample_fb)
 
     def test_available_layers(self):
         result = self.link.available_layers
@@ -41,12 +48,12 @@ class TestResNetLayers(unittest.TestCase):
         # Suppress warning that arises from zero division in BatchNormalization
         with numpy.errstate(divide='ignore'):
             x1 = Variable(xp.asarray(numpy.random.uniform(
-                -1, 1, (1, 3, 224, 224)).astype(numpy.float32)))
+                -1, 1, (1, 3, 224, 224)).astype(self.dtype)))
             y1 = cuda.to_cpu(self.link(x1)['prob'].data)
             self.assertEqual(y1.shape, (1, 1000))
 
             x2 = Variable(xp.asarray(numpy.random.uniform(
-                -1, 1, (1, 3, 128, 128)).astype(numpy.float32)))
+                -1, 1, (1, 3, 128, 128)).astype(self.dtype)))
             y2 = cuda.to_cpu(self.link(x2, layers=['pool5'])['pool5'].data)
             self.assertEqual(y2.shape, (1, 2048))
 
@@ -61,46 +68,49 @@ class TestResNetLayers(unittest.TestCase):
     def test_prepare(self):
         x1 = numpy.random.uniform(0, 255, (320, 240, 3)).astype(numpy.uint8)
         x2 = numpy.random.uniform(0, 255, (320, 240)).astype(numpy.uint8)
-        x3 = numpy.random.uniform(0, 255, (160, 120, 3)).astype(numpy.float32)
-        x4 = numpy.random.uniform(0, 255, (1, 160, 120)).astype(numpy.float32)
+        x3 = numpy.random.uniform(0, 255, (160, 120, 3)).astype(self.dtype)
+        x4 = numpy.random.uniform(0, 255, (1, 160, 120)).astype(self.dtype)
         x5 = numpy.random.uniform(0, 255, (3, 160, 120)).astype(numpy.uint8)
 
-        y1 = resnet.prepare(x1)
-        self.assertEqual(y1.shape, (3, 224, 224))
-        self.assertEqual(y1.dtype, numpy.float32)
-        y2 = resnet.prepare(x2)
-        self.assertEqual(y2.shape, (3, 224, 224))
-        self.assertEqual(y2.dtype, numpy.float32)
-        y3 = resnet.prepare(x3, size=None)
-        self.assertEqual(y3.shape, (3, 160, 120))
-        self.assertEqual(y3.dtype, numpy.float32)
-        y4 = resnet.prepare(x4)
-        self.assertEqual(y4.shape, (3, 224, 224))
-        self.assertEqual(y4.dtype, numpy.float32)
-        y5 = resnet.prepare(x5, size=None)
-        self.assertEqual(y5.shape, (3, 160, 120))
-        self.assertEqual(y5.dtype, numpy.float32)
+        with chainer.using_config('dtype', self.dtype):
+            y1 = resnet.prepare(x1)
+            self.assertEqual(y1.shape, (3, 224, 224))
+            self.assertEqual(y1.dtype, self.dtype)
+            y2 = resnet.prepare(x2)
+            self.assertEqual(y2.shape, (3, 224, 224))
+            self.assertEqual(y2.dtype, self.dtype)
+            y3 = resnet.prepare(x3, size=None)
+            self.assertEqual(y3.shape, (3, 160, 120))
+            self.assertEqual(y3.dtype, self.dtype)
+            y4 = resnet.prepare(x4)
+            self.assertEqual(y4.shape, (3, 224, 224))
+            self.assertEqual(y4.dtype, self.dtype)
+            y5 = resnet.prepare(x5, size=None)
+            self.assertEqual(y5.shape, (3, 160, 120))
+            self.assertEqual(y5.dtype, self.dtype)
 
     def check_extract(self):
         x1 = numpy.random.uniform(0, 255, (320, 240, 3)).astype(numpy.uint8)
         x2 = numpy.random.uniform(0, 255, (320, 240)).astype(numpy.uint8)
 
         with numpy.errstate(divide='ignore'):
-            result = self.link.extract([x1, x2], layers=['res3', 'pool5'])
+            with chainer.using_config('dtype', self.dtype):
+                result = self.link.extract([x1, x2], layers=['res3', 'pool5'])
             self.assertEqual(len(result), 2)
             y1 = cuda.to_cpu(result['res3'].data)
             self.assertEqual(y1.shape, (2, 512, 28, 28))
-            self.assertEqual(y1.dtype, numpy.float32)
+            self.assertEqual(y1.dtype, self.dtype)
             y2 = cuda.to_cpu(result['pool5'].data)
             self.assertEqual(y2.shape, (2, 2048))
-            self.assertEqual(y2.dtype, numpy.float32)
+            self.assertEqual(y2.dtype, self.dtype)
 
             x3 = numpy.random.uniform(0, 255, (80, 60)).astype(numpy.uint8)
-            result = self.link.extract([x3], layers=['res2'], size=None)
+            with chainer.using_config('dtype', self.dtype):
+                result = self.link.extract([x3], layers=['res2'], size=None)
             self.assertEqual(len(result), 1)
             y3 = cuda.to_cpu(result['res2'].data)
             self.assertEqual(y3.shape, (1, 256, 20, 15))
-            self.assertEqual(y3.dtype, numpy.float32)
+            self.assertEqual(y3.dtype, self.dtype)
 
     def test_extract_cpu(self):
         self.check_extract()
@@ -115,14 +125,16 @@ class TestResNetLayers(unittest.TestCase):
         x2 = numpy.random.uniform(0, 255, (320, 240)).astype(numpy.uint8)
 
         with numpy.errstate(divide='ignore'):
-            result = self.link.predict([x1, x2], oversample=False)
+            with chainer.using_config('dtype', self.dtype):
+                result = self.link.predict([x1, x2], oversample=False)
             y = cuda.to_cpu(result.data)
             self.assertEqual(y.shape, (2, 1000))
-            self.assertEqual(y.dtype, numpy.float32)
-            result = self.link.predict([x1, x2], oversample=True)
+            self.assertEqual(y.dtype, self.dtype)
+            with chainer.using_config('dtype', self.dtype):
+                result = self.link.predict([x1, x2], oversample=True)
             y = cuda.to_cpu(result.data)
             self.assertEqual(y.shape, (2, 1000))
-            self.assertEqual(y.dtype, numpy.float32)
+            self.assertEqual(y.dtype, self.dtype)
 
     def test_predict_cpu(self):
         self.check_predict()

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -26,10 +26,8 @@ from chainer.variable import Variable
 class TestResNetLayers(unittest.TestCase):
 
     def setUp(self):
-        self._old_dtype = None
         config = chainer.config
-        if hasattr(config._local, 'dtype'):
-            self._old_dtype = config.dtype
+        self._old_dtype = hasattr(config._local, 'dtype', None)
         config.dtype = self.dtype
         if self.n_layers == 50:
             self.link = resnet.ResNet50Layers(

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -26,9 +26,9 @@ from chainer.variable import Variable
 class TestResNetLayers(unittest.TestCase):
 
     def setUp(self):
-        config = chainer.config
-        self._old_dtype = getattr(config._local, 'dtype', None)
-        config.dtype = self.dtype
+        self._config_user = chainer.using_config('dtype', self.dtype)
+        self._config_user.__enter__()
+
         if self.n_layers == 50:
             self.link = resnet.ResNet50Layers(
                 pretrained_model=None, downsample_fb=self.downsample_fb)
@@ -40,11 +40,7 @@ class TestResNetLayers(unittest.TestCase):
                 pretrained_model=None, downsample_fb=self.downsample_fb)
 
     def tearDown(self):
-        config = chainer.config
-        if self._old_dtype is None:
-            del config.dtype
-        else:
-            config.dtype = self._old_dtype
+        self._config_user.__exit__(None, None, None)
 
     def test_available_layers(self):
         result = self.link.available_layers

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -114,7 +114,7 @@ class TestResNetLayers(unittest.TestCase):
 
     def test_extract_cpu(self):
         err = 'ignore' if self.dtype is numpy.float16 else None
-        with numpy.errstate(over=err): # ignore FP16 overflow
+        with numpy.errstate(over=err):  # ignore FP16 overflow
             self.check_extract()
 
     @attr.gpu
@@ -140,7 +140,7 @@ class TestResNetLayers(unittest.TestCase):
 
     def test_predict_cpu(self):
         err = 'ignore' if self.dtype is numpy.float16 else None
-        with numpy.errstate(over=err): # ignore FP16 overflow
+        with numpy.errstate(over=err):  # ignore FP16 overflow
             self.check_predict()
 
     @attr.gpu

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -27,7 +27,7 @@ class TestResNetLayers(unittest.TestCase):
 
     def setUp(self):
         config = chainer.config
-        self._old_dtype = hasattr(config._local, 'dtype', None)
+        self._old_dtype = getattr(config._local, 'dtype', None)
         config.dtype = self.dtype
         if self.n_layers == 50:
             self.link = resnet.ResNet50Layers(

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -29,8 +29,8 @@ class TestResNetLayers(unittest.TestCase):
         self._old_dtype = None
         config = chainer.config
         if hasattr(config._local, 'dtype'):
-            self._old_dtype = getattr(config, 'dtype')
-        setattr(config, 'dtype', self.dtype)
+            self._old_dtype = config.dtype
+        config.dtype = self.dtype
         if self.n_layers == 50:
             self.link = resnet.ResNet50Layers(
                 pretrained_model=None, downsample_fb=self.downsample_fb)
@@ -44,9 +44,9 @@ class TestResNetLayers(unittest.TestCase):
     def tearDown(self):
         config = chainer.config
         if self._old_dtype is None:
-            delattr(config, 'dtype')
+            del config.dtype
         else:
-            setattr(config, 'dtype', self._old_dtype)
+            config.dtype = self._old_dtype
 
     def test_available_layers(self):
         result = self.link.available_layers

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -113,7 +113,9 @@ class TestResNetLayers(unittest.TestCase):
             self.assertEqual(y3.dtype, self.dtype)
 
     def test_extract_cpu(self):
-        self.check_extract()
+        err = 'ignore' if self.dtype is numpy.float16 else None
+        with numpy.errstate(over=err): # ignore FP16 overflow
+            self.check_extract()
 
     @attr.gpu
     def test_extract_gpu(self):
@@ -137,7 +139,9 @@ class TestResNetLayers(unittest.TestCase):
             self.assertEqual(y.dtype, self.dtype)
 
     def test_predict_cpu(self):
-        self.check_predict()
+        err = 'ignore' if self.dtype is numpy.float16 else None
+        with numpy.errstate(over=err): # ignore FP16 overflow
+            self.check_predict()
 
     @attr.gpu
     def test_predict_gpu(self):


### PR DESCRIPTION
This PR is a part of #4582, makes `L.ResNetLayers` use the default dtype in its helper method.