### PR TITLE
Use default dtype in `F.n_step_rnn` and `F.n_step_birnn`

### DIFF
--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -50,19 +50,6 @@ def _make_tensor_descriptor_array(xs):
     return PointerArray([d.value for d in descs], descs)
 
 
-def _get_cudnn_data_type(dtype):
-    """Return a cudnnDataType_t value corresponding to the numpy float dtype.
-    """
-    if dtype is numpy.float32:
-        return libcudnn.CUDNN_DATA_FLOAT
-    elif dtype is numpy.float16:
-        return libcudnn.CUDNN_DATA_HALF
-    elif dtype is numpy.float64:
-        return libcudnn.CUDNN_DATA_DOUBLE
-    else:
-        raise TypeError('Dtype {} is not supported in cuDNN'.format(dtype))
-
-
 if cuda.cudnn_enabled and _cudnn_version >= 5000:
     # Define RNN parameters using dict.
     _rnn_dirs = {
@@ -167,7 +154,7 @@ class CudnnRNNWeightConcat(function.Function):
         bs = inputs[ws_size:]
         out_size = ws[0].shape[0]
         in_size = ws[0].shape[1]
-        cudnn_data_type = _get_cudnn_data_type(self._dtype)
+        cudnn_data_type = cudnn.get_data_type(self._dtype)
 
         # TODO(unno): Make a wrapper method to avoid access _desc directly
         rnn_desc = cudnn.create_rnn_descriptor(
@@ -344,7 +331,7 @@ class BaseNStepRNN(function.Function):
 
         handle = cudnn.get_handle()
         self.handle = handle
-        cudnn_data_type = _get_cudnn_data_type(self._dtype)
+        cudnn_data_type = cudnn.get_data_type(self._dtype)
 
         # TODO(unno): Make a wrapper method to avoid access _desc directly
         rnn_desc = cudnn.create_rnn_descriptor(

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -51,7 +51,8 @@ def _make_tensor_descriptor_array(xs):
 
 
 def _get_cudnn_data_type(dtype):
-    """Return a cudnnDataType_t value corresponding to the numpy float dtype."""
+    """Return a cudnnDataType_t value corresponding to the numpy float dtype.
+    """
     if dtype is numpy.float32:
         return libcudnn.CUDNN_DATA_FLOAT
     elif dtype is numpy.float16:
@@ -181,7 +182,8 @@ class CudnnRNNWeightConcat(function.Function):
         weights_size = libcudnn.getRNNParamsSize(
             handle, rnn_desc.value, x_desc.value, cudnn_data_type)
         byte_size = self._dtype.itemsize
-        w = cuda.cupy.empty((weights_size // byte_size, 1, 1), dtype=self._dtype)
+        w = cuda.cupy.empty(
+            (weights_size // byte_size, 1, 1), dtype=self._dtype)
         w_desc = cudnn.create_filter_descriptor(w)
 
         for layer in six.moves.range(self.n_layers):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -266,9 +266,21 @@ class TestNStepRNN(unittest.TestCase):
         self.check_call_cudnn_backward('auto')
 
 
-@testing.parameterize(*testing.product({
-    'activation': ['tanh', 'relu']
-}))
+@testing.parameterize(*testing.product_dict(
+    [{'dtype': numpy.float16,
+      'forward_options': {'atol': 5e-3, 'rtol': 5e-3},
+      'backward_options': {'atol': 1e0, 'rtol': 1e0}},
+     {'dtype': numpy.float32,
+      'forward_options': {'atol': 1e-4, 'rtol': 1e-4},
+      'backward_options': {'atol': 1e-2, 'rtol': 5e-2}},
+     {'dtype': numpy.float64,
+      'forward_options': {'atol': 1e-4, 'rtol': 1e-4},
+      'backward_options': {'atol': 1e-2, 'rtol': 5e-2}},
+     ],
+    [{'activation': 'tanh'},
+     {'activation': 'relu'},
+     ],
+))
 class TestNStepBiRNN(unittest.TestCase):
 
     batches = [3, 2, 1]
@@ -279,9 +291,14 @@ class TestNStepBiRNN(unittest.TestCase):
     dropout = 0.0
 
     def setUp(self):
-        self.xs = _shaped_random([(b, self.in_size) for b in self.batches])
+        config = chainer.config
+        self._old_dtype = getattr(config._local, 'dtype', None)
+        config.dtype = self.dtype
+
+        self.xs = _shaped_random(
+            [(b, self.in_size) for b in self.batches], dtype=self.dtype)
         h_shape = (self.n_layers * 2, self.batches[0], self.out_size)
-        self.hx = _shaped_random(h_shape)
+        self.hx = _shaped_random(h_shape, dtype=self.dtype)
 
         i = self.in_size
         o = self.out_size
@@ -289,17 +306,25 @@ class TestNStepBiRNN(unittest.TestCase):
         self.bs = []
         # First layer has the different shape
         for di in range(2):
-            self.ws.append(_shaped_random([(o, i), (o, o)]))
-            self.bs.append(_shaped_random([o, o]))
+            self.ws.append(_shaped_random([(o, i), (o, o)], dtype=self.dtype))
+            self.bs.append(_shaped_random([o, o], dtype=self.dtype))
         # Rest layers
         for _ in range(self.n_layers - 1):
             for di in range(2):
-                self.ws.append(_shaped_random([(o, o * 2), (o, o)]))
-                self.bs.append(_shaped_random([o, o]))
+                self.ws.append(_shaped_random(
+                    [(o, o * 2), (o, o)], dtype=self.dtype))
+                self.bs.append(_shaped_random([o, o], dtype=self.dtype))
 
         self.dys = _shaped_random(
-            [(b, self.out_size * 2) for b in self.batches])
-        self.dhy = _shaped_random(h_shape)
+            [(b, self.out_size * 2) for b in self.batches], dtype=self.dtype)
+        self.dhy = _shaped_random(h_shape, dtype=self.dtype)
+
+    def tearDown(self):
+        config = chainer.config
+        if self._old_dtype is None:
+            del config.dtype
+        else:
+            config.dtype = self._old_dtype
 
     def check_forward(
             self, h_data, xs_data, ws_data, bs_data):
@@ -358,9 +383,9 @@ class TestNStepBiRNN(unittest.TestCase):
                        zip(xf, xb)]
 
         for k, (ysi, xsi) in enumerate(zip(ys, xs_next)):
-            testing.assert_allclose(ysi.data, xsi, rtol=1e-4, atol=1e-4)
+            testing.assert_allclose(ysi.data, xsi, **self.forward_options)
 
-        testing.assert_allclose(hy.data, e_hy, rtol=1e-4, atol=1e-4)
+        testing.assert_allclose(hy.data, e_hy, **self.forward_options)
 
     def test_forward_cpu(self):
         self.check_forward(self.hx, self.xs, self.ws, self.bs)
@@ -403,8 +428,7 @@ class TestNStepBiRNN(unittest.TestCase):
                 activation=self.activation)
             return (hy, ) + ys
 
-        gradient_check.check_backward(
-            f, args, grads, rtol=1e-2, atol=5e-2)
+        gradient_check.check_backward(f, args, grads, **self.backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -269,7 +269,7 @@ class TestNStepRNN(unittest.TestCase):
 @testing.parameterize(*testing.product_dict(
     [{'dtype': numpy.float16,
       'forward_options': {'atol': 5e-3, 'rtol': 5e-3},
-      'backward_options': {'atol': 1e0, 'rtol': 1e0}},
+      'backward_options': {'atol': 3e0, 'rtol': 3e0}},
      {'dtype': numpy.float32,
       'forward_options': {'atol': 1e-4, 'rtol': 1e-4},
       'backward_options': {'atol': 1e-2, 'rtol': 5e-2}},

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -71,9 +71,8 @@ class TestNStepRNN(unittest.TestCase):
     dropout = 0.0
 
     def setUp(self):
-        config = chainer.config
-        self._old_dtype = getattr(config._local, 'dtype', None)
-        config.dtype = self.dtype
+        self._config_user = chainer.using_config('dtype', self.dtype)
+        self._config_user.__enter__()
 
         self.xs = _shaped_random(
             [(b, self.in_size) for b in self.batches], dtype=self.dtype)
@@ -96,11 +95,7 @@ class TestNStepRNN(unittest.TestCase):
         self.dhy = _shaped_random(h_shape, dtype=self.dtype)
 
     def tearDown(self):
-        config = chainer.config
-        if self._old_dtype is None:
-            del config.dtype
-        else:
-            config.dtype = self._old_dtype
+        self._config_user.__exit__(None, None, None)
 
     def check_forward(
             self, h_data, xs_data, ws_data, bs_data):


### PR DESCRIPTION
Merge cupy/cupy#1471  for appropriate cuDNN RNN support, and #5143 first

This PR is a part of #4582, makes `F.n_step_rnn` support the default dtype.