### PR TITLE
[backport] Ignore Theano warns in python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,11 @@ filterwarnings= ignore::FutureWarning
                 # Theano imports numpy.testing.nosetester, which emits
                 # DeprecationWarning from NumPy 1.15.
                 ignore::DeprecationWarning:theano.test
+                # Theano 1.0.2 uses the ABCs from 'collections', which emits
+                # DeprecationWarning in Python 3.7.
+                ignore::DeprecationWarning:theano.compat
+                ignore::DeprecationWarning:theano.misc.ordered_set
+                ignore::DeprecationWarning:theano.misc.frozendict
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test


### PR DESCRIPTION
Backport of #5223