### PR TITLE
modified the iterator section of the tutorial document.

### DIFF
--- a/docs/source/glance.rst
+++ b/docs/source/glance.rst
@@ -204,7 +204,7 @@ Iterator
 ~~~~~~~~
 .. image:: ../image/glance/trainer-iterator.png
 
-Configure :mod:`~chainer.iterators` to step through batches of the data for training and for testing validation. In this case, we'll use a batch size of 100, no repeating, and shuffling not required since we already shuffled the dataset on reading it in.
+Configure :mod:`~chainer.iterators` to step through batches of the data for training and for testing validation. In this case, we'll use a batch size of 100. For the training iterator, repeating and shuffling are implicitly enabled, while they are explicitly disabled for the testing iterator.
 
 .. code-block:: python
 


### PR DESCRIPTION
removed grammatical error from the section.
removed irrational description about repeating and shuffling.
clarify the difference between training and testing iterator (repeat=False, shuffle=False).
