### PR TITLE
Dynamically import matplotlib

### DIFF
--- a/chainer/training/extensions/plot_report.py
+++ b/chainer/training/extensions/plot_report.py
@@ -11,16 +11,22 @@ from chainer.training import extension
 from chainer.training import trigger as trigger_module
 
 
-try:
-    import matplotlib  # NOQA
+_available = None
 
-    _available = True
 
-except (ImportError, TypeError):
-    _available = False
+def _try_import_matplotlib():
+    global matplotlib, _available
+    try:
+        import matplotlib  # NOQA
+        _available = True
+    except (ImportError, TypeError):
+        _available = False
 
 
 def _check_available():
+    if _available is None:
+        _try_import_matplotlib()
+
     if not _available:
         warnings.warn('matplotlib is not installed on your environment, '
                       'so nothing will be plotted at this time. '
@@ -115,7 +121,7 @@ class PlotReport(extension.Extension):
         return _available
 
     def __call__(self, trainer):
-        if _available:
+        if self.available():
             # Dynamically import pyplot to call matplotlib.use()
             # after importing chainer.training.extensions
             import matplotlib.pyplot as plt

--- a/chainer/training/extensions/variable_statistics_plot.py
+++ b/chainer/training/extensions/variable_statistics_plot.py
@@ -11,26 +11,33 @@ from chainer.training import extension
 from chainer.training import trigger as trigger_module
 
 
-try:
-    import matplotlib
-    _available = True
-except ImportError:
-    _available = False
+_available = None
 
 
-if _available:
-    if hasattr(matplotlib.colors, 'to_rgba'):
-        _to_rgba = matplotlib.colors.to_rgba
-    else:
-        # For matplotlib 1.x
-        _to_rgba = matplotlib.colors.ColorConverter().to_rgba
-    _plot_color = _to_rgba('#1f77b4')  # C0 color
-    _plot_color_trans = _plot_color[:3] + (0.2,)  # apply alpha
-    _plot_common_kwargs = {
-        'alpha': 0.2, 'linewidth': 0, 'color': _plot_color_trans}
+def _try_import_matplotlib():
+    global matplotlib, _available, _plot_common_kwargs
+    try:
+        import matplotlib
+        _available = True
+    except ImportError:
+        _available = False
+
+    if _available:
+        if hasattr(matplotlib.colors, 'to_rgba'):
+            _to_rgba = matplotlib.colors.to_rgba
+        else:
+            # For matplotlib 1.x
+            _to_rgba = matplotlib.colors.ColorConverter().to_rgba
+        _plot_color = _to_rgba('#1f77b4')  # C0 color
+        _plot_color_trans = _plot_color[:3] + (0.2,)  # apply alpha
+        _plot_common_kwargs = {
+            'alpha': 0.2, 'linewidth': 0, 'color': _plot_color_trans}
 
 
 def _check_available():
+    if _available is None:
+        _try_import_matplotlib()
+
     if not _available:
         warnings.warn('matplotlib is not installed on your environment, '
                       'so nothing will be plotted at this time. '
@@ -234,7 +241,7 @@ class VariableStatisticsPlot(extension.Extension):
         return _available
 
     def __call__(self, trainer):
-        if _available:
+        if self.available():
             # Dynamically import pyplot to call matplotlib.use()
             # after importing chainer.training.extensions
             import matplotlib.pyplot as plt

--- a/chainer/training/extensions/variable_statistics_plot.py
+++ b/chainer/training/extensions/variable_statistics_plot.py
@@ -15,7 +15,8 @@ _available = None
 
 
 def _try_import_matplotlib():
-    global matplotlib, _available, _plot_common_kwargs
+    global matplotlib, _available
+    global _plot_color, _plot_color_trans, _plot_common_kwargs
     try:
         import matplotlib
         _available = True

--- a/tests/chainer_tests/training_tests/extensions_tests/test_plot_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_plot_report.py
@@ -5,20 +5,21 @@ from chainer import testing
 from chainer.training import extensions
 
 
+try:
+    import matplotlib
+    _available = True
+except ImportError:
+    _available = False
+
+
 class TestPlotReport(unittest.TestCase):
 
     def test_available(self):
-        try:
-            import matplotlib  # NOQA
-            available = True
-        except ImportError:
-            available = False
-
         with warnings.catch_warnings(record=True) as w:
-            self.assertEqual(extensions.PlotReport.available(), available)
+            self.assertEqual(extensions.PlotReport.available(), _available)
 
         # It shows warning only when matplotlib is not available
-        if available:
+        if _available:
             self.assertEqual(len(w), 0)
         else:
             self.assertEqual(len(w), 1)
@@ -28,12 +29,10 @@ class TestPlotReport(unittest.TestCase):
     # because it sometimes does not raise UserWarning despite
     # matplotlib is not installed (this is due to the difference between
     # the behavior of unittest in python2 and that in python3).
-    @unittest.skipUnless(
-        extensions.plot_report._available, 'matplotlib is not installed')
+    @unittest.skipUnless(_available, 'matplotlib is not installed')
     def test_lazy_import(self):
         # To support python2, we do not use self.assertWarns()
         with warnings.catch_warnings(record=True) as w:
-            import matplotlib
             matplotlib.use('Agg')
 
         self.assertEqual(len(w), 0)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_plot_report.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_plot_report.py
@@ -31,9 +31,17 @@ class TestPlotReport(unittest.TestCase):
     # the behavior of unittest in python2 and that in python3).
     @unittest.skipUnless(_available, 'matplotlib is not installed')
     def test_lazy_import(self):
+        # matplotlib.pyplot should be lazily imported because matplotlib.use
+        # has to be called earlier.
+
         # To support python2, we do not use self.assertWarns()
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
             matplotlib.use('Agg')
+            # Test again with a different backend, because the above does not
+            # generate a warning if matplotlib.use('Agg') is called and then
+            # matplotlib.pyplot is imported.
+            matplotlib.use('PS')
 
         self.assertEqual(len(w), 0)
 

--- a/tests/chainer_tests/training_tests/extensions_tests/test_variable_statistics_plot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_variable_statistics_plot.py
@@ -9,6 +9,13 @@ from chainer import testing
 from chainer.training import extensions
 
 
+try:
+    import matplotlib
+    _available = True
+except ImportError:
+    _available = False
+
+
 class TestVariableStatisticsPlot(unittest.TestCase):
 
     def setUp(self):
@@ -30,9 +37,7 @@ class TestVariableStatisticsPlot(unittest.TestCase):
     # because it sometimes does not raise UserWarning despite
     # matplotlib is not installed (this is due to the difference between
     # the behavior of unittest in python2 and that in python3).
-    @unittest.skipUnless(
-        extensions.variable_statistics_plot._available,
-        'matplotlib is not installed')
+    @unittest.skipUnless(_available, 'matplotlib is not installed')
     def test_run_and_save_plot(self):
         import matplotlib
         matplotlib.use('Agg')

--- a/tests/chainer_tests/training_tests/extensions_tests/test_variable_statistics_plot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_variable_statistics_plot.py
@@ -39,7 +39,6 @@ class TestVariableStatisticsPlot(unittest.TestCase):
     # the behavior of unittest in python2 and that in python3).
     @unittest.skipUnless(_available, 'matplotlib is not installed')
     def test_run_and_save_plot(self):
-        import matplotlib
         matplotlib.use('Agg')
         try:
             self.trainer.run()


### PR DESCRIPTION
This PR fixes the following issues.

- Python 3.7 warns `import chainer` on `import matplotlib` (`matplotlib==2.2.3`).  With `filterwarnings=error::DeprecationWarning`, pytest (3.8.0) cannot even run a test with `import chainer`.
- It seems `import chainer` is slower if `matplotlib` is installed.