### PR TITLE
Support all float dtypes in `F.batch_l2_norm_squared`

### DIFF
--- a/chainer/functions/math/batch_l2_norm_squared.py
+++ b/chainer/functions/math/batch_l2_norm_squared.py
@@ -1,4 +1,3 @@
-import numpy
 import six
 
 import chainer
@@ -15,7 +14,7 @@ class BatchL2NormSquared(function_node.FunctionNode):
         x_type, = in_types
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             x_type.ndim >= 2,
         )
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_batch_l2_norm_squared.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_batch_l2_norm_squared.py
@@ -18,30 +18,39 @@ def _as_two_dim(x):
     return x.reshape((len(x), -1))
 
 
-@testing.parameterize(
-    {'shape': (4, 3, 5)},
-    {'shape': (4, 15)},
-)
+@testing.parameterize(*testing.product({
+    'dtype': [np.float16, np.float32, np.float64],
+    'shape': [(4, 3, 5), (4, 15)],
+}))
 class TestBatchL2NormSquared(unittest.TestCase):
 
     def setUp(self):
-        self.x = np.random.uniform(-1, 1, self.shape).astype(np.float32)
-        self.gy = np.random.uniform(-1, 1, self.shape[0]).astype(np.float32)
-        self.ggx = np.random.uniform(-1, 1, self.shape).astype(np.float32)
+        self.x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.gy = np.random.uniform(-1, 1, self.shape[0]).astype(self.dtype)
+        self.ggx = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+
+        if self.dtype == np.float16:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            self.check_double_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+        else:
+            self.check_forward_options = {}
+            self.check_backward_options = {}
+            self.check_double_backward_options = {}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
 
         y = functions.batch_l2_norm_squared(x)
-        self.assertEqual(y.data.dtype, np.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
         x_two_dim = _as_two_dim(self.x)
-        y_expect = np.empty(len(self.x))
+        y_expect = np.empty(len(self.x), dtype=self.dtype)
         for n in six.moves.range(len(self.x)):
             y_expect[n] = sum(map(lambda x: x * x, x_two_dim[n]))
 
-        testing.assert_allclose(y_expect, y_data)
+        testing.assert_allclose(y_expect, y_data, **self.check_forward_options)
 
     def test_forward_cpu(self):
         self.check_forward(self.x)
@@ -52,7 +61,8 @@ class TestBatchL2NormSquared(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
-            functions.batch_l2_norm_squared, x_data, y_grad, eps=1)
+            functions.batch_l2_norm_squared, x_data, y_grad, eps=1,
+            **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
@@ -64,7 +74,8 @@ class TestBatchL2NormSquared(unittest.TestCase):
     def check_double_backward(self, x_data, y_grad, x_grad_grad):
         gradient_check.check_double_backward(
             functions.batch_l2_norm_squared,
-            x_data, y_grad, x_grad_grad, dtype=np.float64)
+            x_data, y_grad, x_grad_grad, dtype=np.float64,
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)


### PR DESCRIPTION
This PR follows #4582 to support all float dtypes in `F.batch_l2_norm_squared`.