### PR TITLE
 Support all float dtypes in `F.sigmoid_cross_entropy`

### DIFF
--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -1,5 +1,3 @@
-import numpy
-
 import chainer
 from chainer.backends import cuda
 from chainer import function_node
@@ -28,7 +26,7 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
         x_type, t_type = in_types
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             t_type.dtype.kind == 'i',
             x_type.shape == t_type.shape
         )

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -55,7 +55,7 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
         # TODO(takagi): Fix to perform division in a specific dtype. See
         # cupy/cupy#1534.
         return utils.force_array(
-            xp.divide(xp.sum(loss), self.count).astype(x.dtype)),
+            xp.divide(xp.sum(loss), self.count), dtype=x.dtype),
 
     def backward(self, inputs, grad_outputs):
         x, t = self.get_retained_inputs()

--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -52,8 +52,10 @@ class SigmoidCrossEntropy(function_node.FunctionNode):
             count = max(1, len(x))
         self.count = count
 
+        # TODO(takagi): Fix to perform division in a specific dtype. See
+        # cupy/cupy#1534.
         return utils.force_array(
-            xp.divide(xp.sum(loss), self.count, dtype=x.dtype)),
+            xp.divide(xp.sum(loss), self.count).astype(x.dtype)),
 
     def backward(self, inputs, grad_outputs):
         x, t = self.get_retained_inputs()
@@ -81,9 +83,11 @@ class SigmoidCrossEntropyGrad(function_node.FunctionNode):
 
         y, = sigmoid.Sigmoid().forward((x,))
         if self.reduce == 'mean':
+            # TODO(takagi): Fix to perform division in a specific dtype. See
+            # cupy/cupy#1534.
             gx = xp.divide(
-                gy * self.ignore_mask * (y - self.t), self.count,
-                dtype=y.dtype)
+                gy * self.ignore_mask * (y - self.t), self.count).astype(
+                    y.dtype)
         else:
             gx = (gy * self.ignore_mask * (y - self.t)).astype(y.dtype)
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -289,14 +289,14 @@ class TestSigmoidCrossEntropyCudnnCall(unittest.TestCase):
         t = chainer.Variable(self.t)
         return functions.sigmoid_cross_entropy(x, t)
 
+    # Note that SigmoidCrossEntropy does not use cudnn on forward
+
     def test_call_cudnn_backward(self):
         with chainer.using_config('use_cudnn', self.use_cudnn):
             y = self.forward()
             with testing.patch('cupy.cudnn.activation_forward') as func:
                 y.backward()
                 self.assertEqual(func.called, self.expect)
-
-    # Note that SoftmaxCrossEntropy does not use cudnn on backward
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -13,32 +13,66 @@ from chainer.testing import attr
 from chainer import utils
 
 
