### PR TITLE
add roi_indices arg for roi_align_2d and roi_pooling_2d

### DIFF
--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_align_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_align_2d.py
@@ -13,6 +13,7 @@ from chainer.testing import condition
 
 @testing.parameterize(*testing.product({
     'sampling_ratio': [0, 1, 2, (1, 2)],
+    'use_indices': [True, False],
 }))
 class TestROIAlign2D(unittest.TestCase):
 
@@ -25,12 +26,14 @@ class TestROIAlign2D(unittest.TestCase):
         numpy.random.shuffle(self.x)
         self.x = 2 * self.x / self.x.size - 1
         self.rois = numpy.array([
-            [0, 1, 1, 6, 6],
-            [2, 6, 2, 7, 11],
-            [1, 3, 1, 5, 10],
-            [0, 3, 3, 3, 3],
-            [2, 1.1, 2.2, 3.3, 4.4],
+            [1, 1, 6, 6],
+            [6, 2, 7, 11],
+            [3, 1, 5, 10],
+            [3, 3, 3, 3],
+            [1.1, 2.2, 3.3, 4.4],
         ], dtype=numpy.float32)
+        self.roi_indices = numpy.array(
+            [0, 2, 1, 0, 2], dtype=numpy.int32)
         n_rois = self.rois.shape[0]
         self.outh, self.outw = 5, 7
         self.spatial_scale = 0.6
@@ -39,14 +42,28 @@ class TestROIAlign2D(unittest.TestCase):
                     self.outh, self.outw)).astype(numpy.float32)
         self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
 
-    def check_forward(self, x_data, roi_data):
+    def check_forward(self, x_data, roi_data, roi_index_data):
         x = chainer.Variable(x_data)
-        rois = chainer.Variable(roi_data)
-        y = functions.roi_average_align_2d(
-            x, rois, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale,
-            sampling_ratio=self.sampling_ratio,
-        )
+        if self.use_indices:
+            rois = chainer.Variable(roi_data)
+            roi_indices = chainer.Variable(roi_index_data)
+            y = functions.roi_average_align_2d(
+                x, rois, roi_indices=roi_indices,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale,
+                sampling_ratio=self.sampling_ratio,
+            )
+        else:
+            xp = cuda.get_array_module(roi_data)
+            roi_data = xp.concatenate(
+                (roi_index_data[:, None].astype(roi_data.dtype), roi_data),
+                axis=1)
+            rois = chainer.Variable(roi_data)
+            y = functions.roi_average_align_2d(
+                x, rois, outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale,
+                sampling_ratio=self.sampling_ratio,
+            )
         self.assertEqual(y.data.dtype, numpy.float32)
         y_data = cuda.to_cpu(y.data)
 
@@ -54,55 +71,99 @@ class TestROIAlign2D(unittest.TestCase):
 
     @condition.retry(3)
     def test_forward_cpu(self):
-        self.check_forward(self.x, self.rois)
+        self.check_forward(self.x, self.rois, self.roi_indices)
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.rois))
+        self.check_forward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
+            cuda.to_gpu(self.roi_indices))
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_cpu_gpu_equal(self):
         # cpu
         x_cpu = chainer.Variable(self.x)
-        rois_cpu = chainer.Variable(self.rois)
-        y_cpu = functions.roi_average_align_2d(
-            x_cpu, rois_cpu, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale,
-            sampling_ratio=self.sampling_ratio,
-        )
+        if self.use_indices:
+            rois_cpu = chainer.Variable(self.rois)
+            roi_indices_cpu = chainer.Variable(self.roi_indices)
+            y_cpu = functions.roi_average_align_2d(
+                x_cpu, rois_cpu, roi_indices=roi_indices_cpu,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale,
+                sampling_ratio=self.sampling_ratio,
+            )
+        else:
+            roi_data = numpy.concatenate(
+                (self.roi_indices[:, None].astype(self.rois.dtype), self.rois),
+                axis=1)
+            rois_cpu = chainer.Variable(roi_data)
+            y_cpu = functions.roi_average_align_2d(
+                x_cpu, rois_cpu,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale,
+                sampling_ratio=self.sampling_ratio,
+            )
 
         # gpu
         x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        rois_gpu = chainer.Variable(cuda.to_gpu(self.rois))
