### PR TITLE
Support all float dtypes in `F.normalize`

### DIFF
--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -44,8 +44,9 @@ class NormalizeL2(function_node.FunctionNode):
         self.retain_inputs((0,))
         x, = inputs
         xp = cuda.get_array_module(x)
-        # Note: Passing dtype argument to numpy.sqrt() because NumPy in Python 2
-        # looks to return a casted value to float32 when it takes a float16 value.
+        # Note: Passing dtype argument to numpy.sqrt() because NumPy in
+        # Python 2 looks to return a casted value to float32 when it takes a
+        # float16 value.
         norm = (xp.sqrt(xp.sum(xp.square(x), axis=self.axis, keepdims=True),
                         dtype=x.dtype)
                 + x.dtype.type(self.eps))

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -1,5 +1,3 @@
-import numpy
-
 from chainer.backends import cuda
 from chainer import function_node
 import chainer.functions
@@ -40,9 +38,7 @@ class NormalizeL2(function_node.FunctionNode):
         type_check.expect(in_types.size() == 1)
         x_type, = in_types
 
-        type_check.expect(
-            x_type.dtype == numpy.float32,
-        )
+        type_check.expect(x_type.dtype.kind == 'f')
 
     def forward(self, inputs):
         self.retain_inputs((0,))

--- a/chainer/functions/normalization/l2_normalization.py
+++ b/chainer/functions/normalization/l2_normalization.py
@@ -44,7 +44,10 @@ class NormalizeL2(function_node.FunctionNode):
         self.retain_inputs((0,))
         x, = inputs
         xp = cuda.get_array_module(x)
-        norm = (xp.sqrt(xp.sum(xp.square(x), axis=self.axis, keepdims=True))
+        # Note: Passing dtype argument to numpy.sqrt() because NumPy in Python 2
+        # looks to return a casted value to float32 when it takes a float16 value.
+        norm = (xp.sqrt(xp.sum(xp.square(x), axis=self.axis, keepdims=True),
+                        dtype=x.dtype)
                 + x.dtype.type(self.eps))
         return utils.force_array(x / norm),
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -135,7 +135,10 @@ class TestL2Normalization(unittest.TestCase):
                 indices.append([slice(None)])
         indices_tuple = list(itertools.product(*indices))
         for index in indices_tuple:
-            numerator = numpy.linalg.norm(self.x[index]) + eps
+            # Note: Casting back the result of `numpy.linalg.norm` to `x.dtype`
+            # because old NumPy casts it to float32 when a float16 value is
+            # given.
+            numerator = numpy.linalg.norm(self.x[index]).astype(x.dtype) + eps
             y_expect[index] = self.x[index] / numerator
         testing.assert_allclose(y_expect, y_data, **self.check_forward_options)
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -35,6 +35,11 @@ def _is_good_param(param):
 
 @testing.parameterize(*filter(_is_good_param, testing.product([
     [
+        {'dtype': numpy.float16},
+        {'dtype': numpy.float32},
+        {'dtype': numpy.float64},
+    ],
+    [
         {'shape': (4, 15), 'axis': 1},
         {'shape': (4,), 'axis': 0},
         {'shape': (4, 3, 2, 5), 'axis': 0},
@@ -64,7 +69,7 @@ class TestL2Normalization(unittest.TestCase):
         self.x = chainer.utils.force_array(
             numpy.random.uniform(0.1, 1, self.shape)
             * (1 - 2 * numpy.random.randint(2, size=self.shape)),
-            numpy.float32)
+            self.dtype)
         if self.nonzeros is not None:
             # Make self.x have limited number of large values
 
@@ -83,26 +88,40 @@ class TestL2Normalization(unittest.TestCase):
                 zero_scale = 10. ** numpy.random.randint(-40, -3)
                 self.x[mask] = numpy.random.uniform(
                     -zero_scale, zero_scale, zeros)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.ggx = numpy.random.uniform(
-            -1, 1, self.shape).astype(numpy.float32)
-        self.check_options = {
-            'dtype': numpy.float64,
-        }
-        if self.nonzeros is None:
-            self.check_options['rtol'] = 1e-4
-            self.check_options['atol'] = 1e-4
+            -1, 1, self.shape).astype(self.dtype)
+
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
         else:
-            self.check_options['rtol'] = 1e-2
-            self.check_options['atol'] = 1e-2
-            self.check_options['eps'] = 1e-4
+            self.check_forward_options = {}
+
+        if self.nonzeros is None:
+            if self.dtype == numpy.float16:
+                self.check_backward_options = {
+                    'dtype': numpy.float64, 'atol': 5e-3, 'rtol': 5e-3}
+                self.check_double_backward_options = {
+                    'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+            else:
+                self.check_backward_options = {
+                    'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-4}
+                self.check_double_backward_options = {
+                    'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-4}
+        else:
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2,
+                'eps': 1e-4}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2,
+                'eps': 1e-4}
 
     def check_forward(self, x_data, axis):
         eps = self.eps
         x = chainer.Variable(x_data)
 
         y = functions.normalize(x, eps=eps, axis=axis)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
         y_expect = numpy.empty_like(self.x)
@@ -118,7 +137,7 @@ class TestL2Normalization(unittest.TestCase):
         for index in indices_tuple:
             numerator = numpy.linalg.norm(self.x[index]) + eps
             y_expect[index] = self.x[index] / numerator
-        testing.assert_allclose(y_expect, y_data)
+        testing.assert_allclose(y_expect, y_data, **self.check_forward_options)
 
     def test_forward_cpu(self):
         self.check_forward(self.x, self.axis)
@@ -132,7 +151,7 @@ class TestL2Normalization(unittest.TestCase):
             return functions.normalize(x, eps=self.eps, axis=axis)
 
         gradient_check.check_backward(
-            f, x_data, y_grad, **self.check_options)
+            f, x_data, y_grad, **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.axis, self.gy)
@@ -150,7 +169,8 @@ class TestL2Normalization(unittest.TestCase):
             return functions.normalize(x, eps=self.eps, axis=axis)
 
         gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, **self.check_options)
+            f, x_data, y_grad, x_grad_grad,
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.axis, self.gy, self.ggx)
@@ -165,7 +185,7 @@ class TestL2Normalization(unittest.TestCase):
         x = chainer.Variable(x_data)
 
         y = functions.normalize(x, axis=self.axis)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
         y_expect = numpy.zeros_like(self.x)


### PR DESCRIPTION
This PR follows #4582 to support all float dtypes in `F.normalize`.
