### PR TITLE
[backport] Fix invalid escape sequence warnings in Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - test ! -s check_autopep8
   # To workaround Travis issue (https://github.com/travis-ci/travis-ci/issues/7261),
   # ignore DeprecationWarning raised in `site.py`.
-  - python -Werror::DeprecationWarning -Wignore::DeprecationWarning:site -m compileall -f -q chainer chainermn examples tests docs
+  - python -Werror::DeprecationWarning -Wignore::DeprecationWarning:site -m compileall -f -q chainer examples tests docs
   - pushd tests
   - pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,9 @@ script:
   - flake8
   - autopep8 -r . --diff | tee check_autopep8
   - test ! -s check_autopep8
+  # To workaround Travis issue (https://github.com/travis-ci/travis-ci/issues/7261),
+  # ignore DeprecationWarning raised in `site.py`.
+  - python -Werror::DeprecationWarning -Wignore::DeprecationWarning:site -m compileall -f -q chainer chainermn examples tests docs
   - pushd tests
   - pytest -m "not slow and not gpu and not cudnn and not ideep" chainer_tests
   - popd

--- a/chainer/optimizer_hooks/gradient_lars.py
+++ b/chainer/optimizer_hooks/gradient_lars.py
@@ -29,13 +29,15 @@ class GradientLARS(object):
         - :math:`\\beta`  : weight_decay
         - :math:`\\eta`   : lars_coeeficient
         - :math:`\\lambda`: local_lr \
-    :math:`=\\eta * \\frac{\|w_t\|}{\|\\nabla L(w_t)\| + \\beta * \|w_t\|}`.
+    :math:`=\\eta * \
+    \\frac{\\|w_t\\|}{\\|\\nabla L(w_t)\\| + \\beta * \\|w_t\\|}`.
 
     As :math:`lr` in chainer.optimizers.SGD or chainer.optimizers.MomentumSGD
-    corresponds to :math:`\\gamma * \\eta`, we define :math:`clip\_rate` as
-    :math:`\\frac{\|w_t\|}{\|\\nabla L(w_t)\| + \\beta * \|w_t\|}`
+    corresponds to :math:`\\gamma * \\eta`, we define :math:`clip\\_rate` as
+    :math:`\\frac{\\|w_t\\|}{\\|\\nabla L(w_t)\\| + \\beta * \\|w_t\\|}`
     and reformulate the aforementioned formula as:
-    :math:`v_{t+1} = m * v_t + lr * clip\_rate * (\\nabla L(w_t) + \\beta w_t)`
+    :math:`v_{t+1} \
+    = m * v_t + lr * clip\\_rate * (\\nabla L(w_t) + \\beta w_t)`
     and implement in this way. So you do not set lars_coeeficient.
 
     Args:

--- a/chainer/training/extensions/variable_statistics_plot.py
+++ b/chainer/training/extensions/variable_statistics_plot.py
@@ -120,12 +120,12 @@ class Statistician(object):
 
 class VariableStatisticsPlot(extension.Extension):
 
-    """Trainer extension to plot statistics for :class:`Variable`\s.
+    """Trainer extension to plot statistics for :class:`Variable`\\s.
 
     This extension collects statistics for a single :class:`Variable`, a list
-    of :class:`Variable`\s or similarly a single or a list of
-    :class:`Link`\s containing one or more :class:`Variable`\s. In case
-    multiple :class:`Variable`\s are found, the means are computed. The
+    of :class:`Variable`\\s or similarly a single or a list of
+    :class:`Link`\\s containing one or more :class:`Variable`\\s. In case
+    multiple :class:`Variable`\\s are found, the means are computed. The
     collected statistics are plotted and saved as an image in the directory
     specified by the :class:`Trainer`.
 

--- a/tests/chainer_tests/function_hooks_tests/test_debug_print.py
+++ b/tests/chainer_tests/function_hooks_tests/test_debug_print.py
@@ -34,7 +34,7 @@ class TestPrintHookToFunction(unittest.TestCase):
         self.f.add_hook(self.h)
         self.f(chainer.Variable(self.x), chainer.Variable(self.x))
         # In some environments, shape is long.
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: CPU
@@ -59,7 +59,7 @@ input data
         self.f.add_hook(self.h)
         self.f(chainer.Variable(cuda.to_gpu(self.x)),
                chainer.Variable(cuda.to_gpu(self.x)))
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: <CUDA Device 0>
@@ -84,7 +84,7 @@ input data
         y.grad = self.gy
         self.f.add_hook(self.h)
         y.backward()
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: CPU
@@ -113,7 +113,7 @@ output gradient
         y.grad = cuda.to_gpu(self.gy)
         self.f.add_hook(self.h)
         y.backward()
-        expect = '''^function\tDummyFunction
+        expect = r'''^function\tDummyFunction
 input data
 <variable at 0x[0-9a-f]+>
 - device: <CUDA Device 0>

--- a/tests/chainer_tests/utils_tests/test_argument.py
+++ b/tests/chainer_tests/utils_tests/test_argument.py
@@ -16,7 +16,7 @@ class TestArgument(unittest.TestCase):
         self.assertEqual(test(), (1, 2))
         self.assertEqual(test(bar=1, foo=2), (2, 1))
 
-        msg = "test\(\) got unexpected keyword argument\(s\) 'ham', 'spam'"
+        msg = r"test\(\) got unexpected keyword argument\(s\) 'ham', 'spam'"
         with six.assertRaisesRegex(self, TypeError, msg):
             test(spam=1, ham=2)
 


### PR DESCRIPTION
Backport of #5317