### PR TITLE
Adjust tolerance of TestMatMul

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1222,7 +1222,7 @@ class TestMatMul(unittest.TestCase):
         if self.dtype == numpy.float16:
             options = {'atol': 1e-3, 'rtol': 1e-3}
         else:
-            options = {'atol': 1e-7, 'rtol': 1e-7}
+            options = {'atol': 2e-7, 'rtol': 2e-7}
         testing.assert_allclose(
             self._get_forward_answer(self.x, self.y), z.data, **options)
 


### PR DESCRIPTION
Matmul (`@`) is not as accurate as other binary operators (`+`, `-`, `*`, `/`) are.

```
E           AssertionError: Parameterized test failed.
E           
E           Base test method: TestMatMul.test_forward_gpu
E           Test parameters:
E             z_shape: (2, 2, 3, 2)
E             dtype: <class 'numpy.float32'>
E             left_const: False
E             y_shape: (2, 4, 2)
E             x_shape: (2, 1, 3, 4)
E             right_const: False
E           
E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=1e-07
E           
E           (mismatch 4.166666666666671%)
E            x: array([[[[-0.812174,  0.495421],
E                    [ 0.275101, -0.099681],
E                    [-1.200468,  0.912167]],...
E            y: array([[[[-0.812174,  0.495421],
E                    [ 0.275101, -0.099681],
E                    [-1.200467,  0.912167]],...
E           
E           assert_allclose failed: 
E             shape: (2, 2, 3, 2) (2, 2, 3, 2)
E             dtype: float32 float32
E             i: (1, 0, 1, 0)
E             x[i]: 0.18142130970954895
E             y[i]: 0.18142150342464447
E             err[i]: 1.9371509552001953e-07
E           x: [[[[-0.8121744   0.49542138]
E                 [ 0.27510148 -0.09968117]
E                 [-1.2004676   0.91216654]]
E           
E                [[-0.9748428  -0.2795514 ]
E                 [-0.6726386   0.46846443]
E                 [-1.3558797  -0.89666116]]]
E           
E           
E               [[[-1.347464    0.26258582]
E                 [ 0.18142131 -0.28605342]
E                 [ 1.365767   -0.35201487]]
E           
E                [[-0.45076287 -0.95992637]
E                 [ 1.2275028  -0.5017683 ]
E                 [ 0.74252594  0.6649538 ]]]]
E           y: [[[[-0.8121744   0.49542138]
E                 [ 0.27510145 -0.09968117]
E                 [-1.2004675   0.91216654]]
E           
E                [[-0.9748428  -0.27955142]
E                 [-0.67263854  0.46846443]
E                 [-1.3558797  -0.8966611 ]]]
E           
E           
E               [[[-1.347464    0.26258582]
E                 [ 0.1814215  -0.28605342]
E                 [ 1.365767   -0.35201487]]
E           
E                [[-0.4507629  -0.9599264 ]
E                 [ 1.2275028  -0.5017683 ]
E                 [ 0.742526    0.66495377]]]]
```