### PR TITLE
Grouped convolutions using matmul

### DIFF
--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -1,5 +1,4 @@
 import numpy
-import six
 
 import chainer
 from chainer import backend

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -6,9 +6,17 @@ from chainer import backend
 from chainer.backends import cuda
 from chainer import configuration
 from chainer import function_node
+from chainer.functions.connection import convolution_2d
 from chainer.utils import conv
 from chainer.utils import conv_nd
 from chainer.utils import type_check
+
+
+def _prod(shape):
+    prod = 1
+    for d in shape:
+        prod *= d
+    return prod
 
 
 class ConvolutionND(function_node.FunctionNode):
@@ -71,11 +79,11 @@ class ConvolutionND(function_node.FunctionNode):
         # oC: output channels
         G = self.groups
         N, iC = x.shape[:2]
-        in_size = x.shape[2:]
         oC = W.shape[0]
         k_size = W.shape[2:]
         iCg = iC // G
         oCg = oC // G
+        dims = len(k_size)
         if iC % G != 0:
             raise TypeError('The number of groups must be '
                             'a divisor of that of input channels')
@@ -83,19 +91,26 @@ class ConvolutionND(function_node.FunctionNode):
             raise TypeError('The number of groups must be '
                             'a divisor of that of output channels')
 
-        _x = x.reshape((N, G, iCg) + in_size)
-        _x = xp.rollaxis(_x, 1)  # (G, N, iCg) + in_size
-        _W = W.reshape((G, oCg, iCg) + k_size)
+        xp = backend.get_array_module(x)
+
+        # (N, iC, k_size..., o_size...)
+        x = conv_nd.im2col_nd(x, k_size, self.stride, self.pad,
+                              cover_all=self.cover_all, dilate=self.dilate)
+        o_size = x.shape[-dims:]
+
+        x = xp.rollaxis(x, 0, dims + 2)  # (iC, k_size..., N, o_size...)
+        mul_len = iCg * _prod(k_size)
+        x = x.reshape(G, mul_len, N * _prod(o_size))
+
+        W = W.reshape(G, oCg, mul_len)
+
+        # (G, oCg, N*o_size) = (G, oCg, iCg*k_size) @ (G, iCg*k_size, N*o_size)
+        y = convolution_2d._matmul(W, x).astype(x.dtype, copy=False)
+        y = y.reshape(oC, N, *o_size)
+        y = xp.rollaxis(y, 1)  # (N, oC, o_size...)
         if b is not None:
-            _b = b.reshape(G, oCg)
+            y += b.reshape(1, b.size, *((1,) * dims))
 
-        _ys = []
-        for g in moves.range(G):
-            _bg = None if b is None else _b[g]
-            _y, = self._forward_xp_core(_x[g], _W[g], _bg, xp)
-            _ys.append(_y)
-
-        y = xp.concatenate(_ys, axis=1)  # (N, oC) + out_size
         return y,
 
     def _forward_xp_core(self, x, W, b, xp):
@@ -231,24 +246,32 @@ class ConvolutionNDGradW(function_node.FunctionNode):
     def _forward_grouped_convolution_xp(self, x, gy, xp):
         G = self.groups
         N, iC = x.shape[:2]
-        in_size = x.shape[2:]
         oC = gy.shape[1]
-        out_size = gy.shape[2:]
+        o_size = gy.shape[2:]
+        o_size_prod = _prod(o_size)
+        k_size = self.ksize
+        dims = len(o_size)
         iCg = iC // G
         oCg = oC // G
+
         # Do not check iCg and oCg because this class is rarely used alone
-        _x = x.reshape((N, G, iCg) + in_size)
-        _x = xp.rollaxis(_x, 1)  # (G, N, iCg) + in_size
-        _gy = gy.reshape((N, G, oCg) + out_size)
-        _gy = xp.rollaxis(_gy, 1)  # (G, N, oCg) + out_size
 
-        # Work-around for NumPy's bug?
-        if xp is numpy:
-            _gy = xp.ascontiguousarray(_gy)
+        # (N, iC, k_size..., o_size...)
+        x = conv_nd.im2col_nd(x, k_size, self.stride, self.pad,
+                              cover_all=self.cover_all, dilate=self.dilate)
 
