### PR TITLE
Support all float dtypes in `F.roi_pooling_2d`

### DIFF
--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -59,9 +59,9 @@ class ROIPooling2D(function.Function):
 
         x_type, roi_type = in_types
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             x_type.ndim == 4,
-            roi_type.dtype == numpy.float32,
+            x_type.dtype == roi_type.dtype,
             roi_type.ndim == 2,
             roi_type.shape[1] == 5,
         )
@@ -76,7 +76,7 @@ class ROIPooling2D(function.Function):
         # `numpy.zeros` needs to be used because the arrays can be
         # returned without having some of its values updated.
         top_data = numpy.zeros((n_rois, channels, self.outh, self.outw),
-                               dtype=numpy.float32)
+                               dtype=bottom_data.dtype)
         self.argmax_data = numpy.zeros(top_data.shape, numpy.int32)
 
         for i_roi in six.moves.range(n_rois):
@@ -122,15 +122,16 @@ class ROIPooling2D(function.Function):
         channels, height, width = bottom_data.shape[1:]
         n_rois = bottom_rois.shape[0]
         top_data = cuda.cupy.empty((n_rois, channels, self.outh,
-                                    self.outw), dtype=numpy.float32)
+                                    self.outw), dtype=bottom_data.dtype)
         self.argmax_data = cuda.cupy.empty(top_data.shape, numpy.int32)
