### PR TITLE
Fix invalid escape sequence warnings in Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - flake8
   - autopep8 -r . --diff | tee check_autopep8
   - test ! -s check_autopep8
-  - python -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests
+  - python -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests docs
   - pushd tests
   - pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests
   - export OMP_NUM_THREADS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ script:
   - flake8
   - autopep8 -r . --diff | tee check_autopep8
   - test ! -s check_autopep8
+  - python -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests
   - pushd tests
   - pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests
   - export OMP_NUM_THREADS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - flake8
   - autopep8 -r . --diff | tee check_autopep8
   - test ! -s check_autopep8
-  - python -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests docs
+  - python -S -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests docs
   - pushd tests
   - pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests
   - export OMP_NUM_THREADS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,6 @@ before_install:
       brew cask uninstall oclint;
       brew install hdf5;
       brew install open-mpi;
-    else
-      sed -i.bak 's/"rU"/"r"/' /home/travis/virtualenv/python3.*/lib/python3.*/site.py;
     fi
 
 install:
@@ -63,7 +61,9 @@ script:
   - flake8
   - autopep8 -r . --diff | tee check_autopep8
   - test ! -s check_autopep8
-  - python -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests docs
+  # To workaround Travis issue (https://github.com/travis-ci/travis-ci/issues/7261),
+  # ignore DeprecationWarning raised in `site.py`.
+  - python -Werror::DeprecationWarning -Wignore::DeprecationWarning:site -m compileall -f -q chainer chainermn examples tests docs
   - pushd tests
   - pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests
   - export OMP_NUM_THREADS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ before_install:
       brew cask uninstall oclint;
       brew install hdf5;
       brew install open-mpi;
+    else
+      sed -i.bak 's/"rU"/"r"/' /home/travis/virtualenv/python3.*/lib/python3.*/site.py;
     fi
 
 install:
@@ -61,7 +63,7 @@ script:
   - flake8
   - autopep8 -r . --diff | tee check_autopep8
   - test ! -s check_autopep8
-  - python -S -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests docs
+  - python -Werror::DeprecationWarning -m compileall -f -q chainer chainermn examples tests docs
   - pushd tests
   - pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests
   - export OMP_NUM_THREADS=1

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -201,21 +201,21 @@ def linear(x, W, b=None, n_batch_axes=1):
             ..., s_n)`-shaped float array. Its first ``n_batch_axes``
             dimensions are handled as *minibatch dimensions*. The
             other dimensions are handled as concatenated one dimension whose
-            size must be :math:`(s_{\\rm n\_batch\_axes} * ... * s_n = N)`.
+            size must be :math:`(s_{\\rm n\\_batch\\_axes} * ... * s_n = N)`.
         W (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`): Weight variable of shape :math:`(M, N)`,
