### PR TITLE
Support negative `axis` for `F.softmax`

### DIFF
--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -44,8 +44,7 @@ class Softmax(function_node.FunctionNode):
 
         type_check.expect(
             x_type.dtype.kind == 'f',
-            x_type.ndim > 1,
-            self.axis < x_type.ndim
+            -x_type.ndim <= self.axis < x_type.ndim,
         )
 
     def forward(self, x):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -10,20 +10,28 @@ from chainer import testing
 from chainer.testing import attr
 
 
-@testing.parameterize(*testing.product({
-    'shape_axis':
-        [{'shape': None, 'axis': 1}, {'shape': (5,), 'axis': 0}, ] +
-        testing.product({'shape': ((2, 3),), 'axis': (0, 1)}) +
-        testing.product({'shape': ((2, 3, 4),), 'axis': (0, -1)}) +
-        testing.product({'shape': ((2, 3, 2, 3),), 'axis': (-3, 3)}),
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
+@testing.parameterize(*testing.product_dict(
+    [
+        {'shape': None, 'axis': 1},
+        {'shape': (5,), 'axis': 0},
+    ] + testing.product({
+        'shape': [(2, 3)],
+        'axis': [0, 1]
+    }) + testing.product({
+        'shape': [(2, 3, 4)],
+        'axis': [0, -1]
+    }) + testing.product({
+        'shape': [(2, 3, 2, 3)],
+        'axis': [-3, 3]
+    }),
+    testing.product({
+        'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    }),
+))
 @testing.fix_random()
 class TestSoftmax(unittest.TestCase):
 
     def setUp(self):
-        self.shape = self.shape_axis['shape']
-        self.axis = self.shape_axis['axis']
         if self.shape is None:
             # For checking numerical stability
             value = -5 if self.dtype == numpy.float16 else -1000

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -12,7 +12,7 @@ from chainer.testing import attr
 
 @testing.parameterize(*testing.product({
     'shape_axis':
-        [{'shape': None, 'axis': 1}, ] +
+        [{'shape': None, 'axis': 1}, {'shape': (5,), 'axis': 0}, ] +
         testing.product({'shape': ((2, 3),), 'axis': (0, 1)}) +
         testing.product({'shape': ((2, 3, 4),), 'axis': (0, -1)}) +
         testing.product({'shape': ((2, 3, 2, 3),), 'axis': (-3, 3)}),

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softmax.py
@@ -14,16 +14,13 @@ from chainer.testing import attr
     [
         {'shape': None, 'axis': 1},
         {'shape': (5,), 'axis': 0},
-    ] + testing.product({
-        'shape': [(2, 3)],
-        'axis': [0, 1]
-    }) + testing.product({
-        'shape': [(2, 3, 4)],
-        'axis': [0, -1]
-    }) + testing.product({
-        'shape': [(2, 3, 2, 3)],
-        'axis': [-3, 3]
-    }),
+        {'shape': (2, 3), 'axis': 0},
+        {'shape': (2, 3), 'axis': 1},
+        {'shape': (2, 3, 4), 'axis': 0},
+        {'shape': (2, 3, 4), 'axis': -1},
+        {'shape': (2, 3, 2, 3), 'axis': -3},
+        {'shape': (2, 3, 2, 3), 'axis': 3},
+    ],
     testing.product({
         'dtype': [numpy.float16, numpy.float32, numpy.float64],
     }),


### PR DESCRIPTION
Merge #5496 first.

This PR also allows 1-dim inputs.

cf. #5381