### PR TITLE
Normalize chainer.config.dtype in  chainer.get_dtype()

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -213,14 +213,14 @@ def get_dtype(dtype=None):
     """Resolves Chainer's default dtype.
 
     Returns:
-        If ``dtype`` is not ``None``, it returns the dtype as is. Otherwise, it
-        returns ``chainer.config.dtype`` (see :ref:`configuration`) normalized
-        to a dtype object.
+        If ``dtype`` is not ``None``, it returns the dtype normalized by
+        ``numpy.dtype()``. Otherwise, it returns ``chainer.config.dtype`` (see
+        :ref:`configuration`) normalized as well.
 
     """
     if dtype is None:
-        return numpy.dtype(config.dtype)
-    return dtype
+        dtype = config.dtype
+    return numpy.dtype(dtype)
 
 
 basic_math.install_variable_arithmetics()

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -214,11 +214,12 @@ def get_dtype(dtype=None):
 
     Returns:
         If ``dtype`` is not ``None``, it returns the dtype as is. Otherwise, it
-        returns ``chainer.config.dtype`` (see :ref:`configuration`).
+        returns ``chainer.config.dtype`` (see :ref:`configuration`) normalized
+        to a dtype object.
 
     """
     if dtype is None:
-        return config.dtype
+        return numpy.dtype(config.dtype)
     return dtype
 
 


### PR DESCRIPTION
This PR fixes `chainer.get_dtype()` to normalize `chainer.config.dtype` in case `chainer.config.dtype` has any of data type specifiers (dtype objects, data types, str, ...) as discussed at https://github.com/chainer/chainer/pull/5143#issuecomment-408788835