### PR TITLE
Improve type_check.argname for optional arguments

### DIFF
--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -11,26 +11,19 @@ class LinearFunction(function_node.FunctionNode):
     _config_use_ideep = None
 
     def check_type_forward(self, in_types):
-        n_in = in_types.size()
-        type_check.expect(2 <= n_in, n_in <= 3)
-        x_type, w_type = in_types[:2]
-        type_check.argname((x_type, w_type), ('x', 'W'))
+        x_type, w_type, b_type = type_check.argname(
+            in_types, ('x', 'W'), ('b',))
 
         type_check.expect(
             x_type.dtype.kind == 'f',
             w_type.dtype.kind == 'f',
+            b_type.dtype == x_type.dtype,
             x_type.ndim == 2,
             w_type.ndim == 2,
+            b_type.ndim == 1,
             x_type.shape[1] == w_type.shape[1],
+            b_type.shape[0] == w_type.shape[0],
         )
-        if type_check.eval(n_in) == 3:
-            b_type = in_types[2]
-            type_check.argname((b_type,), ('b',))
-            type_check.expect(
-                b_type.dtype == x_type.dtype,
-                b_type.ndim == 1,
-                b_type.shape[0] == w_type.shape[0],
-            )
 
     def forward(self, inputs):
         self._config_use_ideep = chainer.config.use_ideep

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -555,6 +555,9 @@ class _MissingArgument(object):
     def __div__(self, other):
         return self
 
+    def __truediv__(self, other):
+        return self
+
 
 _missing_argument = _MissingArgument()
 

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -553,15 +553,17 @@ _missing_argument = _MissingArgument()
 
 
 def argname(in_types, names, optional_names=()):
-    """Assigns user friendly names for the input types.
+    """Destructures the input types with assigning them user friendly names
 
-    This function also asserts that lenghts of in_types and names are the
-    same.
+    This function also asserts that in_types has the appropriate length with
+    that of names.
 
     Args:
