### PR TITLE
[backport] Fix `D.Uniform.log_prob` to avoid returning -inf at boundary

### DIFF
--- a/chainer/distributions/uniform.py
+++ b/chainer/distributions/uniform.py
@@ -100,8 +100,8 @@ class Uniform(distribution.Distribution):
             -exponential.log(self.scale), x.shape)
         return where.where(
             utils.force_array(
-                (x.data >= self.low.data) & (x.data < self.high.data)),
-            logp, xp.full_like(logp.array, -numpy.inf))
+                (x.data >= self.low.data) & (x.data <= self.high.data)),
+            logp, xp.array(-xp.inf, logp.dtype))
 
     @property
     def mean(self):

--- a/chainer/distributions/uniform.py
+++ b/chainer/distributions/uniform.py
@@ -101,7 +101,7 @@ class Uniform(distribution.Distribution):
         return where.where(
             utils.force_array(
                 (x.data >= self.low.data) & (x.data <= self.high.data)),
-            logp, xp.array(-xp.inf, logp.dtype))
+            logp, xp.full_like(logp.array, -numpy.inf))
 
     @property
     def mean(self):


### PR DESCRIPTION
Backport of #5548