### PR TITLE
Support all float dtypes in `F.negative_sampling`

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_negative_sampling.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_negative_sampling.py
@@ -20,6 +20,7 @@ def make_sampler(xp, high):
 
 
 @testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
     't': [[0, 2], [-1, 1, 2]],
     'reduce': ['sum', 'no'],
 }))
@@ -35,24 +36,28 @@ class TestNegativeSamplingFunction(unittest.TestCase):
         x_shape = (batch, self.in_size)
         w_shape = (self.label_size, self.in_size)
 
-        self.x = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
         self.t = numpy.array(self.t).astype(numpy.int32)
-        self.w = numpy.random.uniform(-1, 1, w_shape).astype(numpy.float32)
+        self.w = numpy.random.uniform(-1, 1, w_shape).astype(self.dtype)
 
         if self.reduce == 'no':
             g_shape = self.t.shape
         elif self.reduce == 'sum':
             g_shape = ()
 
-        self.gy = numpy.random.uniform(-1, 1, g_shape).astype(numpy.float32)
+        self.gy = numpy.random.uniform(-1, 1, g_shape).astype(self.dtype)
 
-        self.ggx = numpy.random.uniform(-1, 1, x_shape).astype(numpy.float32)
-        self.ggw = numpy.random.uniform(-1, 1, w_shape).astype(numpy.float32)
+        self.ggx = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+        self.ggw = numpy.random.uniform(-1, 1, w_shape).astype(self.dtype)
 
-        self.check_backward_options = {
-            'eps': 1e-2, 'atol': 5e-4, 'rtol': 5e-3}
+        self.check_forward_options = {}
+        self.check_backward_options = {'eps': 1e-2, 'atol': 5e-4, 'rtol': 5e-3}
         self.check_double_backward_options = {
             'eps': 1e-2, 'atol': 1e-3, 'rtol': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options['dtype'] = numpy.float64
+            self.check_double_backward_options['dtype'] = numpy.float64
 
     def check_forward(self, x_data, t_data, w_data, sampler):
         x = chainer.Variable(x_data)
@@ -64,7 +69,7 @@ class TestNegativeSamplingFunction(unittest.TestCase):
 
         samples = cuda.to_cpu(y.creator.samples)
 
-        loss = numpy.empty((len(self.x),), numpy.float32)
+        loss = numpy.empty((len(self.x),), self.dtype)
         for i in six.moves.range(len(self.x)):
             ix = self.x[i]
             it = self.t[i]
@@ -81,7 +86,7 @@ class TestNegativeSamplingFunction(unittest.TestCase):
         if self.reduce == 'sum':
             loss = loss.sum()
 
-        testing.assert_allclose(y.data, loss)
+        testing.assert_allclose(y.data, loss, **self.check_forward_options)
 
     def test_forward_cpu(self):
         self.check_forward(


### PR DESCRIPTION
Merge #5335 first.

~https://github.com/takagi/chainer/compare/dtype-scatter-add...takagi:dtype-negative-sampling-function~

This PR follows #4582 to support all float dtypes in `F.negative_sampling`. ~Note that because some routines used do not support FP16 data, it computes FP16 inputs in FP32.~
