### PR TITLE
Add quotes to stylecheck install

### DIFF
--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -217,7 +217,7 @@ You can use ``autopep8`` and ``flake8`` commands to check your code.
 In order to avoid confusion from using different tool versions, we pin the versions of those tools.
 Install them with the following command (from within the top directory of Chainer repository)::
 
-  $ pip install -e .[stylecheck]
+  $ pip install -e '.[stylecheck]'
 
 And check your code with::
 


### PR DESCRIPTION
Add quotation marks to `pip install -e '.[stylecheck]'` to allow it to work on shells like zsh that allow brace expansion.

Backwards compatible with bash shell.

Addresses issue #5301 