### PR TITLE
Support all float dtypes in `F.det` and `F.inv`

### DIFF
--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -6,6 +6,7 @@ from chainer import function_node
 import chainer.functions
 from chainer.functions.math import matmul
 from chainer import utils
+from chainer.utils import precision
 from chainer.utils import type_check
 
 
@@ -59,14 +60,14 @@ class BatchDet(function_node.FunctionNode):
         # so assert the last two dimensions are equal.
         type_check.expect(a_type.shape[-1] == a_type.shape[-2])
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward_cpu(self, x):
         self.retain_inputs((0,))
         self.retain_outputs((0,))
         detx = utils.force_array(numpy.linalg.det(x[0]))
         return detx,
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward_gpu(self, x):
         self.retain_inputs((0,))
         self.retain_outputs((0,))

--- a/chainer/functions/math/inv.py
+++ b/chainer/functions/math/inv.py
@@ -6,6 +6,7 @@ from chainer import function_node
 import chainer.functions
 from chainer.functions.math import matmul
 from chainer import utils
+from chainer.utils import precision
 from chainer.utils import type_check
 
 
@@ -56,7 +57,7 @@ class Inv(function_node.FunctionNode):
         # Matrix inversion only allowed for square matrices
         type_check.expect(a_type.shape[0] == a_type.shape[1])
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward_cpu(self, x):
         self.retain_outputs((0,))
         try:
@@ -65,7 +66,7 @@ class Inv(function_node.FunctionNode):
             raise ValueError('Input has singular matrices.')
         return invx,
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward_gpu(self, x):
         self.retain_outputs((0,))
         shape = x[0].shape
@@ -97,7 +98,7 @@ class BatchInv(function_node.FunctionNode):
         # so assert the last two dimensions are equal
         type_check.expect(a_type.shape[-1] == a_type.shape[-2])
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward_cpu(self, x):
         self.retain_outputs((0,))
         try:
@@ -106,7 +107,7 @@ class BatchInv(function_node.FunctionNode):
             raise ValueError('Input has singular matrices.')
         return invx,
 
-    @utils.mixed_precision
+    @precision._fp16_mixed_precision_helper
     def forward_gpu(self, x):
         self.retain_outputs((0,))
         invx, info = _inv_gpu(x[0])

--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -12,46 +12,54 @@ from chainer.testing import attr
 from chainer.utils import type_check
 
 
-@testing.parameterize(*[
-    {'batched': True},
-    {'batched': False}
-])
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'batched': [True, False],
+}))
 class DetFunctionTest(unittest.TestCase):
 
     def setUp(self):
         if self.batched:
             while True:
-                self.x = numpy.random.uniform(
+                x = numpy.random.uniform(
                     .5, 1, (6, 3, 3)).astype(numpy.float32)
                 # Avoid backward/double_backward instability.
                 if not numpy.any(numpy.isclose(
-                        numpy.linalg.det(self.x), 0, atol=1e-2, rtol=1e-2)):
+                        numpy.linalg.det(x), 0, atol=1e-2, rtol=1e-2)):
+                    self.x = x.astype(self.dtype, copy=False)
                     break
             self.y = numpy.random.uniform(
-                .5, 1, (6, 3, 3)).astype(numpy.float32)
-            self.gy = numpy.random.uniform(-1, 1, (6,)).astype(numpy.float32)
+                .5, 1, (6, 3, 3)).astype(self.dtype)
+            self.gy = numpy.random.uniform(-1, 1, (6,)).astype(self.dtype)
             self.ggx = numpy.random.uniform(
-                .5, 1, (6, 3, 3)).astype(numpy.float32)
+                .5, 1, (6, 3, 3)).astype(self.dtype)
             self.ct = self.x.transpose(0, 2, 1)
             self.det = F.batch_det
             self.matmul = F.matmul
         else:
             while True:
-                self.x = numpy.random.uniform(
-                    .5, 1, (5, 5)).astype(numpy.float32)
+                x = numpy.random.uniform(.5, 1, (5, 5)).astype(numpy.float32)
                 if not numpy.isclose(
-                        numpy.linalg.det(self.x), 0, atol=1e-2, rtol=1e-2):
+                        numpy.linalg.det(x), 0, atol=1e-2, rtol=1e-2):
+                    self.x = x.astype(self.dtype, copy=False)
                     break
