### PR TITLE
Check optional dependencies at runtime

### DIFF
--- a/chainer/_environment_check.py
+++ b/chainer/_environment_check.py
@@ -72,7 +72,7 @@ See the following page for more details:
                     version=pkg_resources.get_distribution(pkg).version,
                     requirement=requirement, help=help))
                 found = True
-            except Exception as e:
+            except Exception:
                 warnings.warn(
                     'Failed to check requirement: {}'.format(requirement))
                 break

--- a/chainer/_environment_check.py
+++ b/chainer/_environment_check.py
@@ -45,31 +45,32 @@ def _check_optional_dependencies():
     for dep in chainer._version._optional_dependencies:
         name = dep['name']
         pkgs = dep['packages']
-        version = dep['version']
+        spec = dep['specifier']
         help = dep['help']
         installed = False
         for pkg in pkgs:
             found = False
-            requirement = '{}{}'.format(pkg, version)
+            requirement = '{}{}'.format(pkg, spec)
             try:
                 pkg_resources.require(requirement)
                 found = True
             except pkg_resources.DistributionNotFound:
                 continue
             except pkg_resources.VersionConflict:
-                dist = pkg_resources.get_distribution(pkg).version
-                warnings.warn('''
+                msg = '''
 --------------------------------------------------------------------------------
 {name} ({pkg}) version {version} may not be compatible with this version of Chainer.
 Please consider installing the supported version by running:
   $ pip install '{requirement}'
 
-See the the following page for more details:
+See the following page for more details:
   {help}
 --------------------------------------------------------------------------------
-'''.format(
-    name=name, pkg=pkg, version=pkg_resources.get_distribution(pkg).version,
-    requirement=requirement, help=dep['help']))  # NOQA
+'''  # NOQA
+                warnings.warn(msg.format(
+                    name=name, pkg=pkg,
+                    version=pkg_resources.get_distribution(pkg).version,
+                    requirement=requirement, help=help))
                 found = True
             except Exception as e:
                 warnings.warn(
@@ -80,9 +81,9 @@ See the the following page for more details:
                 if installed:
                     warnings.warn('''
 --------------------------------------------------------------------------------
-Multiple installation of {name} package has been detected.
-You should install only one package from {pkgs}.
-Run `pip list` to see the list of packages currentely installed, then
+Multiple installations of {name} package has been detected.
+You should select only one package from from {pkgs}.
+Run `pip list` to see the list of packages currently installed, then
 `pip uninstall <package name>` to uninstall unnecessary package(s).
 --------------------------------------------------------------------------------
 '''.format(name=name, pkgs=pkgs))

--- a/chainer/_version.py
+++ b/chainer/_version.py
@@ -1,8 +1,6 @@
 __version__ = '5.0.0rc1'
 
 
-# Multiple requirements are installed
-
 _optional_dependencies = [
     {
         'name': 'CuPy',
@@ -13,7 +11,7 @@ _optional_dependencies = [
             'cupy-cuda80',
             'cupy',
         ],
-        'version': '==5.0.0rc1',
+        'specifier': '==5.0.0rc1',
         'help': 'https://docs-cupy.chainer.org/en/latest/install.html',
     },
     {
@@ -21,7 +19,7 @@ _optional_dependencies = [
         'packages': [
             'ideep4py',
         ],
-        'version': '>=2.0, <2.1',
+        'specifier': '>=2.0, <2.1',
         'help': 'https://docs.chainer.org/en/latest/tips.html',
     },
 ]

--- a/chainer/_version.py
+++ b/chainer/_version.py
@@ -1,1 +1,27 @@
 __version__ = '5.0.0rc1'
+
+
+# Multiple requirements are installed
+
+_optional_dependencies = [
+    {
+        'name': 'CuPy',
+        'packages': [
+            'cupy-cuda92',
+            'cupy-cuda91',
+            'cupy-cuda90',
+            'cupy-cuda80',
+            'cupy',
+        ],
+        'version': '==5.0.0rc1',
+        'help': 'https://docs-cupy.chainer.org/en/latest/install.html',
+    },
+    {
+        'name': 'iDeep',
+        'packages': [
+            'ideep4py',
+        ],
+        'version': '>=2.0, <2.1',
+        'help': 'https://docs.chainer.org/en/latest/tips.html',
+    },
+]

--- a/setup.py
+++ b/setup.py
@@ -19,19 +19,12 @@ set CHAINER_PYTHON_350_FORCE environment variable to 1."""
         sys.exit(1)
 
 
-def cupy_requirement(pkg):
-    return '{}==5.0.0rc1'.format(pkg)
-
-
 requirements = {
     'install': [
         'filelock',
         'numpy>=1.9.0',
         'protobuf>=3.0.0',
         'six>=1.9.0',
-    ],
-    'cuda': [
-        cupy_requirement('cupy'),
     ],
     'stylecheck': [
         'autopep8==1.3.5',
@@ -118,22 +111,6 @@ is necessary. Please uninstall the old ChainerMN in advance.
 """
     print(msg)
     exit(1)
-
-# Currently cupy provides source package (cupy) and binary wheel packages
-# (cupy-cudaXX). Chainer can use any one of these packages.
-cupy_pkg = find_any_distribution([
-    'cupy-cuda92',
-    'cupy-cuda91',
-    'cupy-cuda90',
-    'cupy-cuda80',
-    'cupy',
-])
-if cupy_pkg is not None:
-    req = cupy_requirement(cupy_pkg.project_name)
-    install_requires.append(req)
-    print('Use %s' % req)
-else:
-    print('No CuPy installation detected')
 
 here = os.path.abspath(os.path.dirname(__file__))
 # Get __version__ variable


### PR DESCRIPTION
Optional dependencies should not be decleared as requirements, as it makes difficult for users to uninstall the optional dependencies.

One of the common pitfall (when user upgraded their CUDA version):

```
pip install cupy-cuda90
pip install chainer
# -> pip recognizes the dependency from chainer to cupy-cuda90

pip uninstall cupy-cuda90
pip install cupy-cuda92

pip install chainer
# -> pip tries to "fix" broken dependency, causing installation of cupy-cuda90
```