-        _gWs = [self._forward_xp_core(_x[g], _gy[g], xp)[0]
-                for g in moves.range(G)]
-        gW = xp.concatenate(_gWs)  # (oC, iCg) + k_size
+        x = xp.rollaxis(x, 0, dims + 2)  # (iC, k_size..., N, o_size...)
+        mul_len = iCg * _prod(k_size)
+        x = x.reshape(G, mul_len, N * o_size_prod)
+        x = x.transpose(0, 2, 1)  # (G, N*o_size, iCg*k_size)
+
+        gy = xp.rollaxis(gy, 1)  # (oC, N, o_size...)
+        gy = gy.reshape(G, oCg, N * o_size_prod)
+
+        # (G, oCg, iCg*k_size) = (G, oCg, N*o_size) @ (G, N*o_size, iCg*k_size)
+        gW = convolution_2d._matmul(gy, x).astype(self.W_dtype, copy=False)
+        gW = gW.reshape(oC, iCg, *k_size)
+
         return gW,
 
     def _forward_xp_core(self, x, gy, xp):

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -1,8 +1,6 @@
 import numpy
-import six
 
 import chainer
-from chainer import backend
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import configuration

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -229,27 +229,27 @@ class Deconvolution2DFunction(function_node.FunctionNode):
         # yC, yH, yW: y channels, y height, y width
         G = self.groups
         N, xC, xH, xW = x.shape
-        xCg = int(xC / G)
-        _, yCg, kH, kW = W.shape
+        xCg = xC // G
+        _, yCg, kH, kW = W.shape  # _ == xC
+        yC = yCg * G
 
-        xp = backend.get_array_module(x)
+        x = x.transpose(1, 0, 2, 3)  # (xC, N, xH, xW)
+        x = x.reshape(G, xCg, N * xH * xW)
 
-        _x = x.reshape((N, G, xCg, xH, xW))
-        _x = xp.rollaxis(_x, 1)  # (G, N, xCg, xH, xW)
-        _W = W.reshape((G, xCg, yCg, kH, kW))
+        W = W.reshape(G, xCg, yCg * kH * kW)
+        W = W.transpose(0, 2, 1)  # (G, yCg*kH*kW, xCg)
+
+        # (G, yCg*kH*kW, N*xH*xW) = (G, yCg*kH*kW, xCg) @ (G, xCg, N*xH*xW)
+        col = convolution_2d._matmul(W, x).astype(x.dtype, copy=False)
+
+        col = col.reshape(yC, kH, kW, N, xH, xW)
+        col = col.transpose(3, 0, 1, 2, 4, 5)  # (N, yC, kH, kW, xH, xW)
+
+        y = conv.col2im(col, self.sy, self.sx, self.ph, self.pw,
+                        self.outh, self.outw, dy=self.dy, dx=self.dx)
+
         if b is not None:
-            _b = b.reshape((G, yCg))
-
-        _ys = []
-        for g in six.moves.range(G):
-            _bg = None if b is None else _b[g, ]
-            if xp is numpy:
-                _y, = self._forward_cpu_core(_x[g, ], _W[g, ], _bg)
-            else:
-                _y, = self._forward_gpu_core(_x[g, ], _W[g, ], _bg)
-            _ys.append(_y)
-
-        y = xp.concatenate(_ys, axis=1)  # (N, yC, yH, yW)
+            y += b.reshape(1, b.size, 1, 1)
         return y,
 
     def _forward_cudnn(self, x, W, b):

--- a/chainer/functions/connection/deconvolution_nd.py
+++ b/chainer/functions/connection/deconvolution_nd.py
@@ -6,6 +6,7 @@ from chainer import backend
 from chainer.backends import cuda
 from chainer import configuration
 from chainer import function_node
+from chainer.functions.connection import convolution_2d
 from chainer.functions.connection import convolution_nd
 from chainer.utils import conv
 from chainer.utils import conv_nd
@@ -84,32 +85,37 @@ class DeconvolutionND(function_node.FunctionNode):
     def _forward_grouped_convolution_xp(self, x, W, b, xp):
         # G: group count
         # N: batch size
-        # iC: input channels
-        # oC: output channels
+        # xC: input channels
+        # yC: output channels
         G = self.groups
         N, xC = x.shape[:2]
-        in_size = x.shape[2:]
+        x_size = x.shape[2:]
         yCg = W.shape[1]
-        k_size = W.shape[2:]
-
+        yC = yCg * G
         xCg = xC // G
+        k_size = W.shape[2:]
+        dims = len(k_size)
         if xC % G != 0:
             raise TypeError('The number of groups must be '
                             'a divisor of that of input channels')
 
