### PR TITLE
Support 0-dim input in `F.logsumexp`

### DIFF
--- a/chainer/functions/math/logsumexp.py
+++ b/chainer/functions/math/logsumexp.py
@@ -1,6 +1,7 @@
 import chainer
 from chainer.backends import cuda
 from chainer import function_node
+from chainer import utils
 from chainer.utils import type_check
 
 
@@ -43,7 +44,7 @@ class LogSumExp(function_node.FunctionNode):
 
         x, = inputs
         m = x.max(axis=self.axis, keepdims=True)
-        y = x - m
+        y = utils.force_array(x - m)
         xp.exp(y, out=y)
         y_sum = y.sum(axis=self.axis)
         y = xp.asarray(xp.log(y_sum) + m.reshape(y_sum.shape))


### PR DESCRIPTION
Related to #5015 

* Used `chainer.utils.force_array`
* Added shape parameter for tests
* Skiped some tests which is specified axis other than None if input shape is 0-dim
  * referred  to `functions_tests.math_tests.test_einsum._skip_if`
* But does not skip following tests
  * `test_invalid_axis_type`
  * `test_invalid_axis_type_in_tuple`