-        y_gpu = functions.roi_average_align_2d(
-            x_gpu, rois_gpu, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale,
-            sampling_ratio=self.sampling_ratio,
-        )
+        if self.use_indices:
+            rois_gpu = chainer.Variable(cuda.to_gpu(self.rois))
+            roi_indices_gpu = chainer.Variable(
+                cuda.to_gpu(self.roi_indices))
+            y_gpu = functions.roi_average_align_2d(
+                x_gpu, rois_gpu, roi_indices=roi_indices_gpu,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale,
+                sampling_ratio=self.sampling_ratio,
+            )
+        else:
+            roi_data = numpy.concatenate(
+                (self.roi_indices[:, None].astype(self.rois.dtype), self.rois),
+                axis=1)
+            rois_gpu = chainer.Variable(cuda.to_gpu(roi_data))
+            y_gpu = functions.roi_average_align_2d(
+                x_gpu, rois_gpu, outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale,
+                sampling_ratio=self.sampling_ratio,
+            )
         testing.assert_allclose(y_cpu.data, cuda.to_cpu(y_gpu.data))
 
-    def check_backward(self, x_data, roi_data, y_grad):
-        def f(x, rois):
-            return functions.roi_average_align_2d(
-                x, rois, outh=self.outh, outw=self.outw,
-                spatial_scale=self.spatial_scale,
-                sampling_ratio=self.sampling_ratio)
+    def check_backward(self, x_data, roi_data, roi_index_data, y_grad):
+        def f(x, rois, roi_indices):
+            if self.use_indices:
+                return functions.roi_average_align_2d(
+                    x, rois, roi_indices=roi_indices,
+                    outh=self.outh, outw=self.outw,
+                    spatial_scale=self.spatial_scale,
+                    sampling_ratio=self.sampling_ratio)
+            else:
+                xp = cuda.get_array_module(rois.array)
+                roi_data = xp.concatenate(
+                    (roi_indices.array[:, None].astype(rois.dtype),
+                     rois.array), axis=1)
+                rois = chainer.Variable(roi_data)
+                return functions.roi_average_align_2d(
+                    x, rois, outh=self.outh, outw=self.outw,
+                    spatial_scale=self.spatial_scale,
+                    sampling_ratio=self.sampling_ratio)
 
         gradient_check.check_backward(
-            f, (x_data, roi_data), y_grad, no_grads=[False, True],
+            f, (x_data, roi_data, roi_index_data),
+            y_grad, no_grads=[False, True, True],
             **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.rois, self.gy)
+        self.check_backward(self.x, self.rois, self.roi_indices, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
-                            cuda.to_gpu(self.gy))
+        self.check_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
+            cuda.to_gpu(self.roi_indices), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_pooling_2d.py
@@ -11,7 +11,8 @@ from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'use_indices': [True, False],
 }))
 class TestROIPooling2D(unittest.TestCase):
 
@@ -24,11 +25,13 @@ class TestROIPooling2D(unittest.TestCase):
         numpy.random.shuffle(self.x)
         self.x = (2 * self.x / self.x.size - 1).astype(self.dtype)
         self.rois = numpy.array([
-            [0, 1, 1, 6, 6],
-            [2, 6, 2, 7, 11],
-            [1, 3, 1, 5, 10],
-            [0, 3, 3, 3, 3]
+            [1, 1, 6, 6],
+            [6, 2, 7, 11],
+            [3, 1, 5, 10],
+            [3, 3, 3, 3]
         ], dtype=self.dtype)
+        self.roi_indices = numpy.array(
+            [0, 2, 1, 0], dtype=numpy.int32)
         n_rois = self.rois.shape[0]
         self.outh, self.outw = 5, 7
         self.spatial_scale = 0.6
@@ -41,58 +44,110 @@ class TestROIPooling2D(unittest.TestCase):
         else:
             self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
 
-    def check_forward(self, x_data, roi_data):
+    def check_forward(self, x_data, roi_data, roi_index_data):
         x = chainer.Variable(x_data)
-        rois = chainer.Variable(roi_data)
-        y = functions.roi_pooling_2d(
-            x, rois, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale)
+        if self.use_indices:
+            rois = chainer.Variable(roi_data)
+            roi_indices = chainer.Variable(roi_index_data)
+            y = functions.roi_pooling_2d(
+                x, rois, roi_indices=roi_indices,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale)
+        else:
+            xp = cuda.get_array_module(roi_data)
+            roi_data = xp.concatenate(
+                (roi_index_data[:, None].astype(roi_data.dtype), roi_data),
+                axis=1)
+            rois = chainer.Variable(roi_data)
+            y = functions.roi_pooling_2d(
+                x, rois, outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale)
         self.assertEqual(y.data.dtype, self.dtype)
         y_data = cuda.to_cpu(y.data)
 
         self.assertEqual(self.gy.shape, y_data.shape)
 
     def test_forward_cpu(self):