-            where :math:`(N = s_{\\rm n\_batch\_axes} * ... * s_n)`.
+            where :math:`(N = s_{\\rm n\\_batch\\_axes} * ... * s_n)`.
         b (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`): Bias variable (optional) of shape
             :math:`(M,)`.
         n_batch_axes (int): The number of batch axes. The default is 1. The
             input variable is reshaped into
-            (:math:`{\\rm n\_batch\_axes} + 1`)-dimensional tensor.
+            (:math:`{\\rm n\\_batch\\_axes} + 1`)-dimensional tensor.
             This should be greater than 0.
 
     Returns:
         ~chainer.Variable: Output variable. A float array with shape
-        of :math:`(s_1, ..., s_{\\rm n\_batch\_axes}, M)`.
+        of :math:`(s_1, ..., s_{\\rm n\\_batch\\_axes}, M)`.
 
     .. seealso:: :class:`~chainer.links.Linear`
 

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -125,7 +125,7 @@ class Linear(link.Link):
             x (~chainer.Variable): Batch of input vectors.
             n_batch_axes (int): The number of batch axes. The default is 1. The
                 input variable is reshaped into
-                (:math:`{\\rm n\_batch\_axes} + 1`)-dimensional tensor.
+                (:math:`{\\rm n\\_batch\\_axes} + 1`)-dimensional tensor.
                 This should be greater than 0.
 
         Returns:

--- a/chainer/optimizer_hooks/gradient_lars.py
+++ b/chainer/optimizer_hooks/gradient_lars.py
@@ -29,13 +29,13 @@ class GradientLARS(object):
         - :math:`\\beta`  : weight_decay
         - :math:`\\eta`   : lars_coeeficient
         - :math:`\\lambda`: local_lr \
-    :math:`=\\eta * \\frac{\|w_t\|}{\|\\nabla L(w_t)\| + \\beta * \|w_t\|}`.
+    :math:`=\\eta * \\frac{\\|w_t\\|}{\\|\\nabla L(w_t)\\| + \\beta * \\|w_t\\|}`.
 
     As :math:`lr` in chainer.optimizers.SGD or chainer.optimizers.MomentumSGD
-    corresponds to :math:`\\gamma * \\eta`, we define :math:`clip\_rate` as
-    :math:`\\frac{\|w_t\|}{\|\\nabla L(w_t)\| + \\beta * \|w_t\|}`
+    corresponds to :math:`\\gamma * \\eta`, we define :math:`clip\\_rate` as
+    :math:`\\frac{\\|w_t\\|}{\\|\\nabla L(w_t)\\| + \\beta * \\|w_t\\|}`
     and reformulate the aforementioned formula as:
-    :math:`v_{t+1} = m * v_t + lr * clip\_rate * (\\nabla L(w_t) + \\beta w_t)`
+    :math:`v_{t+1} = m * v_t + lr * clip\\_rate * (\\nabla L(w_t) + \\beta w_t)`
     and implement in this way. So you do not set lars_coeeficient.
 
     Args:

--- a/chainer/optimizer_hooks/gradient_lars.py
+++ b/chainer/optimizer_hooks/gradient_lars.py
@@ -29,13 +29,15 @@ class GradientLARS(object):
         - :math:`\\beta`  : weight_decay
         - :math:`\\eta`   : lars_coeeficient
         - :math:`\\lambda`: local_lr \
-    :math:`=\\eta * \\frac{\\|w_t\\|}{\\|\\nabla L(w_t)\\| + \\beta * \\|w_t\\|}`.
+    :math:`=\\eta * \
+    \\frac{\\|w_t\\|}{\\|\\nabla L(w_t)\\| + \\beta * \\|w_t\\|}`.
 
     As :math:`lr` in chainer.optimizers.SGD or chainer.optimizers.MomentumSGD
     corresponds to :math:`\\gamma * \\eta`, we define :math:`clip\\_rate` as
     :math:`\\frac{\\|w_t\\|}{\\|\\nabla L(w_t)\\| + \\beta * \\|w_t\\|}`
     and reformulate the aforementioned formula as:
-    :math:`v_{t+1} = m * v_t + lr * clip\\_rate * (\\nabla L(w_t) + \\beta w_t)`
+    :math:`v_{t+1} \
+    = m * v_t + lr * clip\\_rate * (\\nabla L(w_t) + \\beta w_t)`
     and implement in this way. So you do not set lars_coeeficient.
 
     Args:

--- a/chainer/training/extensions/step_shift.py
+++ b/chainer/training/extensions/step_shift.py
@@ -10,7 +10,7 @@ class StepShift(extension.Extension):
     """Trainer extension to shift an optimizer attribute in "steps".
 
     This extension multiplies the specified attribute of the optimizer in
-    "steps". The typical use case is to scale the attribute at every ``k``\ th
+    "steps". The typical use case is to scale the attribute at every ``k``\\ th
     iteration.
 
     For example, suppose that this extension is invoked at every iteration,

--- a/chainer/training/extensions/variable_statistics_plot.py
+++ b/chainer/training/extensions/variable_statistics_plot.py
@@ -120,12 +120,12 @@ class Statistician(object):
 
 class VariableStatisticsPlot(extension.Extension):
 
-    """Trainer extension to plot statistics for :class:`Variable`\s.
+    """Trainer extension to plot statistics for :class:`Variable`\\s.
 
     This extension collects statistics for a single :class:`Variable`, a list
-    of :class:`Variable`\s or similarly a single or a list of
-    :class:`Link`\s containing one or more :class:`Variable`\s. In case
-    multiple :class:`Variable`\s are found, the means are computed. The
+    of :class:`Variable`\\s or similarly a single or a list of
+    :class:`Link`\\s containing one or more :class:`Variable`\\s. In case
+    multiple :class:`Variable`\\s are found, the means are computed. The
     collected statistics are plotted and saved as an image in the directory
     specified by the :class:`Trainer`.
 

--- a/examples/memnn/memnn.py
+++ b/examples/memnn/memnn.py
@@ -40,7 +40,7 @@ def position_encode(embed, sentences):
 
     .. math::
 
-       m = \sum_j l_j A x_j,
+       m = \\sum_j l_j A x_j,
 
     where :math:`A` is an embed matrix, :math:`x_j` is :math:`j`-th word ID and
 

--- a/examples/memnn/memnn.py
+++ b/examples/memnn/memnn.py
@@ -21,7 +21,7 @@ def bow_encode(embed, sentences):
 
     .. math::
 
-       m = \sum_j A x_j,
+       m = \\sum_j A x_j,
 
     where :math:`A` is an embed matrix, and :math:`x_j` is :math:`j`-th word
     ID.

--- a/tests/chainer_tests/function_hooks_tests/test_debug_print.py
+++ b/tests/chainer_tests/function_hooks_tests/test_debug_print.py
@@ -34,7 +34,7 @@ class TestPrintHookToFunction(unittest.TestCase):
         self.f.add_hook(self.h)
         self.f(chainer.Variable(self.x), chainer.Variable(self.x))
         # In some environments, shape is long.
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: CPU
@@ -59,7 +59,7 @@ input data
         self.f.add_hook(self.h)
         self.f(chainer.Variable(cuda.to_gpu(self.x)),
                chainer.Variable(cuda.to_gpu(self.x)))
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: <CUDA Device 0>
@@ -84,7 +84,7 @@ input data
         y.grad = self.gy
         self.f.add_hook(self.h)
         y.backward()
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: CPU
@@ -113,7 +113,7 @@ output gradient
         y.grad = cuda.to_gpu(self.gy)
         self.f.add_hook(self.h)
         y.backward()
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: <CUDA Device 0>

--- a/tests/chainer_tests/utils_tests/test_argument.py
+++ b/tests/chainer_tests/utils_tests/test_argument.py
@@ -16,7 +16,7 @@ class TestArgument(unittest.TestCase):
         self.assertEqual(test(), (1, 2))
         self.assertEqual(test(bar=1, foo=2), (2, 1))
 
-        msg = "test\(\) got unexpected keyword argument\(s\) 'ham', 'spam'"
+        msg = r"test\(\) got unexpected keyword argument\(s\) 'ham', 'spam'"
         with six.assertRaisesRegex(self, TypeError, msg):
             test(spam=1, ham=2)
 


### PR DESCRIPTION
This fixes #5315.