### PR TITLE
Implement no-double-backprop version of F.softmax_cross_entropy using FunctionNode

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -270,9 +270,11 @@ class _SoftmaxCrossEntropyGrad_NoDoubleBackprop(function_node.FunctionNode):
         return gx, None
 
     def backward(self, input_indexes, grad_outputs):
-        assert False, (
-            'This execution path of F.softmax_cross_entropy does not support '
-            'double-backprop. There must be a bug.')
+        raise RuntimeError(
+            'F.softmax_cross_entropy was called with '
+            '\'enable_double_backprop=False\' argument, but double-backprop '
+            'is actually being performed. Please specify '
+            '\'enable_double_backprop=True\' explicitly.')
 
 
 def _double_backward_softmax_cross_entropy(x, t, normalize, class_weight,


### PR DESCRIPTION
Implements `SoftmaxCrossEntropy` with `FunctionNode`.

This execution path is for single-backward only, so double-backward is not implemented.
This PR does not enhance functionality, but the overhead of `FunctionAdapter` could be reduced.