### PR TITLE
refine roi_average_align_2d interface

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -209,7 +209,7 @@ from chainer.functions.pooling.max_pooling_nd import max_pooling_3d  # NOQA
 from chainer.functions.pooling.max_pooling_nd import max_pooling_nd  # NOQA
 # TODO(kmaehashi) this alias should be removed in
 # https://github.com/chainer/chainer/pull/5198
-from chainer.functions.pooling.roi_align_2d import roi_align_2d as roi_average_align_2d  # NOQA
+from chainer.functions.pooling.roi_average_align_2d import roi_average_align_2d  # NOQA
 from chainer.functions.pooling.roi_pooling_2d import roi_pooling_2d  # NOQA
 from chainer.functions.pooling.spatial_pyramid_pooling_2d import spatial_pyramid_pooling_2d  # NOQA
 from chainer.functions.pooling.unpooling_2d import unpooling_2d  # NOQA

--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -121,18 +121,20 @@ bool get_bilinear_interp_params(
 '''
 
 
-class ROIAlign2D(function.Function):
+class ROIAverageAlign2D(function.Function):
 
-    """ROI align over a set of 2d planes."""
+    """ROI average align over a set of 2d planes."""
 
-    def __init__(self, outh, outw, spatial_scale, sampling_ratio=0):
-        for arg in ['outh', 'outw']:
-            value = eval(arg)
-            if not (isinstance(value, int) and value > 0):
-                raise TypeError(
-                    '{} must be positive integer: {}, {}'
-                    .format(arg, type(value), value)
-                )
+    def __init__(self, outsize, spatial_scale, sampling_ratio=0):
+        outh, outw = outsize
+        if not (isinstance(outh, int) and outh > 0):
+            raise TypeError(
+                'outsize[0] must be positive integer: {}, {}'
+                .format(type(outh), outh))
+        if not (isinstance(outw, int) and outw > 0):
+            raise TypeError(
+                'outsize[1] must be positive integer: {}, {}'
+                .format(type(outw), outw))
         if isinstance(spatial_scale, int):
             spatial_scale = float(spatial_scale)
         elif not (isinstance(spatial_scale, float) and spatial_scale > 0):
@@ -152,22 +154,25 @@ class ROIAlign2D(function.Function):
         self.sampling_ratio = sampling_ratio
 
     def check_type_forward(self, in_types):
-        type_check.expect(in_types.size() == 2)
+        type_check.expect(in_types.size() == 3)
 
-        x_type, roi_type = in_types
+        x_type, roi_type, roi_index_type = in_types
         type_check.expect(
             x_type.dtype == numpy.float32,
             x_type.ndim == 4,
             roi_type.dtype == numpy.float32,
             roi_type.ndim == 2,
-            roi_type.shape[1] == 5,
+            roi_type.shape[1] == 4,
+            roi_index_type.dtype == numpy.int32,
+            roi_index_type.ndim == 1,
+            roi_type.shape[0] == roi_index_type.shape[0],
         )
 
     def forward_cpu(self, inputs):
-        self.retain_inputs((1,))
+        self.retain_inputs((1, 2))
         self._bottom_data_shape = inputs[0].shape
 
-        bottom_data, bottom_rois = inputs
+        bottom_data, bottom_rois, bottom_roi_indices = inputs
         channels, height, width = bottom_data.shape[1:]
         n_rois = bottom_rois.shape[0]
         top_data = numpy.empty((n_rois, channels, self.outh,
@@ -182,14 +187,14 @@ class ROIAlign2D(function.Function):
             c = int(i / pooled_width / pooled_height) % channels
             n = int(i / pooled_width / pooled_height / channels)
 
-            roi_batch_ind = int(bottom_rois[n, 0])
+            roi_batch_ind = int(bottom_roi_indices[n])
+            roi_start_h = bottom_rois[n, 0] * spatial_scale
             roi_start_w = bottom_rois[n, 1] * spatial_scale
-            roi_start_h = bottom_rois[n, 2] * spatial_scale
+            roi_end_h = bottom_rois[n, 2] * spatial_scale
             roi_end_w = bottom_rois[n, 3] * spatial_scale
-            roi_end_h = bottom_rois[n, 4] * spatial_scale
 
-            roi_width = max(roi_end_w - roi_start_w, 1.)
             roi_height = max(roi_end_h - roi_start_h, 1.)
+            roi_width = max(roi_end_w - roi_start_w, 1.)
             bin_size_h = roi_height / pooled_height
             bin_size_w = roi_width / pooled_width
 
@@ -239,10 +244,10 @@ class ROIAlign2D(function.Function):
         return top_data,
 
     def forward_gpu(self, inputs):
-        self.retain_inputs((1,))
+        self.retain_inputs((1, 2))
         self._bottom_data_shape = inputs[0].shape
 
-        bottom_data, bottom_rois = inputs
+        bottom_data, bottom_rois, bottom_roi_indices = inputs
         channels, height, width = bottom_data.shape[1:]
         n_rois = bottom_rois.shape[0]
         top_data = cuda.cupy.empty((n_rois, channels, self.outh,
@@ -252,7 +257,7 @@ class ROIAlign2D(function.Function):
             raw T bottom_data, T spatial_scale, int32 channels,
             int32 height, int32 width, int32 pooled_height, int32 pooled_width,
             int32 sampling_ratio_h, int32 sampling_ratio_w,
-            raw T bottom_rois
+            raw T bottom_rois, raw int32 bottom_roi_indices
             ''',
             'T top_data',
             '''
@@ -261,16 +266,16 @@ class ROIAlign2D(function.Function):
             int c = (i / pooled_width / pooled_height) % channels;
             int n = i / pooled_width / pooled_height / channels;
 
-            int roi_batch_ind = bottom_rois[n * 5 + 0];
+            int roi_batch_ind = bottom_roi_indices[n];
 
-            T roi_start_w = bottom_rois[n * 5 + 1] * spatial_scale;
-            T roi_start_h = bottom_rois[n * 5 + 2] * spatial_scale;
-            T roi_end_w = bottom_rois[n * 5 + 3] * spatial_scale;
-            T roi_end_h = bottom_rois[n * 5 + 4] * spatial_scale;
+            T roi_start_h = bottom_rois[n * 4 + 0] * spatial_scale;
+            T roi_start_w = bottom_rois[n * 4 + 1] * spatial_scale;
+            T roi_end_h = bottom_rois[n * 4 + 2] * spatial_scale;
+            T roi_end_w = bottom_rois[n * 4 + 3] * spatial_scale;
 
             // Force malformed ROIs to be 1x1
-            T roi_width = max(roi_end_w - roi_start_w, (T)1.);
             T roi_height = max(roi_end_h - roi_start_h, (T)1.);
+            T roi_width = max(roi_end_w - roi_start_w, (T)1.);
             T bin_size_h = static_cast<T>(roi_height)
                             / static_cast<T>(pooled_height);
             T bin_size_w = static_cast<T>(roi_width)
@@ -331,16 +336,16 @@ class ROIAlign2D(function.Function):
 
             top_data = output_val;
             ''',
-            'roi_align_2d_fwd',
+            'roi_average_align_2d_fwd',
             preamble=_GET_BILINEAR_INTERP_KERNEL,
         )(bottom_data, self.spatial_scale, channels, height, width,
           self.outh, self.outw, self.sampling_ratio[0], self.sampling_ratio[1],
-          bottom_rois, top_data)
+          bottom_rois, bottom_roi_indices, top_data)
 
         return top_data,
 
     def backward_cpu(self, inputs, gy):
