### PR TITLE
Ignore Theano warns in python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,11 @@ filterwarnings= ignore::FutureWarning
                 # Theano imports numpy.testing.nosetester, which emits
                 # DeprecationWarning from NumPy 1.15.
                 ignore::DeprecationWarning:theano.test
+                # Theano 1.0.2 uses the ABCs from 'collections', which emits
+                # DeprecationWarning in Python 3.7.
+                ignore::DeprecationWarning:theano.compat
+                ignore::DeprecationWarning:theano.misc.ordered_set
+                ignore::DeprecationWarning:theano.misc.frozendict
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test


### PR DESCRIPTION
I run `pytest` with
- Theano 1.0.2
- Python 3.7.0 (default, Jun 29 2018, 20:13:13)
  [Clang 9.1.0 (clang-902.0.39.2)] on darwin