### PR TITLE
Support default dtype in `F.spatial_transformer_grid`

### DIFF
--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -24,7 +24,7 @@ class SpatialTransformerGrid(function.Function):
 
         theta_type = in_types[0]
         type_check.expect(
-            theta_type.dtype == self._dtype,
+            theta_type.dtype.kind == 'f',
             theta_type.ndim == 3,
             theta_type.shape[1] == 2,
             theta_type.shape[2] == 3,

--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -16,7 +16,6 @@ class SpatialTransformerGrid(function.Function):
 
     def __init__(self, output_shape):
         self.output_shape = output_shape
-        self._dtype = chainer.get_dtype()
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -63,13 +62,13 @@ class SpatialTransformerGrid(function.Function):
         xp = cuda.get_array_module(theta)
 
         ys, xs = xp.meshgrid(
-            xp.linspace(-1, 1, H, dtype=self._dtype),
-            xp.linspace(-1, 1, W, dtype=self._dtype), indexing='ij',
+            xp.linspace(-1, 1, H, dtype=theta.dtype),
+            xp.linspace(-1, 1, W, dtype=theta.dtype), indexing='ij',
             copy=False
         )
 
         coords = xp.concatenate(
-            [xs[None], ys[None], xp.ones((1, H, W), dtype=self._dtype)],
+            [xs[None], ys[None], xp.ones((1, H, W), dtype=theta.dtype)],
             axis=0)
         grid = theta.dot(coords.reshape(3, H * W)).reshape(B, 2, H, W)
         return grid,
@@ -99,13 +98,13 @@ class SpatialTransformerGrid(function.Function):
         xp = cuda.get_array_module(theta)
 
         ys, xs = xp.meshgrid(
-            xp.linspace(-1, 1, H, dtype=self._dtype),
-            xp.linspace(-1, 1, W, dtype=self._dtype), indexing='ij',
+            xp.linspace(-1, 1, H, dtype=theta.dtype),
+            xp.linspace(-1, 1, W, dtype=theta.dtype), indexing='ij',
             copy=False
         )
 
         coords = xp.concatenate(
-            [xs[None], ys[None], xp.ones((1, H, W), dtype=self._dtype)],
+            [xs[None], ys[None], xp.ones((1, H, W), dtype=theta.dtype)],
             axis=0)
         coords_T = coords.reshape(3, H * W).transpose(1, 0)
         ggrid = ggrid.reshape(B, 2, H * W)

--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -16,6 +16,7 @@ class SpatialTransformerGrid(function.Function):
 
     def __init__(self, output_shape):
         self.output_shape = output_shape
+        self._dtype = chainer.get_dtype()
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -23,7 +24,7 @@ class SpatialTransformerGrid(function.Function):
 
         theta_type = in_types[0]
         type_check.expect(
-            theta_type.dtype.char == 'f',
+            theta_type.dtype == self._dtype,
             theta_type.ndim == 3,
             theta_type.shape[1] == 2,
             theta_type.shape[2] == 3,
@@ -62,13 +63,13 @@ class SpatialTransformerGrid(function.Function):
         xp = cuda.get_array_module(theta)
 
         ys, xs = xp.meshgrid(
-            xp.linspace(-1, 1, H, dtype=numpy.float32),
-            xp.linspace(-1, 1, W, dtype=numpy.float32), indexing='ij',
+            xp.linspace(-1, 1, H, dtype=self._dtype),
+            xp.linspace(-1, 1, W, dtype=self._dtype), indexing='ij',
             copy=False
         )
 
         coords = xp.concatenate(
-            [xs[None], ys[None], xp.ones((1, H, W), dtype=numpy.float32)],
+            [xs[None], ys[None], xp.ones((1, H, W), dtype=self._dtype)],
             axis=0)
         grid = theta.dot(coords.reshape(3, H * W)).reshape(B, 2, H, W)
         return grid,
@@ -98,13 +99,13 @@ class SpatialTransformerGrid(function.Function):
         xp = cuda.get_array_module(theta)
 
         ys, xs = xp.meshgrid(
-            xp.linspace(-1, 1, H, dtype=numpy.float32),
-            xp.linspace(-1, 1, W, dtype=numpy.float32), indexing='ij',
+            xp.linspace(-1, 1, H, dtype=self._dtype),
+            xp.linspace(-1, 1, W, dtype=self._dtype), indexing='ij',
             copy=False
         )
 
         coords = xp.concatenate(
-            [xs[None], ys[None], xp.ones((1, H, W), dtype=numpy.float32)],
+            [xs[None], ys[None], xp.ones((1, H, W), dtype=self._dtype)],
             axis=0)
         coords_T = coords.reshape(3, H * W).transpose(1, 0)
         ggrid = ggrid.reshape(B, 2, H * W)

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
@@ -27,20 +27,14 @@ from chainer.testing import attr
 class TestSpatialTransformerGrid(unittest.TestCase):
 
     def setUp(self):
-        self._config_user = chainer.using_config('dtype', self.dtype)
-        self._config_user.__enter__()
-
         B = 3
         self.theta = numpy.random.uniform(size=(B, 2, 3)).astype(self.dtype)
         self.output_shape = (5, 6)
         self.grads = numpy.random.uniform(
-            size=(B, 2) + self.output_shape).astype(self.theta.dtype)
+            size=(B, 2) + self.output_shape).astype(self.dtype)
 
         self.check_backward_options = {
             'atol': 1e-4, 'rtol': 1e-3}
-
-    def tearDown(self):
-        self._config_user.__exit__(None, None, None)
 
     def check_forward(self, theta, output_shape):
         grid = functions.spatial_transformer_grid(theta, output_shape).data
@@ -58,7 +52,7 @@ class TestSpatialTransformerGrid(unittest.TestCase):
         expected = numpy.array(
             expected).reshape(B, H, W, 2).transpose(0, 3, 1, 2)
         testing.assert_allclose(grid, expected, **self.forward_options)
-        self.assertEqual(grid.dtype, theta.dtype)
+        self.assertEqual(grid.dtype, self.dtype)
 
     def test_forward_cpu(self):
         self.check_forward(self.theta, self.output_shape)

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
@@ -27,11 +27,8 @@ from chainer.testing import attr
 class TestSpatialTransformerGrid(unittest.TestCase):
 
     def setUp(self):
-        self._old_dtype = None
-        config = chainer.config
-        if hasattr(config._local, 'dtype'):
-            self._old_dtype = config.dtype
-        config.dtype = self.dtype
+        self._config_user = chainer.using_config('dtype', self.dtype)
+        self._config_user.__enter__()
 
         B = 3
         self.theta = numpy.random.uniform(size=(B, 2, 3)).astype(self.dtype)
@@ -43,11 +40,7 @@ class TestSpatialTransformerGrid(unittest.TestCase):
             'atol': 1e-4, 'rtol': 1e-3}
 
     def tearDown(self):
