### PR TITLE
[backport] Use arr.item() instead of np.asscalar(arr) to support NumPy 1.16

### DIFF
--- a/chainer/training/extensions/exponential_shift.py
+++ b/chainer/training/extensions/exponential_shift.py
@@ -73,7 +73,7 @@ class ExponentialShift(extension.Extension):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
         if isinstance(self._last_value, numpy.ndarray):
-            self._last_value = numpy.asscalar(self._last_value)
+            self._last_value = self._last_value.item()
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/chainer/training/extensions/inverse_shift.py
+++ b/chainer/training/extensions/inverse_shift.py
@@ -78,7 +78,7 @@ class InverseShift(extension.Extension):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
         if isinstance(self._last_value, numpy.ndarray):
-            self._last_value = numpy.asscalar(self._last_value)
+            self._last_value = self._last_value.item()
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/chainer/training/extensions/linear_shift.py
+++ b/chainer/training/extensions/linear_shift.py
@@ -58,7 +58,7 @@ class LinearShift(extension.Extension):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
         if isinstance(self._last_value, numpy.ndarray):
-            self._last_value = numpy.asscalar(self._last_value)
+            self._last_value = self._last_value.item()
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/chainer/training/extensions/polynomial_shift.py
+++ b/chainer/training/extensions/polynomial_shift.py
@@ -84,7 +84,7 @@ class PolynomialShift(extension.Extension):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
         if isinstance(self._last_value, numpy.ndarray):
-            self._last_value = numpy.asscalar(self._last_value)
+            self._last_value = self._last_value.item()
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/chainer/training/extensions/step_shift.py
+++ b/chainer/training/extensions/step_shift.py
@@ -77,7 +77,7 @@ class StepShift(extension.Extension):
         self._t = serializer('_t', self._t)
         self._last_value = serializer('_last_value', self._last_value)
         if isinstance(self._last_value, numpy.ndarray):
-            self._last_value = numpy.asscalar(self._last_value)
+            self._last_value = self._last_value.item()
 
     def _get_optimizer(self, trainer):
         return self._optimizer or trainer.updater.get_optimizer('main')

--- a/docs/source/guides/extensions.rst
+++ b/docs/source/guides/extensions.rst
@@ -159,7 +159,7 @@ The learning rate will be dropped according to the curve below with :math:`{\rm 
             self._t = serializer('_t', self._t)
             self._last_value = serializer('_last_value', self._last_value)
             if isinstance(self._last_value, np.ndarray):
-                self._last_value = np.asscalar(self._last_value)
+                self._last_value = self._last_value.item()
 
 .. code-block:: python
 


### PR DESCRIPTION
Backport of #5510