-        _x = x.reshape((N, G, xCg) + in_size)
-        _x = xp.rollaxis(_x, 1)  # (G, N, xCg) + in_size
-        _W = W.reshape((G, xCg, yCg) + k_size)
+        x = xp.rollaxis(x, 1)  # (xC, N, x_size...)
+        x = x.reshape(G, xCg, N * convolution_nd._prod(x_size))
+
+        W = W.reshape(G, xCg, yCg * convolution_nd._prod(k_size))
+        W = W.transpose(0, 2, 1)  # (G, yCg*k_size, xCg)
+
+        # (G, yCg*k_size, N*x_size) = (G, yCg*k_size, xCg) @ (G, xCg, N*x_size)
+        col = convolution_2d._matmul(W, x).astype(x.dtype, copy=False)
+
+        col = col.reshape((yC,) + k_size + (N,) + x_size)
+        col = xp.rollaxis(col, dims + 1)  # (N, yC, k_size..., x_size...)
+
+        y = conv_nd.col2im_nd(col, self.stride, self.pad, self.outs,
+                              dilate=self.dilate)
+
         if b is not None:
-            _b = b.reshape(G, yCg)
-
-        _ys = []
-        for g in moves.range(G):
-            _bg = None if b is None else _b[g]
-            _y, = self._forward_xp_core(_x[g], _W[g], _bg, xp)
-            _ys.append(_y)
-
-        y = xp.concatenate(_ys, axis=1)  # (N, yC) + out_size
+            y += b.reshape(1, yC, *((1,) * dims))
         return y,
 
     def _forward_xp_core(self, x, W, b, xp):

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -1,6 +1,7 @@
 import numpy
 import six
 
+from chainer import backend
 from chainer.backends import cuda
 
 
@@ -124,6 +125,13 @@ def im2col_gpu(img, kh, kw, sy, sx, ph, pw, cover_all=False, dy=1, dx=1,
     return col
 
 
+def im2col(img, kh, kw, sy, sx, ph, pw, cover_all=False, dy=1, dx=1,
+           out_h=None, out_w=None):
+    fn = im2col_gpu if isinstance(img, cuda.ndarray) else im2col_cpu
+    return fn(img, kh, kw, sy, sx, ph, pw, cover_all=cover_all, dy=dy, dx=dx,
+              out_h=out_h, out_w=out_w)
+
+
 def col2im_cpu(col, sy, sx, ph, pw, h, w, dy=1, dx=1):
     n, c, kh, kw, out_h, out_w = col.shape
     img = numpy.zeros((n, c, h + 2 * ph + sy - 1, w + 2 * pw + sx - 1),
@@ -170,3 +178,8 @@ def col2im_gpu(col, sy, sx, ph, pw, h, w, dy=1, dx=1):
         'col2im')(col.reduced_view(),
                   h, w, out_h, out_w, kh, kw, sy, sx, ph, pw, dx, dy, img)
     return img
+
+
+def col2im(col, sy, sx, ph, pw, h, w, dy=1, dx=1):
+    fn = col2im_gpu if isinstance(col, cuda.ndarray) else col2im_cpu
+    return fn(col, sy, sx, ph, pw, h, w, dy, dx)

--- a/chainer/utils/conv.py
+++ b/chainer/utils/conv.py
@@ -1,7 +1,6 @@
 import numpy
 import six
 
-from chainer import backend
 from chainer.backends import cuda
 
 

--- a/chainer/utils/conv_nd.py
+++ b/chainer/utils/conv_nd.py
@@ -78,6 +78,11 @@ def im2col_nd_gpu(img, ksize, stride, pad, cover_all=False, dilate=1):
     return col
 
 
+def im2col_nd(img, ksize, stride, pad, cover_all=False, dilate=1):
+    fn = im2col_nd_gpu if isinstance(img, cuda.ndarray) else im2col_nd_cpu
+    return fn(img, ksize, stride, pad, cover_all=cover_all, dilate=dilate)
+
+
 def col2im_nd_cpu(col, stride, pad, dims, dilate=1):
     n, c = col.shape[:2]  # (n, c, kx_1, ..., kx_N, out_1, ..., out_N)
     mid = (len(col.shape) - 2) // 2 + 2
@@ -130,3 +135,8 @@ def col2im_nd_gpu(col, stride, pad, dims, dilate=1):
         *(dims + outs + ksize + stride + pad + dilate + (img,)))
 
     return img
