### PR TITLE
Fix backward computation in F.forget

### DIFF
--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -54,9 +54,10 @@ class Forget(function_node.FunctionNode):
         with function.force_backprop_mode():
             outs = _call_func(self.func, dummy_inputs)
             assert len(outs) == len(grad_outputs)
-            outs = chainer.functions.identity(*outs)
-        if not isinstance(outs, tuple):
-            outs = (outs,)
+            if len(outs) > 1:
+                # Avoid doing backward multiple times when `outs` is a tuple
+                outs = chainer.functions.identity(*outs)
+
         for out, grad_output in zip(outs, grad_outputs):
             out.grad_var = grad_output
         outs[0].backward()

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -53,10 +53,14 @@ class Forget(function_node.FunctionNode):
 
         with function.force_backprop_mode():
             outs = _call_func(self.func, dummy_inputs)
-        assert len(outs) == len(grad_outputs)
+            assert len(outs) == len(grad_outputs)
+            outs = chainer.functions.identity(*outs)
+        if not isinstance(outs, tuple):
+            outs = (outs,)
         for out, grad_output in zip(outs, grad_outputs):
             out.grad_var = grad_output
-            out.backward()
+        outs[0].backward()
+
         return tuple([inp.grad_var for inp in dummy_inputs])
 
 

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -1,3 +1,4 @@
+import chainer
 from chainer import function
 from chainer import function_node
 from chainer import variable
@@ -41,6 +42,11 @@ class Forget(function_node.FunctionNode):
         return tuple(out.data for out in outs)
 
     def backward(self, indexes, grad_outputs):
+        # Double backprop is not allowed
+        if chainer.config.enable_backprop:
+            raise RuntimeError('double backpropagation in functions.forget is '
+                               'not allowed.')
+
         inputs = self.get_retained_inputs()
         # Create new variables that have no creators
         dummy_inputs = tuple([variable.Variable(inp.array) for inp in inputs])

--- a/tests/chainer_tests/functions_tests/util_tests/test_forget.py
+++ b/tests/chainer_tests/functions_tests/util_tests/test_forget.py
@@ -110,6 +110,18 @@ class TestForgetError(unittest.TestCase):
             functions.forget(lambda: (self.v,) * 12 + (1,))
 
 
+class TestForgetDoubleBackpropError(unittest.TestCase):
+
+    def setUp(self):
+        self.v = chainer.Variable(numpy.zeros(1))
+
+    def test_invalid_double_backprop(self):
+        with self.assertRaises(RuntimeError):
+            x = functions.forget(lambda v: v, self.v)
+            x.grad_var = variable.Variable(numpy.ones_like(x.data))
+            x.backward(enable_double_backprop=True)
+
+
 class TestForgetGrad(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/functions_tests/util_tests/test_forget.py
+++ b/tests/chainer_tests/functions_tests/util_tests/test_forget.py
@@ -12,12 +12,16 @@ from chainer.testing import attr
 from chainer import variable
 
 
+@testing.parameterize(*testing.product({
+    'out_len': [1, 2],
+}))
 class TestForget(unittest.TestCase):
 
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
         self.y = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
-        self.gz = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
+        self.gz0 = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
+        self.gz1 = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
         self.ggx = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
         self.ggy = numpy.random.uniform(-1, 1, (3, 4)).astype(numpy.float32)
 
@@ -27,26 +31,41 @@ class TestForget(unittest.TestCase):
     def check_forward(self, x_data, y_data):
         x = chainer.Variable(x_data)
         y = chainer.Variable(y_data)
-        z = functions.forget(lambda x, y: (x + y + x,), x, y)
-        testing.assert_allclose(x_data + y_data + x_data, z.data)
+        if self.out_len == 1:
+            z = functions.forget(lambda x, y: (x + y + x,), x, y)
+            testing.assert_allclose(x_data + y_data + x_data, z.data)
+        elif self.out_len == 2:
+            z = functions.forget(lambda x, y: (x + y + x, x * y), x, y)
+            testing.assert_allclose(x_data + y_data + x_data, z[0].data)
+            testing.assert_allclose(x_data * y_data, z[1].data)
 
     def test_forward_cpu(self):
         self.check_forward(self.x, self.y)
 
-    def check_backward(self, x_data, y_data, gz_data):
+    def check_backward(self, x_data, y_data, *gz_data):
         def f(x, y):
-            return functions.forget(lambda x, y: (x + y + x), x, y)
+            if self.out_len == 1:
+                return functions.forget(lambda x, y: (x + y + x), x, y)
+            elif self.out_len == 2:
+                return functions.forget(lambda x, y: (x + y + x, x * y), x, y)
 
         gradient_check.check_backward(
             f, (x_data, y_data), gz_data, **self.check_backward_options)
 
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.y, self.gz)
+        if self.out_len == 1:
+            self.check_backward(self.x, self.y, self.gz0)
+        elif self.out_len == 2:
+            self.check_backward(self.x, self.y, self.gz0, self.gz1)
 
     @attr.gpu
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.y),
-                            cuda.to_gpu(self.gz))
+        if self.out_len == 1:
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.y),
+                                cuda.to_gpu(self.gz0))
+        elif self.out_len == 2:
+            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.y),
+                                cuda.to_gpu(self.gz0), cuda.to_gpu(self.gz1))
 
 
 class TestForgetError(unittest.TestCase):


### PR DESCRIPTION
Current `F.forget` doesn't do backward computation appropriately. If `func` includes some model parameters, their gradient parameters may not be set.

Example:
```python
import chainer.functions as F
import chainer.links as L
import numpy as np

class MLP(chainer.Chain):
    def __init__(self):
        super(MLP, self).__init__()
        with self.init_scope():
            self.lin = L.Linear(None, 10)

    def forward(self, x):
        return F.forget(self.lin, x)

def main():
    model = MLP()
    model.cleargrads()
    x = np.random.uniform(-1, 1, (64, 768)).astype(np.float32)
    x = chainer.Variable(x, requires_grad=True)

    y = F.sum(model(x))
    y.backward()
    print(model.lin.W.grad)  # => None
    print(model.lin.b.grad)  # => None

if __name__ == '__main__':
    main()
```

This issue exists because current backward implementation in `F.forget` calls `chainer.grad` function. This PR fixes the issue by replacing the `chainer.grad` with `*.backward()`.