### PR TITLE
Unchain all variables after running extensions

### DIFF
--- a/chainer/training/extensions/__init__.py
+++ b/chainer/training/extensions/__init__.py
@@ -19,4 +19,5 @@ from chainer.training.extensions.step_shift import StepShift  # NOQA
 from chainer.training.extensions.value_observation import observe_lr  # NOQA
 from chainer.training.extensions.value_observation import observe_value  # NOQA
 from chainer.training.extensions.variable_statistics_plot import VariableStatisticsPlot  # NOQA
+from chainer.training.extensions.variable_unchain import unchain_variables # NOQA
 from chainer.training.extensions.warmup_shift import WarmupShift  # NOQA

--- a/chainer/training/extensions/__init__.py
+++ b/chainer/training/extensions/__init__.py
@@ -19,5 +19,5 @@ from chainer.training.extensions.step_shift import StepShift  # NOQA
 from chainer.training.extensions.value_observation import observe_lr  # NOQA
 from chainer.training.extensions.value_observation import observe_value  # NOQA
 from chainer.training.extensions.variable_statistics_plot import VariableStatisticsPlot  # NOQA
-from chainer.training.extensions.variable_unchain import unchain_variables # NOQA
+from chainer.training.extensions.variable_unchain import unchain_variables  # NOQA
 from chainer.training.extensions.warmup_shift import WarmupShift  # NOQA

--- a/chainer/training/extensions/variable_unchain.py
+++ b/chainer/training/extensions/variable_unchain.py
@@ -8,7 +8,9 @@ class unchain_variables(extension.Extension):
     """Trainer extension to unchain all comptational graphs.
 
     This extenstion unchains all comptational graphs after all extensions are
-    run to avoid any memory problem.
+    run to release memory and to avoid memory leak.
+    This extension can be used as a last resort when there is an extension that
+    use a variable graph and cannot release the graph in itself.
     It observes the previous ``chainer.config.keep_graph_on_report`` flag.
     The extension is triggered when the flag is turned on.
 

--- a/chainer/training/extensions/variable_unchain.py
+++ b/chainer/training/extensions/variable_unchain.py
@@ -10,7 +10,7 @@ class unchain_variables(extension.Extension):
     This extenstion unchains all comptational graphs after all extensions are
     run to avoid any memory problem.
     It observes the previous ``chainer.config.keep_graph_on_report`` flag.
-    The extension is enable while the flag is turned on.
+    The extension is triggered when the flag is turned on.
 
     """
     priority = 0

--- a/chainer/training/extensions/variable_unchain.py
+++ b/chainer/training/extensions/variable_unchain.py
@@ -1,0 +1,32 @@
+from chainer import configuration
+from chainer.training import extension
+from chainer import variable
+import six
+
+
+class unchain_variables(extension.Extension):
+    """Trainer extension to unchain all comptational graphs.
+
+    This extenstion unchain all comptational graphs after all extensions is
+    run to avoid any memory problem.
+    It observes the previous ``chainer.config.keep_graph_on_report`` flag.
+    The extension is enable while the flag is turned on.
+
+    """
+    priority = 0
+
+    def __init__(self):
+        self._prev_flag = None
+
+    def initialize(self, _):
+        self._prev_flag = configuration.config.keep_graph_on_report
+
+    def trigger(self, _):
+        flag = self._prev_flag
+        self._prev_flag = configuration.config.keep_graph_on_report
+        return flag
+
+    def __call__(self, trainer):
+        for var in six.itervalues(trainer.observation):
+            if isinstance(var, variable.Variable):
+                var.unchain_backward()

--- a/chainer/training/extensions/variable_unchain.py
+++ b/chainer/training/extensions/variable_unchain.py
@@ -7,7 +7,7 @@ import six
 class unchain_variables(extension.Extension):
     """Trainer extension to unchain all comptational graphs.
 
-    This extenstion unchain all comptational graphs after all extensions is
+    This extenstion unchains all comptational graphs after all extensions are
     run to avoid any memory problem.
     It observes the previous ``chainer.config.keep_graph_on_report`` flag.
     The extension is enable while the flag is turned on.

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -11,7 +11,6 @@ from chainer import serializer as serializer_module
 from chainer.training import extension as extension_module
 from chainer.training import trigger as trigger_module
 from chainer.utils import argument
-from chainer import variable
 
 
 # Select the best-resolution timer function
@@ -317,9 +316,6 @@ class Trainer(object):
                     for name, entry in extensions:
                         if entry.trigger(self):
                             entry.extension(self)
-                    for var in self.observation.values():
-                        if isinstance(var, variable.Variable):
-                            var.unchain_backward()
         except Exception as e:
             if show_loop_exception_msg:
                 # Show the exception here, as it will appear as if chainer

--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -11,6 +11,7 @@ from chainer import serializer as serializer_module
 from chainer.training import extension as extension_module
 from chainer.training import trigger as trigger_module
 from chainer.utils import argument
+from chainer import variable
 
 
 # Select the best-resolution timer function
@@ -316,6 +317,9 @@ class Trainer(object):
                     for name, entry in extensions:
                         if entry.trigger(self):
                             entry.extension(self)
+                    for var in self.observation.values():
+                        if isinstance(var, variable.Variable):
+                            var.unchain_backward()
         except Exception as e:
             if show_loop_exception_msg:
                 # Show the exception here, as it will appear as if chainer

--- a/docs/source/reference/training.rst
+++ b/docs/source/reference/training.rst
@@ -137,6 +137,17 @@ These extensions provide features to take snapshots of models.
    chainer.training.extensions.snapshot
    chainer.training.extensions.snapshot_object
 
+Memory Release
+~~~~~~~~~~~~~~
+
+These extensions provide features to release memories.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   chainer.training.extensions.unchain_variables
+
 
 .. _triggers:
 

--- a/docs/source/reference/training.rst
+++ b/docs/source/reference/training.rst
@@ -148,7 +148,6 @@ These extensions provide features to release memories.
 
    chainer.training.extensions.unchain_variables
 
-
 .. _triggers:
 
 Triggers


### PR DESCRIPTION
When the `configuration.config.keep_graph_on_report` flag is turned on, the computational graph created by the updater is kept *and seems not to be released* in current implementation.
I added the `unchain_backward()` after all extensions are executed.