-        in_types (tuple of TypeInfoTuple): Tuple of type information to assign
-            name to.
-        names (tuple of str): Human-readabel names of ``in_types``.
+        in_types (TypeInfoTuple): Tuple of type information to destructure.
+        names (tuple of str): Human-readable names of required arguments in
+            ``in_types``.
+        optional_names (tuple of str): Human-readable names of optional
+            arguments in ``in_types``.
     """
     min_len = len(names)
     max_len = min_len + len(optional_names)

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -506,58 +506,48 @@ Invalid operation is performed in: {0} (Forward)
 
 class _MissingArgument(object):
     def __init__(self):
-        # typical attributes
+        # typical attributes for efficiency
         for name in ('shape', 'dtype', 'kind', 'ndim', 'size'):
             setattr(self, name, self)
 
     def __getattr__(self, name):
         return self
 
-    def __bool__(self):
-        return True
-
-    def __call__(self, *args, **kwargs):
+    def __getitem__(self, *args, **kwargs):
         return self
 
-    def __getitem__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         return self
 
     def __nonzero__(self):
         return True
 
-    def __eq__(self, other):
-        return self
+    def __bool__(self):
+        return True
 
-    def __ne__(self, other):
-        return self
 
-    def __lt__(self, other):
-        return self
+# Set boolean operators to _MissingArgument
+_bool_ops = ['__eq__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__']
+for op in _bool_ops:
+    setattr(_MissingArgument, op, lambda self, other: self)
 
-    def __gt__(self, other):
-        return self
+# Set binary operators to _MissingArgument
+_bin_ops = ['__add__', '__radd__', '__sub__', '__rsub__', '__mul__',
+            '__rmul__']
+if sys.version_info < (3, 0, 0):
+    _bin_ops += ['__div__', '__rdiv__']
+else:
+    _bin_ops += ['__truediv__', '__rtruediv__']
+_bin_ops += ['__floordiv__', '__rfloordiv__', '__mod__', '__rmod__', '__pow__',
+             '__lshift__', '__rlshift__', '__rshift__', '__rrshift__',
+             '__and__', '__rand__', '__xor__', '__rxor__', '__or__', '__ror__']
+for op in _bin_ops:
+    setattr(_MissingArgument, op, lambda self, other: self)
 
-    def __le__(self, other):
-        return self
-
-    def __ge__(self, other):
-        return self
-
-    def __add__(self, other):
-        return self
-
-    def __sub__(self, other):
-        return self
-
-    def __mul__(self, other):
-        return self
-
-    def __div__(self, other):
-        return self
-
-    def __truediv__(self, other):
-        return self
-
+# Set unary operators to _MissingArgument
+_un_ops = ['__neg__', '__pos__', '__invert__']
+for op in _un_ops:
+    setattr(_MissingArgument, op, lambda self: self)
 
 _missing_argument = _MissingArgument()
 

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -522,9 +522,6 @@ class _MissingArgument(object):
     def __getitem__(self, *args, **kwargs):
         return self
 
-    def __len__(self):
-        return self
-
     def __nonzero__(self):
         return True
 

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -351,25 +351,55 @@ class TestMissingArgument(unittest.TestCase):
     def test_missing_argument(self):
         x = T._MissingArgument()
 
+        # Typical attributes
         assert x.shape is x
         assert x.dtype is x
         assert x.kind is x
         assert x.ndim is x
         assert x.size is x
+
         assert x.foo is x       # __getattr__
-        assert bool(x)          # __nonzero__ in Py2, __bool__ in Py3
-        assert x() is x         # __call__
         assert x[0] is x        # __getitem__
-        assert (x == 1) is x    # __eq__
-        assert (x != 1) is x    # __ne__
-        assert (x < 1) is x     # __lt__
-        assert (x > 1) is x     # __gt__
-        assert (x <= 1) is x    # __le__
-        assert (x >= 1) is x    # __ge__
-        assert (x + 1) is x     # __add__
-        assert (x - 1) is x     # __sub__
-        assert (x * 1) is x     # __mul__
-        assert (x / 1.0) is x   # __div__ in Py2, __truediv__ in Py3
+        assert x() is x         # __call__
+        assert bool(x)
+
+        # Boolean operators
+        assert (x == 1) is x
+        assert (x != 1) is x
+        assert (x < 1) is x
+        assert (x <= 1) is x
+        assert (x > 1) is x
+        assert (x >= 1) is x
+
+        # Binary operators
+        assert (x + 1) is x
+        assert (1 + x) is x
+        assert (x - 1) is x
+        assert (1 - x) is x
+        assert (x * 1) is x
+        assert (1 * x) is x
+        assert (x / 1) is x
+        assert (1 / x) is x
+        assert (x // 1) is x
+        assert (1 // x) is x
+        assert (x % 1) is x
+        assert (1 % x) is x
+        assert (x ** 1) is x
+        assert (x << 1) is x
+        assert (1 << x) is x
+        assert (x >> 1) is x
+        assert (1 >> x) is x
+        assert (x & 1) is x
+        assert (1 & x) is x
+        assert (x ^ 1) is x
+        assert (1 ^ x) is x
+        assert (x | 1) is x
+        assert (1 | x) is x
+
+        # Unary operators
+        assert -x is x
+        assert +x is x
+        assert ~x is x
 
 
 class TestArgname(unittest.TestCase):

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -372,40 +372,27 @@ class TestMissingArgument(unittest.TestCase):
         assert (x / 1.0) is x   # __div__ in Py2, __truediv__ in Py3
 
 
-class TestOptionalArguments(unittest.TestCase):
+class TestArgname(unittest.TestCase):
 
-    def test_no_optional_argument(self):
-        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),)
+    def test_required_arguments(self):
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),
+                numpy.zeros((4, 5, 6)).astype(numpy.float32),)
         ts = T.get_types(data, 'name', False)
-        x_type, = T.argname(ts, ('x',), ())
+        x_type, y_type = T.argname(ts, ('x', 'y'))
+        assert x_type.shape.eval() == data[0].shape
         assert x_type.name == 'x'
-
-    def test_one_optional_argument(self):
-        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),) * 2
-        ts = T.get_types(data, 'name', False)
-        x_type, y_type = T.argname(ts, ('x',), ('y',))
-        assert x_type.name == 'x'
+        assert y_type.shape.eval() == data[1].shape
         assert y_type.name == 'y'
 
-        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),)
-        ts = T.get_types(data, 'name', False)
-        x_type, y_type = T.argname(ts, ('x',), ('y',))
-        assert x_type.name == 'x'
-        assert y_type is T._missing_argument
-
-    def test_more_than_one_optional_arguments(self):
-        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),) * 3
+    def test_optional_arguments(self):
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),
+                numpy.zeros((4, 5, 6)).astype(numpy.float32),)
         ts = T.get_types(data, 'name', False)
         x_type, y_type, z_type = T.argname(ts, ('x',), ('y', 'z'))
+        assert x_type.shape.eval() == data[0].shape
         assert x_type.name == 'x'
+        assert y_type.shape.eval() == data[1].shape
         assert y_type.name == 'y'
-        assert z_type.name == 'z'
-
-        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),)
-        ts = T.get_types(data, 'name', False)
-        x_type, y_type, z_type = T.argname(ts, ('x',), ('y', 'z'))
-        assert x_type.name == 'x'
-        assert y_type is T._missing_argument
         assert z_type is T._missing_argument
 
     def test_too_less_arguments(self):

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -346,6 +346,81 @@ class TestListItem(unittest.TestCase):
         self.assertEqual('[[0]]', T._repr([[T.Constant(0)]]))
 
 
+class TestMissingArgument(unittest.TestCase):
+
+    def test_missing_argument(self):
+        x = T._MissingArgument()
+
+        assert x.shape is x
+        assert x.dtype is x
+        assert x.kind is x
+        assert x.ndim is x
+        assert x.size is x
+        assert x.foo is x       # __getattr__
+        assert bool(x)          # __nonzero__ in Py2, __bool__ in Py3
+        assert x() is x         # __call__
+        assert x[0] is x        # __getitem__
+        assert (x == 1) is x    # __eq__
+        assert (x != 1) is x    # __ne__
+        assert (x < 1) is x     # __lt__
+        assert (x > 1) is x     # __gt__
+        assert (x <= 1) is x    # __le__
+        assert (x >= 1) is x    # __ge__
+        assert (x + 1) is x     # __add__
+        assert (x - 1) is x     # __sub__
+        assert (x * 1) is x     # __mul__
+        assert (x / 1.0) is x   # __div__ in Py2, __truediv__ in Py3
+
+
+class TestOptionalArguments(unittest.TestCase):
+
+    def test_no_optional_argument(self):
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),)
+        ts = T.get_types(data, 'name', False)
+        x_type, = T.argname(ts, ('x',), ())
+        assert x_type.name == 'x'
+
+    def test_one_optional_argument(self):
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),) * 2
+        ts = T.get_types(data, 'name', False)
+        x_type, y_type = T.argname(ts, ('x',), ('y',))
+        assert x_type.name == 'x'
+        assert y_type.name == 'y'
+
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),)
+        ts = T.get_types(data, 'name', False)
+        x_type, y_type = T.argname(ts, ('x',), ('y',))
+        assert x_type.name == 'x'
+        assert y_type is T._missing_argument
+
+    def test_more_than_one_optional_arguments(self):
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),) * 3
+        ts = T.get_types(data, 'name', False)
+        x_type, y_type, z_type = T.argname(ts, ('x',), ('y', 'z'))
+        assert x_type.name == 'x'
+        assert y_type.name == 'y'
+        assert z_type.name == 'z'
+
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),)
+        ts = T.get_types(data, 'name', False)
+        x_type, y_type, z_type = T.argname(ts, ('x',), ('y', 'z'))
+        assert x_type.name == 'x'
+        assert y_type is T._missing_argument
+        assert z_type is T._missing_argument
+
+    def test_too_less_arguments(self):
+        data = ()
+        ts = T.get_types(data, 'name', False)
+        with self.assertRaises(T.InvalidType):
+            x_type, y_type = T.argname(ts, ('x',), ('y',))
+
+    def test_too_many_arguments(self):
+        data = (numpy.zeros((1, 2, 3)).astype(numpy.float32),) * 3
+        ts = T.get_types(data, 'name', False)
+        with self.assertRaises(T.InvalidType):
+            x_type, y_type = T.argname(ts, ('x',), ('y',))
+
+
 class TestProd(unittest.TestCase):
 
     def test_name(self):


### PR DESCRIPTION
This PR improves `type_check.argname()` (#4680) interface for handling optional arguments nicely.