### PR TITLE
Trivial fix for parameterized test case of F.contrastive

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_contrastive.py
@@ -15,7 +15,7 @@ from chainer.testing import attr
 @testing.parameterize(
     *testing.product({
         'batchsize': [5, 10], 'input_dim': [2, 3], 'margin': [1, 2],
-        'reduce': ['mean', 'no'], 'label_dtype': [numpy.int32, numpy.int32]
+        'reduce': ['mean', 'no'], 'label_dtype': [numpy.int32, numpy.int64]
     })
 )
 class TestContrastive(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a parameterized test case of `F.contrastive`. The case was introduced in https://github.com/chainer/chainer/pull/3466 .