### PR TITLE
Use normcdfinv in F.ndtri

### DIFF
--- a/chainer/functions/math/ndtri.py
+++ b/chainer/functions/math/ndtri.py
@@ -35,7 +35,7 @@ class Ndtri(function_node.FunctionNode):
         self.retain_outputs((0,))
         return cuda.elementwise(
             'T x', 'T y',
-            'y = -sqrt(2.0) * erfcinv(2 * x)',
+            'y = normcdfinv(x)',
             'elementwise_ndtri',
         )(x[0]),
 


### PR DESCRIPTION
Use [`normcdfinv`](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html#group__CUDA__MATH__DOUBLE_1g78e93df6c3fbade8628d33e11fc94595) in `F.ndtri`.