### PR TITLE
Avoid use of ideep in doctest

### DIFF
--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -141,9 +141,15 @@ You can also use :func:`chainer.using_config` to change the configuration.
         y = chainer.functions.relu(x)
     print(type(y.data))
 
-.. testoutput::
+.. code-block:: console
 
     <class 'ideep4py.mdarray'>
+
+.. Avoid dependency to iDeep module in doctest.
+.. testoutput::
+   :hide:
+
+   <class '...'>
 
 Convert Your Model to iDeep
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -141,7 +141,7 @@ You can also use :func:`chainer.using_config` to change the configuration.
         y = chainer.functions.relu(x)
     print(type(y.data))
 
-.. code-block:: console
+.. code-block:: none
 
     <class 'ideep4py.mdarray'>
 


### PR DESCRIPTION
This fixes #5134.
Please merge https://github.com/chainer/chainer-test/pull/441 after this PR and backport got merged.