### PR TITLE
Introduce `utils.mixed_presision` decorator

### DIFF
--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -14,7 +14,6 @@ from chainer.utils.experimental import experimental  # NOQA
 from chainer.utils.sparse import CooMatrix  # NOQA
 from chainer.utils.sparse import get_order  # NOQA
 from chainer.utils.sparse import to_coo  # NOQA
-from chainer.utils.precision import mixed_precision  # NOQA
 from chainer.utils.walker_alias import WalkerAlias  # NOQA
 
 

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -14,6 +14,7 @@ from chainer.utils.experimental import experimental  # NOQA
 from chainer.utils.sparse import CooMatrix  # NOQA
 from chainer.utils.sparse import get_order  # NOQA
 from chainer.utils.sparse import to_coo  # NOQA
+from chainer.utils.precision import mixed_precision  # NOQA
 from chainer.utils.walker_alias import WalkerAlias  # NOQA
 
 

--- a/chainer/utils/precision.py
+++ b/chainer/utils/precision.py
@@ -9,7 +9,8 @@ def mixed_precision(fn):
     """
     @functools.wraps(fn)
     def wrapper(self, in_data):
-        flag = any([x.dtype == numpy.float16 for x in in_data])
+        flag = all([x.dtype.kind != 'f' or x.dtype == numpy.float16
+                    for x in in_data])
 
         in_data1 = []
         for x in in_data:

--- a/chainer/utils/precision.py
+++ b/chainer/utils/precision.py
@@ -2,7 +2,7 @@ import numpy
 import functools
 
 
-def mixed_precision(fn):
+def _fp16_mixed_precision_helper(fn):
     """Decorator to perform forward computation in FP32 for FP16 inputs,
        returning outputs casted back to FP16. Do nothing for FP32 and FP64
        inputs.

--- a/chainer/utils/precision.py
+++ b/chainer/utils/precision.py
@@ -10,13 +10,25 @@ def mixed_precision(fn):
     @functools.wraps(fn)
     def wrapper(self, in_data):
         flag = any([x.dtype == numpy.float16 for x in in_data])
-        in_data = tuple([
-            x.astype(numpy.float32) if x.dtype == numpy.float16 else x
-            for x in in_data])
-        out_data = fn(self, in_data)
+
+        in_data1 = []
+        for x in in_data:
+            if x.dtype == numpy.float16:
+                in_data1.append(x.astype(numpy.float32))
+            else:
+                in_data1.append(x)
+        in_data1 = tuple(in_data1)
+
+        out_data = fn(self, in_data1)
+
         if flag:
-            out_data = tuple([
-                y.astype(numpy.float16) if y.dtype == numpy.float32 else y
-                for y in out_data])
+            out_data1 = []
+            for y in out_data:
+                if y is not None and y.dtype == numpy.float32:
+                    out_data1.append(y.astype(numpy.float16))
+                else:
+                    out_data1.append(y)
+            out_data = tuple(out_data1)
+
         return out_data
     return wrapper

--- a/chainer/utils/precision.py
+++ b/chainer/utils/precision.py
@@ -9,8 +9,6 @@ def mixed_precision(fn):
     """
     @functools.wraps(fn)
     def wrapper(self, in_data):
-        for x in in_data:
-            assert x.dtype.kind == 'f'  # should check in check_type_forward
         mask = tuple(x.dtype == numpy.float16 for x in in_data)
         in_data = tuple(x.astype(numpy.float32) if m else x
                         for x, m in zip(in_data, mask))

--- a/chainer/utils/precision.py
+++ b/chainer/utils/precision.py
@@ -1,0 +1,21 @@
+import numpy
+import functools
+
+
+def mixed_precision(fn):
+    """Decorator to perform forward computation in FP32 for FP16 inputs,
+       returning outputs casted back to FP16. Do nothing for FP32 and FP64
+       inputs.
+    """
+    @functools.wraps(fn)
+    def wrapper(self, in_data):
+        for x in in_data:
+            assert x.dtype.kind == 'f'  # should check in check_type_forward
+        mask = tuple(x.dtype == numpy.float16 for x in in_data)
+        in_data = tuple(x.astype(numpy.float32) if m else x
+                        for x, m in zip(in_data, mask))
+        out_data = fn(self, in_data)
+        out_data = tuple(y.astype(numpy.float16) if m else y
+                         for y, m in zip(out_data, mask))
+        return out_data
+    return wrapper

--- a/chainer/utils/precision.py
+++ b/chainer/utils/precision.py
@@ -9,11 +9,14 @@ def mixed_precision(fn):
     """
     @functools.wraps(fn)
     def wrapper(self, in_data):
-        mask = tuple(x.dtype == numpy.float16 for x in in_data)
-        in_data = tuple(x.astype(numpy.float32) if m else x
-                        for x, m in zip(in_data, mask))
+        flag = any([x.dtype == numpy.float16 for x in in_data])
+        in_data = tuple([
+            x.astype(numpy.float32) if x.dtype == numpy.float16 else x
+            for x in in_data])
         out_data = fn(self, in_data)
-        out_data = tuple(y.astype(numpy.float16) if m else y
-                         for y, m in zip(out_data, mask))
+        if flag:
+            out_data = tuple([
+                y.astype(numpy.float16) if y.dtype == numpy.float32 else y
+                for y in out_data])
         return out_data
     return wrapper

--- a/tests/chainer_tests/utils_tests/test_precision.py
+++ b/tests/chainer_tests/utils_tests/test_precision.py
@@ -4,12 +4,12 @@ import numpy
 
 from chainer import function_node
 from chainer import testing
