### PR TITLE
For proper resuming, don't raise KeyError at UpdateRule deserialization

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -292,13 +292,20 @@ class UpdateRule(object):
                 self_copy.init_state(variable.Variable(arr, grad=arr))
 
                 for key in self._state:
-                    self._state[key] = serializer(key, None)
+                    try:
+                        value = serializer(key, None)
+                    except KeyError:
+                        if self.enabled:
+                            raise
+                        value = None
                     # leave the update rule state as `None` if the keys are not
                     # contained in the snapshot, so that these states can be
                     # automatically initialized with the `_prepare` method
-                    if self._state[key] is None:
+                    if value is None:
                         self._state = None
                         break
+                    else:
+                        self._state[key] = value
         else:
             for key in self._state:
                 self._state[key] = serializer(key, self._state[key])

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -9,6 +9,7 @@ import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import optimizers
+from chainer import serializer
 from chainer import testing
 from chainer.testing import attr
 
@@ -50,6 +51,25 @@ class TestHyperparameter(unittest.TestCase):
         self.assertEqual(self.child.get_dict(), child_copy.get_dict())
         self.assertEqual(self.parent.get_dict(), parent_copy.get_dict())
         self.assertIs(child_copy.parent, parent_copy)
+
+
+class DummyDeserializer(serializer.Deserializer):
+
+    def __init__(self, target):
+        super(DummyDeserializer, self).__init__()
+        self.target = target
+
+    def __getitem__(self, key):
+        raise NotImplementedError
+
+    def __call__(self, key, value):
+        if value is None:
+            value = self.target[key]
+        elif isinstance(value, np.ndarray):
+            np.copyto(value, self.target[key])
+        else:
+            value = type(value)(np.asarray(self.target[key]))
+        return value
 
 
 class TestUpdateRule(unittest.TestCase):
@@ -176,6 +196,13 @@ class TestUpdateRule(unittest.TestCase):
         self.update_rule.update(chainer.Variable(
             cuda.to_gpu(self.data, 1), grad=cuda.to_gpu(self.grad, 1)))
 
+    def get_target(self):
+        target = {}
+        target['t'] = 100
+        target['a'] = 1
+        target['b'] = np.array([2, 3, 4], dtype=np.float32)
+        return target
+
     @attr.gpu
     def test_state_copy_to_cpu(self):
         self.setup_state()
@@ -189,6 +216,42 @@ class TestUpdateRule(unittest.TestCase):
         self.var.to_cpu()
         self.update_rule.update_core = update_core
         self.update_rule.update(self.var)
+
+    def test_deserialize(self):
+        self.setup_state()
+        target = self.get_target()
+        self.update_rule.serialize(DummyDeserializer(target))
+
+        self.assertEqual(self.update_rule.t, target['t'])
+        self.assertIsNotNone(self.update_rule.state)
+        self.assertEqual(self.update_rule.state['a'], target['a'])
+        np.testing.assert_array_equal(self.update_rule.state['b'], target['b'])
+
+    def test_deserialize_by_strict_deserializer(self):
+        self.setup_state()
+        target = self.get_target()
+        del target['a']
+        with self.assertRaises(KeyError):
+            self.update_rule.serialize(DummyDeserializer(target))
+
+    def test_deserialize_by_nonstrict_deserializer(self):
+        self.setup_state()
+        target = self.get_target()
+        target['a'] = None
+        self.update_rule.serialize(DummyDeserializer(target))
+
+        self.assertEqual(self.update_rule.t, target['t'])
+        self.assertIsNone(self.update_rule.state)
+
+    def test_deserialize_disabled_update_rule_by_strict_deserializer(self):
+        self.setup_state()
+        self.update_rule.enabled = False
+        target = self.get_target()
+        del target['a']
+        self.update_rule.serialize(DummyDeserializer(target))
+
+        self.assertEqual(self.update_rule.t, target['t'])
+        self.assertIsNone(self.update_rule.state)
 
 
 class TestOptimizer(unittest.TestCase):


### PR DESCRIPTION
When a network is trained with some parameters set `update_rule.enabled=False`, the snapshot of an optimizer can't be deserialized if `strict=False` option isn't set to the deserializer.

This PR fixes the problem by checking `update_rule.enabled` at the time of deserialization. Some tests are also added.

The following is the minimal example that reproduce the issue.

```python
import chainer
from chainer import functions, links, optimizers, serializers
import numpy


class Model(chainer.Chain):
    def __init__(self):
        super().__init__()
        with self.init_scope():
            self.l1 = links.Linear(10, 10)
            self.l2 = links.Linear(10, 10)

    def __call__(self, x, t):
        h = self.l1(x)
        h = self.l2(h)
        h = functions.mean(h, axis=1)
        return functions.sigmoid_cross_entropy(h, t)


def main():
    model = Model()
    optimizer = optimizers.MomentumSGD()
    optimizer.setup(model)
    model.l1.W.update_rule.enabled = False

    x = numpy.random.random((4, 10)).astype(numpy.float32)
    t = numpy.asarray([0, 1, 0, 1], dtype=numpy.int32)
    optimizer.update(model, x, t)

    serializers.save_npz('optimizer.npz', optimizer)

    model = Model()
    optimizer = optimizers.MomentumSGD()
    optimizer.setup(model)
    model.l1.W.update_rule.enabled = False

    serializers.load_npz('optimizer.npz', optimizer)


if __name__ == '__main__':
    main()
```

Even though the `update_rule.enabled` options are kept to be **the same** across two models, `strict=False` is required for the `load_npz` function. I'd like to say this is a bug.

I checked a related issue #3125. Its fix doesn't check `update_rule.enabled` at the time of deserialization. I think `strict=False` should be required **only** if the `update_rule.enabled` options are **changed** when loading the snapshot.