### PR TITLE
Make deserializers overwrite `intel64.mdarray`

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -1,6 +1,7 @@
 import numpy
 
 from chainer.backends import cuda
+from chainer.backends import intel64
 from chainer import serializer
 
 
@@ -139,6 +140,8 @@ class HDF5Deserializer(serializer.Deserializer):
             dataset.read_direct(value)
         elif isinstance(value, cuda.ndarray):
             value.set(numpy.asarray(dataset, dtype=value.dtype))
+        elif isinstance(value, intel64.mdarray):
+            intel64.ideep.basic_copyto(value, numpy.asarray(dataset))
         else:
             value = type(value)(numpy.asarray(dataset))
         return value

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -2,6 +2,7 @@ import numpy
 import six
 
 from chainer.backends import cuda
+from chainer.backends import intel64
 from chainer import serializer
 
 
@@ -149,6 +150,8 @@ class NpzDeserializer(serializer.Deserializer):
             numpy.copyto(value, dataset)
         elif isinstance(value, cuda.ndarray):
             value.set(numpy.asarray(dataset, dtype=value.dtype))
+        elif isinstance(value, intel64.mdarray):
+            intel64.ideep.basic_copyto(value, numpy.asarray(dataset))
         else:
             value = type(value)(numpy.asarray(dataset))
         return value

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -8,6 +8,7 @@ import numpy
 
 import chainer
 from chainer.backends import cuda
+from chainer.backends import intel64
 from chainer import link
 from chainer import links
 from chainer import optimizers
@@ -147,6 +148,11 @@ class TestHDF5Deserializer(unittest.TestCase):
     def test_deserialize_gpu(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(cuda.to_gpu(y))
+
+    @attr.ideep
+    def test_deserialize_ideep(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        self.check_deserialize(intel64.mdarray(y))
 
     @attr.gpu
     def test_deserialize_none_value_gpu(self):

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -8,6 +8,7 @@ import six
 
 import chainer
 from chainer.backends import cuda
+from chainer.backends import intel64
 from chainer import link
 from chainer import links
 from chainer import optimizers
@@ -136,6 +137,11 @@ class TestNpzDeserializer(unittest.TestCase):
     def test_deserialize_gpu(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(cuda.to_gpu(y), 'y')
+
+    @attr.ideep
+    def test_deserialize_ideep(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        self.check_deserialize(intel64.mdarray(y), 'y')
 
     @attr.gpu
     def test_deserialize_by_passing_none_gpu(self):


### PR DESCRIPTION
Make deserializer overwrite arrays of any backend.

I locally tested the added tests fail without this fix.  Note that `type(value)(numpy.asarray(dataset))` created new `intel64.mdarray`.