### PR TITLE
Avoid Iterable in CaffeFunction

### DIFF
--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -14,7 +14,6 @@ from chainer.links.connection import linear
 from chainer.links.connection import scale
 from chainer.links.normalization import batch_normalization
 from chainer.utils import argument
-from chainer.utils import collections_abc
 
 
 try:
@@ -221,7 +220,7 @@ class CaffeFunction(link.Chain):
             func = self.forwards[func_name]
             input_vars = tuple(variables[blob] for blob in bottom)
             output_vars = func(*input_vars)
-            if not isinstance(output_vars, collections_abc.Iterable):
+            if not isinstance(output_vars, tuple):
                 output_vars = output_vars,
             for var, name in zip(output_vars, top):
                 variables[name] = var

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -220,7 +220,7 @@ class CaffeFunction(link.Chain):
             func = self.forwards[func_name]
             input_vars = tuple(variables[blob] for blob in bottom)
             output_vars = func(*input_vars)
-            if not isinstance(output_vars, tuple):
+            if not isinstance(output_vars, (tuple, list)):
                 output_vars = output_vars,
             for var, name in zip(output_vars, top):
                 variables[name] = var

--- a/chainer/links/caffe/caffe_function.py
+++ b/chainer/links/caffe/caffe_function.py
@@ -599,6 +599,7 @@ def _get_width(blob):
 
 
 # Internal class
+# __call__ must return Variable or tuple
 
 class _SingleArgumentFunction(object):
 


### PR DESCRIPTION
The current logic of the internals of `L.CaffeFunction` depends on `Variable` is not `Iterable`, which I'd like to avoid.

Split from #5444.