### PR TITLE
[backport] Ignore protobuf is warned by Python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ filterwarnings= ignore::FutureWarning
                 # causing AttributeError in the subsequent uses of
                 # ``theano.gof``. (#4810)
                 ignore::DeprecationWarning:theano.gof.cmodule
+                # ``collections.MutableSequence`` in protobuf is warned by
+                # Python 3.7.
+                ignore::DeprecationWarning:google.protobuf.internal.containers
                 # ChainerMN depends on `add_link`. Although it is marked
                 # as 'deprecated', it is planned to make the function active again
                 # in #4250.


### PR DESCRIPTION
Backport of #5514