### PR TITLE
[backport] Ignore scipy<1.0 is warned by using deprecated feature of numpy>=1.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,12 @@ exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 [tool:pytest]
 filterwarnings= ignore::FutureWarning
                 error::DeprecationWarning
+                # importing old SciPy is warned because it tries to
+                # import nose via numpy.testing
+                ignore::DeprecationWarning:scipy._lib._numpy_compat
+                # importing stats from old SciPy is warned because it tries to
+                # import numpy.testing.decorators
+                ignore::DeprecationWarning:scipy.stats.morestats
                 # Theano 0.8 causes DeprecationWarnings. It is fixed in 0.9.
                 ignore::DeprecationWarning:theano.configparser
                 # Theano 1.0.2 passes a deprecated argument to distutils during


### PR DESCRIPTION
Backport of #5471