### PR TITLE
Test statistics of initializers

### DIFF
--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -104,7 +104,7 @@ class NormalBase(unittest.TestCase):
                 assert False
 
         sampless = cuda.to_cpu(ws.reshape(n, -1).T)
-        alpha = 0.05 / len(sampless)
+        alpha = 0.01 / len(sampless)
         for samples in sampless:
             _, p = stats.kstest(samples, stats.norm(0, expected_std).cdf)
             assert p >= alpha

--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -86,9 +86,9 @@ class NormalBase(unittest.TestCase):
         from scipy import stats
 
         ws = xp.empty((n,) + self.shape, dtype=self.dtype)
-        for w in ws:
+        for i in range(n):
             initializer = self.target(**self.target_kwargs)
-            initializer(w)
+            initializer(xp.squeeze(ws[i:i+1], axis=0))
 
         fan = self.fan_option or default_fan.get(self.target)
         expected_std = self.scale or default_scale.get(self.target) or 1.
@@ -103,7 +103,7 @@ class NormalBase(unittest.TestCase):
             else:
                 assert False
 
-        sampless = ws.reshape(n, -1).T
+        sampless = cuda.to_cpu(ws.reshape(n, -1).T)
         alpha = 0.05 / len(sampless)
         for samples in sampless:
             _, p = stats.kstest(samples, stats.norm(0, expected_std).cdf)

--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -15,6 +15,10 @@ default_scale = {
     initializers.Normal: 0.05,
 }
 
