### PR TITLE
ChainerMN: add an error message when mpi4py is missing

### DIFF
--- a/chainermn/communicators/__init__.py
+++ b/chainermn/communicators/__init__.py
@@ -49,7 +49,8 @@ def create_communicator(
             import mpi4py.MPI
         except ImportError as e:
             raise ImportError(str(e) + ": "
-                              "ChainerMN requires mpi4py for distributed training. "
+                              "ChainerMN requires mpi4py for"
+                              "distributed training. "
                               "Please read the Chaier official document "
                               "and setup MPI and mpi4py.")
         mpi_comm = mpi4py.MPI.COMM_WORLD

--- a/chainermn/communicators/__init__.py
+++ b/chainermn/communicators/__init__.py
@@ -45,7 +45,13 @@ def create_communicator(
     """
 
     if mpi_comm is None:
-        import mpi4py.MPI
+        try:
+            import mpi4py.MPI
+        except ImportError as e:
+            raise ImportError(str(e) + ": "
+                              "ChainerMN requires mpi4py for distributed training. "
+                              "Please read the Chaier official document "
+                              "and setup MPI and mpi4py.")
         mpi_comm = mpi4py.MPI.COMM_WORLD
 
     if communicator_name != 'pure_nccl' and allreduce_grad_dtype is not None:


### PR DESCRIPTION
This PR adds an error message if `mpi4py` is missing when `chainermn` is imported, since installing `mpi4py` is not straightforward and users are expected read through the document.

