### PR TITLE
Document attributes before methods in class documentation

### DIFF
--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -6,6 +6,18 @@
 .. autoclass:: {{ objname }}
 
    ..
+      Attributes
+
+{% block attributes %} {% if attributes %}
+
+   .. rubric:: Attributes
+
+{% for item in attributes %}
+   .. autoattribute:: {{ item }}
+{%- endfor %}
+{% endif %} {% endblock %}
+
+   ..
       Methods
 
 {% block methods %}
@@ -49,15 +61,3 @@
 {%- endfor %}
 
 {% endblock %}
-
-   ..
-      Attributes
-
-{% block attributes %} {% if attributes %}
-
-   .. rubric:: Attributes
-
-{% for item in attributes %}
-   .. autoattribute:: {{ item }}
-{%- endfor %}
-{% endif %} {% endblock %}


### PR DESCRIPTION
I think it's more convenient.
(I'm not sure why I've written in the oppsite way in the first place)