### PR TITLE
Tentative fix: pytest<3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = {
         'pycodestyle==2.3.1',
     ],
     'test': [
-        'pytest',
+        'pytest<3.8',
         'mock',
     ],
     'doctest': [


### PR DESCRIPTION
I cannot run the tests with `pytest==3.8.0`.