### PR TITLE
[backport] Support old numpy in `F.split_axis`

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -10,6 +10,25 @@ from chainer import function_node
 from chainer.utils import type_check
 
 
+_numpy_split_ok = numpy.lib.NumpyVersion(numpy.__version__) >= '1.11.0'
+
+
+def _fix_numpy_split(ys, x, indices_or_sections, axis):
+    """Make the output of np.split compatible with numpy >= 1.11"""
+    if all(y.ndim == x.ndim for y in ys):
+        return ys
+    tmp = [len(t) for t in numpy.split(
+        numpy.empty(x.shape[axis], dtype=numpy.int8), indices_or_sections, 0)]
+    shape = list(x.shape)
+    for i, t in enumerate(tmp):
+        y = ys[i]
+        if y.ndim != x.ndim:
+            assert y.size == 0
+            shape[axis] = t
+            ys[i] = y.reshape(shape)
+    return ys
+
+
 def _get_indices_or_sections(indices_or_sections):
     """Checks and convert ``indices_or_sections`` argument
 
@@ -93,9 +112,11 @@ class SplitAxis(function_node.FunctionNode):
             indices_or_sections = self.indices
         else:
             indices_or_sections = self.sections
-        ret = tuple(self._xp.split(x, indices_or_sections, self.axis))
+        ret = self._xp.split(x, indices_or_sections, self.axis)
+        if self._xp == numpy and not _numpy_split_ok:
+            ret = _fix_numpy_split(ret, x, indices_or_sections, self.axis)
         self._shapes = [r.shape for r in ret]
-        return ret
+        return tuple(ret)
 
     def _ideep_is_supported(self, inputs):
         # Returns True if iDeep supports current configuration of inputs and
@@ -175,11 +196,6 @@ def split_axis(x, indices_or_sections, axis, force_tuple=True):
         :class:`~chainer.Variable` otherwise.
         When ``force_tuple`` is ``True``, returned value is always a tuple
         regardless of the number of outputs.
-
-    .. note::
-        This function raises :class:`ValueError` if at least
-        one of the outputs is split to zero-size
-        (i.e. ``axis``-th value of its shape is zero).
 
     """
     res = SplitAxis(indices_or_sections, axis).apply((x,))

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -31,6 +31,8 @@ def inject_backend_tests(method_names):
              (slice(None), slice(5, None))]},
         {'shape': (7, 3), 'axis': 0, 'ys_section': [2, 5],
          'slices': [slice(None, 2), slice(2, 5), slice(5, None)]},
+        {'shape': (7, 0), 'axis': 0, 'ys_section': [2, 5],
+         'slices': [slice(None, 2), slice(2, 5), slice(5, None)]},
         {'shape': (2, 9, 3), 'axis': 1, 'ys_section': 3,
          'slices': [
              (slice(None), slice(None, 3)),
@@ -128,7 +130,6 @@ def inject_backend_tests(method_names):
         {'dtype': numpy.float64},
     ],
 ))
-@testing.with_requires('numpy>=1.11')
 @inject_backend_tests(['test_forward', 'test_backward'])
 class TestSplitAxis(unittest.TestCase):
 


### PR DESCRIPTION
Backport of #5157