-@testing.parameterize(
-    {'shape': (8, 7), 'normalize': True, 'label_dtype': numpy.int32},
-    {'shape': (8, 7), 'normalize': False, 'label_dtype': numpy.int32},
-    {'shape': (8, 7), 'normalize': True, 'ignore_all': True,
-     'label_dtype': numpy.int32},
+@testing.parameterize(*(testing.product({
+    # Test dtype
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'shape': [(8, 7)],
+    'normalize': [True],
+    'label_dtype': [numpy.int32],
+}) + [
+    # Test normalize
+    {'dtype': numpy.float32,
+     'shape': (8, 7),
+     'normalize': False,
+     'label_dtype': numpy.int32,
+     },
+    # Test ignore_all
+    {'dtype': numpy.float32,
+     'shape': (8, 7),
+     'normalize': True,
+     'ignore_all': True,
+     'label_dtype': numpy.int32,
+     },
     # too large shape causes int32 -> float64 issue
-    {'shape': (65536, 1), 'normalize': False, 'label_dtype': numpy.int32},
-    {'shape': (8, 7), 'normalize': True, 'label_dtype': numpy.int8},
-    {'shape': (8, 7), 'normalize': True, 'label_dtype': numpy.int16},
-    {'shape': (8, 7), 'normalize': True, 'label_dtype': numpy.int64},
-)
+    {'dtype': numpy.float32,
+     'shape': (65536, 1),
+     'normalize': False,
+     'label_dtype': numpy.int32,
+     },
+] + testing.product({
+    # Test label_dtype
+    'dtype': [numpy.float32],
+    'shape': [(8, 7)],
+    'normalize': [True],
+    'label_dtype': [numpy.int8, numpy.int16, numpy.int32, numpy.int64],
+})))
 class TestSigmoidCrossEntropy(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         if getattr(self, 'ignore_all', False):
             self.t = -numpy.ones(self.shape).astype(self.label_dtype)
         else:
             self.t = numpy.random.randint(-1, 2,
                                           self.shape).astype(self.label_dtype)
-        self.gy = numpy.random.random(self.shape).astype(numpy.float32)
+        self.gy = numpy.random.random(self.shape).astype(self.dtype)
         self.ggx = numpy.random.uniform(
-            -1, 1, self.shape).astype(numpy.float32)
+            -1, 1, self.shape).astype(self.dtype)
 
-        self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
-        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+        if self.dtype == numpy.float16:
+            self.places = 2
+            self.check_backward_options = {'atol': 5e-1, 'rtol': 5e-1}
+            self.check_double_backward_options = {'atol': 8e-1, 'rtol': 8e-1}
+        elif self.dtype == numpy.float32:
+            self.places = 5
+            self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
+            self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
+        elif self.dtype == numpy.float64:
+            self.places = 5
+            self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
+            self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
+        else:
+            raise ValueError('invalid dtype')
 
     def check_forward(self, x_data, t_data, use_cudnn='always'):
         x_val = chainer.Variable(x_data)
@@ -47,7 +81,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
             loss = functions.sigmoid_cross_entropy(x_val, t_val,
                                                    self.normalize)
         self.assertEqual(loss.data.shape, ())
-        self.assertEqual(loss.data.dtype, numpy.float32)
+        self.assertEqual(loss.data.dtype, self.dtype)
         loss_value = float(cuda.to_cpu(loss.data))
 
         # Compute expected value
@@ -67,7 +101,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
             loss_expect /= non_ignore_count
         else:
             loss_expect /= self.t.shape[0]
-        self.assertAlmostEqual(loss_expect, loss_value, places=5)
+        self.assertAlmostEqual(loss_expect, loss_value, places=self.places)
 
     def check_forward_no_reduction(self, x_data, t_data):
         x_val = chainer.Variable(x_data)
@@ -75,7 +109,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
         loss = functions.sigmoid_cross_entropy(
             x_val, t_val, self.normalize, reduce='no')
         self.assertEqual(loss.data.shape, self.x.shape)
-        self.assertEqual(loss.data.dtype, numpy.float32)
+        self.assertEqual(loss.data.dtype, self.dtype)
         loss_value = cuda.to_cpu(loss.data)
 
         # Compute expected value
@@ -90,7 +124,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
                             xd * (td - (xd >= 0)) -
                             math.log(1 + math.exp(-numpy.abs(xd))))
                     self.assertAlmostEqual(
-                        loss_expect, loss_value[i, j], places=5)
+                        loss_expect, loss_value[i, j], places=self.places)
 
     def test_forward_cpu(self):
         with chainer.using_config('use_cudnn', 'always'):
@@ -102,6 +136,10 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     @attr.gpu
     def test_forward_gpu(self):
+        # TODO(takagi): curiously large error on FP64
+        if self.dtype == numpy.float64:
+            self.places = 0
+
         with chainer.using_config('use_cudnn', 'always'):
             self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
@@ -113,6 +151,10 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     @attr.gpu
     def test_forward_gpu_no_cudnn(self):
