### PR TITLE
Fix location of chainermn docs in sidebar

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,8 +16,8 @@ Chainer -- A flexible framework of neural networks
    install
    guides/index
    examples/index
-   chainermn/index
    reference/index
+   chainermn/index
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
I think it's better to place ChainerMN docs after Chainer Reference.

Ref #5226.