### PR TITLE
Fix collections.Iterable

### DIFF
--- a/chainer/functions/pooling/pooling_2d.py
+++ b/chainer/functions/pooling/pooling_2d.py
@@ -1,9 +1,8 @@
-import collections
-
 import numpy
 
 from chainer.backends import cuda
 from chainer import function_node
+from chainer.utils import collections_abc
 from chainer.utils import conv
 from chainer.utils import type_check
 
@@ -13,7 +12,7 @@ if cuda.cudnn_enabled:
 
 
 def _pair(x):
-    if isinstance(x, collections.Iterable):
+    if isinstance(x, collections_abc.Iterable):
         return x
     return x, x
 

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -1,4 +1,3 @@
-import collections
 import warnings
 
 import numpy
@@ -15,6 +14,7 @@ from chainer.links.connection import linear
 from chainer.links.connection import scale
 from chainer.links.normalization import batch_normalization
 from chainer.utils import argument
+from chainer.utils import collections_abc
 
 
 try:
@@ -211,6 +211,7 @@ class CaffeFunction(link.Chain):
             argument.assert_kwargs_empty(kwargs)
 
         variables = dict(inputs)
+        disable = set(disable)
         for func_name, bottom, top in self.layers:
             if (func_name in disable or
                 func_name not in self.forwards or
@@ -220,7 +221,7 @@ class CaffeFunction(link.Chain):
             func = self.forwards[func_name]
             input_vars = tuple(variables[blob] for blob in bottom)
             output_vars = func(*input_vars)
-            if not isinstance(output_vars, collections.Iterable):
+            if not isinstance(output_vars, collections_abc.Iterable):
                 output_vars = output_vars,
             for var, name in zip(output_vars, top):
                 variables[name] = var

--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -1,3 +1,5 @@
+import collections
+
 from chainer.functions.theano import theano_function
 from chainer import link
 from chainer.utils import collections_abc

--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -1,7 +1,6 @@
-import collections
-
 from chainer.functions.theano import theano_function
 from chainer import link
+from chainer.utils import collections_abc
 
 
 def _to_var_tuple(vs):
@@ -11,7 +10,7 @@ def _to_var_tuple(vs):
 
     if isinstance(vs, theano.tensor.TensorVariable):
         return vs,
-    elif isinstance(vs, collections.Iterable):
+    elif isinstance(vs, collections_abc.Iterable):
         vs = tuple(vs)
         if not all(isinstance(v, theano.tensor.TensorVariable) for v in vs):
             raise TypeError(msg)


### PR DESCRIPTION
- While I've not found a code to produce `DeprecationWarning` by using `chainer`, I'd like to fix `collections.Iterable`, too. (#5097)
- `disable` arg of `CaffeFunction.forward` had to be `collections.abc.Collection`, but the docstring says just `Iterable`.