### PR TITLE
Remove unnecessary version checking in ChainerMN

### DIFF
--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -57,18 +57,7 @@ class Recv(chainer.Function):
 
         if inputs == ():
             # Expected to be invoked without any args in usual case.
-            if chainer.__version__.startswith('1.'):
-                # For backward compatibility.
-                dummy_var = chainer.Variable(
-                    xp.array([], dtype=xp.float32),
-                    volatile='auto')
-            else:
-                # This variable is necessary to backprop correctly
-                # in Chainer v2. This trick relies on the fact
-                # chainer.Variable.requires_grad is True by default
-                # in Chainer v2.0.0.
-                dummy_var = chainer.Variable(xp.array([], dtype=xp.float32))
-
+            dummy_var = chainer.Variable(xp.array([], dtype=xp.float32))
             dummy_var.name = 'dummy_var'
             return super(Recv, self).__call__(dummy_var)
 

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -46,11 +46,6 @@ class MultiNodeBatchNormalization(link.Link):
         chainer.utils.experimental(
             'chainermn.links.MultiNodeBatchNormalization')
 
-        if chainer.__version__.startswith('1.'):
-            raise RuntimeError(
-                'MultiNodeBatchNormalization works only with '
-                'chainer >= 2.0.0.')
-
         super(MultiNodeBatchNormalization, self).__init__()
         self.comm = comm
         self.avg_mean = numpy.zeros(size, dtype=dtype)

--- a/chainermn/links/n_step_rnn.py
+++ b/chainermn/links/n_step_rnn.py
@@ -1,51 +1,22 @@
 import chainer
-import chainer.functions.connection as fconn
 import chainer.links.connection as lconn
 import chainermn.functions
-
-
-# Chainer <=v3
-CHAINER_VERSION_OLD_RNN = (int(chainer.__version__.split('.')[0]) <= 3)
-
-if CHAINER_VERSION_OLD_RNN:
-    _rnn_n_cells = {
-        fconn.n_step_gru.n_step_bigru: 1,
-        fconn.n_step_gru.n_step_gru: 1,
-        fconn.n_step_lstm.n_step_bilstm: 2,
-        fconn.n_step_lstm.n_step_lstm: 2,
-        fconn.n_step_rnn.n_step_birnn: 1,
-        fconn.n_step_rnn.n_step_rnn: 1,
-    }
 
 
 class _MultiNodeNStepRNN(chainer.Chain):
 
     def __init__(self, link, communicator, rank_in, rank_out):
-        if chainer.__version__.startswith('4.0.0b'):
-            raise ValueError(
-                'Multi node stacked RNN link does not support '
-                'Chainer 4.0.0b1-4.0.0b4 versions.')
-
         super(_MultiNodeNStepRNN, self).__init__(actual_rnn=link)
 
         self.communicator = communicator
         self.rank_in = rank_in
         self.rank_out = rank_out
 
-        if CHAINER_VERSION_OLD_RNN:
-            if not hasattr(link, 'rnn') or link.rnn not in _rnn_n_cells:
-                raise ValueError(
-                    'link must be NStepRNN and its inherited link')
-            else:
-                self.n_cells = _rnn_n_cells[link.rnn]
-
-        else:  # expect Chainer >=4.0.0rc1
-            check_lstm = isinstance(link, lconn.n_step_rnn.NStepRNNBase)
-            if not check_lstm:
-                raise ValueError(
-                    'link must be NStepRNN and its inherited link')
-            else:
-                self.n_cells = link.n_cells
+        check_lstm = isinstance(link, lconn.n_step_rnn.NStepRNNBase)
+        if not check_lstm:
+            raise ValueError('link must be NStepRNN and its inherited link')
+        else:
+            self.n_cells = link.n_cells
 
     def __call__(self, *inputs):
         cells = [None for _ in range(self.n_cells)]


### PR DESCRIPTION
This PR removes unnecessary version checking in ChainerMN.

Background:
Before ChainerMN was merged into Chainer repository, ChainerMN has to check Chainer version installed in the environment. This was because some features in ChainerMN depended on Chainer's internal structures. However, ChainerMN is now integrated to Chainer and installed together. These version checking code is no longer necessary.

