### PR TITLE
Fix `D.Uniform.log_prob` to avoid returning -inf at boundary

### DIFF
--- a/chainer/distributions/uniform.py
+++ b/chainer/distributions/uniform.py
@@ -98,7 +98,7 @@ class Uniform(distribution.Distribution):
             -exponential.log(self.scale), x.shape)
         return where.where(
             utils.force_array(
-                (x.data >= self.low.data) & (x.data < self.high.data)),
+                (x.data >= self.low.data) & (x.data <= self.high.data)),
             logp, xp.array(-xp.inf, logp.dtype))
 
     @property


### PR DESCRIPTION
I found `dist.log_prob(dist.sample())` is returning `-inf`.