### PR TITLE
Add iDeep to backend docs

### DIFF
--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -28,6 +28,12 @@ _SHOULD_USE_IDEEP = {
 
 
 def is_ideep_available():
+    """Returns if iDeep is available.
+
+    Returns:
+        bool: ``True`` if iDeep is installed.
+    """
+
     return _ideep_version is not None
 
 

--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -1,5 +1,11 @@
-CUDA utilities
---------------
+CUDA and Backend Utilities
+==========================
+
+.. module:: chainer.backends
+
+CUDA
+----
+
 .. automodule:: chainer.backends.cuda
 
 .. currentmodule:: /
@@ -57,3 +63,17 @@ cuDNN support
 
    chainer.backends.cuda.set_max_workspace_size
    chainer.backends.cuda.get_max_workspace_size
+
+iDeep
+-----
+
+`iDeep <https://github.com/intel/ideep>`__ is a module that provides NumPy-like API and DNN acceleration using MKL-DNN for Intel CPUs.
+See :doc:`../tips` and :doc:`../performance` for details.
+
+.. module:: chainer.backends.intel64
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.backends.intel64.is_ideep_available

--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -68,9 +68,10 @@ iDeep
 -----
 
 `iDeep <https://github.com/intel/ideep>`__ is a module that provides NumPy-like API and DNN acceleration using MKL-DNN for Intel CPUs.
-See :doc:`../tips` and :doc:`../performance` for details.
+See :doc:`../../tips` and :doc:`../../performance` for details.
 
 .. module:: chainer.backends.intel64
+.. currentmodule:: chainer
 
 .. autosummary::
    :toctree: generated/


### PR DESCRIPTION
* Separate "CUDA Utilities" section and add iDeep.
  Context: in #5095 (move ``chainer.backends.cuda.copyto`` to ``chainer.backend.copyto``), I want a generic section to add backend-agnostic functions.
* Expose `intel64.is_ideep_available` as public API, as it is convenient because users can use this to decide whether to call ``to_intel64`` or not.