### PR TITLE
Tests with maxtasksperchild=1 or 10 are slow

### DIFF
--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -353,7 +353,8 @@ class BaseTestMultiprocessIterator(object):
         None, lambda order, _: numpy.random.permutation(len(order))],
     'maxtasksperchild': [None, 10],
 }))
-class TestMultiprocessIterator(BaseTestMultiprocessIterator, unittest.TestCase):
+class TestMultiprocessIterator(
+        BaseTestMultiprocessIterator, unittest.TestCase):
     pass
 
 
@@ -365,7 +366,8 @@ class TestMultiprocessIterator(BaseTestMultiprocessIterator, unittest.TestCase):
     'maxtasksperchild': [1],
 }))
 @attr.slow
-class TestMultiprocessIteratorSlow(BaseTestMultiprocessIterator, unittest.TestCase):
+class TestMultiprocessIteratorSlow(
+        BaseTestMultiprocessIterator, unittest.TestCase):
     pass
 
 

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -17,6 +17,7 @@ import six
 from chainer import iterators
 from chainer import serializer
 from chainer import testing
+from chainer.testing import attr
 
 
 class DummySerializer(serializer.Serializer):
@@ -52,14 +53,7 @@ class DummyDeserializer(serializer.Deserializer):
         return value
 
 
-@testing.parameterize(*testing.product({
-    'n_prefetch': [1, 2],
-    'shared_mem': [None, 1000000],
-    'order_sampler': [
-        None, lambda order, _: numpy.random.permutation(len(order))],
-    'maxtasksperchild': [None, 1, 10],
-}))
-class TestMultiprocessIterator(unittest.TestCase):
+class BaseTestMultiprocessIterator(object):
 
     def setUp(self):
         self.n_processes = 2
@@ -350,6 +344,29 @@ class TestMultiprocessIterator(unittest.TestCase):
         it.next()
         it.finalize()
         self.assertRaises(NotImplementedError, it.reset)
+
+
+@testing.parameterize(*testing.product({
+    'n_prefetch': [1, 2],
+    'shared_mem': [None, 1000000],
+    'order_sampler': [
+        None, lambda order, _: numpy.random.permutation(len(order))],
+    'maxtasksperchild': [None, 10],
+}))
+class TestMultiprocessIterator(BaseTestMultiprocessIterator, unittest.TestCase):
+    pass
+
+
+@testing.parameterize(*testing.product({
+    'n_prefetch': [1, 2],
+    'shared_mem': [None, 1000000],
+    'order_sampler': [
+        None, lambda order, _: numpy.random.permutation(len(order))],
+    'maxtasksperchild': [1],
+}))
+@attr.slow
+class TestMultiprocessIteratorSlow(BaseTestMultiprocessIterator, unittest.TestCase):
+    pass
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -351,7 +351,7 @@ class BaseTestMultiprocessIterator(object):
     'shared_mem': [None, 1000000],
     'order_sampler': [
         None, lambda order, _: numpy.random.permutation(len(order))],
-    'maxtasksperchild': [None, 10],
+    'maxtasksperchild': [None],
 }))
 class TestMultiprocessIterator(
         BaseTestMultiprocessIterator, unittest.TestCase):
@@ -363,7 +363,7 @@ class TestMultiprocessIterator(
     'shared_mem': [None, 1000000],
     'order_sampler': [
         None, lambda order, _: numpy.random.permutation(len(order))],
-    'maxtasksperchild': [1],
+    'maxtasksperchild': [1, 10],
 }))
 @attr.slow
 class TestMultiprocessIteratorSlow(


### PR DESCRIPTION
Close #5494.

- I left 267 tests (39.15 s)
- I marked 112 slow tests (104.72 s)