### PR TITLE
[backport] Support all float dtypes in `F.scatter_add` and `F.get_item`

### DIFF
--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -42,20 +42,19 @@ class GetItem(function_node.FunctionNode):
 
     def backward(self, indexes, gy):
         return GetItemGrad(
-            self.slices, self.inputs[0].shape, self.inputs[0].dtype).apply(gy)
+            self.slices, self.inputs[0].shape).apply(gy)
 
 
 class GetItemGrad(function_node.FunctionNode):
 
-    def __init__(self, slices, in_shape, in_dtype):
+    def __init__(self, slices, in_shape):
         self.slices = slices
         self._in_shape = in_shape
-        self._in_dtype = in_dtype
 
     def forward(self, inputs):
         gy, = inputs
         xp = backend.get_array_module(*inputs)
-        gx = xp.zeros(self._in_shape, self._in_dtype)
+        gx = xp.zeros(self._in_shape, gy.dtype)
         if xp is numpy:
             try:
                 numpy.add.at(gx, self.slices, gy)

--- a/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_get_item.py
@@ -8,29 +8,35 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import parameterize
 
 
-@parameterize(
-    {'axes': [1, 2], 'offsets': 0, 'sliced_shape': (4, 2, 1)},
-    {'axes': [1, 2], 'offsets': [0, 1, 1], 'sliced_shape': (4, 2, 1)},
-    {'axes': 1, 'offsets': 1, 'sliced_shape': (4, 2, 2)},
-    {'axes': 1, 'offsets': [0, 1, 1], 'sliced_shape': (4, 2, 2)},
-    {'axes': [], 'offsets': 0, 'new_axes': 0, 'sliced_shape': (1, 4, 3, 2)},
-    {'axes': [], 'offsets': 0, 'new_axes': 2, 'sliced_shape': (4, 3, 1, 2)},
-    {'axes': [], 'offsets': 0, 'new_axes': 3, 'sliced_shape': (4, 3, 2, 1)},
-    {'slices': (1, -1, 0), 'sliced_shape': ()},
-    {'slices': (1, -1), 'sliced_shape': (2,)},
-    {'slices': (1, Ellipsis, -1), 'sliced_shape': (3,)},
-    {'slices': (1, None, Ellipsis, None, -1), 'sliced_shape': (1, 3, 1)},
-)
+@testing.parameterize(*testing.product_dict(
+    [{'dtype': numpy.float16},
+     {'dtype': numpy.float32},
+     {'dtype': numpy.float64},
+     ],
+    [{'axes': [1, 2], 'offsets': 0, 'sliced_shape': (4, 2, 1)},
+     {'axes': [1, 2], 'offsets': [0, 1, 1], 'sliced_shape': (4, 2, 1)},
+     {'axes': 1, 'offsets': 1, 'sliced_shape': (4, 2, 2)},
+     {'axes': 1, 'offsets': [0, 1, 1], 'sliced_shape': (4, 2, 2)},
+     {'axes': [], 'offsets': 0, 'new_axes': 0, 'sliced_shape': (1, 4, 3, 2)},
+     {'axes': [], 'offsets': 0, 'new_axes': 2, 'sliced_shape': (4, 3, 1, 2)},
+     {'axes': [], 'offsets': 0, 'new_axes': 3, 'sliced_shape': (4, 3, 2, 1)},
+     {'slices': (1, -1, 0), 'sliced_shape': ()},
+     {'slices': (1, -1), 'sliced_shape': (2,)},
+     {'slices': (1, Ellipsis, -1), 'sliced_shape': (3,)},
+     {'slices': (1, None, Ellipsis, None, -1), 'sliced_shape': (1, 3, 1)},
+     ]
+))
 class TestGetItem(unittest.TestCase):
 
     def setUp(self):
-        self.x_data = numpy.random.uniform(-1, 1, (4, 3, 2))
+        self.x_data = numpy.random.uniform(-1, 1, (4, 3, 2)).astype(self.dtype)
         self.shape = (4, 2, 1)
