### PR TITLE
Check eps < CUDNN_BN_MIN_EPSILON in FixedBatchNormalization.

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -398,6 +398,28 @@ class TestBatchNormalizationCudnnEps(unittest.TestCase):
             functions.batch_normalization(*self.args, eps=2e-6)
 
 
+@attr.cudnn
+class TestFixedBatchNormalizationCudnnEps(unittest.TestCase):
+    def setUp(self):
+        ndim = 0
+        param_shape = (3,)
+        dtype = numpy.float32
+        gamma = cuda.cupy.random.uniform(.5, 1, param_shape).astype(dtype)
+        beta = cuda.cupy.random.uniform(-1, 1, param_shape).astype(dtype)
+        mean = cuda.cupy.random.uniform(-1, 1, param_shape).astype(dtype)
+        var = cuda.cupy.random.uniform(-1, 1, param_shape).astype(dtype)
+        shape = (7,) + param_shape + (2,) * ndim
+        x = cuda.cupy.random.uniform(-1, 1, shape).astype(dtype)
+        self.args = [x, gamma, beta, mean, var]
+
+    def test_valid(self):
+        functions.fixed_batch_normalization(*self.args, eps=1e-5)
+
+    def test_invalid(self):
+        with self.assertRaises(RuntimeError):
+            functions.fixed_batch_normalization(*self.args, eps=2e-6)
+
+
 class TestBatchNormalizationWarning(unittest.TestCase):
     def setUp(self):
         pass


### PR DESCRIPTION
I added lines checking the eps value in FixedBatchNormalization as is already done in BatchNormalization. I also added the test case based on the one for functions.batch_normalization.