### PR TITLE
Relax tolerance of check_double_backward test

### DIFF
--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -780,7 +780,8 @@ class TestCheckDoubleBackward(unittest.TestCase):
         def f(x):
             return x * param
 
-        gradient_check.check_double_backward(f, x, gy, ggx, param, ggparam)
+        gradient_check.check_double_backward(
+            f, x, gy, ggx, param, ggparam, atol=1e-3, rtol=1e-3)
 
     def test_double_backward_with_params_cpu(self):
         self.check_double_backward_with_params(numpy)


### PR DESCRIPTION
This test sometimes fails due to the strict tolerance.