-        self.gy_data = numpy.random.uniform(-1, 1, self.sliced_shape)
-        self.ggx_data = numpy.random.uniform(-1, 1, (4, 3, 2))
+        self.gy_data = numpy.random.uniform(
+            -1, 1, self.sliced_shape).astype(self.dtype)
+        self.ggx_data = numpy.random.uniform(
+            -1, 1, (4, 3, 2)).astype(self.dtype)
 
         if not hasattr(self, 'slices'):
             # Convert axes, offsets and shape to slices
@@ -49,10 +55,13 @@ class TestGetItem(unittest.TestCase):
 
             self.slices = tuple(self.slices)
 
+        self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-4}
+        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = functions.get_item(x, self.slices)
-        self.assertEqual(y.data.dtype, numpy.float)
+        self.assertEqual(y.data.dtype, self.dtype)
         numpy.testing.assert_equal(cuda.to_cpu(x_data)[self.slices],
                                    cuda.to_cpu(y.data))
 
@@ -68,7 +77,7 @@ class TestGetItem(unittest.TestCase):
             return functions.get_item(x, self.slices)
 
         gradient_check.check_backward(
-            f, (x_data,), y_grad, dtype='d')
+            f, (x_data,), y_grad, dtype='d', **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x_data, self.gy_data)
@@ -83,7 +92,8 @@ class TestGetItem(unittest.TestCase):
             return functions.get_item(x, self.slices)
 
         gradient_check.check_double_backward(
-            f, (x_data,), y_grad, ggx_data, dtype='d')
+            f, (x_data,), y_grad, ggx_data, dtype='d',
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.x_data, self.gy_data, self.ggx_data)
@@ -95,53 +105,60 @@ class TestGetItem(unittest.TestCase):
                                    cuda.to_gpu(self.ggx_data))
 
 
