### PR TITLE
Fix sphinx version to 1.7.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,12 @@ requirements = {
         'mock',
     ],
     'doctest': [
-        'sphinx',
+        'sphinx==1.7.9',
         'matplotlib',
         'theano',
     ],
     'docs': [
-        'sphinx',
+        'sphinx==1.7.9',
         'sphinx_rtd_theme',
     ],
     'travis': [


### PR DESCRIPTION
It looks the newer version of sphinx is causing test errors in Travis tests for MacOS.