### PR TITLE
Feature:Hinge Max Margin one vs max hinge loss function

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -104,6 +104,7 @@ from chainer.functions.loss.cross_covariance import cross_covariance  # NOQA
 from chainer.functions.loss.ctc import connectionist_temporal_classification  # NOQA
 from chainer.functions.loss.decov import decov  # NOQA
 from chainer.functions.loss.hinge import hinge  # NOQA
+from chainer.functions.loss.hinge_max_margin import hinge_max_margin  # NOQA
 from chainer.functions.loss.huber_loss import huber_loss  # NOQA
 from chainer.functions.loss.mean_absolute_error import mean_absolute_error  # NOQA
 from chainer.functions.loss.mean_squared_error import mean_squared_error  # NOQA

--- a/chainer/functions/loss/hinge_max_margin.py
+++ b/chainer/functions/loss/hinge_max_margin.py
@@ -1,0 +1,181 @@
+import numpy
+
+from chainer.backends import cuda
+from chainer import function as F
+from chainer.utils import type_check
+
+
+class HingeMaxMargin(F.Function):
+
+    """Hinge max margin loss."""
+
+    def __init__(self, norm='L2', reduce='mean'):
+        if norm in ['L1', 'L2', 'Huber']:
+            self.norm = norm
+        else:
+            raise NotImplementedError(
+                "norm should be either 'L1', 'L2' or 'Huber'")
+
+        if reduce in ['mean', 'along_second_axis']:
+            self.reduce = reduce
+        else:
+            raise ValueError(
+                "only 'mean' and 'along_second_axis' are valid for 'reduce', but '%s' is "
+                'given' % reduce)
+        self.mask = None
+        self.margin = None
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 2)
+
+        x_type, t_type = in_types
+        type_check.expect(
+            x_type.dtype == numpy.float32,
+            t_type.dtype.kind == 'i',
+            x_type.ndim == 2,
+            t_type.ndim == 1,
+            x_type.shape[0] == t_type.shape[0],
+        )
+
+    def forward(self, inputs):
+        xp = cuda.get_array_module(*inputs)
+        x, t = inputs
+
+        num = len(x)
+        self.mask = xp.zeros_like(x)
+        self.mask[xp.arange(num), t] = -1
+        temp = xp.copy(x)
+        temp[xp.arange(num), t] = numpy.finfo(numpy.float32).min
+        self.mask[xp.arange(num), xp.argmax(temp, 1)] = 1
+        self.margin = xp.maximum(0, 1 + numpy.sum(self.mask * x, 1))
+
+        if self.norm == 'L1':
+            loss = self.margin
+        elif self.norm == 'L2':
+            loss = self.margin ** 2
+        elif self.norm == 'Huber':
+            quad = (self.margin < 2).astype(x.dtype)
+            loss = self.margin**2 / 4 * quad + (self.margin-1)*(1-quad)
+        else:
+            raise NotImplementedError()
+
+        if self.reduce == 'mean':
+            loss = xp.array(loss.sum() / num, dtype=x.dtype)
+
+        return loss,
+
+    def backward(self, inputs, grad_outputs):
+        xp = cuda.get_array_module(*inputs)
+        t, gloss = inputs[1], grad_outputs[0]
+
+        if self.reduce == 'mean':
+            gloss /= len(t)
+
+        if self.norm == 'L1':
+            gx = gloss * xp.sign(self.mask * xp.expand_dims(self.margin, 1))
+        elif self.norm == 'L2':
+            gx = 2 * gloss * self.mask * xp.expand_dims(self.margin, 1)
+        elif self.norm == 'Huber':
+            gx = gloss * self.mask * \
+                xp.expand_dims(xp.minimum(
+                    self.margin / 2, xp.sign(self.margin)), 1)
+        else:
+            raise NotImplementedError()
+
+        return gx, None
+
+
+def hinge_max_margin(x, t, norm='L2', reduce='mean'):
+    """Computes the hinge loss for a one vs max classification task.
+
+        .. math::
+            margin_{i} = ReLu \\left ( 1-x_{i,t_{i}}+max_{k,k\\neq t_{i}} \\left ( x_{i,k} \\right )\\right )
+
+        and
+
+        .. math::
+            loss_{i} = \\left \\{ \\begin{array}{cc}
+            margin_{i} & {\\rm if~norm} = {\\rm L1} \\\\
+            margin_{i}^{2} & {\\rm if~norm} = {\\rm L2} \\\\
+            margin_{i}-1 & \\rm if~norm} = {\\rm Huber \\& margin_{i} \\geqslant 2} \\\\
+            margin_{i}^{2} & {\\rm if~norm} = {\\rm Huber \\& margin_{i}<2}
+
+            \\end{array} \\right.
+
+        All 3 norms are continuous.
+        ``'L2'`` and ``'Huber'`` are differentiable, ``'L1'`` is not.
+
+        The output is a variable whose value depends on the value of
+        the option ``reduce``. If it is ``'along_second_axis'``, it holds the loss
+        values for each example. If it is ``'mean'``, it takes the mean of loss values.
+
+        See: `Huber loss - Wikipedia <https://en.wikipedia.org/wiki/Huber_loss>`
+        and Structured support vector machine - Wikipedia
+        <https://en.wikipedia.org/wiki/Structured_support_vector_machine>'
+
+    Args:
+        x (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray` of :class:`numpy.float`):
+            Input variable. The shape of ``x`` should be (:math:`N`, :math:`K`)
+            .
+        t (:class:`~chainer.Variable` or :class:`numpy.ndarray` or \
+        :class:`cupy.ndarray` of signed integer):
+            The :math:`N`-dimensional label vector with values
+            :math:`t_n \\in \\{0, 1, 2, \\dots, K-1\\}`.
+            The shape of ``t`` should be (:math:`N`,).
+        norm (string): Specifies norm type. Either ``'L1'`` , ``'L2'`` , ``'Huber'`` are
+            acceptable.
+        reduce (str): Reduction option. Its value must be either
+            ``'mean'`` [default] or ``'along_second_axis'``.
+             Otherwise, :class:`ValueError` is raised.
+
+    Returns:
+        ~chainer.Variable:
+            A variable object holding the hinge max margin loss.
+            If ``reduce`` is ``'along_second_axis'``, the output variable holds array
+            whose shape is same :math:`N`.
+            If it is ``'mean'``, the output variable holds a scalar value.
+
+    .. admonition:: Example
+
+        In this case, the batch size ``N`` is 4 and the number of classes ``K``
+        is 2.
+        >>> import numpy as np
+        >>> x = np.stack((np.arange(10),5*np.ones((10,))),1).astype(np.float32)
+        >>> t = np.ones((10,),np.int32)
+        >>> hinge_max_margin(x, t, norm='L1', reduce='along_second_axis')
+        variable([0., 0., 0., 0., 0., 1., 2., 3., 4., 5.])
+        >>> hinge_max_margin(x, t)
+        variable(5.5)
+        >>> hinge_max_margin(x, t, norm='L1')
+        variable(1.5)
+        >>> hinge_max_margin(x, t, norm='Huber')
+        variable(1.025)
+
+
+    """
+    return HingeMaxMargin(norm, reduce)(x, t)
+
+
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+u=np.linspace(-4,2)
+m = np.clip((1-u),0,np.inf)
+h = (u>=-1)*m**2/4 + (u<=-1)*(m-1)
+h = (m<2)*m**2/4 + (m>=2)*(m-1)
+
+plt.figure()
+plt.plot(u,h,'r*')
+plt.plot(u,m**2/4)
+plt.plot(u,m)
+
+
+plt.figure()
+plt.plot(u,(m>0)*np.maximum(-m/2,-1),'r*')
+plt.plot(u,(m>0)*-m/2)
+plt.plot(u,-(m>0))
+"""
+
+if __name__ == '__main__':
+    help(hinge_max_margin)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge_max_margin.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge_max_margin.py
@@ -7,9 +7,11 @@ from chainer import gradient_check, testing, Variable, no_backprop_mode
 from chainer.functions import hinge_max_margin
 from chainer.testing import attr
 
+asl = 'along_second_axis'
+
 
 @testing.parameterize(*testing.product({
-    'reduce': ['along_second_axis', 'mean'],
+    'reduce': [asl, 'mean'],
     'norm': ['L1', 'L2', 'Huber'],
     'label_dtype': [numpy.int8, numpy.int16, numpy.int32, numpy.int64],
 }))
@@ -22,7 +24,7 @@ class TestHingeMaxMargin(unittest.TestCase):
         self.t = numpy.random.randint(
             0, shape[1], shape[:1]).astype(self.label_dtype)
         self.x[numpy.arange(shape[0]), self.t] += 1
-        if self.reduce == 'along_second_axis':
+        if self.reduce == asl:
             self.gy = numpy.random.uniform(
                 -1, 1, self.x.shape).astype(numpy.float32)
 
@@ -63,9 +65,9 @@ class TestHingeMaxMargin(unittest.TestCase):
                 with no_backprop_mode():
                     no_sign_change = numpy.allclose(numpy.sign(
                         hinge_max_margin(x_data_plus, t_data_numpy, self.norm,
-                                         'along_second_axis').data),
+                                         asl).data),
                         numpy.sign(hinge_max_margin(x_data_minus, t_data_numpy,
-                                   self.norm, 'along_second_axis').data))
+                                                    self.norm, asl).data))
                 if not no_sign_change:
                     x_data = xp.random.uniform(-1, 1, x_data.shape).astype(
                         x_data.dtype)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge_max_margin.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge_max_margin.py
@@ -1,0 +1,121 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer.backends import cuda
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import attr
+
+from non_iid.hinge.hinge_max_margin import hinge_max_margin, HingeMaxMargin
+
+@testing.parameterize(*testing.product({
+    'reduce': ['along_second_axis', 'mean'],
+    'norm': ['L1', 'L2','Huber'],
+    'label_dtype': [numpy.int8, numpy.int16, numpy.int32, numpy.int64],
+}))
+class TestHingeMaxMargin(unittest.TestCase):
+
+    def setUp(self):
+        numpy.random.seed(0)
+        shape = (200, 3)
+        self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
+        self.t = numpy.random.randint(
+            0, shape[1], shape[:1]).astype(self.label_dtype)
+        self.x[numpy.arange(shape[0]),self.t]+=1
+        if self.reduce == 'along_second_axis':
+            self.gy = numpy.random.uniform(
+                -1, 1, self.x.shape).astype(numpy.float32)
+
+        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+
+    def check_forward(self, x_data, t_data):
+        x_val = chainer.Variable(x_data)
+        t_val = chainer.Variable(t_data)
+
+        loss = hinge_max_margin(x_val, t_val, self.norm, self.reduce)
+        if self.reduce == 'mean':
+            self.assertEqual(loss.data.shape, ())
+        else:
+            new_shape = list(x_data.shape) #list
+            del new_shape[1]
+            self.assertEqual(list(loss.data.shape), new_shape)
+        self.assertEqual(loss.data.dtype, numpy.float32)
+
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, self.t)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
+
+    def check_backward(self, x_data, t_data):
+        xp = cuda.get_array_module(x_data)
+        if self.norm == 'L1':#L2 and Huber are differnetiable
+            no_sign_change = False
+            delta = self.check_backward_options['atol'] * 5
+            t_data_numpy = cuda.to_cpu(t_data)
+            while not no_sign_change:
+                samples = len(x_data)
+                x_data_plus = cuda.to_cpu(x_data.copy())
+                x_data_plus[numpy.arange(samples),t_data_numpy] += delta
+                x_data_minus = cuda.to_cpu(x_data.copy())
+                x_data_minus[numpy.arange(samples), t_data_numpy] -= delta
+                with chainer.no_backprop_mode():
+                    no_sign_change = numpy.allclose(numpy.sign(hinge_max_margin(x_data_plus, t_data_numpy, self.norm,
+                                                                                'along_second_axis').data),
+                                                    numpy.sign(hinge_max_margin(x_data_minus, t_data_numpy, self.norm,
+                                                                                'along_second_axis').data))
+                if not no_sign_change:
+                    x_data = xp.random.uniform(-1, 1, x_data.shape).astype(x_data.dtype)
+                    x_data[numpy.arange(x_data.shape[0]), t_data] += 1
+
+        gradient_check.check_backward(
+            HingeMaxMargin(self.norm), (x_data, t_data), None,
+            dtype='d',
+            **self.check_backward_options)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.t)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))
+
+
+class TestHingeMaxMarginInvalidOption(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.random.uniform(-1, 1, (10, 5)).astype(numpy.float32)
+        self.t = numpy.random.randint(0, 5, (10,)).astype(numpy.int32)
+
+    def check_invalid_norm_option(self, xp):
+        x = xp.asarray(self.x)
+        t = xp.asarray(self.t)
+        with self.assertRaises(NotImplementedError):
+            hinge_max_margin(x, t, 'invalid_norm', 'mean')
+
+    def test_invalid_norm_option_cpu(self):
+        self.check_invalid_norm_option(numpy)
+
+    @attr.gpu
+    def test_invalid_norm_option_gpu(self):
+        self.check_invalid_norm_option(cuda.cupy)
+
+    def check_invalid_reduce_option(self, xp):
+        x = xp.asarray(self.x)
+        t = xp.asarray(self.t)
+        with self.assertRaises(ValueError):
+            hinge_max_margin(x, t, 'L1', 'invalid_option')
+
+    def test_invalid_reduce_option_cpu(self):
+        self.check_invalid_reduce_option(numpy)
+
+    @attr.gpu
+    def test_invalid_reduce_option_gpu(self):
+        self.check_invalid_reduce_option(cuda.cupy)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge_max_margin.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge_max_margin.py
@@ -2,17 +2,15 @@ import unittest
 
 import numpy
 
-import chainer
 from chainer.backends import cuda
-from chainer import gradient_check
-from chainer import testing
+from chainer import gradient_check, testing, Variable, no_backprop_mode
+from chainer.functions import hinge_max_margin
 from chainer.testing import attr
 
-from non_iid.hinge.hinge_max_margin import hinge_max_margin, HingeMaxMargin
 
 @testing.parameterize(*testing.product({
     'reduce': ['along_second_axis', 'mean'],
-    'norm': ['L1', 'L2','Huber'],
+    'norm': ['L1', 'L2', 'Huber'],
     'label_dtype': [numpy.int8, numpy.int16, numpy.int32, numpy.int64],
 }))
 class TestHingeMaxMargin(unittest.TestCase):
@@ -23,7 +21,7 @@ class TestHingeMaxMargin(unittest.TestCase):
         self.x = numpy.random.uniform(-1, 1, shape).astype(numpy.float32)
         self.t = numpy.random.randint(
             0, shape[1], shape[:1]).astype(self.label_dtype)
-        self.x[numpy.arange(shape[0]),self.t]+=1
+        self.x[numpy.arange(shape[0]), self.t] += 1
         if self.reduce == 'along_second_axis':
             self.gy = numpy.random.uniform(
                 -1, 1, self.x.shape).astype(numpy.float32)
@@ -31,18 +29,17 @@ class TestHingeMaxMargin(unittest.TestCase):
         self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
 
     def check_forward(self, x_data, t_data):
-        x_val = chainer.Variable(x_data)
-        t_val = chainer.Variable(t_data)
+        x_val = Variable(x_data)
+        t_val = Variable(t_data)
 
         loss = hinge_max_margin(x_val, t_val, self.norm, self.reduce)
         if self.reduce == 'mean':
             self.assertEqual(loss.data.shape, ())
         else:
-            new_shape = list(x_data.shape) #list
+            new_shape = list(x_data.shape)  # list
             del new_shape[1]
             self.assertEqual(list(loss.data.shape), new_shape)
         self.assertEqual(loss.data.dtype, numpy.float32)
-
 
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
@@ -53,29 +50,34 @@ class TestHingeMaxMargin(unittest.TestCase):
 
     def check_backward(self, x_data, t_data):
         xp = cuda.get_array_module(x_data)
-        if self.norm == 'L1':#L2 and Huber are differnetiable
+        if self.norm == 'L1':  # L2 and Huber are differentiable
             no_sign_change = False
             delta = self.check_backward_options['atol'] * 5
             t_data_numpy = cuda.to_cpu(t_data)
             while not no_sign_change:
                 samples = len(x_data)
                 x_data_plus = cuda.to_cpu(x_data.copy())
-                x_data_plus[numpy.arange(samples),t_data_numpy] += delta
+                x_data_plus[numpy.arange(samples), t_data_numpy] += delta
                 x_data_minus = cuda.to_cpu(x_data.copy())
                 x_data_minus[numpy.arange(samples), t_data_numpy] -= delta
-                with chainer.no_backprop_mode():
-                    no_sign_change = numpy.allclose(numpy.sign(hinge_max_margin(x_data_plus, t_data_numpy, self.norm,
-                                                                                'along_second_axis').data),
-                                                    numpy.sign(hinge_max_margin(x_data_minus, t_data_numpy, self.norm,
-                                                                                'along_second_axis').data))
+                with no_backprop_mode():
+                    no_sign_change = numpy.allclose(numpy.sign(
+                        hinge_max_margin(x_data_plus, t_data_numpy, self.norm,
+                                         'along_second_axis').data),
+                        numpy.sign(hinge_max_margin(x_data_minus, t_data_numpy,
+                                   self.norm, 'along_second_axis').data))
                 if not no_sign_change:
-                    x_data = xp.random.uniform(-1, 1, x_data.shape).astype(x_data.dtype)
+                    x_data = xp.random.uniform(-1, 1, x_data.shape).astype(
+                        x_data.dtype)
                     x_data[numpy.arange(x_data.shape[0]), t_data] += 1
-
-        gradient_check.check_backward(
-            HingeMaxMargin(self.norm), (x_data, t_data), None,
-            dtype='d',
-            **self.check_backward_options)
+        else:
+            def f(x, t):
+                y = hinge_max_margin(x, t, norm=self.norm)
+                return y
+            gradient_check.check_backward(
+                f, (x_data, t_data), None,
+                dtype='d',
+                **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x, self.t)


### PR DESCRIPTION
This is a one vs Max Margin loss (current hinge only one vs all). 
An alternative to this function would be to modify the hinge function to take an argument comparison='one_vs_all' (current and default) or 'one_vs_max' this implementation.  I am open to either implementation.  Also I would suggest adding hinge support for 'Huber' "norm".

3 norms 'L2' (default,margin squared), 'L1' (margin) and Huber (quadratic for margin less than 2, else linear)
2 reduce methods 'mean' (default, average by example) and 'along_second_axis' (loss for each example)

Thank you.