### PR TITLE
[hotfix] [backport] Fix backward compatibility of `Link.__call__` MRO

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -194,9 +194,12 @@ class Link(object):
             self._within_init_scope = old_flag
 
     def __call__(self, *args, **kwargs):
-        try:
-            forward = self.forward
-        except AttributeError:
+        # (See #5078) super().__call__ is used when the method is injected by a
+        # mixin class. To keep backward compatibility, the injected one is
+        # prioritized over forward().
+        forward = getattr(super(Link, self), '__call__',
+                          getattr(self, 'forward', None))
+        if forward is None:
             raise TypeError(
                 '{} object has neither \'Link.__call__\' method overridden'
                 ' nor \'forward\' method defined.'.format(self))

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -79,6 +79,22 @@ class TestLink(unittest.TestCase):
             self.link.p = p
         self.assertTrue(all(p is not param for param in self.link.params()))
 
+    def test_call_injected_with_mixin(self):
+        call = mock.MagicMock()
+        call.return_value = 3
+
+        class CallMixin(object):
+            __call__ = call
+
+        class InjectedLink(chainer.Link, CallMixin):
+            pass
+
+        link = InjectedLink()
+        ret = link(1, a=2)
+
+        call.assert_called_once_with(1, a=2)
+        assert ret == call.return_value
+
     def test_add_param(self):
         with testing.assert_warns(DeprecationWarning):
             self.link.add_param('z', (2, 3))


### PR DESCRIPTION
Backport of #5151