### PR TITLE
Disallow summing over ellipsis in `F.einsum`

### DIFF
--- a/chainer/functions/math/einsum.py
+++ b/chainer/functions/math/einsum.py
@@ -54,11 +54,11 @@ def _einsum(xp, dtype, in_subscripts, out_subscript, *inputs, **kwargs):
     if sum_ellipsis:
         sum_ndim = y.ndim - len(out_subscript)
         if check_undefined_ellipsis_sum and sum_ndim > 0:
-            warnings.warn(
+            raise ValueError(
                 "einsum should not support summing over Ellipsis, "
                 "while NumPy 1.14 sometimes accidentally supports it. "
-                "This feature will be deleted in a future version "
-                "of Chainer. See also NumPy issues #10926, #9984.",
+                "This feature is no longer supported by Chainer. "
+                "See also NumPy issues #10926, #9984.",
             )
         y = xp.sum(y, axis=tuple(range(sum_ndim)))
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_einsum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_einsum.py
@@ -229,7 +229,7 @@ class TestEinSumUndefinedSemantics(unittest.TestCase):
         with warnings.catch_warnings(record=True) as ws:
             warnings.simplefilter("always")
             einsum.einsum(self.subscripts, *self.inputs)
-            self.assertEqual(len(ws), 1)
+            assert ws
 
 
 def diag_einsum(

--- a/tests/chainer_tests/functions_tests/math_tests/test_einsum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_einsum.py
@@ -1,6 +1,5 @@
 import functools
 import unittest
-import warnings
 
 import numpy
 

--- a/tests/chainer_tests/functions_tests/math_tests/test_einsum.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_einsum.py
@@ -225,11 +225,9 @@ class TestEinSumUndefinedSemantics(unittest.TestCase):
             for shape in self.shapes
         ])
 
-    def test_warn(self):
-        with warnings.catch_warnings(record=True) as ws:
-            warnings.simplefilter("always")
+    def test_bad_ellipsis_sum(self):
+        with self.assertRaises(ValueError):
             einsum.einsum(self.subscripts, *self.inputs)
-            assert ws
 
 
 def diag_einsum(


### PR DESCRIPTION
This feature is controversial and I'd rather not support it in the next stable release.