+        ctype = 'float' + str(bottom_data.itemsize * 8)
         cuda.elementwise(
             '''
-            raw float32 bottom_data, float32 spatial_scale, int32 channels,
-            int32 height, int32 width, int32 pooled_height, int32 pooled_width,
-            raw float32 bottom_rois
-            ''',
-            'float32 top_data, int32 argmax_data',
+            raw {ctype} bottom_data, {ctype} spatial_scale,
+            int32 channels, int32 height, int32 width, int32 pooled_height,
+            int32 pooled_width, raw {ctype} bottom_rois
+            '''.format(ctype=ctype),
+            '{ctype} top_data, int32 argmax_data'.format(ctype=ctype),
             '''
             // pos in output filter
             int pw = i % pooled_width;
@@ -195,7 +196,7 @@ class ROIPooling2D(function.Function):
         bottom_rois = inputs[1]
         channels, height, width = self._bottom_data_shape[1:]
         n_rois = bottom_rois.shape[0]
-        bottom_delta = numpy.zeros(self._bottom_data_shape, numpy.float32)
+        bottom_delta = numpy.zeros(self._bottom_data_shape, bottom_rois.dtype)
 
         for i_roi in six.moves.range(n_rois):
             idx, xmin, ymin, xmax, ymax = bottom_rois[i_roi]
@@ -235,14 +236,18 @@ class ROIPooling2D(function.Function):
     def backward_gpu(self, inputs, gy):
         bottom_rois = inputs[1]
         channels, height, width = self._bottom_data_shape[1:]
-        bottom_diff = cuda.cupy.zeros(self._bottom_data_shape, numpy.float32)
+        bottom_diff = cuda.cupy.zeros(
+            self._bottom_data_shape, bottom_rois.dtype)
+
+        ctype = 'float' + str(bottom_rois.itemsize * 8)
         cuda.elementwise(
             '''
-            raw float32 top_diff, raw int32 argmax_data, int32 num_rois,
-            float32 spatial_scale, int32 channels, int32 height, int32 width,
-            int32 pooled_height, int32 pooled_width, raw float32 bottom_rois
-            ''',
-            'float32 bottom_diff',
+            raw {ctype} top_diff, raw int32 argmax_data, int32 num_rois,
+            {ctype} spatial_scale, int32 channels, int32 height,
+            int32 width, int32 pooled_height, int32 pooled_width,
+            raw {ctype} bottom_rois
+            '''.format(ctype=ctype),
+            '{ctype} bottom_diff'.format(ctype=ctype),
             '''
             int w = i % width;
             int h = (i / width) % height;

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -124,14 +124,13 @@ class ROIPooling2D(function.Function):
         top_data = cuda.cupy.empty((n_rois, channels, self.outh,
                                     self.outw), dtype=bottom_data.dtype)
         self.argmax_data = cuda.cupy.empty(top_data.shape, numpy.int32)
-        ctype = 'float' + str(bottom_data.itemsize * 8)
         cuda.elementwise(
             '''
-            raw {ctype} bottom_data, {ctype} spatial_scale,
+            raw T bottom_data, T spatial_scale,
             int32 channels, int32 height, int32 width, int32 pooled_height,
-            int32 pooled_width, raw {ctype} bottom_rois
-            '''.format(ctype=ctype),
-            '{ctype} top_data, int32 argmax_data'.format(ctype=ctype),
+            int32 pooled_width, raw T bottom_rois
+            ''',
+            'T top_data, int32 argmax_data',
             '''
             // pos in output filter
             int pw = i % pooled_width;
@@ -239,15 +238,14 @@ class ROIPooling2D(function.Function):
         bottom_diff = cuda.cupy.zeros(
             self._bottom_data_shape, bottom_rois.dtype)
 
-        ctype = 'float' + str(bottom_rois.itemsize * 8)
         cuda.elementwise(
             '''
-            raw {ctype} top_diff, raw int32 argmax_data, int32 num_rois,
-            {ctype} spatial_scale, int32 channels, int32 height,
+            raw T top_diff, raw int32 argmax_data, int32 num_rois,
+            T spatial_scale, int32 channels, int32 height,
             int32 width, int32 pooled_height, int32 pooled_width,
-            raw {ctype} bottom_rois
-            '''.format(ctype=ctype),
-            '{ctype} bottom_diff'.format(ctype=ctype),
+            raw T bottom_rois
+            ''',
+            'T bottom_diff',
             '''
             int w = i % width;
             int h = (i / width) % height;

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -126,9 +126,9 @@ class ROIPooling2D(function.Function):
         self.argmax_data = cuda.cupy.empty(top_data.shape, numpy.int32)
         cuda.elementwise(
             '''
-            raw T bottom_data, T spatial_scale,
-            int32 channels, int32 height, int32 width, int32 pooled_height,
-            int32 pooled_width, raw T bottom_rois
+            raw T bottom_data, T spatial_scale, int32 channels,
+            int32 height, int32 width, int32 pooled_height, int32 pooled_width,
+            raw T bottom_rois
             ''',
             'T top_data, int32 argmax_data',
             '''
@@ -241,9 +241,8 @@ class ROIPooling2D(function.Function):
         cuda.elementwise(
             '''
             raw T top_diff, raw int32 argmax_data, int32 num_rois,
-            T spatial_scale, int32 channels, int32 height,
-            int32 width, int32 pooled_height, int32 pooled_width,
-            raw T bottom_rois
+            T spatial_scale, int32 channels, int32 height, int32 width,
+            int32 pooled_height, int32 pooled_width, raw T bottom_rois
             ''',
             'T bottom_diff',
             '''

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
@@ -10,29 +10,32 @@ from chainer import testing
 from chainer.testing import attr
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+}))
 class TestROIPooling2D(unittest.TestCase):
 
     def setUp(self):
         N = 3
         n_channels = 3
         self.x = numpy.arange(
-            N * n_channels * 12 * 8,
-            dtype=numpy.float32).reshape((N, n_channels, 12, 8))
+            N * n_channels * 12 * 8).reshape((N, n_channels, 12, 8))
         numpy.random.shuffle(self.x)
-        self.x = 2 * self.x / self.x.size - 1
+        self.x = (2 * self.x / self.x.size - 1).astype(self.dtype)
         self.rois = numpy.array([
             [0, 1, 1, 6, 6],
             [2, 6, 2, 7, 11],
             [1, 3, 1, 5, 10],
             [0, 3, 3, 3, 3]
-        ], dtype=numpy.float32)
+        ], dtype=self.dtype)
         n_rois = self.rois.shape[0]
         self.outh, self.outw = 5, 7
         self.spatial_scale = 0.6
         self.gy = numpy.random.uniform(
             -1, 1, (n_rois, n_channels,
-                    self.outh, self.outw)).astype(numpy.float32)
-        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+                    self.outh, self.outw)).astype(self.dtype)
+        self.check_backward_options = {
+            'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, x_data, roi_data):
         x = chainer.Variable(x_data)
@@ -40,7 +43,7 @@ class TestROIPooling2D(unittest.TestCase):
         y = functions.roi_pooling_2d(
             x, rois, outh=self.outh, outw=self.outw,
             spatial_scale=self.spatial_scale)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
         self.assertEqual(self.gy.shape, y_data.shape)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
@@ -34,8 +34,11 @@ class TestROIPooling2D(unittest.TestCase):
         self.gy = numpy.random.uniform(
             -1, 1, (n_rois, n_channels,
                     self.outh, self.outw)).astype(self.dtype)
-        self.check_backward_options = {
-            'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+        else:
+            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
 
     def check_forward(self, x_data, roi_data):
         x = chainer.Variable(x_data)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
@@ -19,7 +19,8 @@ class TestROIPooling2D(unittest.TestCase):
         N = 3
         n_channels = 3
         self.x = numpy.arange(
-            N * n_channels * 12 * 8).reshape((N, n_channels, 12, 8))
+            N * n_channels * 12 * 8,
+            dtype=numpy.float32).reshape((N, n_channels, 12, 8))
         numpy.random.shuffle(self.x)
         self.x = (2 * self.x / self.x.size - 1).astype(self.dtype)
         self.rois = numpy.array([


### PR DESCRIPTION
This PR follows #4582 to support all float dtypes in `F.roi_pooling_2d`.