### PR TITLE
Ignore float warnings if testing extreme value

### DIFF
--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -41,6 +41,14 @@ class TestBernoulli(testing.distribution_unittest):
         self.support = '{0, 1}'
         self.continuous = False
 
+        self.old_settings = None
+        if self.extreme_values:
+            self.old_settings = numpy.seterr(divide='ignore', invalid='ignore')
+
+    def tearDown(self):
+        if self.old_settings is not None:
+            numpy.seterr(**self.old_settings)
+
     def sample_for_test(self):
         smp = numpy.random.randint(
             2, size=self.sample_shape + self.shape).astype(numpy.float32)


### PR DESCRIPTION
#5025 has tests that leave warnings.  This PR tentatively suppresses them.

While it's clear that `entropy` method should not warn `0 * log(0)`, other methods (e.g. `log_prob`) may warn `-inf` from `log(0)`.