+default_coeff = {
+    initializers.HeNormal: math.sqrt(2),
+}
+
 default_fan = {
     initializers.LeCunNormal: 'fan_in',
     initializers.GlorotNormal: 'fan_avg',
@@ -90,8 +94,7 @@ class NormalBase(unittest.TestCase):
 
         fan = self.fan_option or default_fan.get(self.target)
         expected_std = self.scale or default_scale.get(self.target) or 1.
-        if self.target == initializers.HeNormal:
-            expected_std *= math.sqrt(2.)
+        expected_std *= default_coeff.get(self.target) or 1.
         if fan is not None:
             if fan == 'fan_in':
                 expected_std *= math.sqrt(1. / self.fans[0])

--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -80,10 +80,9 @@ class NormalBase(unittest.TestCase):
     def test_shaped_initializer_gpu(self):
         self.check_shaped_initializer(cuda.cupy)
 
-    def check_initializer_statistics(self, xp):
+    def check_initializer_statistics(self, xp, n):
         from scipy import stats
 
-        n = 100000
         ws = xp.empty((n,) + self.shape, dtype=self.dtype)
         for w in ws:
             initializer = self.target(**self.target_kwargs)
@@ -109,18 +108,29 @@ class NormalBase(unittest.TestCase):
             _, p = stats.kstest(samples, stats.norm(0, expected_std).cdf)
             assert p >= alpha
 
+    @testing.with_requires('scipy')
+    @condition.retry(3)
+    def test_initializer_statistics_cpu(self):
+        self.check_initializer_statistics(numpy, 100)
+
+    @attr.gpu
+    @testing.with_requires('scipy')
+    @condition.retry(3)
+    def test_initializer_statistics_gpu(self):
+        self.check_initializer_statistics(cuda.cupy, 100)
+
     @attr.slow
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_cpu(self):
-        self.check_initializer_statistics(numpy)
+    def test_initializer_statistics_slow_cpu(self):
+        self.check_initializer_statistics(numpy, 100000)
 
     @attr.slow
     @attr.gpu
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_gpu(self):
-        self.check_initializer_statistics(cuda.cupy)
+    def test_initializer_statistics_slow_gpu(self):
+        self.check_initializer_statistics(cuda.cupy, 100000)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -26,24 +26,22 @@ default_fan = {
 }
 
 
-@testing.parameterize(*(
-    testing.product_dict(
-        [
-            {'target': initializers.Normal, 'fan_option': None},
-            {'target': initializers.LeCunNormal, 'fan_option': None},
-            {'target': initializers.GlorotNormal, 'fan_option': None},
-            {'target': initializers.HeNormal, 'fan_option': 'fan_in'},
-            {'target': initializers.HeNormal, 'fan_option': 'fan_out'}
-        ],
-        [
-            {'shape': (2, 3), 'fans': (3, 2)},
-            {'shape': (2, 3, 4), 'fans': (12, 8)},
-        ],
-        testing.product({
-            'scale': [None, 7.3],
-            'dtype': [numpy.float16, numpy.float32, numpy.float64],
-        })
-    )
+@testing.parameterize(*testing.product_dict(
+    [
+        {'target': initializers.Normal, 'fan_option': None},
+        {'target': initializers.LeCunNormal, 'fan_option': None},
+        {'target': initializers.GlorotNormal, 'fan_option': None},
+        {'target': initializers.HeNormal, 'fan_option': 'fan_in'},
+        {'target': initializers.HeNormal, 'fan_option': 'fan_out'}
+    ],
+    [
+        {'shape': (2, 3), 'fans': (3, 2)},
+        {'shape': (2, 3, 4), 'fans': (12, 8)},
+    ],
+    testing.product({
+        'scale': [None, 7.3],
+        'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    })
 ))
 class NormalBase(unittest.TestCase):
 

--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -1,11 +1,25 @@
+import math
 import unittest
+
+import numpy
 
 from chainer import backend
 from chainer.backends import cuda
 from chainer import initializers
 from chainer import testing
 from chainer.testing import attr
-import numpy
+from chainer.testing import condition
+
+
+default_scale = {
+    initializers.Normal: 0.05,
+}
+
+default_fan = {
+    initializers.LeCunNormal: 'fan_in',
+    initializers.GlorotNormal: 'fan_avg',
+    initializers.HeNormal: 'fan_in',
+}
 
 
 @testing.parameterize(*(
@@ -17,23 +31,28 @@ import numpy
             {'target': initializers.HeNormal, 'fan_option': 'fan_in'},
             {'target': initializers.HeNormal, 'fan_option': 'fan_out'}
         ],
-        testing.product(
-            {'shape': [(2, 3), (2, 3, 4)],
-             'dtype': [numpy.float16, numpy.float32, numpy.float64]
-             }
-        )
+        [
+            {'shape': (2, 3), 'fans': (3, 2)},
+            {'shape': (2, 3, 4), 'fans': (12, 8)},
+        ],
+        testing.product({
+            'scale': [None, 7.3],
+            'dtype': [numpy.float16, numpy.float32, numpy.float64],
+        })
     )
 ))
 class NormalBase(unittest.TestCase):
 
     def setUp(self):
-        pass
+        kwargs = {}
+        if self.scale is not None:
+            kwargs['scale'] = self.scale
+        if self.fan_option is not None:
+            kwargs['fan_option'] = self.fan_option
+        self.target_kwargs = kwargs
 
     def check_initializer(self, w):
-        if self.fan_option is None:
-            initializer = self.target(scale=0.1)
-        else:
-            initializer = self.target(scale=0.1, fan_option=self.fan_option)
+        initializer = self.target(**self.target_kwargs)
         initializer(w)
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
@@ -48,7 +67,7 @@ class NormalBase(unittest.TestCase):
         self.check_initializer(w)
 
     def check_shaped_initializer(self, xp):
-        initializer = self.target(scale=0.1, dtype=self.dtype)
+        initializer = self.target(dtype=self.dtype, **self.target_kwargs)
         w = initializers.generate_array(initializer, self.shape, xp)
         self.assertIs(backend.get_array_module(w), xp)
         self.assertTupleEqual(w.shape, self.shape)
@@ -60,6 +79,48 @@ class NormalBase(unittest.TestCase):
     @attr.gpu
     def test_shaped_initializer_gpu(self):
         self.check_shaped_initializer(cuda.cupy)
+
+    def check_initializer_statistics(self, xp):
+        from scipy import stats
+
+        n = 100000
+        ws = xp.empty((n,) + self.shape, dtype=self.dtype)
+        for w in ws:
+            initializer = self.target(**self.target_kwargs)
+            initializer(w)
+
+        fan = self.fan_option or default_fan.get(self.target)
+        expected_std = self.scale or default_scale.get(self.target) or 1.
+        if self.target == initializers.HeNormal:
+            expected_std *= math.sqrt(2.)
+        if fan is not None:
+            if fan == 'fan_in':
+                expected_std *= math.sqrt(1. / self.fans[0])
+            elif fan == 'fan_out':
+                expected_std *= math.sqrt(1. / self.fans[1])
+            elif fan == 'fan_avg':
+                expected_std *= math.sqrt(2. / sum(self.fans))
+            else:
+                assert False
+
+        sampless = ws.reshape(n, -1).T
+        alpha = 0.05 / len(sampless)
+        for samples in sampless:
+            _, p = stats.kstest(samples, stats.norm(0, expected_std).cdf)
+            assert p >= alpha
+
+    @attr.slow
+    @testing.with_requires('scipy')
+    @condition.repeat_with_success_at_least(5, 3)
+    def test_initializer_statistics_cpu(self):
+        self.check_initializer_statistics(numpy)
+
+    @attr.slow
+    @attr.gpu
+    @testing.with_requires('scipy')
+    @condition.repeat_with_success_at_least(5, 3)
+    def test_initializer_statistics_gpu(self):
+        self.check_initializer_statistics(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/initializer_tests/test_orthogonal.py
+++ b/tests/chainer_tests/initializer_tests/test_orthogonal.py
@@ -96,7 +96,7 @@ class OrthogonalBase(unittest.TestCase):
             initializer(xp.squeeze(ws[i:i+1], axis=0))
 
         expected_scale = self.scale or 1.1
-        sampless = ws.reshape(n, -1).T
+        sampless = cuda.to_cpu(ws.reshape(n, -1).T)
         alpha = 0.05 / len(sampless)
 
         ab = 0.5 * (self.dim_in - 1)

--- a/tests/chainer_tests/initializer_tests/test_orthogonal.py
+++ b/tests/chainer_tests/initializer_tests/test_orthogonal.py
@@ -101,18 +101,20 @@ class OrthogonalBase(unittest.TestCase):
 
         ab = 0.5 * (self.dim_in - 1)
 
+        beta_cdf = stats.beta(
+            ab, ab, loc=-expected_scale, scale=2*expected_scale).cdf
+
+        def abs_beta_cdf(x):
+            return numpy.fmax(0, 2 * beta_cdf(x) - 1)
+
         for samples in sampless:
             if self.dim_in == 1:
                 numpy.testing.assert_allclose(abs(samples), expected_scale)
                 _, p = stats.chisquare((numpy.sign(samples) + 1) // 2)
             else:
                 _, p = stats.kstest(
-                    samples,
-                    stats.beta(
-                        ab, ab,
-                        loc=-expected_scale,
-                        scale=2*expected_scale
-                    ).cdf
+                    numpy.abs(samples),
+                    abs_beta_cdf
                 )
             assert p >= alpha
 

--- a/tests/chainer_tests/initializer_tests/test_orthogonal.py
+++ b/tests/chainer_tests/initializer_tests/test_orthogonal.py
@@ -97,7 +97,7 @@ class OrthogonalBase(unittest.TestCase):
 
         expected_scale = self.scale or 1.1
         sampless = cuda.to_cpu(ws.reshape(n, -1).T)
-        alpha = 0.05 / len(sampless)
+        alpha = 0.01 / len(sampless)
 
         ab = 0.5 * (self.dim_in - 1)
 

--- a/tests/chainer_tests/initializer_tests/test_uniform.py
+++ b/tests/chainer_tests/initializer_tests/test_uniform.py
@@ -28,23 +28,21 @@ default_fan = {
 }
 
 
-@testing.parameterize(*(
-    testing.product_dict(
-        [
-            {'target': initializers.Uniform, 'fan_option': None},
-            {'target': initializers.LeCunUniform, 'fan_option': None},
-            {'target': initializers.GlorotUniform, 'fan_option': None},
-            {'target': initializers.HeUniform, 'fan_option': None},
-        ],
-        [
-            {'shape': (2, 3), 'fans': (3, 2)},
-            {'shape': (2, 3, 4), 'fans': (12, 8)},
-        ],
-        testing.product({
-            'scale': [None, 7.3],
-            'dtype': [numpy.float16, numpy.float32, numpy.float64],
-        })
-    )
+@testing.parameterize(*testing.product_dict(
+    [
+        {'target': initializers.Uniform, 'fan_option': None},
+        {'target': initializers.LeCunUniform, 'fan_option': None},
+        {'target': initializers.GlorotUniform, 'fan_option': None},
+        {'target': initializers.HeUniform, 'fan_option': None},
+    ],
+    [
+        {'shape': (2, 3), 'fans': (3, 2)},
+        {'shape': (2, 3, 4), 'fans': (12, 8)},
+    ],
+    testing.product({
+        'scale': [None, 7.3],
+        'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    })
 ))
 class TestUniform(unittest.TestCase):
 

--- a/tests/chainer_tests/initializer_tests/test_uniform.py
+++ b/tests/chainer_tests/initializer_tests/test_uniform.py
@@ -87,9 +87,9 @@ class TestUniform(unittest.TestCase):
         from scipy import stats
 
         ws = xp.empty((n,) + self.shape, dtype=self.dtype)
-        for w in ws:
+        for i in range(n):
             initializer = self.target(**self.target_kwargs)
-            initializer(w)
+            initializer(xp.squeeze(ws[i:i+1], axis=0))
 
         fan = self.fan_option or default_fan.get(self.target)
         expected_max = self.scale or default_scale.get(self.target) or 1.
@@ -104,7 +104,7 @@ class TestUniform(unittest.TestCase):
             else:
                 assert False
 
-        sampless = ws.reshape(n, -1).T
+        sampless = cuda.to_cpu(ws.reshape(n, -1).T)
         alpha = 0.05 / len(sampless)
         for samples in sampless:
             _, p = stats.kstest(

--- a/tests/chainer_tests/initializer_tests/test_uniform.py
+++ b/tests/chainer_tests/initializer_tests/test_uniform.py
@@ -1,29 +1,63 @@
+import math
 import unittest
+
+import numpy
 
 from chainer import backend
 from chainer.backends import cuda
 from chainer import initializers
 from chainer import testing
 from chainer.testing import attr
-import numpy
+from chainer.testing import condition
 
 
-@testing.parameterize(*testing.product({
-    'target': [
-        initializers.Uniform,
-        initializers.LeCunUniform,
-        initializers.HeUniform,
-        initializers.GlorotUniform,
-    ],
-    'shape': [(2, 3), (2, 3, 4)],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
+default_scale = {
+    initializers.Uniform: 0.05,
+}
+
+default_coeff = {
+    initializers.LeCunUniform: math.sqrt(3),
+    initializers.GlorotUniform: math.sqrt(3),
+    initializers.HeUniform: math.sqrt(6),
+}
+
+default_fan = {
+    initializers.LeCunUniform: 'fan_in',
+    initializers.GlorotUniform: 'fan_avg',
+    initializers.HeUniform: 'fan_in',
+}
+
+
+@testing.parameterize(*(
+    testing.product_dict(
+        [
+            {'target': initializers.Uniform, 'fan_option': None},
+            {'target': initializers.LeCunUniform, 'fan_option': None},
+            {'target': initializers.GlorotUniform, 'fan_option': None},
+            {'target': initializers.HeUniform, 'fan_option': None},
+        ],
+        [
+            {'shape': (2, 3), 'fans': (3, 2)},
+            {'shape': (2, 3, 4), 'fans': (12, 8)},
+        ],
+        testing.product({
+            'scale': [None, 7.3],
+            'dtype': [numpy.float16, numpy.float32, numpy.float64],
+        })
+    )
+))
 class TestUniform(unittest.TestCase):
 
-    scale = 0.1
+    def setUp(self):
+        kwargs = {}
+        if self.scale is not None:
+            kwargs['scale'] = self.scale
+        if self.fan_option is not None:
+            kwargs['fan_option'] = self.fan_option
+        self.target_kwargs = kwargs
 
     def check_initializer(self, w):
-        initializer = self.target(scale=self.scale)
+        initializer = self.target(**self.target_kwargs)
         initializer(w)
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
@@ -38,7 +72,7 @@ class TestUniform(unittest.TestCase):
         self.check_initializer(w)
 
     def check_shaped_initializer(self, xp):
-        initializer = self.target(scale=self.scale, dtype=self.dtype)
+        initializer = self.target(dtype=self.dtype, **self.target_kwargs)
         w = initializers.generate_array(initializer, self.shape, xp)
         self.assertIs(backend.get_array_module(w), xp)
         self.assertTupleEqual(w.shape, self.shape)
@@ -50,6 +84,60 @@ class TestUniform(unittest.TestCase):
     @attr.gpu
     def test_shaped_initializer_gpu(self):
         self.check_shaped_initializer(cuda.cupy)
+
+    def check_initializer_statistics(self, xp, n):
+        from scipy import stats
+
+        ws = xp.empty((n,) + self.shape, dtype=self.dtype)
+        for w in ws:
+            initializer = self.target(**self.target_kwargs)
+            initializer(w)
+
+        fan = self.fan_option or default_fan.get(self.target)
+        expected_max = self.scale or default_scale.get(self.target) or 1.
+        expected_max *= default_coeff.get(self.target) or 1.
+        if fan is not None:
+            if fan == 'fan_in':
+                expected_max *= math.sqrt(1. / self.fans[0])
+            elif fan == 'fan_out':
+                expected_max *= math.sqrt(1. / self.fans[1])
+            elif fan == 'fan_avg':
+                expected_max *= math.sqrt(2. / sum(self.fans))
+            else:
+                assert False
+
+        sampless = ws.reshape(n, -1).T
+        alpha = 0.05 / len(sampless)
+        for samples in sampless:
+            _, p = stats.kstest(
+                samples,
+                stats.uniform(-expected_max, 2*expected_max).cdf
+            )
+            assert p >= alpha
+
+    @testing.with_requires('scipy')
+    @condition.retry(3)
+    def test_initializer_statistics_cpu(self):
+        self.check_initializer_statistics(numpy, 100)
+
+    @attr.gpu
+    @testing.with_requires('scipy')
+    @condition.retry(3)
+    def test_initializer_statistics_gpu(self):
+        self.check_initializer_statistics(cuda.cupy, 100)
+
+    @attr.slow
+    @testing.with_requires('scipy')
+    @condition.repeat_with_success_at_least(5, 3)
+    def test_initializer_statistics_slow_cpu(self):
+        self.check_initializer_statistics(numpy, 100000)
+
+    @attr.slow
+    @attr.gpu
+    @testing.with_requires('scipy')
+    @condition.repeat_with_success_at_least(5, 3)
+    def test_initializer_statistics_slow_gpu(self):
+        self.check_initializer_statistics(cuda.cupy, 100000)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/initializer_tests/test_uniform.py
+++ b/tests/chainer_tests/initializer_tests/test_uniform.py
@@ -105,7 +105,7 @@ class TestUniform(unittest.TestCase):
                 assert False
 
         sampless = cuda.to_cpu(ws.reshape(n, -1).T)
-        alpha = 0.05 / len(sampless)
+        alpha = 0.01 / len(sampless)
         for samples in sampless:
             _, p = stats.kstest(
                 samples,


### PR DESCRIPTION
Test `scale` arg of `chainer.initializers`.

This PR adds statistical tests ~and fixes bias of sign of `Orthogonal` initializer~.