### PR TITLE
update base image & specify numpy version in Dockerfile

### DIFF
--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip install --no-cache-dir numpy==1.15 cupy-cuda92==5.0.0rc1 chainer==5.0.0rc1
+RUN pip install --no-cache-dir numpy==1.14 cupy-cuda92==5.0.0rc1 chainer==5.0.0rc1

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn6-devel
+FROM nvidia/cuda:9.2-cudnn7-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip install --no-cache-dir cupy-cuda80==5.0.0rc1 chainer==5.0.0rc1
+RUN pip install --no-cache-dir numpy==1.15 cupy-cuda92==5.0.0rc1 chainer==5.0.0rc1

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn6-devel
+FROM nvidia/cuda:9.2-cudnn7-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python3-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip3 install --no-cache-dir cupy-cuda80==5.0.0rc1 chainer==5.0.0rc1
+RUN pip3 install --no-cache-dir numpy==1.15 cupy-cuda92==5.0.0rc1 chainer==5.0.0rc1

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python3-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip3 install --no-cache-dir numpy==1.15 cupy-cuda92==5.0.0rc1 chainer==5.0.0rc1
+RUN pip3 install --no-cache-dir numpy==1.14 cupy-cuda92==5.0.0rc1 chainer==5.0.0rc1


### PR DESCRIPTION
Now that pip automatically installs numpy 1.15 which chainer and cupy do not support according to installation guide pages.

Also, the base image used in both docker/python2 and docker/python3 is a bit old.

Feel free to close if not appropriate. :smile: 