### PR TITLE
add bounds arg for roi_pooling

### DIFF
--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -53,7 +53,7 @@ class ROIPooling2D(function.Function):
     def __init__(self, outh, outw, spatial_scale, bounds):
         self.outh, self.outw = outh, outw
         self.spatial_scale = spatial_scale
-        if not isinstance(bounds, str) or bounds not in ['inner', 'outer']:
+        if bounds not in ['inner', 'outer']:
             raise TypeError(
                 'bounds must be string and \'inner\' or \'outer\': {}, {}'
                 .format(type(bounds), bounds))

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -141,8 +141,10 @@ class ROIPooling2D(function.Function):
             int roi_batch_ind = bottom_rois[num * 5 + 0];
             int roi_start_w = round(bottom_rois[num * 5 + 1] * spatial_scale);
             int roi_start_h = round(bottom_rois[num * 5 + 2] * spatial_scale);
-            int roi_end_w = round((bottom_rois[num * 5 + 3] + 1.0) * spatial_scale);
-            int roi_end_h = round((bottom_rois[num * 5 + 4] + 1.0) * spatial_scale);
+            int roi_end_w = round(
+                (bottom_rois[num * 5 + 3] + 1.0) * spatial_scale);
+            int roi_end_h = round(
+                (bottom_rois[num * 5 + 4] + 1.0) * spatial_scale);
 
             // Force malformed ROIs to be 1x1
             int roi_width = max(roi_end_w - roi_start_w, 1);

--- a/chainer/functions/pooling/roi_pooling_2d.py
+++ b/chainer/functions/pooling/roi_pooling_2d.py
@@ -82,11 +82,11 @@ class ROIPooling2D(function.Function):
         for i_roi in six.moves.range(n_rois):
             idx, xmin, ymin, xmax, ymax = bottom_rois[i_roi]
             xmin = int(round(xmin * self.spatial_scale))
-            xmax = int(round(xmax * self.spatial_scale))
+            xmax = int(round((xmax + 1.) * self.spatial_scale))
             ymin = int(round(ymin * self.spatial_scale))
-            ymax = int(round(ymax * self.spatial_scale))
-            roi_width = max(xmax - xmin + 1, 1)
-            roi_height = max(ymax - ymin + 1, 1)
+            ymax = int(round((ymax + 1.) * self.spatial_scale))
+            roi_width = max(xmax - xmin, 1)
+            roi_height = max(ymax - ymin, 1)
             strideh = 1. * roi_height / self.outh
             stridew = 1. * roi_width / self.outw
 
@@ -141,12 +141,12 @@ class ROIPooling2D(function.Function):
             int roi_batch_ind = bottom_rois[num * 5 + 0];
             int roi_start_w = round(bottom_rois[num * 5 + 1] * spatial_scale);
             int roi_start_h = round(bottom_rois[num * 5 + 2] * spatial_scale);
-            int roi_end_w = round(bottom_rois[num * 5 + 3] * spatial_scale);
-            int roi_end_h = round(bottom_rois[num * 5 + 4] * spatial_scale);
+            int roi_end_w = round((bottom_rois[num * 5 + 3] + 1.0) * spatial_scale);
+            int roi_end_h = round((bottom_rois[num * 5 + 4] + 1.0) * spatial_scale);
 
             // Force malformed ROIs to be 1x1
-            int roi_width = max(roi_end_w - roi_start_w + 1, 1);
-            int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+            int roi_width = max(roi_end_w - roi_start_w, 1);
+            int roi_height = max(roi_end_h - roi_start_h, 1);
             float bin_size_h = static_cast<float>(roi_height)
                            / static_cast<float>(pooled_height);
             float bin_size_w = static_cast<float>(roi_width)
@@ -201,11 +201,11 @@ class ROIPooling2D(function.Function):
             idx, xmin, ymin, xmax, ymax = bottom_rois[i_roi]
             idx = int(idx)
             xmin = int(round(xmin * self.spatial_scale))
-            xmax = int(round(xmax * self.spatial_scale))
+            xmax = int(round((xmax + 1.0) * self.spatial_scale))
             ymin = int(round(ymin * self.spatial_scale))
-            ymax = int(round(ymax * self.spatial_scale))
-            roi_width = max(xmax - xmin + 1, 1)
-            roi_height = max(ymax - ymin + 1, 1)
+            ymax = int(round((ymax + 1.0) * self.spatial_scale))
+            roi_width = max(xmax - xmin, 1)
+            roi_height = max(ymax - ymin, 1)
 
             strideh = float(roi_height) / float(self.outh)
             stridew = float(roi_width) / float(self.outw)
@@ -263,9 +263,9 @@ class ROIPooling2D(function.Function):
                                         * spatial_scale);
                 int roi_start_h = round(bottom_rois[roi_n * 5 + 2]
                                         * spatial_scale);
