### PR TITLE
Ignore `DeprecationWarning`s at importing Theano

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,14 +18,6 @@ filterwarnings= ignore::FutureWarning
                 # causing AttributeError in the subsequent uses of
                 # ``theano.gof``. (#4810)
                 ignore::DeprecationWarning:theano.gof.cmodule
-                # Theano imports numpy.testing.nosetester, which emits
-                # DeprecationWarning from NumPy 1.15.
-                ignore::DeprecationWarning:theano.test
-                # Theano 1.0.2 uses the ABCs from 'collections', which emits
-                # DeprecationWarning in Python 3.7.
-                ignore::DeprecationWarning:theano.compat
-                ignore::DeprecationWarning:theano.misc.ordered_set
-                ignore::DeprecationWarning:theano.misc.frozendict
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test

--- a/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
+++ b/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
@@ -21,7 +21,8 @@ class TheanoFunctionTestBase(object):
     def setUp(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
-            import theano  # Theano 1.0.2 causes DeprecationWarning
+            # Theano 1.0.2 causes DeprecationWarning
+            import theano  # NOQA
 
         self.input_data = [
             numpy.random.uniform(

--- a/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
+++ b/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 
@@ -18,6 +19,10 @@ class TheanoFunctionTestBase(object):
     backward_test_options = {'atol': 1e-4}
 
     def setUp(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            import theano  # Theano 1.0.2 causes DeprecationWarning
+
         self.input_data = [
             numpy.random.uniform(
                 -1, 1, d['shape']).astype(getattr(numpy, d['type']))


### PR DESCRIPTION
Motivation: fix Travis failure (macOS, python 3.4).

After the change
```
% pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests/links_tests/theano_tests -x
============================= test session starts ==============================
platform darwin -- Python 3.4.4, pytest-3.7.1, py-1.5.4, pluggy-0.7.1
rootdir: /Users/tos/GitHub/chainer, inifile: setup.cfg
plugins: timeout-1.2.1, cov-2.5.1
collected 40 items / 20 deselected

chainer_tests/links_tests/theano_tests/test_theano_function.py ......... [ 45%]
...........                                                              [100%]

=============================== warnings summary ===============================
tests/chainer_tests/links_tests/theano_tests/test_theano_function.py::TestTheanoFunctionTwoOutputs_param_1::test_backward_cpu
  /Users/tos/.pyenv/versions/3.4.4/lib/python3.4/importlib/_bootstrap.py:321: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88
    return f(*args, **kwds)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```
(The PR only suppresses `DeprecationWarning`s)