### PR TITLE
Use `xp.einsum` in `F.bilinear`

### DIFF
--- a/chainer/functions/connection/bilinear.py
+++ b/chainer/functions/connection/bilinear.py
@@ -80,20 +80,8 @@ class BilinearFunction(function_node.FunctionNode):
         W = inputs[2]
 
         xp = cuda.get_array_module(*inputs)
-        if xp is numpy:
-            # optimize: y = numpy.einsum('ij,ik,jkl->il', e1, e2, W)
-            y = numpy.tensordot(numpy.einsum('ij,ik->ijk', e1, e2), W, axes=2)
-        else:
-            i_len, j_len = e1.shape
-            k_len = e2.shape[1]
-            # 'ij,ik->ijk'
-            e1e2 = e1[:, :, None] * e2[:, None, :]
-            # ijk->i[jk]
-            e1e2 = e1e2.reshape(i_len, j_len * k_len)
-            # jkl->[jk]l
-            W_mat = W.reshape(-1, W.shape[2])
-            # 'i[jk],[jk]l->il'
-            y = e1e2.dot(W_mat)
+        # optimize: y = xp.einsum('ij,ik,jkl->il', e1, e2, W)
+        y = xp.tensordot(xp.einsum('ij,ik->ijk', e1, e2), W, axes=2)
 
         if len(inputs) == 6:
             V1, V2, b = inputs[3:]
@@ -123,28 +111,14 @@ class BilinearFunctionGrad(function_node.FunctionNode):
         W, gy = inputs[2], inputs[-1]
 
         xp = cuda.get_array_module(*inputs)
-        if xp is numpy:
-            # optimize: gW = numpy.einsum('ij,ik,il->jkl', e1, e2, gy)
-            gW = numpy.einsum('ij,ik->jki', e1, e2).dot(gy)
+        # optimize: gW = xp.einsum('ij,ik,il->jkl', e1, e2, gy)
+        gW = xp.einsum('ij,ik->jki', e1, e2).dot(gy)
 
-            gy_W = numpy.tensordot(gy, W, axes=(1, 2))  # 'il,jkl->ijk'
-            # optimize: ge1 = numpy.einsum('ik,jkl,il->ij', e2, W, gy)
-            ge1 = numpy.einsum('ik,ijk->ij', e2, gy_W)
-            # optimize: ge2 = numpy.einsum('ij,jkl,il->ik', e1, W, gy)
-            ge2 = numpy.einsum('ij,ijk->ik', e1, gy_W)
-        else:
-            kern = cuda.reduce('T in0, T in1, T in2', 'T out',
-                               'in0 * in1 * in2', 'a + b', 'out = a', 0,
-                               'bilinear_product')
-
-            e1_b = e1[:, :, None, None]  # ij
-            e2_b = e2[:, None, :, None]  # ik
-            gy_b = gy[:, None, None, :]  # il
-            W_b = W[None, :, :, :]  # jkl
-
-            gW = kern(e1_b, e2_b, gy_b, axis=0)  # 'ij,ik,il->jkl'
-            ge1 = kern(e2_b, W_b, gy_b, axis=(2, 3))  # 'ik,jkl,il->ij'
-            ge2 = kern(e1_b, W_b, gy_b, axis=(1, 3))  # 'ij,jkl,il->ik'
+        gy_W = xp.tensordot(gy, W, axes=(1, 2))  # 'il,jkl->ijk'
+        # optimize: ge1 = xp.einsum('ik,jkl,il->ij', e2, W, gy)
+        ge1 = xp.einsum('ik,ijk->ij', e2, gy_W)
+        # optimize: ge2 = xp.einsum('ij,jkl,il->ik', e1, W, gy)
+        ge2 = xp.einsum('ij,ijk->ik', e1, gy_W)
 
         ret = ge1.reshape(inputs[0].shape), ge2.reshape(inputs[1].shape), gW
 


### PR DESCRIPTION
Do the other fix to #4736 than #4738.  `cupy>=v5.0.0b2` has moderately efficient `einsum`.

This PR should not be backported to v4.