### PR TITLE
Support all float data types in `F.absolute_error`

### DIFF
--- a/chainer/functions/loss/absolute_error.py
+++ b/chainer/functions/loss/absolute_error.py
@@ -1,5 +1,3 @@
-import numpy
-
 from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils

--- a/chainer/functions/loss/absolute_error.py
+++ b/chainer/functions/loss/absolute_error.py
@@ -14,7 +14,7 @@ class AbsoluteError(function_node.FunctionNode):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
             in_types[0].dtype.kind == 'f',
-            in_types[1].dtype.kind == 'f',
+            in_types[0].dtype == in_types[1].dtype,
             in_types[0].shape == in_types[1].shape
         )
 

--- a/chainer/functions/loss/absolute_error.py
+++ b/chainer/functions/loss/absolute_error.py
@@ -13,8 +13,8 @@ class AbsoluteError(function_node.FunctionNode):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
         type_check.expect(
-            in_types[0].dtype == numpy.float32,
-            in_types[1].dtype == numpy.float32,
+            in_types[0].dtype.kind == 'f',
+            in_types[1].dtype.kind == 'f',
             in_types[0].shape == in_types[1].shape
         )
 


### PR DESCRIPTION
This PR follows #4582, generalizes `F.absolute_error` to support all float data types.