-        bottom_rois = inputs[1]
+        bottom_rois, bottom_roi_indices = inputs[1:]
         channels, height, width = self._bottom_data_shape[1:]
         bottom_diff = numpy.zeros(self._bottom_data_shape, gy[0].dtype)
 
@@ -355,14 +360,14 @@ class ROIAlign2D(function.Function):
             c = int(i / pooled_width / pooled_height) % channels
             n = int(i / pooled_width / pooled_height / channels)
 
-            roi_batch_ind = int(bottom_rois[n, 0])
+            roi_batch_ind = int(bottom_roi_indices[n])
+            roi_start_h = bottom_rois[n, 0] * spatial_scale
             roi_start_w = bottom_rois[n, 1] * spatial_scale
-            roi_start_h = bottom_rois[n, 2] * spatial_scale
+            roi_end_h = bottom_rois[n, 2] * spatial_scale
             roi_end_w = bottom_rois[n, 3] * spatial_scale
-            roi_end_h = bottom_rois[n, 4] * spatial_scale
 
-            roi_width = max(roi_end_w - roi_start_w, 1.)
             roi_height = max(roi_end_h - roi_start_h, 1.)
+            roi_width = max(roi_end_w - roi_start_w, 1.)
             bin_size_h = roi_height / pooled_height
             bin_size_w = roi_width / pooled_width
 
