### PR TITLE
Improve type check messages for some functions

### DIFF
--- a/chainer/functions/connection/shift.py
+++ b/chainer/functions/connection/shift.py
@@ -23,8 +23,7 @@ class Shift(function_node.FunctionNode):
         self.dy, self.dx = _pair(dilate)
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size()
-        type_check.expect(n_in == 1)
+        type_check.argname(in_types, ('x',))
 
         x_type = in_types[0]
         type_check.expect(

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -11,7 +11,7 @@ class Accuracy(function.Function):
         self.ignore_label = ignore_label
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x', 't'))
         x_type, t_type = in_types
 
         type_check.expect(

--- a/chainer/functions/evaluation/binary_accuracy.py
+++ b/chainer/functions/evaluation/binary_accuracy.py
@@ -10,7 +10,7 @@ class BinaryAccuracy(function.Function):
     ignore_label = -1
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x', 't'))
         x_type, t_type = in_types
 
         type_check.expect(

--- a/chainer/functions/evaluation/classification_summary.py
+++ b/chainer/functions/evaluation/classification_summary.py
@@ -22,7 +22,7 @@ class ClassificationSummary(function.Function):
         self.ignore_label = ignore_label
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x', 't'))
         x_type, t_type = in_types
 
         type_check.expect(

--- a/chainer/functions/evaluation/r2_score.py
+++ b/chainer/functions/evaluation/r2_score.py
@@ -14,7 +14,7 @@ class R2_score(function.Function):
             raise ValueError("invalid multioutput argument")
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('pred', 'true'))
         pred_type, true_type = in_types
 
         type_check.expect(

--- a/chainer/functions/loss/absolute_error.py
+++ b/chainer/functions/loss/absolute_error.py
@@ -9,7 +9,7 @@ class AbsoluteError(function_node.FunctionNode):
     """Element-wise absolute error function."""
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x0', 'x1'))
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,

--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -20,7 +20,7 @@ class Contrastive(function_node.FunctionNode):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 3)
+        type_check.argname(in_types, ('x0', 'x1', 'y'))
 
         x0_type, x1_type, y_type = in_types
         type_check.expect(

--- a/chainer/functions/loss/cross_covariance.py
+++ b/chainer/functions/loss/cross_covariance.py
@@ -21,7 +21,7 @@ class CrossCovariance(function_node.FunctionNode):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('y', 'z'))
         y_type, z_type = in_types
 
         type_check.expect(

--- a/chainer/functions/loss/cross_covariance.py
+++ b/chainer/functions/loss/cross_covariance.py
@@ -22,14 +22,14 @@ class CrossCovariance(function_node.FunctionNode):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 2)
-        z_type, y_type = in_types
+        y_type, z_type = in_types
 
         type_check.expect(
             y_type.dtype.kind == 'f',
             y_type.dtype == z_type.dtype,
             y_type.ndim == 2,
             z_type.ndim == 2,
-            z_type.shape[0] == y_type.shape[0]
+            y_type.shape[0] == z_type.shape[0]
         )
 
     def forward(self, inputs):

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -117,7 +117,8 @@ class ConnectionistTemporalClassification(function.Function):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 4)
+        type_check.argname(
+            in_types, ('input_length', 'label_length', 't', 'x'))
         input_length_type, label_length_type, t_type, x_type = in_types
         type_check.expect(
             input_length_type.dtype == numpy.int32,

--- a/chainer/functions/loss/decov.py
+++ b/chainer/functions/loss/decov.py
@@ -20,7 +20,7 @@ class DeCov(function.Function):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('h',))
         h_type, = in_types
 
         type_check.expect(

--- a/chainer/functions/loss/hinge.py
+++ b/chainer/functions/loss/hinge.py
@@ -30,7 +30,7 @@ class Hinge(function.Function):
                 'given' % reduce)
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x', 't'))
 
         x_type, t_type = in_types
         type_check.expect(

--- a/chainer/functions/loss/huber_loss.py
+++ b/chainer/functions/loss/huber_loss.py
@@ -17,7 +17,7 @@ class HuberLoss(function_node.FunctionNode):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x', 't'))
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,

--- a/chainer/functions/loss/mean_absolute_error.py
+++ b/chainer/functions/loss/mean_absolute_error.py
@@ -11,7 +11,7 @@ class MeanAbsoluteError(function_node.FunctionNode):
     """Mean absolute error function."""
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x0', 'x1'))
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,

--- a/chainer/functions/loss/mean_squared_error.py
+++ b/chainer/functions/loss/mean_squared_error.py
@@ -10,7 +10,7 @@ class MeanSquaredError(function_node.FunctionNode):
     """Mean squared error (a.k.a. Euclidean loss) function."""
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x0', 'x1'))
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].dtype == in_types[1].dtype,

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -38,7 +38,7 @@ class NegativeSamplingFunction(function_node.FunctionNode):
         self.samples = samples
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 3)
+        type_check.argname(in_types, ('x', 't', 'W'))
         x_type, t_type, w_type = in_types
 
         type_check.expect(

--- a/chainer/functions/loss/squared_error.py
+++ b/chainer/functions/loss/squared_error.py
@@ -10,7 +10,7 @@ class SquaredError(function_node.FunctionNode):
     """Squared error function."""
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x0', 'x1'))
         type_check.expect(
             in_types[0].dtype == numpy.float32,
             in_types[1].dtype == numpy.float32,

--- a/chainer/functions/loss/triplet.py
+++ b/chainer/functions/loss/triplet.py
@@ -22,7 +22,7 @@ class Triplet(function_node.FunctionNode):
         self.reduce = reduce
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 3)
+        type_check.argname(in_types, ('anchor', 'positive', 'negative'))
 
         type_check.expect(
             in_types[0].dtype == numpy.float32,


### PR DESCRIPTION
Partially addressed #4969.

- `connection/shift.py`
- `evaluation/*.py`
- `loss/*.py`