### PR TITLE
[backport] Use collections.abc to avoid DeprecationWarning in Python 3.7

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -5,8 +5,8 @@ import chainer
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import function_node
-from chainer.utils import type_check
 from chainer.utils import collections_abc
+from chainer.utils import type_check
 
 
 _numpy_split_ok = numpy.lib.NumpyVersion(numpy.__version__) >= '1.11.0'

--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -1,5 +1,3 @@
-import collections
-
 import numpy
 import six
 
@@ -8,6 +6,7 @@ from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import function_node
 from chainer.utils import type_check
+from chainer.utils import collections_abc
 
 
 _numpy_split_ok = numpy.lib.NumpyVersion(numpy.__version__) >= '1.11.0'
@@ -51,7 +50,7 @@ def _get_indices_or_sections(indices_or_sections):
         if ios.ndim >= 2:
             raise TypeError('indices_or_sections must be 1-D sequence')
         is_seq = ios.ndim != 0
-    elif isinstance(ios, collections.Sequence):
+    elif isinstance(ios, collections_abc.Sequence):
         # Any sequence except numpy.ndarray
         ios = list(ios)
         is_seq = True

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -1,4 +1,3 @@
-import collections
 import numpy
 import six
 
@@ -7,6 +6,7 @@ from chainer.backends import cuda
 from chainer import function
 from chainer import utils
 from chainer.utils import type_check
+from chainer.utils import collections_abc
 
 
 def _logsumexp(a, xp, axis=None):
@@ -388,7 +388,7 @@ def connectionist_temporal_classification(
     <https://www.cs.toronto.edu/~graves/preprint.pdf>`_
 
     """
-    if not isinstance(x, collections.Sequence):
+    if not isinstance(x, collections_abc.Sequence):
         raise TypeError('x must be a list of Variables')
     if not isinstance(blank_symbol, int):
         raise TypeError('blank_symbol must be non-negative integer.')

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -5,8 +5,8 @@ import chainer
 from chainer.backends import cuda
 from chainer import function
 from chainer import utils
-from chainer.utils import type_check
 from chainer.utils import collections_abc
+from chainer.utils import type_check
 
 
 def _logsumexp(a, xp, axis=None):

--- a/chainer/functions/math/tensordot.py
+++ b/chainer/functions/math/tensordot.py
@@ -4,8 +4,8 @@ import six
 from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
-from chainer.utils import type_check
 from chainer.utils import collections_abc
+from chainer.utils import type_check
 
 
 def _tensordot(a, b, a_axes, b_axes, c_axes=None):

--- a/chainer/functions/math/tensordot.py
+++ b/chainer/functions/math/tensordot.py
@@ -1,5 +1,3 @@
-import collections
-
 import numpy
 import six
 
@@ -7,6 +5,7 @@ from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check
+from chainer.utils import collections_abc
 
 
 def _tensordot(a, b, a_axes, b_axes, c_axes=None):
@@ -62,7 +61,7 @@ class TensorDot(function_node.FunctionNode):
         self.c_axes = c_axes
         self.dtype = dtype
 
-        if isinstance(axes, collections.Sequence):
+        if isinstance(axes, collections_abc.Sequence):
             if len(axes) != 2:
                 raise ValueError('axes must be a pair of sequence of integers '
                                  'when it is a list or tuple.')
@@ -89,7 +88,7 @@ class TensorDot(function_node.FunctionNode):
             a_axes = [[], []]  # 0:row axes, 1:col axes
             b_axes = [[], []]  # 0:row axes, 1:col axes
             axes = self.axes
-            if isinstance(axes, collections.Sequence):
+            if isinstance(axes, collections_abc.Sequence):
                 a_axes[1], b_axes[0] = axes
                 if numpy.isscalar(a_axes[1]):
                     a_axes[1] = a_axes[1],

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -9,6 +9,8 @@ from chainer import function
 from chainer import function_node
 from chainer.utils import argument
 from chainer.utils import type_check
+from chainer.utils import collections_abc
+
 
 if cuda.cudnn_enabled:
     cudnn = cuda.cudnn

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -9,8 +9,6 @@ from chainer import function
 from chainer import function_node
 from chainer.utils import argument
 from chainer.utils import type_check
-from chainer.utils import collections_abc
-
 
 if cuda.cudnn_enabled:
     cudnn = cuda.cudnn

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -9,8 +9,8 @@ import chainer
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import initializers
-from chainer import variable
 from chainer.utils import collections_abc
+from chainer import variable
 
 
 def _is_shape(value):

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -1,4 +1,3 @@
-import collections
 import contextlib
 import copy
 import warnings
@@ -11,12 +10,13 @@ from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import initializers
 from chainer import variable
+from chainer.utils import collections_abc
 
 
 def _is_shape(value):
     if value is None:
         return True
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections_abc.Sequence):
         try:
             return all(int(x) for x in value)
         except TypeError:

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import collections
 import shutil
 import tempfile
 
@@ -12,6 +13,14 @@ from chainer.utils.conv import get_conv_outsize  # NOQA
 from chainer.utils.conv import get_deconv_outsize  # NOQA
 from chainer.utils.experimental import experimental  # NOQA
 from chainer.utils.walker_alias import WalkerAlias  # NOQA
+
+
+# TODO(kmaehashi) remove this when `six.moves.collections_abc` is implemented.
+# See: https://github.com/chainer/chainer/issues/5097
+try:
+    collections_abc = collections.abc
+except AttributeError:  # python <3.3
+    collections_abc = collections
 
 
 def force_array(x, dtype=None):

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -1,5 +1,5 @@
-import contextlib
 import collections
+import contextlib
 import shutil
 import tempfile
 


### PR DESCRIPTION
Backport of #5172