### PR TITLE
Support negative `axis` for `F.log_softmax`

### DIFF
--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -64,8 +64,7 @@ class LogSoftmax(function_node.FunctionNode):
 
         type_check.expect(
             x_type.dtype.kind == 'f',
-            x_type.ndim > 1,
-            self.axis < x_type.ndim,
+            -x_type.ndim <= self.axis < x_type.ndim,
         )
 
     def forward(self, xs):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -10,11 +10,19 @@ from chainer import testing
 from chainer.testing import attr
 
 
-@testing.parameterize(*testing.product({
-    'shape': [None, (2, 3), (2, 2, 3), (2, 2, 2, 3)],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'axis': [0, 1],
-}))
+@testing.parameterize(*testing.product_dict(
+    testing.product({
+        'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    }),
+    testing.product({
+        'shape': [None, (2, 3), (2, 2, 3), (2, 2, 2, 3)],
+        'axis': [1],
+    }) + [
+        {'shape': (2, 3), 'axis': 0},
+        {'shape': (2, 2, 3), 'axis': 2},
+        {'shape': (2, 2, 2, 3), 'axis': -4},
+    ],
+))
 @testing.fix_random()
 class TestLogSoftmax(unittest.TestCase):
 


### PR DESCRIPTION
This PR also allows 1-dim inputs.