### PR TITLE
[backport] Fix occasional test failure of `l2normalize` with float16

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_l2_normalization.py
@@ -66,8 +66,16 @@ def _is_good_param(param):
 class TestL2Normalization(unittest.TestCase):
 
     def setUp(self):
+        min_abs = 0.1
+        if self.dtype == numpy.float16:
+            tuple_axis = self.axis
+            if not isinstance(tuple_axis, tuple):
+                tuple_axis = (tuple_axis,)
+            aggr_size = numpy.prod(
+                [self.shape[i] for i in tuple_axis], dtype=int)
+            min_abs = max(min_abs, 0.5 / aggr_size)
         self.x = chainer.utils.force_array(
-            numpy.random.uniform(0.1, 1, self.shape)
+            numpy.random.uniform(min_abs, 1, self.shape)
             * (1 - 2 * numpy.random.randint(2, size=self.shape)),
             self.dtype)
         if self.nonzeros is not None:
@@ -109,9 +117,6 @@ class TestL2Normalization(unittest.TestCase):
                 self.check_double_backward_options = {
                     'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-4}
         else:
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2,
-                'eps': 1e-4}
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2,
                 'eps': 1e-4}


### PR DESCRIPTION
Backport of #5380