-@testing.parameterize(
-    {'slices': [], 'sliced_shape': (0, 3, 2)},
-    {'slices': ([],), 'sliced_shape': (0, 3, 2)},
-    {'slices': ([[]],), 'sliced_shape': (1, 0, 3, 2)},
-    {'slices': numpy.array([], dtype=numpy.bool),
-        'sliced_shape': (0, 3, 2)},
-    {'slices': (1, [1]), 'sliced_shape': (1, 2)},
-    {'slices': ([1], slice(1, 2)), 'sliced_shape': (1, 1, 2)},
-    {'slices': [1, 0], 'sliced_shape': (2, 3, 2)},
-    {'slices': ([1, 0],), 'sliced_shape': (2, 3, 2)},
-    {'slices': numpy.array([[1, 0], [2, 3]]),
-        'sliced_shape': (2, 2, 3, 2)},
-    {'slices': ([1, 0], [1, 1]), 'sliced_shape': (2, 2)},
-    {'slices': ([1, 0], slice(None), [[1, 1], [1, 1]]),
-        'sliced_shape': (2, 2, 3)},
-    {'slices': ([1, 0], slice(1, 2), [0, 0]), 'sliced_shape': (2, 1)},
-    {'slices': ([[1, 1], [1, 0]], slice(1, 2), 1),
-        'sliced_shape': (2, 2, 1)},
-    {'slices': numpy.array([True] * 18 + [False] * 6).reshape(4, 3, 2),
-        'sliced_shape': (18,)},
-    {'slices': numpy.array([True, False, False, True]),
-        'sliced_shape': (2, 3, 2)},
-    {'slices': (slice(None), numpy.array([True, False, True])),
-        'sliced_shape': (4, 2, 2)},
-    {'slices': numpy.array([False, False, False, False]),
-        'sliced_shape': (0, 3, 2)},
-    {'slices': (3, 2, Ellipsis, 1),
-        'sliced_shape': ()},
-    {'slices': (numpy.array(False)),
-        'input_shape': (), 'sliced_shape': (0,)},
-    {'slices': (numpy.array(True)),
-        'input_shape': (), 'sliced_shape': (1,)},
-)
+@testing.parameterize(*testing.product_dict(
+    [{'dtype': numpy.float16},
+     {'dtype': numpy.float32},
+     {'dtype': numpy.float64},
+     ],
+    [{'slices': [], 'sliced_shape': (0, 3, 2)},
+     {'slices': ([],), 'sliced_shape': (0, 3, 2)},
+     {'slices': ([[]],), 'sliced_shape': (1, 0, 3, 2)},
+     {'slices': numpy.array([], dtype=numpy.bool),
+         'sliced_shape': (0, 3, 2)},
+     {'slices': (1, [1]), 'sliced_shape': (1, 2)},
+     {'slices': ([1], slice(1, 2)), 'sliced_shape': (1, 1, 2)},
+     {'slices': [1, 0], 'sliced_shape': (2, 3, 2)},
+     {'slices': ([1, 0],), 'sliced_shape': (2, 3, 2)},
+     {'slices': numpy.array([[1, 0], [2, 3]]),
+         'sliced_shape': (2, 2, 3, 2)},
+     {'slices': ([1, 0], [1, 1]), 'sliced_shape': (2, 2)},
+     {'slices': ([1, 0], slice(None), [[1, 1], [1, 1]]),
+         'sliced_shape': (2, 2, 3)},
+     {'slices': ([1, 0], slice(1, 2), [0, 0]), 'sliced_shape': (2, 1)},
+     {'slices': ([[1, 1], [1, 0]], slice(1, 2), 1),
+         'sliced_shape': (2, 2, 1)},
+     {'slices': numpy.array([True] * 18 + [False] * 6).reshape(4, 3, 2),
+         'sliced_shape': (18,)},
+     {'slices': numpy.array([True, False, False, True]),
+         'sliced_shape': (2, 3, 2)},
+     {'slices': (slice(None), numpy.array([True, False, True])),
+         'sliced_shape': (4, 2, 2)},
+     {'slices': numpy.array([False, False, False, False]),
+         'sliced_shape': (0, 3, 2)},
+     {'slices': (3, 2, Ellipsis, 1),
+         'sliced_shape': ()},
+     {'slices': (numpy.array(False)),
+         'input_shape': (), 'sliced_shape': (0,)},
+     {'slices': (numpy.array(True)),
+         'input_shape': (), 'sliced_shape': (1,)},
+     ]
+))
 class TestGetItemAdvanced(unittest.TestCase):
 
     input_shape = (4, 3, 2)
 
     def setUp(self):
         self.x_data = numpy.random.uniform(
-            -1, 1, self.input_shape).astype(numpy.float32)
+            -1, 1, self.input_shape).astype(self.dtype)
         self.gy_data = numpy.random.uniform(
-            -1, 1, self.sliced_shape).astype(numpy.float32)
+            -1, 1, self.sliced_shape).astype(self.dtype)
+
+        self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-4}
 
     def check_forward(self, x_data):
         x = chainer.Variable(x_data)
         y = functions.get_item(x, self.slices)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         numpy.testing.assert_equal(cuda.to_cpu(x_data)[self.slices],
                                    cuda.to_cpu(y.data))
 
@@ -157,7 +174,7 @@ class TestGetItemAdvanced(unittest.TestCase):
             return functions.get_item(x, self.slices)
 
         gradient_check.check_backward(
-            f, (x_data,), y_grad, dtype='d')
+            f, (x_data,), y_grad, dtype='d', **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.x_data, self.gy_data)
@@ -168,7 +185,7 @@ class TestGetItemAdvanced(unittest.TestCase):
                             cuda.to_gpu(self.gy_data))
 
 
