### PR TITLE
remove deprecated is_linear arg

### DIFF
--- a/tests/chainer_tests/testing_tests/test_unary_math_function_test.py
+++ b/tests/chainer_tests/testing_tests/test_unary_math_function_test.py
@@ -33,8 +33,7 @@ def dummy_linear(x):
 
 
 @testing.unary_math_function_unittest(dummy_linear,
-                                      func_expected=lambda x, dtype: x,
-                                      is_linear=True)
+                                      func_expected=lambda x, dtype: x)
 class TestIsLinear(unittest.TestCase):
     pass
 


### PR DESCRIPTION
it seems deprecated arg `is_linear` causes test fail in `AppVeyor`.
https://github.com/chainer/chainer/pull/5198#issuecomment-419634854