### PR TITLE
[backport] Fix `train_imagenet_data_parallel.py` example cannot be run

### DIFF
--- a/examples/imagenet/train_imagenet_data_parallel.py
+++ b/examples/imagenet/train_imagenet_data_parallel.py
@@ -26,6 +26,7 @@ import googlenet
 import googlenetbn
 import nin
 import resnet50
+import resnext50
 import train_imagenet
 
 
@@ -38,7 +39,7 @@ def main():
         'googlenetbn_fp16': googlenetbn.GoogLeNetBNFp16,
         'nin': nin.NIN,
         'resnet50': resnet50.ResNet50,
-        'resnext50': resnet50.ResNeXt50,
+        'resnext50': resnext50.ResNeXt50,
     }
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Backport of #5469