-            self.y = numpy.random.uniform(.5, 1, (5, 5)).astype(numpy.float32)
-            self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)
-            self.ggx = numpy.random.uniform(
-                .5, 1, (5, 5)).astype(numpy.float32)
+            self.y = numpy.random.uniform(.5, 1, (5, 5)).astype(self.dtype)
+            self.gy = numpy.random.uniform(-1, 1, ()).astype(self.dtype)
+            self.ggx = numpy.random.uniform(.5, 1, (5, 5)).astype(self.dtype)
             self.ct = self.x.transpose()
             self.det = F.det
             self.matmul = F.matmul
 
-        self.check_backward_options = {'atol': 5e-3, 'rtol': 1e-3}
-        self.check_double_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-3, 'rtol': 5e-3}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-3, 'rtol': 1e-3}
+            self.check_double_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+        else:
+            self.check_forward_options = {}
+            self.check_backward_options = {'atol': 5e-3, 'rtol': 1e-3}
+            self.check_double_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
 
     def det_transpose(self, gpu=False):
         if gpu:
@@ -74,7 +82,7 @@ class DetFunctionTest(unittest.TestCase):
         self.det_transpose(gpu=False)
 
     def det_scaling(self, gpu=False):
-        scaling = numpy.random.randn(1).astype('float32')
+        scaling = numpy.random.randn(1).astype(self.dtype)
         if gpu:
             cx = cuda.to_gpu(self.x)
             sx = cuda.to_gpu(scaling * self.x)
@@ -86,7 +94,8 @@ class DetFunctionTest(unittest.TestCase):
         sxv = chainer.Variable(sx)
         cxd = self.det(cxv)
         sxd = self.det(sxv)
-        testing.assert_allclose(cxd.data * c, sxd.data)
+        testing.assert_allclose(
+            cxd.data * c, sxd.data, **self.check_forward_options)
 
     @attr.gpu
     def test_det_scaling_gpu(self):
@@ -97,18 +106,18 @@ class DetFunctionTest(unittest.TestCase):
 
     def det_identity(self, gpu=False):
         if self.batched:
-            chk = numpy.ones(len(self.x), dtype=numpy.float32)
-            dt = numpy.identity(self.x.shape[1], dtype=numpy.float32)
+            chk = numpy.ones(len(self.x), dtype=self.dtype)
+            dt = numpy.identity(self.x.shape[1], dtype=self.dtype)
             idt = numpy.repeat(dt[None], len(self.x), axis=0)
         else:
-            idt = numpy.identity(self.x.shape[1], dtype=numpy.float32)
-            chk = numpy.ones(1, dtype=numpy.float32)
+            idt = numpy.identity(self.x.shape[1], dtype=self.dtype)
+            chk = numpy.ones(1, dtype=self.dtype)
         if gpu:
             chk = cuda.to_gpu(chk)
             idt = cuda.to_gpu(idt)
         idtv = chainer.Variable(idt)
         idtd = self.det(idtv)
-        testing.assert_allclose(idtd.data, chk, rtol=1e-4, atol=1e-4)
+        testing.assert_allclose(idtd.data, chk, **self.check_forward_options)
 
     @attr.gpu
     def test_det_identity_gpu(self):
@@ -129,7 +138,7 @@ class DetFunctionTest(unittest.TestCase):
         dxy1 = self.det(self.matmul(vx, vy))
         dxy2 = self.det(vx) * self.det(vy)
         testing.assert_allclose(
-            dxy1.data, dxy2.data, rtol=1e-4, atol=1e-4)
+            dxy1.data, dxy2.data, **self.check_forward_options)
 
     def test_det_product_cpu(self):
         self.det_product(gpu=False)
@@ -143,14 +152,12 @@ class DetFunctionTest(unittest.TestCase):
         x_data = cuda.to_gpu(self.x)
         y_grad = cuda.to_gpu(self.gy)
         gradient_check.check_backward(
-            self.det, x_data, y_grad,
-            **self.check_backward_options)
+            self.det, x_data, y_grad, **self.check_backward_options)
 
     def test_batch_backward_cpu(self):
         x_data, y_grad = self.x, self.gy
         gradient_check.check_backward(
-            self.det, x_data, y_grad,
-            **self.check_backward_options)
+            self.det, x_data, y_grad, **self.check_backward_options)
 
     @attr.gpu
     def test_batch_double_backward_gpu(self):
