### PR TITLE
[backport] ChainerMN: add an error message when mpi4py is missing

### DIFF
--- a/chainermn/communicators/__init__.py
+++ b/chainermn/communicators/__init__.py
@@ -45,7 +45,14 @@ def create_communicator(
     """
 
     if mpi_comm is None:
-        import mpi4py.MPI
+        try:
+            import mpi4py.MPI
+        except ImportError as e:
+            raise ImportError(str(e) + ": "
+                              "ChainerMN requires mpi4py for "
+                              "distributed training. "
+                              "Please read the Chainer official document "
+                              "and setup MPI and mpi4py.")
         mpi_comm = mpi4py.MPI.COMM_WORLD
 
     if communicator_name != 'pure_nccl' and allreduce_grad_dtype is not None:


### PR DESCRIPTION
Backport of #5559