### PR TITLE
[backport] Use "documentation" instead of "document" in our documentation

### DIFF
--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -87,7 +87,7 @@ def split_dataset(dataset, split_at, order=None):
         dataset: Dataset to split.
         split_at (int): Position at which the base dataset is split.
         order (sequence of ints): Permutation of indexes in the base dataset.
-            See the document of :class:`SubDataset` for details.
+            See the documentation of :class:`SubDataset` for details.
 
     Returns:
         tuple: Two :class:`SubDataset` objects. The first subset represents the
@@ -142,7 +142,7 @@ def split_dataset_n(dataset, n, order=None):
         dataset: Dataset to split.
         n(int): The number of subsets.
         order (sequence of ints): Permutation of indexes in the base dataset.
-            See the document of :class:`SubDataset` for details.
+            See the documentation of :class:`SubDataset` for details.
 
     Returns:
         list: List of ``n`` :class:`SubDataset` objects.

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -117,7 +117,7 @@ def get_item(x, slices):
 
     .. note::
 
-       See NumPy document for details of `indexing
+       See NumPy documentation for details of `indexing
        <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_.
 
     .. admonition:: Example

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -360,7 +360,7 @@ Assign a Parameter object directly to an attribute within a \
         """Copies the link hierarchy to new one.
 
         The whole hierarchy rooted by this link is copied. There are three
-        modes to perform copy. Please see the document for the argument
+        modes to perform copy. Please see the documentation for the argument
         ``mode`` below.
 
         The name of the link is reset on the copy, since the copied instance

--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -222,7 +222,7 @@ method to evaluate expression.
     __gt__ = _make_bool_operator('>', '<=', operator.__gt__)
     __ge__ = _make_bool_operator('>=', '<', operator.__ge__)
 
-    # Please refer the Python document to know priority of operators.
+    # Please refer the Python documentation to know priority of operators.
     # https://docs.python.org/3.4/reference/expressions.html
 
     __add__ = _make_bin_operator('+', 4, operator.__add__)

--- a/chainermn/functions/pseudo_connect.py
+++ b/chainermn/functions/pseudo_connect.py
@@ -50,7 +50,7 @@ def pseudo_connect(delegate_variable, *actual_variables):
 
         This model receives inputs from rank=3 process and sends its outputs
         to rank=1 process. The entire graph can be seen as one connected
-        component ``ConnectedGraphSub``. Please refer the document of
+        component ``ConnectedGraphSub``. Please refer the documentation of
         ``MultiNodeChainList`` for detail.
 
         On the other hand, see the next example::

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -3,13 +3,13 @@
 API Compatibility Policy
 ========================
 
-This document explains the design policy on compatibilities of Chainer APIs.
+This documentation explains the design policy on compatibilities of Chainer APIs.
 Development team should follow this policy on deciding to add, extend, and change APIs and their behaviors.
 
-This document is written for both users and developers.
+This documentation is written for both users and developers.
 Users can decide the level of dependencies on Chainer’s implementations in their codes based on this document.
-Developers should read through this document before creating pull requests that contain changes on the interface.
-Note that this document may contain ambiguities on the level of supported compatibilities.
+Developers should read through this documentation before creating pull requests that contain changes on the interface.
+Note that this documentation may contain ambiguities on the level of supported compatibilities.
 
 
 Targeted Versions
@@ -78,7 +78,7 @@ Any API that is not experimental is called *stable* in this document.
 When users use experimental APIs for the first time, warnings are raised once for each experimental API,
 unless users explicitly disable the emission of the warnings in advance.
 
-See the document of :meth:`chainer.utils.experimental` to know how developers mark APIs as experimental
+See the documentation of :meth:`chainer.utils.experimental` to know how developers mark APIs as experimental
 and how users enable or disable the warnings practically.
 
 .. note::

--- a/docs/source/contribution.rst
+++ b/docs/source/contribution.rst
@@ -9,8 +9,8 @@ Anyone that wants to register an issue or to send a pull request should read thr
 
 .. note::
 
-   Many points of this document are updated at v2.
-   We strongly recommend all contributors of v1 to read through the document again.
+   Many points of this documentation are updated at v2.
+   We strongly recommend all contributors of v1 to read through the documentation again.
 
 Classification of Contributions
 -------------------------------
@@ -23,7 +23,7 @@ There are several ways to contribute to Chainer community:
 4. Open-sourcing an external example
 5. Writing a post about Chainer
 
-This document mainly focuses on 1 and 2, though other contributions are also appreciated.
+This documentation mainly focuses on 1 and 2, though other contributions are also appreciated.
 
 
 Development Cycle
@@ -140,7 +140,7 @@ Issues and PRs are labeled by the following tags:
 * **Feature**: feature requests (issues) and their implementations (PRs)
 * **NoCompat**: disrupts backward compatibility
 * **Test**: test fixes and updates
-* **Document**: document fixes and improvements
+* **Document**: documentation fixes and improvements
 * **Example**: fixes and improvements on the examples
 * **Install**: fixes installation script
 * **Contribution-Welcome**: issues that we request for contribution (only issues are categorized to this)
@@ -407,7 +407,7 @@ The test functions decorated by ``slow`` are skipped if ``-m='not slow'`` is giv
 
 .. note::
    If you want to specify more than two attributes, use ``and`` operator like ``-m='not cudnn and not slow'``.
-   See detail in `the document of pytest <https://docs.pytest.org/en/latest/example/markers.html>`_.
+   See detail in `the documentation of pytest <https://docs.pytest.org/en/latest/example/markers.html>`_.
 
 Once you send a pull request, your code is automatically tested by `Travis-CI <https://travis-ci.org/chainer/chainer/>`_ **except for tests annotated with ``gpu``, ``multi_gpu`` and ``slow``**.
 Since Travis-CI does not support CUDA, we cannot check your CUDA-related code automatically.

--- a/docs/source/guides/gpu.rst
+++ b/docs/source/guides/gpu.rst
@@ -26,7 +26,7 @@ After reading this section, you will be able to:
        with cupy.cuda.Device(1):
            pass
    except cupy.cuda.runtime.CUDARuntimeError:
-       raise RuntimeError('doctest in this document requires 2 GPUs') from None
+       raise RuntimeError('doctest in this documentation requires 2 GPUs') from None
 
 Relationship between Chainer and CuPy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -59,7 +59,7 @@ Chainer changes the default allocator of CuPy to the memory pool, so user can us
 Basics of :class:`cupy.ndarray`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See `the document of CuPy <https://docs-cupy.chainer.org/en/latest/>`_ for the basic usage of :class:`cupy.ndarray`
+See `the documentation of CuPy <https://docs-cupy.chainer.org/en/latest/>`_ for the basic usage of :class:`cupy.ndarray`
 
 CuPy is a GPU array backend that implements a subset of NumPy interface.
 The :class:`cupy.ndarray` class is in its core, which is a compatible GPU alternative of :class:`numpy.ndarray`.

--- a/docs/source/reference/check.rst
+++ b/docs/source/reference/check.rst
@@ -92,7 +92,7 @@ Repeat decorators
 These decorators have a decorated test run multiple times
 in a single invocation. Criteria of passing / failing
 of the test changes according to the type of decorators.
-See the document of each decorator for details.
+See the documentation of each decorator for details.
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/reference/static_graph_design.rst
+++ b/docs/source/reference/static_graph_design.rst
@@ -3,9 +3,9 @@ Static Subgraph Optimizations: Design Notes
 
 .. module:: chainer.graph_optimizations
 
-This document is intended provide information on the architecture and design 
+This documentation is intended provide information on the architecture and design 
 of the static subgraph optimizations feature for those who are interested in 
-contributing to its development. This document also describes how existing
+contributing to its development. This documentation also describes how existing
 Chainer functions can be modified to run more efficiently when static
 subgraph optimizations are enabled.
 

--- a/docs/source/upgrade_v2.rst
+++ b/docs/source/upgrade_v2.rst
@@ -3,7 +3,7 @@
 Upgrade Guide from v1 to v2
 ===========================
 
-This document provides detailed information of differences between Chainer v1 and v2.
+This documentation provides detailed information of differences between Chainer v1 and v2.
 You will know by reading it which part of your code is required (or recommended) to be fixed when you upgrade Chainer from v1 to v2.
 
 .. contents::


### PR DESCRIPTION
Backport of #5450