+
+
+def col2im_nd(col, stride, pad, dims, dilate=1):
+    fn = col2im_nd_gpu if isinstance(col, cuda.ndarray) else col2im_nd_cpu
+    return fn(col, stride, pad, dims, dilate)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -119,7 +119,7 @@ class TestConvolution2DFunction(unittest.TestCase):
                 groups=self.groups)
 
         testing.assert_allclose(
-            y_expected.data, y_actual.data, atol=5e-4, rtol=5e-3)
+            y_expected.data, y_actual.data, atol=1e-3, rtol=5e-3)
 
     def test_forward(self, backend_config):
         self.check_forward(self.inputs, backend_config)

--- a/tests/chainer_tests/utils_tests/test_conv.py
+++ b/tests/chainer_tests/utils_tests/test_conv.py
@@ -67,13 +67,11 @@ class TestIm2Col(unittest.TestCase):
 
     def check_im2col(self, kh, kw, sy, sx, ph, pw, dy, dx, gpu):
         if gpu:
-            im2col = conv.im2col_gpu
             img = cuda.to_gpu(self.img)
         else:
-            im2col = conv.im2col_cpu
             img = self.img
 
-        col = im2col(img, kh, kw, sy, sx, ph, pw, dy=dy, dx=dx)
+        col = conv.im2col(img, kh, kw, sy, sx, ph, pw, dy=dy, dx=dx)
         col_h = conv.get_conv_outsize(self.h, kh, sy, ph, d=dy)
         col_w = conv.get_conv_outsize(self.w, kw, sx, pw, d=dx)
         self.assertEqual(col.shape, (2, 3, kh, kw, col_h, col_w))
@@ -127,13 +125,12 @@ class TestCol2Im(unittest.TestCase):
         col = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
 
         if gpu:
-            col2im = conv.col2im_gpu
             col_data = cuda.to_gpu(col)
         else:
-            col2im = conv.col2im_cpu
             col_data = col
 
-        img = col2im(col_data, sy, sx, ph, pw, self.h, self.w, dy=dy, dx=dx)
+        img = conv.col2im(
+            col_data, sy, sx, ph, pw, self.h, self.w, dy=dy, dx=dx)
         img = cuda.to_cpu(img)
         self.assertEqual(img.shape, (2, 3, self.h, self.w))
         for y in moves.range(self.h):

--- a/tests/chainer_tests/utils_tests/test_conv_nd.py
+++ b/tests/chainer_tests/utils_tests/test_conv_nd.py
@@ -44,13 +44,11 @@ class TestIm2ColND(unittest.TestCase):
     def check_im2col_nd(self, ksize, stride, pad, gpu):
         dims = self.dims
         if gpu:
-            im2col = conv_nd.im2col_nd_gpu
             img = cuda.to_gpu(self.img)
         else:
-            im2col = conv_nd.im2col_nd_cpu
             img = self.img
 
-        col = im2col(img, ksize, stride, pad)
+        col = conv_nd.im2col_nd(img, ksize, stride, pad)
         outs = tuple(conv_nd.get_conv_outsize(d, k, s, p)
                      for (d, k, s, p) in zip(dims, ksize, stride, pad))
         expected_shape = (2, 3) + ksize + outs
@@ -174,13 +172,11 @@ class TestCol2ImND(unittest.TestCase):
         col = numpy.random.uniform(-1, 1, col_shape).astype(numpy.float32)
 
         if gpu:
-            col2im = conv_nd.col2im_nd_gpu
             col_data = cuda.to_gpu(col)
         else:
-            col2im = conv_nd.col2im_nd_cpu
             col_data = col
 
-        img = col2im(col_data, stride, pad, dims)
+        img = conv_nd.col2im_nd(col_data, stride, pad, dims)
         img = cuda.to_cpu(img)
         img_shape = (2, 3) + dims
         self.assertEqual(img.shape, img_shape)


### PR DESCRIPTION
Fix #5403. The grouped convolution is rewritten using single `matmul` call instead of iterating over all subchannels in Python. The performance of non-cuDNN paths are improved. In particular, the degradation of `depthwise_convolution_2d` observed in #5403 is almost recovered. A quick benchmarking in my environment is: the MobileNet inference took 85.4 ms (this patch) vs 84.0 ms (v4.5.0) vs 575 ms (master).

This patch should be backported to v5, since the degradation of `depthwise_convolution_2d` is critical.