### PR TITLE
Fix cpu codes of indexing in `F.softmax_cross_entropy`

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -91,14 +91,16 @@ class SoftmaxCrossEntropy(function.Function):
             log_y *= _broadcast_to(self.class_weight.reshape(shape), x.shape)
         log_yd = numpy.rollaxis(log_y, 1)
         log_yd = log_yd.reshape(len(log_yd), -1)
-        log_p = log_yd[numpy.maximum(t.ravel(), 0), numpy.arange(t.size)]
+        t_valid = t != self.ignore_label
+        t = t * t_valid
+        log_p = log_yd[t.ravel(), numpy.arange(t.size)]
 
-        log_p *= (t.ravel() != self.ignore_label)
+        log_p *= t_valid.ravel()
         if self.reduce == 'mean':
             # deal with the case where the SoftmaxCrossEntropy is
             # unpickled from the old version
             if self.normalize:
-                count = (t != self.ignore_label).sum()
+                count = t_valid.sum()
             else:
                 count = len(x)
             self._coeff = 1.0 / max(count, 1)
@@ -170,15 +172,17 @@ class SoftmaxCrossEntropy(function.Function):
         else:
             y = log_softmax._log_softmax(x)
             numpy.exp(y, out=y)
+        t_valid = t != self.ignore_label
+        t = t * t_valid
         if y.ndim == 2:
             gx = y
-            gx[numpy.arange(len(t)), numpy.maximum(t, 0)] -= 1
+            gx[numpy.arange(len(t)), t] -= 1
             if self.class_weight is not None:
                 shape = [1 if d != 1 else -1 for d in six.moves.range(x.ndim)]
                 c = _broadcast_to(self.class_weight.reshape(shape), x.shape)
-                c = c[numpy.arange(len(t)), numpy.maximum(t, 0)]
+                c = c[numpy.arange(len(t)), t]
                 gx *= _broadcast_to(numpy.expand_dims(c, 1), gx.shape)
-            gx *= (t != self.ignore_label).reshape((len(t), 1))
+            gx *= t_valid.reshape((len(t), 1))
         else:
             # in the case where y.ndim is higher than 2,
             # we think that a current implementation is inefficient
@@ -187,15 +191,15 @@ class SoftmaxCrossEntropy(function.Function):
             gx = y.reshape(y.shape[0], y.shape[1], -1)
             fst_index = numpy.arange(t.size) // n_unit
             trd_index = numpy.arange(t.size) % n_unit
-            gx[fst_index, numpy.maximum(t.ravel(), 0), trd_index] -= 1
+            gx[fst_index, t.ravel(), trd_index] -= 1
             if self.class_weight is not None:
                 shape = [1 if d != 1 else -1 for d in six.moves.range(x.ndim)]
                 c = _broadcast_to(self.class_weight.reshape(shape), x.shape)
                 c = c.reshape(gx.shape)
-                c = c[fst_index, numpy.maximum(t.ravel(), 0), trd_index]
+                c = c[fst_index, t.ravel(), trd_index]
                 c = c.reshape(y.shape[0], 1, -1)
                 gx *= _broadcast_to(c, gx.shape)
-            gx *= (t != self.ignore_label).reshape((len(t), 1, -1))
+            gx *= t_valid.reshape((len(t), 1, -1))
             gx = gx.reshape(y.shape)
         if self.reduce == 'mean':
             gx *= gloss * self._coeff

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -396,6 +396,7 @@ class TestSoftmaxCrossEntropyInvalidReduce(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
+    'ignore_label': [-2, 9],
     'reduce': ['mean', 'no'],
     'enable_double_backprop': [False, True],
     'class_weight': [None, numpy.ones((3,), dtype=numpy.float32)]})
@@ -403,7 +404,6 @@ class TestSoftmaxCrossEntropyInvalidReduce(unittest.TestCase):
 class TestNonDefaultIgnoreLabel(unittest.TestCase):
 
     def setUp(self):
-        self.ignore_label = -2
         self.x = numpy.random.uniform(-1, 1, (2, 3)).astype(numpy.float32)
         self.t = numpy.full((2,), self.ignore_label, dtype=numpy.int32)
         if self.reduce == 'mean':


### PR DESCRIPTION
Fix #5127 

(As a side-effect, this PR changes behavior on bad input.  In the cpu computation, except for `ignore_label`, negative `t` will be treated as `n + t`, while it was treated as `0`.)