### PR TITLE
Unsupport ideep4py 2+ in Chainer v4

### DIFF
--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import warnings
 
 import chainer
 from chainer.configuration import config
@@ -9,6 +10,12 @@ _error = None
 
 try:
     import ideep4py as ideep  # NOQA
+
+    # ideep4py 2+ is not supported.
+    # Note that ideep4py.__version__ was added in ideep4py 2.0.0.
+    if hasattr(ideep, '__version__'):
+        warnings.warn('''ideep4py {} is not compatible with this version of Chainer.'''.format(ideep.__version__))
+
     from ideep4py import mdarray  # NOQA
     _ideep_version = 0
 except ImportError as e:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -42,7 +42,7 @@ You can accelerate performance of Chainer by installing the following optional c
     * See `CuPy Installation Guide <https://docs-cupy.chainer.org/en/latest/install.html>`__ for instructions.
 
 * Intel CPU (experimental)
-    * `iDeep <https://github.com/intel/ideep>`_ 1.0.3+
+    * `iDeep <https://github.com/intel/ideep>`_ 1.0.3+ (2+ is not supported)
     * See :doc:`tips` for instructions.
 
 Optional Features


### PR DESCRIPTION
https://github.com/chainer/chainer/issues/5082#issuecomment-413084915

It's better to detect and warn ideep4py 2+ in Chainer v4.