### PR TITLE
Add Google Colaboratory installation steps and link to community examples

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,4 +44,5 @@ Indices and tables
 
    Slack Chat <https://bit.ly/join-chainer-slack>
    Forums <https://groups.google.com/forum/#!forum/chainer>
+   Notebook Examples <https://chainer-colab-notebook.readthedocs.io/en/latest/>
    Examples in Awesome Chainer <https://github.com/chainer-community/awesome-chainer>

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -108,6 +108,15 @@ You can refer to the following flags to confirm if CUDA/cuDNN support is actuall
    ``True`` if cuDNN support is available.
 
 
+Google Colaboratory
+~~~~~~~~~~~~~~~~~~~
+
+You can install Chainer and CuPy using the following snippet on `Google Colaboratory <https://colab.research.google.com/>`_::
+
+   !curl https://colab.chainer.org/install | sh -
+
+See `chainer/google-colaboratory <https://github.com/chainer/google-colaboratory>`_ for more details and examples.
+
 Uninstall Chainer
 -----------------
 


### PR DESCRIPTION
Introduce https://github.com/chainer/google-colaboratory in official docs.