### PR TITLE
[backport] Ignore `DeprecationWarning`s at importing Theano

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,14 +16,6 @@ filterwarnings= ignore::FutureWarning
                 # causing AttributeError in the subsequent uses of
                 # ``theano.gof``. (#4810)
                 ignore::DeprecationWarning:theano.gof.cmodule
-                # Theano imports numpy.testing.nosetester, which emits
-                # DeprecationWarning from NumPy 1.15.
-                ignore::DeprecationWarning:theano.test
-                # Theano 1.0.2 uses the ABCs from 'collections', which emits
-                # DeprecationWarning in Python 3.7.
-                ignore::DeprecationWarning:theano.compat
-                ignore::DeprecationWarning:theano.misc.ordered_set
-                ignore::DeprecationWarning:theano.misc.frozendict
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test

--- a/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
+++ b/tests/chainer_tests/links_tests/theano_tests/test_theano_function.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 
@@ -18,6 +19,11 @@ class TheanoFunctionTestBase(object):
     backward_test_options = {'atol': 1e-4}
 
     def setUp(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            # Theano 1.0.2 causes DeprecationWarning
+            import theano  # NOQA
+
         self.input_data = [
             numpy.random.uniform(
                 -1, 1, d['shape']).astype(getattr(numpy, d['type']))


### PR DESCRIPTION
Backport of #5230