-@parameterize(
+@testing.parameterize(
     {'slices': ([1, 0], [1, 1]), 'sliced_shape': (2, 2)},
     {'slices': ([1, 0], slice(None), [[1, 1], [1, 1]]),
      'sliced_shape': (2, 2, 3)},

--- a/tests/chainer_tests/functions_tests/array_tests/test_scatter_add.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_scatter_add.py
@@ -11,37 +11,48 @@ from chainer.testing import attr
 from chainer.utils import type_check
 
 
-@testing.parameterize(
-    {'slices': (0, slice(0, 1), numpy.array(-1)), 'b_data': numpy.array([1])},
-    {'slices': (slice(None), 0, [0, 2]),
-     'b_data': numpy.random.uniform(size=(4, 2))},
-    {'slices': ([1, 0], [0, 0], [2, 0]),
-     'b_data': numpy.random.uniform(size=(2,))},
-    {'slices': 1, 'b_data': numpy.random.uniform(size=(2, 3))},
-    {'slices': numpy.array([False, True, False, True]),
-     'b_data': numpy.random.uniform(size=(2, 2, 3))},
-    {'slices': [], 'b_data': numpy.empty(shape=(0, 2, 3))},
-)
+@testing.parameterize(*testing.product_dict(
+    [{'dtype': numpy.float16},
+     {'dtype': numpy.float32},
+     {'dtype': numpy.float64},
+     ],
+    [{'slices': (0, slice(0, 1), numpy.array(-1)), 'b_data': numpy.array([1])},
+     {'slices': (slice(None), 0, [0, 2]),
+      'b_data': numpy.random.uniform(size=(4, 2))},
+     {'slices': ([1, 0], [0, 0], [2, 0]),
+      'b_data': numpy.random.uniform(size=(2,))},
+     {'slices': 1, 'b_data': numpy.random.uniform(size=(2, 3))},
+     {'slices': numpy.array([False, True, False, True]),
+      'b_data': numpy.random.uniform(size=(2, 2, 3))},
+     {'slices': [], 'b_data': numpy.empty(shape=(0, 2, 3))},
+     ]
+))
 class TestScatterAdd(unittest.TestCase):
 
     def setUp(self):
         self.shape = (4, 2, 3)
         self.a_data = numpy.random.uniform(
-            -1, 1, self.shape).astype(numpy.float32)
+            -1, 1, self.shape).astype(self.dtype)
         self.a_data_original = self.a_data.copy()
         self.gy_data = numpy.random.uniform(
-            -1, 1, self.shape).astype(numpy.float32)
-        self.b_data = self.b_data.astype(numpy.float32)
+            -1, 1, self.shape).astype(self.dtype)
+        self.b_data = self.b_data.astype(self.dtype)
         self.gga_data = numpy.random.uniform(
-            -1, 1, self.a_data.shape).astype(numpy.float32)
+            -1, 1, self.a_data.shape).astype(self.dtype)
         self.ggb_data = numpy.random.uniform(
-            -1, 1, self.b_data.shape).astype(numpy.float32)
+            -1, 1, self.b_data.shape).astype(self.dtype)
+
+        self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-4}
+        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_backward_options['dtype'] = numpy.float64
+            self.check_double_backward_options['dtype'] = numpy.float64
 
     def check_forward(self, a_data, b_data):
         a = chainer.Variable(a_data)
         b = chainer.Variable(b_data)
         y = functions.scatter_add(a, self.slices, b)
-        self.assertEqual(y.data.dtype, numpy.float32)
+        self.assertEqual(y.data.dtype, self.dtype)
         # Test to make sure that the input values are not changed
         numpy.testing.assert_equal(cuda.to_cpu(a.data), self.a_data_original)
 
@@ -61,7 +72,7 @@ class TestScatterAdd(unittest.TestCase):
             return functions.scatter_add(a, self.slices, b)
 
         gradient_check.check_backward(
-            f, (a_data, b_data), y_grad, atol=1e-3, rtol=1e-3)
+            f, (a_data, b_data), y_grad, **self.check_backward_options)
 
     def test_backward_cpu(self):
         self.check_backward(self.a_data, self.b_data, self.gy_data)
@@ -78,7 +89,7 @@ class TestScatterAdd(unittest.TestCase):
 
         gradient_check.check_double_backward(
             f, (a_data, b_data), y_grad, (a_grad_grad, b_grad_grad),
-            atol=1e-3, rtol=1e-3)
+            **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):
         self.check_double_backward(self.a_data, self.b_data, self.gy_data,


### PR DESCRIPTION
Backport of #5335