### PR TITLE
Fix L.Convolution2D error message

### DIFF
--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -149,10 +149,10 @@ class Convolution2D(link.Link):
         kh, kw = _pair(self.ksize)
         if self.out_channels % self.groups != 0:
             raise ValueError('the number of output channels must be'
-                             'divisible by the number of groups')
+                             ' divisible by the number of groups')
         if in_channels % self.groups != 0:
             raise ValueError('the number of input channels must be'
-                             'divisible by the number of groups')
+                             ' divisible by the number of groups')
         W_shape = (self.out_channels, int(in_channels / self.groups), kh, kw)
         self.W.initialize(W_shape)
 


### PR DESCRIPTION
The ValueError message of L.Convolution2D is not splitted by a space.

Before:
the number of input channels must bedivisible by the number of groups
After
the number of input channels must be divisible by the number of groups