### PR TITLE
Avoid using `pkg_resources` to retrieve Chainer version

### DIFF
--- a/chainermn/__init__.py
+++ b/chainermn/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import chainer
 
 from chainermn import communicators  # NOQA
 from chainermn import datasets  # NOQA
@@ -20,4 +20,4 @@ from chainermn.optimizers import create_multi_node_optimizer  # NOQA
 
 global_except_hook._add_hook_if_enabled()
 
-__version__ = pkg_resources.get_distribution('chainer').version
+__version__ = chainer.__version__


### PR DESCRIPTION
`chainermn.__version__` will be kept for backward compatibility, and now it points to the version of Chainer.
However, we should avoid using `pkg_resources` (c.f. #3628)

Ref #5226.