### PR TITLE
Fix `F.softmax` and `F.log_softmax` with `axis=-1` on gpu

### DIFF
--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -1,3 +1,6 @@
+import functools
+import operator
+
 import numpy
 
 import chainer
@@ -16,10 +19,9 @@ if cuda.cudnn_enabled:
 
 
 def _get_tensor4d_shape(axis, shape):
-    left_shape = numpy.prod(shape[slice(0, axis)], dtype=numpy.int)
+    left_shape = functools.reduce(operator.mul, shape[:axis], 1)
     center_shape = shape[axis]
-    right_shape = numpy.prod(
-        shape[slice(axis + 1, len(shape))], dtype=numpy.int)
+    right_shape = functools.reduce(operator.mul, shape[axis:][1:], 1)
     return left_shape, center_shape, right_shape, 1
 
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -19,7 +19,7 @@ from chainer.testing import attr
         'axis': [1],
     }) + [
         {'shape': (2, 3), 'axis': 0},
-        {'shape': (2, 2, 3), 'axis': 2},
+        {'shape': (2, 2, 3), 'axis': -1},
         {'shape': (2, 2, 2, 3), 'axis': -4},
     ],
 ))

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -14,8 +14,8 @@ from chainer.testing import attr
     'shape_axis':
         [{'shape': None, 'axis': 1}, ] +
         testing.product({'shape': ((2, 3),), 'axis': (0, 1)}) +
-        testing.product({'shape': ((2, 3, 4),), 'axis': (0, 2)}) +
-        testing.product({'shape': ((2, 3, 2, 3),), 'axis': (1, 3)}),
+        testing.product({'shape': ((2, 3, 4),), 'axis': (0, -1)}) +
+        testing.product({'shape': ((2, 3, 2, 3),), 'axis': (-3, 3)}),
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @testing.fix_random()


### PR DESCRIPTION
This PR fixes a bug in #5381.

`_get_tensor4d_shape` implicitly assumed `axis` is nonnegative.  (`shape[slice(axis + 1, len(shape))]` doesn't work if `axis=-1`.)