@@ -218,15 +225,22 @@ class DetFunctionTest(unittest.TestCase):
                 cuda.to_gpu(self.x), cuda.to_gpu(self.gy), ValueError)
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestDetSmallCase(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(.5, 1, (2, 2)).astype(numpy.float32)
+        self.x = numpy.random.uniform(.5, 1, (2, 2)).astype(self.dtype)
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-3, 'rtol': 5e-3}
+        else:
+            self.check_forward_options = {}
 
     def check_by_definition(self, x):
         ans = F.det(chainer.Variable(x)).data
         y = x[0, 0] * x[1, 1] - x[0, 1] * x[1, 0]
-        testing.assert_allclose(ans, y)
+        testing.assert_allclose(ans, y, **self.check_forward_options)
 
     def test_answer_cpu(self):
         self.check_by_definition(self.x)
@@ -236,41 +250,51 @@ class TestDetSmallCase(unittest.TestCase):
         self.check_by_definition(cuda.to_gpu(self.x))
 
 
-@testing.parameterize(
-    *testing.product({
-        'shape': [(s, s) for s in six.moves.range(1, 5)],
-    }))
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'shape': [(s, s) for s in six.moves.range(1, 5)],
+}))
 class TestDetGPUCPUConsistency(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(.5, 1, self.shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
 
     @attr.gpu
     def test_answer_gpu_cpu(self):
         x = cuda.to_gpu(self.x)
         y = F.det(chainer.Variable(x))
         gpu = cuda.to_cpu(y.data)
-        cpu = numpy.linalg.det(self.x)
-        testing.assert_allclose(gpu, cpu)
+        if self.dtype == numpy.float16:
+            cpu = numpy.linalg.det(
+                self.x.astype(numpy.float32)).astype(numpy.float16)
+            testing.assert_allclose(gpu, cpu, atol=5e-3, rtol=5e-3)
+        else:
+            cpu = numpy.linalg.det(self.x)
+            testing.assert_allclose(gpu, cpu)
 
 
-@testing.parameterize(
-    *testing.product({
-        'shape': [(w, s, s) for s in six.moves.range(1, 5)
-                  for w in six.moves.range(1, 5)],
-    }))
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'shape': [(w, s, s) for s in six.moves.range(1, 5)
+              for w in six.moves.range(1, 5)],
+}))
 class TestBatchDetGPUCPUConsistency(unittest.TestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(.5, 1, self.shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
 
     @attr.gpu
     def test_answer_gpu_cpu(self):
         x = cuda.to_gpu(self.x)
         y = F.batch_det(chainer.Variable(x))
         gpu = cuda.to_cpu(y.data)
-        cpu = numpy.linalg.det(self.x)
-        testing.assert_allclose(gpu, cpu)
+        if self.dtype == numpy.float16:
+            cpu = numpy.linalg.det(
+                self.x.astype(numpy.float32)).astype(numpy.float16)
+            testing.assert_allclose(gpu, cpu, atol=5e-3, rtol=5e-3)
+        else:
+            cpu = numpy.linalg.det(self.x)
+            testing.assert_allclose(gpu, cpu)
 
 
 class DetFunctionRaiseTest(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/math_tests/test_inv.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_inv.py
@@ -8,7 +8,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import type_check
 
 
@@ -28,6 +27,7 @@ def _make_eye(shape):
 
 
 @testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'shape': [(1, 1), (5, 5)],
 }))
 class InvFunctionTest(unittest.TestCase):
@@ -35,20 +35,30 @@ class InvFunctionTest(unittest.TestCase):
     def setUp(self):
         self.x = (numpy.eye(self.shape[-1]) +
                   numpy.random.uniform(-0.01, 0.01, self.shape)).astype(
-            numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+            self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.ggx = (numpy.eye(self.shape[-1]) +
                     numpy.random.uniform(-0.01, 0.01, self.shape)).astype(
-            numpy.float32)
-        self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-4}
-        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-4}
-        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-4}
+            self.dtype)
+
+        if self.dtype == numpy.float16:
+            self.check_forward_dtype = numpy.float32
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-3}
+            self.check_double_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-3, 'rtol': 5e-3}
+        else:
+            self.check_forward_dtype = self.dtype
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
+            self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-4}
+            self.check_double_backward_options = {'atol': 5e-4, 'rtol': 5e-4}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = functions.inv(x)
-        testing.assert_allclose(
-            _inv(self.x), y.data, **self.check_forward_options)
+        x1 = self.x.astype(self.check_forward_dtype, copy=False)
+        testing.assert_allclose(_inv(x1), y.data, **self.check_forward_options)
 
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
@@ -59,7 +69,6 @@ class InvFunctionTest(unittest.TestCase):
             functions.inv, x_data, y_grad, x_grad_grad,
             **self.check_double_backward_options)
 
