### PR TITLE
Use data type rather than data type object for default dtype

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -154,7 +154,7 @@ _chainer_dtype = os.environ.get('CHAINER_DTYPE', 'float32')
 if _chainer_dtype not in ('float16', 'float32', 'float64'):
     raise TypeError('incorrect dtype name in CHAINER_DTYPE: "{}". '
                     'Only float16/32/64 are allowed.'.format(_chainer_dtype))
-global_config.dtype = numpy.dtype(_chainer_dtype)
+global_config.dtype = numpy.dtype(_chainer_dtype).type
 
 
 def is_debug():


### PR DESCRIPTION
This PR fixes the default dtype to use data type, such as `numpy.float32`, rather than data type object (an instance of `numpy.dtype`) as the configuration reference expects.