-        config = chainer.config
-        if self._old_dtype is None:
-            del config.dtype
-        else:
-            config.dtype = self._old_dtype
+        self._config_user.__exit__(None, None, None)
 
     def check_forward(self, theta, output_shape):
         grid = functions.spatial_transformer_grid(theta, output_shape).data

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
@@ -10,20 +10,44 @@ from chainer import testing
 from chainer.testing import attr
 
 
-@testing.parameterize(*testing.product({
-    'use_cudnn': ['always', 'never'],
-}))
+@testing.parameterize(*testing.product_dict(
+    [{'dtype': numpy.float16,
+      'forward_options': {'atol': 1e-4, 'rtol': 1e-3},
+      'backward_options': {'atol': 1e-2, 'rtol': 1e-1}},
+     {'dtype': numpy.float32,
+      'forward_options': {},
+      'backward_options': {}},
+     {'dtype': numpy.float64,
+      'forward_options': {},
+      'backward_options': {}},
+    ],
+    [{'use_cudnn': 'always'},
+     {'use_cudnn': 'never'}]
+))
 class TestSpatialTransformerGrid(unittest.TestCase):
 
     def setUp(self):
+        self._old_dtype = None
+        config = chainer.config
+        if hasattr(config._local, 'dtype'):
+            self._old_dtype = config.dtype
+        config.dtype = self.dtype
+
         B = 3
-        self.theta = numpy.random.uniform(size=(B, 2, 3)).astype(numpy.float32)
+        self.theta = numpy.random.uniform(size=(B, 2, 3)).astype(self.dtype)
         self.output_shape = (5, 6)
         self.grads = numpy.random.uniform(
             size=(B, 2) + self.output_shape).astype(self.theta.dtype)
 
         self.check_backward_options = {
             'atol': 1e-4, 'rtol': 1e-3}
+
+    def tearDown(self):
+        config = chainer.config
+        if self._old_dtype is None:
+            del config.dtype
+        else:
+            config.dtype = self._old_dtype
 
     def check_forward(self, theta, output_shape):
         grid = functions.spatial_transformer_grid(theta, output_shape).data
@@ -40,7 +64,7 @@ class TestSpatialTransformerGrid(unittest.TestCase):
                     expected.append(self.theta[b].dot(coord))
         expected = numpy.array(
             expected).reshape(B, H, W, 2).transpose(0, 3, 1, 2)
-        testing.assert_allclose(grid, expected)
+        testing.assert_allclose(grid, expected, **self.forward_options)
         self.assertEqual(grid.dtype, theta.dtype)
 
     def test_forward_cpu(self):
@@ -57,7 +81,7 @@ class TestSpatialTransformerGrid(unittest.TestCase):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             gradient_check.check_backward(
                 f, (theta,), (grads,), dtype=numpy.float64,
-                **self.check_backward_options)
+                **self.backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.theta, self.output_shape, self.grads)

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
@@ -24,7 +24,7 @@ class TestSpatialTransformerGrid(unittest.TestCase):
             size=(B, 2) + self.output_shape).astype(self.dtype)
 
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
             self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-1}
         else:
             self.check_forward_options = {}

--- a/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_spatial_transformer_grid.py
@@ -20,7 +20,7 @@ from chainer.testing import attr
      {'dtype': numpy.float64,
       'forward_options': {},
       'backward_options': {}},
-    ],
+     ],
     [{'use_cudnn': 'always'},
      {'use_cudnn': 'never'}]
 ))


### PR DESCRIPTION
This PR is a part of #4582, makes `F.spatial_transformer_gird` use the default dtype.