### PR TITLE
Retain outputs in `F.erfinv`

### DIFF
--- a/chainer/functions/math/erfinv.py
+++ b/chainer/functions/math/erfinv.py
@@ -31,11 +31,11 @@ class ErfInv(function_node.FunctionNode):
             raise ImportError("SciPy is not available. Forward computation"
                               " of erfinv in CPU can not be done." +
                               str(_import_error))
-        self.retain_inputs((0,))
+        self.retain_outputs((0,))
         return utils.force_array(special.erfinv(x[0]), dtype=x[0].dtype),
 
     def forward_gpu(self, x):
-        self.retain_inputs((0,))
+        self.retain_outputs((0,))
         return cuda.elementwise(
             'T x', 'T y',
             'y = erfinv(x)',
@@ -43,8 +43,8 @@ class ErfInv(function_node.FunctionNode):
         )(x[0]),
 
     def backward(self, indexes, gy):
-        x = self.get_retained_inputs()[0]
-        return BACKWORDC * chainer.functions.exp(erfinv(x) ** 2) * gy[0],
+        y, = self.get_retained_outputs()
+        return BACKWORDC * chainer.functions.exp(y ** 2) * gy[0],
 
 
 def erfinv(x):


### PR DESCRIPTION
This PR improves the speed of backward of `F.erfinv`.