### PR TITLE
Avoid keyword arguments in `FunctionHook` callbacks

### DIFF
--- a/chainer/function_hook.py
+++ b/chainer/function_hook.py
@@ -97,14 +97,14 @@ class FunctionHook(object):
             raise KeyError('hook %s already exists' % self.name)
 
         function_hooks[self.name] = self
-        self.added()
+        self.added(None)
         return self
 
     def __exit__(self, *_):
-        chainer.get_function_hooks()[self.name].deleted()
+        chainer.get_function_hooks()[self.name].deleted(None)
         del chainer.get_function_hooks()[self.name]
 
-    def added(self, function=None):
+    def added(self, function):
         """Callback function invoked when a function hook is added
 
         Args:
@@ -113,7 +113,7 @@ class FunctionHook(object):
         """
         pass
 
-    def deleted(self, function=None):
+    def deleted(self, function):
         """Callback function invoked when a function hook is deleted
 
         Args:

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -644,7 +644,7 @@ Use apply() method instead.\
         if name in hooks:
             raise KeyError('Hook %s already exists' % name)
         hooks[name] = hook
-        hook.added(function=self)
+        hook.added(self)
 
     def delete_hook(self, name):
         """Unregisters the function hook.
@@ -654,7 +654,7 @@ Use apply() method instead.\
 
         """
         if name in self.local_function_hooks:
-            self.local_function_hooks[name].deleted(function=self)
+            self.local_function_hooks[name].deleted(self)
             del self.local_function_hooks[name]
         else:
             raise KeyError('Hook %s does not exist' % name)


### PR DESCRIPTION
There should be no point in making it named/optional.