### PR TITLE
Fix tolerance of matmul tests

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1220,7 +1220,7 @@ class TestMatMul(unittest.TestCase):
             y = chainer.Variable(y_data)
         z = operator.matmul(x, y)
         if self.dtype == numpy.float16:
-            options = {'atol': 1e-3, 'rtol': 1e-3}
+            options = {'atol': 2e-3, 'rtol': 2e-3}
         else:
             options = {'atol': 2e-7, 'rtol': 2e-7}
         testing.assert_allclose(

--- a/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_matmul.py
@@ -11,6 +11,13 @@ from chainer.testing import attr
 from chainer.utils import type_check
 
 
+def _matmul_tol(x1_dtype, x2_dtype):
+    if x1_dtype == numpy.float16 or x2_dtype == numpy.float16:
+        return {'atol': 2e-3, 'rtol': 2e-3}
+    else:
+        return {'atol': 1e-4, 'rtol': 1e-5}
+
+
 @testing.parameterize(*testing.product_dict(
     [
         # matmul
@@ -108,25 +115,19 @@ class TestMatMul(unittest.TestCase):
         else:
             return numpy.einsum('...ij,...jk->...ik', x1, x2)
 
-    def check_forward(self, x1_data, x2_data, atol=1e-4, rtol=1e-5):
+    def check_forward(self, x1_data, x2_data):
+        tol = _matmul_tol(x1_data.dtype, x2_data.dtype)
         x1 = chainer.Variable(x1_data)
         x2 = chainer.Variable(x2_data)
         y = self.op(x1, x2)
-        testing.assert_allclose(self.forward_answer, y.data, atol, rtol)
+        testing.assert_allclose(self.forward_answer, y.data, **tol)
 
     def test_matmul_forward_cpu(self):
-        if self.x1.dtype == numpy.float16 or self.x2.dtype == numpy.float16:
-            self.check_forward(self.x1, self.x2, atol=1e-3, rtol=1e-3)
-        else:
-            self.check_forward(self.x1, self.x2)
+        self.check_forward(self.x1, self.x2)
 
     @attr.gpu
     def test_matmul_forward_gpu(self):
-        if self.x1.dtype == numpy.float16 or self.x2.dtype == numpy.float16:
-            self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2),
-                               atol=1e-3, rtol=1e-3)
-        else:
-            self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
+        self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
     def check_backward(self, x1_data, x2_data, y_grad, atol, rtol):
         gradient_check.check_backward(
@@ -237,26 +238,20 @@ class TestBatchMatMul(unittest.TestCase):
 
         return numpy.einsum('...ij,...jk->...ik', x1, x2)
 
-    def check_forward(self, x1_data, x2_data, atol=1e-4, rtol=1e-5):
+    def check_forward(self, x1_data, x2_data):
+        tol = _matmul_tol(x1_data.dtype, x2_data.dtype)
         x1 = chainer.Variable(x1_data)
         x2 = chainer.Variable(x2_data)
         with testing.assert_warns(DeprecationWarning):
             y = self.op(x1, x2)
-        testing.assert_allclose(self.forward_answer, y.data, atol, rtol)
+        testing.assert_allclose(self.forward_answer, y.data, **tol)
 
     def test_matmul_forward_cpu(self):
-        if self.x1.dtype == numpy.float16 or self.x2.dtype == numpy.float16:
-            self.check_forward(self.x1, self.x2, atol=1e-3, rtol=1e-3)
-        else:
-            self.check_forward(self.x1, self.x2)
+        self.check_forward(self.x1, self.x2)
 
     @attr.gpu
     def test_matmul_forward_gpu(self):
-        if self.x1.dtype == numpy.float16 or self.x2.dtype == numpy.float16:
-            self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2),
-                               atol=1e-3, rtol=1e-3)
-        else:
-            self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
+        self.check_forward(cuda.to_gpu(self.x1), cuda.to_gpu(self.x2))
 
     def check_backward(self, x1_data, x2_data, y_grad, atol, rtol):
         with testing.assert_warns(DeprecationWarning):


### PR DESCRIPTION
`numpy.matmul` may have large error (>1ulp) with `float16` inputs

```
>>> import numpy as np
>>> x = np.array([[0.8896484375, 0.767578125, 0.712890625, 0.76318359375, 0.5224609375]], 'e')
>>> y = np.array([
...     [0.76416015625, 0.68994140625],
...     [0.82861328125, 0.85205078125],
...     [0.99169921875, 0.95751953125],
...     [0.5947265625, 0.89990234375],
...     [0.61865234375, 0.98681640625]], 'e')
>>> x@y
array([[2.797, 3.152]], dtype=float16)
>>> x.astype('d')@y.astype('d')
array([[2.79993963, 3.15279126]])
```