### PR TITLE
Fix backward of HuberLoss

### DIFF
--- a/chainer/functions/loss/huber_loss.py
+++ b/chainer/functions/loss/huber_loss.py
@@ -54,7 +54,7 @@ class HuberLoss(function_node.FunctionNode):
         gx = chainer.functions.clip(diff, -delta, delta)
 
         if self.reduce == 'sum_along_second_axis':
-            gy = gy.reshape(gy.shape + (1,) * (diff.ndim - 1))
+            gy = chainer.functions.expand_dims(gy, 1)
         gx = chainer.functions.broadcast_to(gy, gx.shape) * gx
         return gx, -gx
 


### PR DESCRIPTION
While inputs with ndim > 2 were undocumented, `backward` should not fail whenever `type_check_forward` and `forward` succeed.

Close #5487.
See also the discussion in #3867.
