### PR TITLE
Add isort settings in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,7 @@ python_classes = Test
 python_functions = test
 minversion = 2.9
 addopts = --doctest-modules
+
+[isort]
+known_first_party = chainer,chainer_tests
+force_single_line = True


### PR DESCRIPTION
For ease of making PRs, I've added isort configuration which seems to generate import lines that conform to the convention in this repository.

If you don't like this, please close it silently.