@@ -412,10 +417,10 @@ class ROIAlign2D(function.Function):
                     ix += 1
                 iy += 1
 
-        return bottom_diff, None
+        return bottom_diff, None, None
 
     def backward_gpu(self, inputs, gy):
-        bottom_rois = inputs[1]
+        bottom_rois, bottom_roi_indices = inputs[1:]
         channels, height, width = self._bottom_data_shape[1:]
         bottom_diff = cuda.cupy.zeros(self._bottom_data_shape, gy[0].dtype)
         cuda.elementwise(
@@ -425,7 +430,7 @@ class ROIAlign2D(function.Function):
             int32 channels, int32 height, int32 width,
             int32 pooled_height, int32 pooled_width,
             int32 sampling_ratio_h, int32 sampling_ratio_w,
-            raw T bottom_rois
+            raw T bottom_rois, raw int32 bottom_roi_indices
             ''',
             'raw T bottom_diff',
             '''
@@ -436,11 +441,11 @@ class ROIAlign2D(function.Function):
             int n = i / pooled_width / pooled_height / channels;
 
             // Do not using rounding; this implementation detail is critical
-            int roi_batch_ind = bottom_rois[n * 5 + 0];
-            T roi_start_w = bottom_rois[n * 5 + 1] * spatial_scale;
-            T roi_start_h = bottom_rois[n * 5 + 2] * spatial_scale;
-            T roi_end_w = bottom_rois[n * 5 + 3] * spatial_scale;
-            T roi_end_h = bottom_rois[n * 5 + 4] * spatial_scale;
+            int roi_batch_ind = bottom_roi_indices[n];
+            T roi_start_h = bottom_rois[n * 4 + 0] * spatial_scale;
+            T roi_start_w = bottom_rois[n * 4 + 1] * spatial_scale;
+            T roi_end_h = bottom_rois[n * 4 + 2] * spatial_scale;
+            T roi_end_w = bottom_rois[n * 4 + 3] * spatial_scale;
 
             // Force malformed ROIs to be 1x1
             T roi_width = max(roi_end_w - roi_start_w, (T)1.);
@@ -510,31 +515,35 @@ class ROIAlign2D(function.Function):
                 }
             }
             ''',
-            'roi_align_2d_bwd',
+            'roi_average_align_2d_bwd',
             preamble=_GET_BILINEAR_INTERP_KERNEL,
         )(gy[0], bottom_rois.shape[0],
           self.spatial_scale, channels, height, width, self.outh, self.outw,
           self.sampling_ratio[0], self.sampling_ratio[1],
-          bottom_rois, bottom_diff, size=gy[0].size)
+          bottom_rois, bottom_roi_indices, bottom_diff, size=gy[0].size)
 
-        return bottom_diff, None
+        return bottom_diff, None, None
 
 
-def roi_align_2d(x, rois, outh, outw, spatial_scale, sampling_ratio=0):
-    """Spatial Region of Interest (ROI) align function.
+def roi_average_align_2d(
+        x, rois, roi_indices, outsize, spatial_scale, sampling_ratio=0
+):
+    """Spatial Region of Interest (ROI) average align function.
 
     This function acts similarly to :class:`~functions.ROIPooling2D`, but
-    it computes the maximum of input spatial patch with bilinear interpolation
+    it computes average of input spatial patch with bilinear interpolation
     for each channel with the region of interest.
 
     Args:
         x (~chainer.Variable): Input variable. The shape is expected to be
             4 dimentional: (n: batch, c: channel, h, height, w: width).
         rois (~chainer.Variable): Input roi variable. The shape is expected to
-            be (n: data size, 5), and each datum is set as below:
-            (batch_index, x_min, y_min, x_max, y_max).
-        outh (int): Height of output image after pooled.
-        outw (int): Width of output image after pooled.
+            be (n: data size, 4), and each datum is set as below:
+            (y_min, x_min, y_max, x_max).
+        roi_indices (~chainer.Variable): Input roi variable. The shape is
+            expected to be (n: data size, ).
+        outsize ((int, int)): Expected output size after pooled
+            (height, width).
         spatial_scale (float): Scale of the roi is resized.
         sampling_ratio (int or tuple of int): Sampling step for the alignment.
             It must meet >=0 and is automatically decided when 0 is passed.
@@ -548,4 +557,5 @@ def roi_align_2d(x, rois, outh, outw, spatial_scale, sampling_ratio=0):
     `Mask R-CNN <https://arxiv.org/abs/1703.06870>`_.
 
     """
-    return ROIAlign2D(outh, outw, spatial_scale, sampling_ratio)(x, rois)
+    return ROIAverageAlign2D(outsize, spatial_scale, sampling_ratio)(
+        x, rois, roi_indices)

--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -126,7 +126,7 @@ class ROIAverageAlign2D(function.Function):
     """ROI average align over a set of 2d planes."""
 
     def __init__(self, outsize, spatial_scale, sampling_ratio=0):
-        outh, outw = outsize
+        outh, outw = _pair(outsize)
         if not (isinstance(outh, int) and outh > 0):
             raise TypeError(
                 'outsize[0] must be positive integer: {}, {}'

--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -536,19 +536,22 @@ def roi_average_align_2d(
 
     Args:
         x (~chainer.Variable): Input variable. The shape is expected to be
-            4 dimentional: (n: batch, c: channel, h, height, w: width).
+            4 dimentional: ``(n: batch, c: channel, h, height, w: width)``.
         rois (~chainer.Variable): Input roi variable. The shape is expected to
-            be (n: data size, 4), and each datum is set as below:
-            (y_min, x_min, y_max, x_max).
+            be ``(n: data size, 4)``, and each datum is set as below:
+            ``(y_min, x_min, y_max, x_max)``.
         roi_indices (~chainer.Variable): Input roi variable. The shape is
-            expected to be (n: data size, ).
-        outsize ((int, int)): Expected output size after pooled
-            (height, width).
+            expected to be ``(n: data size, )``.
+        outsize ((int, int) or int): Expected output size after pooled
+            (height, width). ``outsize=o`` and ``outsize=(o, o)``
+            are equivalent.
         spatial_scale (float): Scale of the roi is resized.
-        sampling_ratio (int or tuple of int): Sampling step for the alignment.
+        sampling_ratio ((int, int) or int): Sampling step for the alignment.
             It must meet >=0 and is automatically decided when 0 is passed.
             Use of different ratio in height and width axis is also supported
-            by passing tuple of int as (sampling_ratio_h, sampling_ratio_w).
+            by passing tuple of int as
+            ``(sampling_ratio_h, sampling_ratio_w)``.
+            ``sampling_ratio=s`` and ``sampling_ratio=(s, s)`` are equivalent.
 
     Returns:
         ~chainer.Variable: Output variable.

--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -565,10 +565,10 @@ def roi_average_align_2d(
             are equivalent.
         spatial_scale (float): Scale of the roi is resized.
         sampling_ratio ((int, int) or int): Sampling step for the alignment.
-            It must meet ``>=1`` and is automatically decided when :obj:`None`
-            is passed.  Use of different ratio in height and width axis is also
-            supported by passing tuple of int as
-            ``(sampling_ratio_h, sampling_ratio_w)``.
+            It must be an integer over :math:`1` or :obj:`None`, and the value
+            is automatically decided when :obj:`None` is passed.  Use of
+            different ratio in height and width axis is also supported by
+            passing tuple of int as ``(sampling_ratio_h, sampling_ratio_w)``.
             ``sampling_ratio=s`` and ``sampling_ratio=(s, s)`` are equivalent.
 
     Returns:

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
@@ -1,3 +1,4 @@
+import collections
 import unittest
 
 import numpy
@@ -11,8 +12,15 @@ from chainer.testing import attr
 from chainer.testing import condition
 
 
+def _pair(x):
+    if isinstance(x, collections.Iterable):
+        return x
+    return x, x
+
+
 @testing.parameterize(*testing.product({
     'sampling_ratio': [0, 1, 2, (1, 2)],
+    'outsize': [5, 7, (5, 7)],
 }))
 class TestROIAlign2D(unittest.TestCase):
 
@@ -33,11 +41,11 @@ class TestROIAlign2D(unittest.TestCase):
         ], dtype=numpy.float32)
         self.roi_indices = numpy.array([0, 2, 1, 0, 2], dtype=numpy.int32)
         n_rois = self.rois.shape[0]
-        self.outsize = (5, 7)
         self.spatial_scale = 0.6
+        outsize = _pair(self.outsize)
         self.gy = numpy.random.uniform(
             -1, 1, (n_rois, n_channels,
-                    self.outsize[0], self.outsize[1])).astype(numpy.float32)
+                    outsize[0], outsize[1])).astype(numpy.float32)
         self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
 
     def check_forward(self, x_data, roi_data, roi_index_data):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
@@ -19,7 +19,7 @@ def _pair(x):
 
 
 @testing.parameterize(*testing.product({
-    'sampling_ratio': [0, 1, 2, (1, 2)],
+    'sampling_ratio': [None, 1, 2, (None, 3), (1, 2)],
     'outsize': [5, 7, (5, 7)],
 }))
 class TestROIAlign2D(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
@@ -25,25 +25,27 @@ class TestROIAlign2D(unittest.TestCase):
         numpy.random.shuffle(self.x)
         self.x = 2 * self.x / self.x.size - 1
         self.rois = numpy.array([
-            [0, 1, 1, 6, 6],
-            [2, 6, 2, 7, 11],
-            [1, 3, 1, 5, 10],
-            [0, 3, 3, 3, 3],
-            [2, 1.1, 2.2, 3.3, 4.4],
+            [1, 1, 6, 6],
+            [2, 6, 11, 7],
+            [1, 3, 10, 5],
+            [3, 3, 3, 3],
+            [1.1, 2.2, 3.3, 4.4],
         ], dtype=numpy.float32)
+        self.roi_indices = numpy.array([0, 2, 1, 0, 2], dtype=numpy.int32)
         n_rois = self.rois.shape[0]
-        self.outh, self.outw = 5, 7
+        self.outsize = (5, 7)
         self.spatial_scale = 0.6
         self.gy = numpy.random.uniform(
             -1, 1, (n_rois, n_channels,
-                    self.outh, self.outw)).astype(numpy.float32)
+                    self.outsize[0], self.outsize[1])).astype(numpy.float32)
         self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
 
-    def check_forward(self, x_data, roi_data):
+    def check_forward(self, x_data, roi_data, roi_index_data):
         x = chainer.Variable(x_data)
         rois = chainer.Variable(roi_data)
+        roi_indices = chainer.Variable(roi_index_data)
         y = functions.roi_average_align_2d(
-            x, rois, outh=self.outh, outw=self.outw,
+            x, rois, roi_indices, outsize=self.outsize,
             spatial_scale=self.spatial_scale,
             sampling_ratio=self.sampling_ratio,
         )
@@ -54,12 +56,14 @@ class TestROIAlign2D(unittest.TestCase):
 
     @condition.retry(3)
     def test_forward_cpu(self):
-        self.check_forward(self.x, self.rois)
+        self.check_forward(self.x, self.rois, self.roi_indices)
 
     @attr.gpu
     @condition.retry(3)
     def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.rois))
+        self.check_forward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
+            cuda.to_gpu(self.roi_indices))
 
     @attr.gpu
     @condition.retry(3)
@@ -67,8 +71,9 @@ class TestROIAlign2D(unittest.TestCase):
         # cpu
         x_cpu = chainer.Variable(self.x)
         rois_cpu = chainer.Variable(self.rois)
+        roi_indices_cpu = chainer.Variable(self.roi_indices)
         y_cpu = functions.roi_average_align_2d(
-            x_cpu, rois_cpu, outh=self.outh, outw=self.outw,
+            x_cpu, rois_cpu, roi_indices_cpu, outsize=self.outsize,
             spatial_scale=self.spatial_scale,
             sampling_ratio=self.sampling_ratio,
         )
@@ -76,33 +81,35 @@ class TestROIAlign2D(unittest.TestCase):
         # gpu
         x_gpu = chainer.Variable(cuda.to_gpu(self.x))
         rois_gpu = chainer.Variable(cuda.to_gpu(self.rois))
+        roi_indices_gpu = chainer.Variable(cuda.to_gpu(self.roi_indices))
         y_gpu = functions.roi_average_align_2d(
-            x_gpu, rois_gpu, outh=self.outh, outw=self.outw,
+            x_gpu, rois_gpu, roi_indices_gpu, outsize=self.outsize,
             spatial_scale=self.spatial_scale,
             sampling_ratio=self.sampling_ratio,
         )
         testing.assert_allclose(y_cpu.data, cuda.to_cpu(y_gpu.data))
 
-    def check_backward(self, x_data, roi_data, y_grad):
-        def f(x, rois):
+    def check_backward(self, x_data, roi_data, roi_index_data, y_grad):
+        def f(x, rois, roi_indices):
             return functions.roi_average_align_2d(
-                x, rois, outh=self.outh, outw=self.outw,
+                x, rois, roi_indices, outsize=self.outsize,
                 spatial_scale=self.spatial_scale,
                 sampling_ratio=self.sampling_ratio)
 
         gradient_check.check_backward(
-            f, (x_data, roi_data), y_grad, no_grads=[False, True],
-            **self.check_backward_options)
+            f, (x_data, roi_data, roi_index_data), y_grad,
+            no_grads=[False, True, True], **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
-        self.check_backward(self.x, self.rois, self.gy)
+        self.check_backward(self.x, self.rois, self.roi_indices, self.gy)
 
     @attr.gpu
     @condition.retry(3)
     def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
-                            cuda.to_gpu(self.gy))
+        self.check_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.rois),
+            cuda.to_gpu(self.roi_indices), cuda.to_gpu(self.gy))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
related to #5304 
support new interface `roi_average_align_2d`
![roi_average_align_2d](https://user-images.githubusercontent.com/9300063/45253132-ec911000-b39c-11e8-85d7-9e1288f808bc.png)