-        self.check_forward(self.x, self.rois)
+        self.check_forward(self.x, self.rois, self.roi_indices)
 
     @attr.gpu
     def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.rois))
+        self.check_forward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
+            cuda.to_gpu(self.roi_indices))
 
     @attr.gpu
     def test_forward_cpu_gpu_equal(self):
         # cpu
         x_cpu = chainer.Variable(self.x)
-        rois_cpu = chainer.Variable(self.rois)
-        y_cpu = functions.roi_pooling_2d(
-            x_cpu, rois_cpu, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale)
+        if self.use_indices:
+            rois_cpu = chainer.Variable(self.rois)
+            roi_indices_cpu = chainer.Variable(self.roi_indices)
+            y_cpu = functions.roi_pooling_2d(
+                x_cpu, rois_cpu, roi_indices=roi_indices_cpu,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale)
+        else:
+            roi_data = numpy.concatenate(
+                (self.roi_indices[:, None].astype(self.rois.dtype), self.rois),
+                axis=1)
+            rois_cpu = chainer.Variable(roi_data)
+            y_cpu = functions.roi_pooling_2d(
+                x_cpu, rois_cpu,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale)
 
         # gpu
         x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        rois_gpu = chainer.Variable(cuda.to_gpu(self.rois))
-        y_gpu = functions.roi_pooling_2d(
-            x_gpu, rois_gpu, outh=self.outh, outw=self.outw,
-            spatial_scale=self.spatial_scale)
+        if self.use_indices:
+            rois_gpu = chainer.Variable(cuda.to_gpu(self.rois))
+            roi_indices_gpu = chainer.Variable(
+                cuda.to_gpu(self.roi_indices))
+            y_gpu = functions.roi_pooling_2d(
+                x_gpu, rois_gpu, roi_indices=roi_indices_gpu,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale)
+        else:
+            roi_data = numpy.concatenate(
+                (self.roi_indices[:, None].astype(self.rois.dtype), self.rois),
+                axis=1)
+            rois_gpu = chainer.Variable(cuda.to_gpu(roi_data))
+            y_gpu = functions.roi_pooling_2d(
+                x_gpu, rois_gpu,
+                outh=self.outh, outw=self.outw,
+                spatial_scale=self.spatial_scale)
         testing.assert_allclose(y_cpu.data, cuda.to_cpu(y_gpu.data))
 
-    def check_backward(self, x_data, roi_data, y_grad):
-        def f(x, rois):
-            return functions.roi_pooling_2d(
-                x, rois, outh=self.outh, outw=self.outw,
-                spatial_scale=self.spatial_scale)
+    def check_backward(self, x_data, roi_data, roi_index_data, y_grad):
+        def f(x, rois, roi_indices):
+            if self.use_indices:
+                return functions.roi_pooling_2d(
+                    x, rois, roi_indices=roi_indices,
+                    outh=self.outh, outw=self.outw,
+                    spatial_scale=self.spatial_scale)
+            else:
+                xp = cuda.get_array_module(rois.array)
+                roi_data = xp.concatenate(
+                    (roi_indices.array[:, None].astype(rois.dtype),
+                     rois.array), axis=1)
+                rois = chainer.Variable(roi_data)
+                return functions.roi_pooling_2d(
+                    x, rois, outh=self.outh, outw=self.outw,
+                    spatial_scale=self.spatial_scale)
 
         gradient_check.check_backward(
-            f, (x_data, roi_data), y_grad, no_grads=[False, True],
+            f, (x_data, roi_data, roi_index_data),
+            y_grad, no_grads=[False, True, True],
             **self.check_backward_options)
 
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.rois, self.gy)
+        self.check_backward(self.x, self.rois, self.roi_indices, self.gy)
 
     @attr.gpu
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
-                            cuda.to_gpu(self.gy))
+        self.check_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
+            cuda.to_gpu(self.roi_indices), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
current inteface accepts `rois` formatted as
`(batch_index, x_min, y_min, x_max, y_max)`, but there is no need to
concatenate `batch_index` and `(x_min, y_min, x_max, y_max)`.
I think it is better to move `roi_pooling` and `roi_align` interfaces
to accept `rois` and `roi_indices` separately.
This PR is the first step of the inteface change, and it keeps
back-compatibilty with `roi_indices=None (default)`.
When you pass `roi_indices`, you can use new interface.

cc. @wkentaro