### PR TITLE
Refactor `gradient_check.check_backward`

### DIFF
--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -350,7 +350,8 @@ class _CheckBackward(object):
         rtol = self.rtol
         # Compare the gradients
         try:
-            testing.assert_allclose(gx_numeric, gx_backward, atol=atol, rtol=rtol)
+            testing.assert_allclose(
+                gx_numeric, gx_backward, atol=atol, rtol=rtol)
         except AssertionError as e:
             eps = self.eps
             x_data = self.x_data
@@ -387,13 +388,14 @@ class _CheckBackward(object):
             if not no_grad]
         direction_param_shapes = [p.shape for p in params]
         direction_shapes = direction_xs_shapes + direction_param_shapes
-        directions = [xp.random.normal(size=shape) for shape in direction_shapes]
+        directions = [
+            xp.random.normal(size=shape) for shape in direction_shapes]
         # The direction vector is normalized in order to keep the scale of
         # differentiation error invariant with respect to the number of input
         # dimensions. Ideally, the scale of the curvature with respect to each
         # input dimension should be taken into account, but we ignore the
-        # differences and assume that the curvature is uniform with respect to all
-        # the input dimentions.
+        # differences and assume that the curvature is uniform with respect to
+        # all the input dimentions.
         norm = math.sqrt(sum([xp.square(d).sum() for d in directions]))
         if norm != 0:
             # norm could be zero if input arrays are 0-sized.
@@ -403,7 +405,8 @@ class _CheckBackward(object):
         return directions
 
     def _filter_list(self, lst, ignore_list):
-        return [x for x, ignore in six.moves.zip(lst, ignore_list) if not ignore]
+        return [
+            x for x, ignore in six.moves.zip(lst, ignore_list) if not ignore]
 
     def _clear_grads(self, xs):
         for x in xs:
@@ -427,7 +430,8 @@ class _CheckBackward(object):
         else:
             if numpy.dtype(dtype).kind != 'f':
                 raise ValueError('`dtype` is allowed only float type')
-            casted_data = [x.array.astype(dtype, copy=False) for x in variables]
+            casted_data = [
+                x.array.astype(dtype, copy=False) for x in variables]
 
             # Even skipped variable must have the same dtype.
             for x, skip in six.moves.zip(x_vars, no_grads):
@@ -450,7 +454,8 @@ class _CheckBackward(object):
                     data = xp.array(data)
                 x.data = data
 
-            # Clear gradients to support func that calls backward inside of itself.
+            # Clear gradients to support func that calls backward inside of
+            # itself.
             self._clear_grads(x_vars)
             self._clear_grads(params)
 
@@ -489,7 +494,8 @@ class _CheckBackward(object):
 
         y, y_grad = _set_y_grad(y, y_grad)
 
-        # Clear gradients which may exist if func calls backward inside of itself.
+        # Clear gradients which may exist if func calls backward inside of
+        # itself.
         self._clear_grads(variables)
 
         # We only need to call `backward` for one result `Variable`.

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -337,8 +337,12 @@ class _CheckBackward(object):
     def run(self):
         directions = self._sample_directions()
 
-        # Compute backward gradients
-        gx_backward, y0_data = self._directional_backward_gradients(directions)
+        # Compute backward gradients.
+        # Uninitialized parameters may be initialized.
+        # If self.y_grad is None, it is also updated with 1s.
+        gx_backward, y0_data, y_grad = (
+            self._directional_backward_gradients(directions))
+        self.y_grad = y_grad
 
         # Compute numeric gradients
         gx_numeric = self._directional_numeric_gradients(directions, y0_data)
@@ -453,7 +457,7 @@ class _CheckBackward(object):
             if g is not None:
                 gx_accum += (g.astype('d') * direction).sum()
 
-        return gx_accum, y0_data
+        return gx_accum, y0_data, y_grad
 
     def _directional_numeric_gradients(self, directions, y0_data):
         func = self.func

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -341,7 +341,8 @@ class _CheckBackward(object):
         # This must be done before sampling a direction vector, because
         # otherwise the shapes of uninitialized parameters wouldn't be
         # determined.
-        xs_backward, y_backward, y0_data, y_grad = self._forward_for_backward_gradients()
+        xs_backward, y_backward, y0_data, y_grad = (
+            self._forward_for_backward_gradients())
         self.y_grad = y_grad
 
         # Sample a direction vector.

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -352,6 +352,11 @@ class _CheckBackward(object):
         gx_backward = self._directional_backward_gradients(
             xs_backward, y_backward, directions)
 
+        # If no input has a gradient, we don't need to compare with numeric
+        # gradient.
+        if len(self.x_data) + len(self.params) == self.no_grads.count(True):
+            return
+
         # Compute numeric gradients
         gx_numeric = self._directional_numeric_gradients(directions, y0_data)
 


### PR DESCRIPTION
In the current implementation of  `gradient_check.check_backward`, computation of backward gradients / numerical gradients / some checks are mixed and very difficult to understand.

I refactored the function for readability and maintainability.