-from chainer import utils
+from chainer.utils import precision
 
 
 class F(function_node.FunctionNode):
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward(self, x):
         self.x = x
         return x
@@ -17,7 +17,7 @@ class F(function_node.FunctionNode):
 
 class G(function_node.FunctionNode):
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward(self, x):
         return None,
 

--- a/tests/chainer_tests/utils_tests/test_precision.py
+++ b/tests/chainer_tests/utils_tests/test_precision.py
@@ -1,0 +1,53 @@
+import unittest
+
+import numpy
+
+from chainer import function_node
+from chainer import testing
+from chainer import utils
+
+
+class F(function_node.FunctionNode):
+
+    @utils.mixed_precision
+    def forward(self, x):
+        self.x = x
+        return x
+
+
+class TestMixedPrecision(unittest.TestCase):
+
+    def test_fp16(self):
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.float16),) * 2
+        f = F()
+        y = f.apply(x)
+        assert f.x[0].dtype == numpy.float32
+        assert f.x[1].dtype == numpy.float32
+        assert y[0].dtype == numpy.float16
+        assert y[1].dtype == numpy.float16
+
+    def test_fp32(self):
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.float32),) * 2
+        f = F()
+        y = f.apply(x)
+        assert f.x[0] is x[0]
+        assert f.x[1] is x[1]
+        assert y[0].dtype == numpy.float32
+        assert y[1].dtype == numpy.float32
+
+    def test_fp64(self):
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.float64),) * 2
+        f = F()
+        y = f.apply(x)
+        assert f.x[0] is x[0]
+        assert f.x[1] is x[1]
+        assert y[0].dtype == numpy.float64
+        assert y[1].dtype == numpy.float64
+
+    def test_int8(self):
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.int8),) * 2
+        with self.assertRaises(AssertionError):
+            F().apply(x)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_precision.py
+++ b/tests/chainer_tests/utils_tests/test_precision.py
@@ -44,10 +44,15 @@ class TestMixedPrecision(unittest.TestCase):
         assert y[0].dtype == numpy.float64
         assert y[1].dtype == numpy.float64
 
-    def test_int8(self):
-        x = (numpy.zeros((1, 2, 3), dtype=numpy.int8),) * 2
-        with self.assertRaises(AssertionError):
-            F().apply(x)
+    def test_float16_int8(self):
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.float16),
+             numpy.zeros((1, 2, 3), dtype=numpy.int8))
+        f = F()
+        y = f.apply(x)
+        assert f.x[0].dtype == numpy.float32
+        assert f.x[1] is x[1]
+        assert y[0].dtype == numpy.float16
+        assert y[1].dtype == numpy.int8
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_precision.py
+++ b/tests/chainer_tests/utils_tests/test_precision.py
@@ -25,7 +25,8 @@ class G(function_node.FunctionNode):
 class TestMixedPrecision(unittest.TestCase):
 
     def test_fp16(self):
-        x = (numpy.zeros((1, 2, 3), dtype=numpy.float16),) * 2
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.float16),
+             numpy.zeros((1, 2, 3), dtype=numpy.float16))
         f = F()
         y = f.apply(x)
         assert f.x[0].dtype == numpy.float32
@@ -34,7 +35,8 @@ class TestMixedPrecision(unittest.TestCase):
         assert y[1].dtype == numpy.float16
 
     def test_fp32(self):
-        x = (numpy.zeros((1, 2, 3), dtype=numpy.float32),) * 2
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.float32),
+             numpy.zeros((1, 2, 3), dtype=numpy.float32))
         f = F()
         y = f.apply(x)
         assert f.x[0] is x[0]
@@ -43,7 +45,8 @@ class TestMixedPrecision(unittest.TestCase):
         assert y[1].dtype == numpy.float32
 
     def test_fp64(self):
-        x = (numpy.zeros((1, 2, 3), dtype=numpy.float64),) * 2
+        x = (numpy.zeros((1, 2, 3), dtype=numpy.float64),
+             numpy.zeros((1, 2, 3), dtype=numpy.float64))
         f = F()
         y = f.apply(x)
         assert f.x[0] is x[0]

--- a/tests/chainer_tests/utils_tests/test_precision.py
+++ b/tests/chainer_tests/utils_tests/test_precision.py
@@ -15,6 +15,13 @@ class F(function_node.FunctionNode):
         return x
 
 
+class G(function_node.FunctionNode):
+
+    @utils.mixed_precision
+    def forward(self, x):
+        return None,
+
+
 class TestMixedPrecision(unittest.TestCase):
 
     def test_fp16(self):
@@ -53,6 +60,11 @@ class TestMixedPrecision(unittest.TestCase):
         assert f.x[1] is x[1]
         assert y[0].dtype == numpy.float16
         assert y[1].dtype == numpy.int8
+
+    def test_none(self):
+        x = numpy.zeros((1, 2, 3), dtype=numpy.float64),
+        y = G().apply(x)
+        assert y[0].data is None
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR introduces `utils.mixed_presision` decorator that makes forward computation perform in FP32 for FP16 inputs, returning outputs casted back to FP16. It does nothing for FP32 and FP64 inputs.

```Python
class BatchDet(function_node.FunctionNode):
    ...
    @utils.mixed_precision
    def forward_cpu(self, x):
        self.retain_inputs((0,))
        self.retain_outputs((0,))
        detx = utils.force_array(numpy.linalg.det(x[0]))  # numpy.linalg.det does not support FP16
        return detx,
    ...
```