+        # TODO(takagi): curiously large error on FP64
+        if self.dtype == numpy.float64:
+            self.places = 0
+
         with chainer.using_config('use_cudnn', 'never'):
             self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
@@ -200,6 +242,10 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     @attr.gpu
     def test_double_backward_gpu(self):
+        # TODO(takagi): curiously large error on FP64
+        if self.dtype == numpy.float64:
+            self.check_double_backward_options = {'atol': 3e1, 'rtol': 1e-2}
+
         with chainer.using_config('use_cudnn', 'always'):
             self.check_double_backward(cuda.to_gpu(self.x),
                                        cuda.to_gpu(self.t),

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -136,10 +136,6 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     @attr.gpu
     def test_forward_gpu(self):
-        # TODO(takagi): curiously large error on FP64
-        if self.dtype == numpy.float64:
-            self.places = 0
-
         with chainer.using_config('use_cudnn', 'always'):
             self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
@@ -151,10 +147,6 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     @attr.gpu
     def test_forward_gpu_no_cudnn(self):
-        # TODO(takagi): curiously large error on FP64
-        if self.dtype == numpy.float64:
-            self.places = 0
-
         with chainer.using_config('use_cudnn', 'never'):
             self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
 
@@ -242,10 +234,6 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
     @attr.gpu
     def test_double_backward_gpu(self):
-        # TODO(takagi): curiously large error on FP64
-        if self.dtype == numpy.float64:
-            self.check_double_backward_options = {'atol': 3e1, 'rtol': 1e-2}
-
         with chainer.using_config('use_cudnn', 'always'):
             self.check_double_backward(cuda.to_gpu(self.x),
                                        cuda.to_gpu(self.t),

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -61,7 +61,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         if self.dtype == numpy.float16:
             self.places = 2
-            self.check_backward_options = {'atol': 5e-1, 'rtol': 5e-1}
+            self.check_backward_options = {'atol': 8e-1, 'rtol': 8e-1}
             self.check_double_backward_options = {'atol': 8e-1, 'rtol': 8e-1}
         elif self.dtype == numpy.float32:
             self.places = 5

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -65,16 +65,10 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
                 'dtype':numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
             self.check_double_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
-        elif self.dtype == numpy.float32:
+        elif
             self.places = 5
             self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
             self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
-        elif self.dtype == numpy.float64:
-            self.places = 5
-            self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
-            self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
-        else:
-            raise ValueError('invalid dtype')
 
     def check_forward(self, x_data, t_data, use_cudnn='always'):
         x_val = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -62,7 +62,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
         if self.dtype == numpy.float16:
             self.places = 2
             self.check_backward_options = {
-                'dtype':numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
+                'dtype': numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
             self.check_double_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
         else:

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -61,8 +61,10 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
 
         if self.dtype == numpy.float16:
             self.places = 2
-            self.check_backward_options = {'atol': 8e-1, 'rtol': 8e-1}
-            self.check_double_backward_options = {'atol': 8e-1, 'rtol': 8e-1}
+            self.check_backward_options = {
+                'dtype':numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
+            self.check_double_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
         elif self.dtype == numpy.float32:
             self.places = 5
             self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-3}

--- a/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py
@@ -65,7 +65,7 @@ class TestSigmoidCrossEntropy(unittest.TestCase):
                 'dtype':numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
             self.check_double_backward_options = {
                 'dtype': numpy.float64, 'atol': 5e-2, 'rtol': 5e-2}
-        elif
+        else:
             self.places = 5
             self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-3}
             self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-3}


### PR DESCRIPTION
This PR follows #4582 to support all float dtypes in `F.sigmoid_cross_entropy`.

I found that it has relatively large error in forward computation when it computes FP64 data with CuPy. It seems that [this line](https://github.com/takagi/chainer/blob/c910fd0db9640784da9262908c7e4bdbb83c60b5/chainer/functions/loss/sigmoid_cross_entropy.py#L56) with dtype argument would cause the error between numpy and CuPy. I will check it later.