### PR TITLE
Support default dtype in `L.VGG16Layers`

### DIFF
--- a/chainer/links/model/vision/vgg.py
+++ b/chainer/links/model/vision/vgg.py
@@ -338,6 +338,7 @@ def prepare(image, size=(224, 224)):
         raise ImportError('PIL cannot be loaded. Install Pillow!\n'
                           'The actual import error is as follows:\n' +
                           str(_import_error))
+    dtype = chainer.get_dtype()
     if isinstance(image, numpy.ndarray):
         if image.ndim == 3:
             if image.shape[0] == 1:
@@ -348,10 +349,10 @@ def prepare(image, size=(224, 224)):
     image = image.convert('RGB')
     if size:
         image = image.resize(size)
-    image = numpy.asarray(image, dtype=numpy.float32)
+    image = numpy.asarray(image, dtype=dtype)
     image = image[:, :, ::-1]
     image -= numpy.array(
-        [103.939, 116.779, 123.68], dtype=numpy.float32)
+        [103.939, 116.779, 123.68], dtype=dtype)
     image = image.transpose((2, 0, 1))
     return image
 

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -156,17 +156,12 @@ class TestResNetLayers(unittest.TestCase):
 class TestVGG16Layers(unittest.TestCase):
 
     def setUp(self):
-        config = chainer.config
-        self._old_dtype = getattr(config._local, 'dtype', None)
-        config.dtype = self.dtype
+        self._config_user = chainer.using_config('dtype', self.dtype)
+        self._config_user.__enter__()
         self.link = vgg.VGG16Layers(pretrained_model=None)
 
     def tearDown(self):
-        config = chainer.config
-        if self._old_dtype is None:
-            del config.dtype
-        else:
-            config.dtype = self._old_dtype
+        self._config_user.__exit__(None, None, None)
 
     def test_available_layers(self):
         result = self.link.available_layers

--- a/tests/chainer_tests/links_tests/model_tests/test_vision.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_vision.py
@@ -156,10 +156,8 @@ class TestResNetLayers(unittest.TestCase):
 class TestVGG16Layers(unittest.TestCase):
 
     def setUp(self):
-        self._old_dtype = None
         config = chainer.config
-        if hasattr(config._local, 'dtype'):
-            self._old_dtype = config.dtype
+        self._old_dtype = getattr(config._local, 'dtype', None)
         config.dtype = self.dtype
         self.link = vgg.VGG16Layers(pretrained_model=None)
 


### PR DESCRIPTION
This PR is a part of #4582, makes `L.VGG16Layers` use the default dtype in its methods.