-                int roi_end_w = round(bottom_rois[roi_n * 5 + 3]
+                int roi_end_w = round((bottom_rois[roi_n * 5 + 3] + 1.0)
                                       * spatial_scale);
-                int roi_end_h = round(bottom_rois[roi_n * 5 + 4]
+                int roi_end_h = round((bottom_rois[roi_n * 5 + 4] + 1.0)
                                       * spatial_scale);
 
                 // Skip if ROI doesn't include (h, w)
@@ -282,8 +282,8 @@ class ROIPooling2D(function.Function):
                 // this bottom unit
 
                 // Force malformed ROIs to be 1x1
-                int roi_width = max(roi_end_w - roi_start_w + 1, 1);
-                int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+                int roi_width = max(roi_end_w - roi_start_w, 1);
+                int roi_height = max(roi_end_h - roi_start_h, 1);
 
                 float bin_size_h = static_cast<float>(roi_height)
                                / static_cast<float>(pooled_height);

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
@@ -11,7 +11,8 @@ from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'bounds': ['inner', 'outer'],
 }))
 class TestROIPooling2D(unittest.TestCase):
 
@@ -29,6 +30,8 @@ class TestROIPooling2D(unittest.TestCase):
             [1, 3, 1, 5, 10],
             [0, 3, 3, 3, 3]
         ], dtype=self.dtype)
+        if self.bounds == 'outer':
+            self.rois[:, 3:] += 1.0
         n_rois = self.rois.shape[0]
         self.outh, self.outw = 5, 7
         self.spatial_scale = 0.6
@@ -46,7 +49,8 @@ class TestROIPooling2D(unittest.TestCase):
         rois = chainer.Variable(roi_data)
         y = functions.roi_pooling_2d(
             x, rois, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale)
+            spatial_scale=self.spatial_scale,
+            bounds=self.bounds)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
@@ -66,21 +70,24 @@ class TestROIPooling2D(unittest.TestCase):
         rois_cpu = chainer.Variable(self.rois)
         y_cpu = functions.roi_pooling_2d(
             x_cpu, rois_cpu, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale)
+            spatial_scale=self.spatial_scale,
+            bounds=self.bounds)
 
         # gpu
         x_gpu = chainer.Variable(cuda.to_gpu(self.x))
         rois_gpu = chainer.Variable(cuda.to_gpu(self.rois))
         y_gpu = functions.roi_pooling_2d(
             x_gpu, rois_gpu, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale)
+            spatial_scale=self.spatial_scale,
+            bounds=self.bounds)
         testing.assert_allclose(y_cpu.data, cuda.to_cpu(y_gpu.data))
 
     def check_backward(self, x_data, roi_data, y_grad):
         def f(x, rois):
             return functions.roi_pooling_2d(
                 x, rois, outh=self.outh, outw=self.outw,
-                spatial_scale=self.spatial_scale)
+                spatial_scale=self.spatial_scale,
+                bounds=self.bounds)
 
         gradient_check.check_backward(
             f, (x_data, roi_data), y_grad, no_grads=[False, True],
@@ -93,6 +100,58 @@ class TestROIPooling2D(unittest.TestCase):
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
                             cuda.to_gpu(self.gy))
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestROIPooling2DInnerOuterROIS(unittest.TestCase):
+
+    def setUp(self):
+        N = 3
+        n_channels = 3
+        self.x = numpy.arange(
+            N * n_channels * 12 * 8,
+            dtype=numpy.float32).reshape((N, n_channels, 12, 8))
+        numpy.random.shuffle(self.x)
+        self.x = (2 * self.x / self.x.size - 1).astype(self.dtype)
+        self.inner_rois = numpy.array([
+            [0, 1, 1, 6, 6],
+            [2, 6, 2, 7, 11],
+            [1, 3, 1, 5, 10],
+            [0, 3, 3, 3, 3]
+        ], dtype=self.dtype)
+        self.outer_rois = self.inner_rois.copy()
+        self.outer_rois[:, 3:] += 1.0
+        self.outh, self.outw = 5, 7
+        self.spatial_scale = 0.6
+
+    def check_forward_inner_outer_rois(
+            self, x_data, inner_roi_data, outer_roi_data):
+        x = chainer.Variable(x_data)
+        inner_rois = chainer.Variable(inner_roi_data)
+        outer_rois = chainer.Variable(outer_roi_data)
+        y_inner = functions.roi_pooling_2d(
+            x, inner_rois, outh=self.outh, outw=self.outw,
+            spatial_scale=self.spatial_scale,
+            bounds='inner',
+        )
+        y_outer = functions.roi_pooling_2d(
+            x, outer_rois, outh=self.outh, outw=self.outw,
+            spatial_scale=self.spatial_scale,
+            bounds='outer',
+        )
+        testing.assert_allclose(y_inner.data, y_outer.data)
+
+    def test_forward_inner_outer_rois_cpu(self):
+        self.check_forward_inner_outer_rois(
+            self.x, self.inner_rois, self.outer_rois)
+
+    @attr.gpu
+    def test_forward_inner_outer_rois_gpu(self):
+        self.check_forward_inner_outer_rois(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.inner_rois),
+            cuda.to_gpu(self.outer_rois))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
DO NOT MERGE YET
MERGE AFTER #5287 

there are 2 format of bounding box representation; inner_bounds and
outer_bounds.
For inner_bounds, `roi_height = y_max - y_min + 1` and `roi_width =
x_max - x_min + 1`.
But for outer_bounds, `roi_height = y_max - y_min` and `roi_width =
x_max - x_min` 
I set arg for this two representations.