-    @condition.retry(3)
     def test_identity_cpu(self):
         eye = _make_eye(self.x.shape)
         x = chainer.Variable(self.x)
@@ -68,7 +77,6 @@ class InvFunctionTest(unittest.TestCase):
             y.data, eye, **self.check_forward_options)
 
     @attr.gpu
-    @condition.retry(3)
     def test_identity_gpu(self):
         eye = cuda.to_gpu(_make_eye(self.x.shape))
         x = chainer.Variable(cuda.to_gpu(self.x))
@@ -76,30 +84,24 @@ class InvFunctionTest(unittest.TestCase):
         testing.assert_allclose(
             y.data, eye, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x),
@@ -108,6 +110,7 @@ class InvFunctionTest(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'shape': [(5, 1, 1), (3, 5, 5)],
 }))
 class BatchInvFunctionTest(unittest.TestCase):
@@ -115,22 +118,32 @@ class BatchInvFunctionTest(unittest.TestCase):
     def setUp(self):
         self.x = (numpy.eye(self.shape[-1]) +
                   numpy.random.uniform(-0.01, 0.01, self.shape)).astype(
-            numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+            self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.ggx = (numpy.eye(self.shape[-1]) +
                     numpy.random.uniform(-0.01, 0.01, self.shape)).astype(
-            numpy.float32)
-        self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-4}
-        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-4}
-        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-4}
+            self.dtype)
 
-    def check_forward(self, x_data, atol=1e-7, rtol=1e-7):
+        if self.dtype == numpy.float16:
+            self.check_forward_dtype = numpy.float32
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-3}
+            self.check_double_backward_options = {
+                'dtype': numpy.float64, 'atol': 5e-3, 'rtol': 5e-3}
+        else:
+            self.check_forward_dtype = self.dtype
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
+            self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-4}
+            self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+
+    def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = functions.batch_inv(x)
-        testing.assert_allclose(
-            _inv(self.x), y.data, **self.check_forward_options)
+        x1 = self.x.astype(self.check_forward_dtype, copy=False)
+        testing.assert_allclose(_inv(x1), y.data, **self.check_forward_options)
 
-    def check_backward(self, x_data, y_grad, **kwargs):
+    def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             functions.batch_inv, x_data, y_grad,
             **self.check_backward_options)
@@ -140,7 +153,6 @@ class BatchInvFunctionTest(unittest.TestCase):
             functions.batch_inv, x_data, y_grad, x_grad_grad,
             **self.check_double_backward_options)
 
-    @condition.retry(3)
     def test_identity_cpu(self):
         eye = _make_eye(self.x.shape)
         x = chainer.Variable(self.x)
@@ -149,7 +161,6 @@ class BatchInvFunctionTest(unittest.TestCase):
             y.data, eye, **self.check_forward_options)
 
     @attr.gpu
-    @condition.retry(3)
     def test_identity_gpu(self):
         eye = cuda.to_gpu(_make_eye(self.x.shape))
         x = chainer.Variable(cuda.to_gpu(self.x))
@@ -157,30 +168,24 @@ class BatchInvFunctionTest(unittest.TestCase):
         testing.assert_allclose(
             y.data, eye, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 
-    @condition.retry(3)
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x, self.gy, self.ggx)
 
     @attr.gpu
-    @condition.retry(3)
     def test_double_backward_gpu(self):
         self.check_double_backward(
             cuda.to_gpu(self.x),


### PR DESCRIPTION
Merge ~https://github.com/cupy/cupy/pull/1617~ and #5306 first.

https://github.com/takagi/chainer/compare/mixed-precision-decorator...takagi:dtype-det

This PR follows #4582 to support all float dtypes in `F.det` as well as `F.inv` used in `F.det` backward computation. Note that some routines used do not support FP16 data, `F.det` and `F.inv` compute FP16 inputs in FP32.
