### PR TITLE
Fix text_classification example fails on Python 3 (#5590)

### DIFF
--- a/examples/text_classification/text_datasets.py
+++ b/examples/text_classification/text_datasets.py
@@ -31,7 +31,7 @@ def read_dbpedia(tf, split, shrink=1, char_based=False):
     dataset = []
     f = tf.extractfile('dbpedia_csv/{}.csv'.format(split))
     if sys.version_info > (3, 0):
-         f = io.TextIOWrapper(f, encoding='utf-8')
+        f = io.TextIOWrapper(f, encoding='utf-8')
     for i, (label, title, text) in enumerate(csv.reader(f)):
         if i % shrink != 0:
             continue

--- a/examples/text_classification/text_datasets.py
+++ b/examples/text_classification/text_datasets.py
@@ -3,6 +3,7 @@ import glob
 import io
 import os
 import shutil
+import sys
 import tarfile
 import tempfile
 
@@ -29,6 +30,8 @@ def download_dbpedia():
 def read_dbpedia(tf, split, shrink=1, char_based=False):
     dataset = []
     f = tf.extractfile('dbpedia_csv/{}.csv'.format(split))
+    if sys.version_info > (3, 0):
+         f = io.TextIOWrapper(f, encoding='utf-8')
     for i, (label, title, text) in enumerate(csv.reader(f)):
         if i % shrink != 0:
             continue


### PR DESCRIPTION
Fix text_classification example fails on Python 3 #5590

I have confirmed that it runs fine on Python 2.7.12, 3.4.3, 3.6.4.