### PR TITLE
Support old numpy in `F.split_axis`

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -188,11 +188,6 @@ def split_axis(x, indices_or_sections, axis, force_tuple=True):
         When ``force_tuple`` is ``True``, returned value is always a tuple
         regardless of the number of outputs.
 
-    .. note::
-        This function raises :class:`ValueError` if at least
-        one of the outputs is split to zero-size
-        (i.e. ``axis``-th value of its shape is zero).
-
     """
     res = SplitAxis(indices_or_sections, axis).apply((x,))
     if force_tuple or len(res) != 1:

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -128,7 +128,6 @@ def inject_backend_tests(method_names):
         {'dtype': numpy.float64},
     ],
 ))
-@testing.with_requires('numpy>=1.11')
 @inject_backend_tests(['test_forward', 'test_backward'])
 class TestSplitAxis(unittest.TestCase):
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -31,6 +31,8 @@ def inject_backend_tests(method_names):
              (slice(None), slice(5, None))]},
         {'shape': (7, 3), 'axis': 0, 'ys_section': [2, 5],
          'slices': [slice(None, 2), slice(2, 5), slice(5, None)]},
+        {'shape': (7, 0), 'axis': 0, 'ys_section': [2, 5],
+         'slices': [slice(None, 2), slice(2, 5), slice(5, None)]},
         {'shape': (2, 9, 3), 'axis': 1, 'ys_section': 3,
          'slices': [
              (slice(None), slice(None, 3)),


### PR DESCRIPTION
This PR fixes #4153.

Outputs of `np.split` differ among numpy versions if there's an output with size 0.  It's possible that  intensionally such case had been unsupported.  #4153 added the support, but didn't work with numpy<1.11.