### PR TITLE
Improve type check messages for some array functions

### DIFF
--- a/chainer/functions/array/diagonal.py
+++ b/chainer/functions/array/diagonal.py
@@ -13,7 +13,7 @@ class Diagonal(function_node.FunctionNode):
         self.axis2 = axis2
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
         in_type = in_types[0]
         type_check.expect(max(self.axis1, self.axis2) < in_type.ndim)
         type_check.expect(-in_type.ndim <= min(self.axis1, self.axis2))

--- a/chainer/functions/array/dstack.py
+++ b/chainer/functions/array/dstack.py
@@ -13,9 +13,11 @@ class Dstack(function_node.FunctionNode):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
+        type_check.argname((in_types[0],), ('x0',))
 
         ndim = type_check.eval(in_types[0].ndim)
         for i in six.moves.range(1, type_check.eval(in_types.size())):
+            type_check.argname((in_types[i],), ('x{}'.format(i),))
             type_check.expect(
                 in_types[0].dtype == in_types[i].dtype,
                 in_types[0].ndim == in_types[i].ndim,

--- a/chainer/functions/array/expand_dims.py
+++ b/chainer/functions/array/expand_dims.py
@@ -12,7 +12,7 @@ class ExpandDims(function_node.FunctionNode):
         self.axis = int(axis)
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
         x_type, = in_types
         if self.axis >= 0:
             type_check.expect(x_type.ndim >= self.axis)

--- a/chainer/functions/array/flip.py
+++ b/chainer/functions/array/flip.py
@@ -20,7 +20,7 @@ class Flip(function_node.FunctionNode):
         self.axis = axis
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
         x_type = in_types[0]
 
         type_check.expect(x_type.ndim > 0)

--- a/chainer/functions/array/fliplr.py
+++ b/chainer/functions/array/fliplr.py
@@ -8,12 +8,12 @@ class FlipLR(function_node.FunctionNode):
     """Flip array in the left/right direction."""
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
-        x_type = in_types[0]
+        type_check.argname(in_types, ('a',))
+        a_type = in_types[0]
 
         type_check.expect(
-            x_type.dtype.kind == 'f',
-            x_type.ndim >= 2
+            a_type.dtype.kind == 'f',
+            a_type.ndim >= 2
         )
 
     def forward(self, inputs):

--- a/chainer/functions/array/flipud.py
+++ b/chainer/functions/array/flipud.py
@@ -8,12 +8,12 @@ class FlipUD(function_node.FunctionNode):
     """Flip array in the up/down direction."""
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
-        x_type = in_types[0]
+        type_check.argname(in_types, ('a',))
+        a_type = in_types[0]
 
         type_check.expect(
-            x_type.dtype.kind == 'f',
-            x_type.ndim >= 1
+            a_type.dtype.kind == 'f',
+            a_type.ndim >= 1
         )
 
     def forward(self, inputs):

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -35,7 +35,7 @@ class GetItem(function_node.FunctionNode):
         self.slices = slices
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
 
     def forward(self, xs):
         return utils.force_array(xs[0][self.slices]),

--- a/chainer/functions/array/hstack.py
+++ b/chainer/functions/array/hstack.py
@@ -13,9 +13,11 @@ class Hstack(function_node.FunctionNode):
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
+        type_check.argname((in_types[0],), ('x0',))
 
         ndim = type_check.eval(in_types[0].ndim)
         for i in six.moves.range(1, type_check.eval(in_types.size())):
+            type_check.argname((in_types[i],), ('x{}'.format(i),))
             type_check.expect(
                 in_types[0].dtype == in_types[i].dtype,
                 in_types[0].ndim == in_types[i].ndim,

--- a/chainer/functions/array/im2col.py
+++ b/chainer/functions/array/im2col.py
@@ -38,8 +38,7 @@ class Im2Col(function_node.FunctionNode):
         self.cover_all = cover_all
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size()
-        type_check.expect(n_in == 1)
+        type_check.argname(in_types, ('x',))
 
         x_type = in_types[0]
         type_check.expect(
@@ -75,13 +74,12 @@ class Im2ColGrad(function_node.FunctionNode):
         self.in_shape = in_shape
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size()
-        type_check.expect(n_in == 1)
+        type_check.argname(in_types, ('gy',))
 
-        x_type = in_types[0]
+        gy_type = in_types[0]
         type_check.expect(
-            x_type.dtype.kind == 'f',
-            x_type.ndim == 4
+            gy_type.dtype.kind == 'f',
+            gy_type.ndim == 4
         )
 
     def forward(self, inputs):

--- a/chainer/functions/array/moveaxis.py
+++ b/chainer/functions/array/moveaxis.py
@@ -58,8 +58,8 @@ class Moveaxis(function_node.FunctionNode):
             self.destination = destination
 
     def check_type_forward(self, in_types):
+        type_check.argname(in_types, ('x',))
         type_check.expect(
-            in_types.size() == 1,
             in_types[0].dtype.kind == 'f',
         )
 

--- a/chainer/functions/array/pad.py
+++ b/chainer/functions/array/pad.py
@@ -21,7 +21,7 @@ class Pad(function_node.FunctionNode):
         # Depending on the arguments, pad_width and keywords, the input value
         # may be inappropriate. In that case, numpy.pad or cupy.pad will raise
         # errors, so that only check the size and the dtype in this function.
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
         x_type = in_types[0]
         type_check.expect(x_type.dtype.kind == 'f')
 

--- a/chainer/functions/array/pad_sequence.py
+++ b/chainer/functions/array/pad_sequence.py
@@ -18,7 +18,8 @@ class PadSequence(function_node.FunctionNode):
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() > 0)
 
-        for in_type in in_types:
+        for i, in_type in enumerate(in_types):
+            type_check.argname((in_type,), ('x{}'.format(i),))
             type_check.expect(
                 in_type.ndim > 0,
                 in_type.shape[1:] == in_types[0].shape[1:],

--- a/chainer/functions/array/permutate.py
+++ b/chainer/functions/array/permutate.py
@@ -45,7 +45,7 @@ class Permutate(function_node.FunctionNode):
         self.inv = inv
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x', 'indices'))
         x_type, ind_type = in_types
         if self.axis < 0:
             type_check.expect(x_type.ndim >= -self.axis)

--- a/chainer/functions/array/repeat.py
+++ b/chainer/functions/array/repeat.py
@@ -34,7 +34,7 @@ class Repeat(function_node.FunctionNode):
         self.axis = axis
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
 
     def forward(self, inputs):
         self.retain_inputs((0,))

--- a/chainer/functions/array/reshape.py
+++ b/chainer/functions/array/reshape.py
@@ -20,10 +20,7 @@ class Reshape(function_node.FunctionNode):
         assert self._cnt <= 1
 
     def check_type_forward(self, in_types):
-        type_check.expect(
-            in_types.size() == 1,
-        )
-
+        type_check.argname(in_types, ('x',))
         x_type, = in_types
 
         if self._cnt == 0:

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -12,8 +12,7 @@ class ResizeImages(function_node.FunctionNode):
         self.out_W = output_shape[1]
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size()
-        type_check.expect(n_in == 1)
+        type_check.argname(in_types, ('x',))
 
         x_type = in_types[0]
         type_check.expect(
@@ -72,13 +71,12 @@ class ResizeImagesGrad(function_node.FunctionNode):
         self.input_shape = input_shape
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size()
-        type_check.expect(n_in == 1)
+        type_check.argname(in_types, ('gy',))
 
-        x_type = in_types[0]
+        gy_type = in_types[0]
         type_check.expect(
-            x_type.dtype.char == 'f',
-            x_type.ndim == 4
+            gy_type.dtype.char == 'f',
+            gy_type.ndim == 4
         )
 
     def forward(self, inputs):

--- a/chainer/functions/array/rollaxis.py
+++ b/chainer/functions/array/rollaxis.py
@@ -19,7 +19,7 @@ class Rollaxis(function_node.FunctionNode):
         self.start = start
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
         x_type = in_types[0]
 
         if self.axis >= 0:

--- a/chainer/functions/array/scatter_add.py
+++ b/chainer/functions/array/scatter_add.py
@@ -27,7 +27,7 @@ class ScatterAdd(function_node.FunctionNode):
         self.slices = slices
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('a', 'b'))
         n_nones = len([item for item in self.slices if item is None])
         valid_slice = len(self.slices) - n_nones
         type_check.expect(in_types[0].ndim >= valid_slice)

--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -12,7 +12,7 @@ class SelectItem(function_node.FunctionNode):
     """Select elements stored in given indices."""
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.argname(in_types, ('x', 't'))
 
         x_type, t_type = in_types
         type_check.expect(

--- a/chainer/functions/array/separate.py
+++ b/chainer/functions/array/separate.py
@@ -12,7 +12,7 @@ class Separate(function_node.FunctionNode):
         self.axis = axis
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
         x_type = in_types[0]
         if self.axis >= 0:
             type_check.expect(self.axis < x_type.ndim)

--- a/chainer/functions/array/space2depth.py
+++ b/chainer/functions/array/space2depth.py
@@ -12,7 +12,7 @@ class Space2Depth(function_node.FunctionNode):
         self.r = r
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 1)
+        type_check.argname(in_types, ('x',))
         type_check.expect(
             in_types[0].dtype.kind == 'f',
             in_types[0].ndim == 4

--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -18,8 +18,7 @@ class SpatialTransformerGrid(function.Function):
         self.output_shape = output_shape
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size()
-        type_check.expect(n_in == 1)
+        type_check.argname(in_types, ('theta',))
 
         theta_type = in_types[0]
         type_check.expect(


### PR DESCRIPTION
Partially addressing #4969. It fixes `diagonal`, ..., `spatial_transformer_grid` in alphabetical order of names under `chainer.functions.array`.