### PR TITLE
[backport] Fix test warnings in NumPy 1.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,24 +9,25 @@ exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 [tool:pytest]
 filterwarnings= ignore::FutureWarning
                 error::DeprecationWarning
+                error::PendingDeprecationWarning
                 # importing old SciPy is warned because it tries to
                 # import nose via numpy.testing
-                ignore::DeprecationWarning:scipy._lib._numpy_compat
+                ignore::DeprecationWarning:scipy\._lib\._numpy_compat
                 # importing stats from old SciPy is warned because it tries to
                 # import numpy.testing.decorators
-                ignore::DeprecationWarning:scipy.stats.morestats
+                ignore::DeprecationWarning:scipy\.stats\.morestats
                 # Theano 0.8 causes DeprecationWarnings. It is fixed in 0.9.
-                ignore::DeprecationWarning:theano.configparser
+                ignore::DeprecationWarning:theano\.configparser
                 # Theano 1.0.2 passes a deprecated argument to distutils during
                 # importing ``theano.gof`` module.
                 # Without this configuration, the DeprecationWarning would be
                 # treated as an exception, and therefore the import would fail,
                 # causing AttributeError in the subsequent uses of
                 # ``theano.gof``. (#4810)
-                ignore::DeprecationWarning:theano.gof.cmodule
+                ignore::DeprecationWarning:theano\.gof\.cmodule
                 # ``collections.MutableSequence`` in protobuf is warned by
                 # Python 3.7.
-                ignore::DeprecationWarning:google.protobuf.internal.containers
+                ignore::DeprecationWarning:google\.protobuf\.internal\.containers
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import warnings
 
 import numpy
 
@@ -368,7 +369,9 @@ class TestSameTypes(unittest.TestCase):
     def test_all_numpy_subclasses(self):
         x = numpy.array([0])
         y = numpy.array([[1], [2]])
-        z = numpy.matrix("3,4; 5,6")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            z = numpy.matrix("3,4; 5,6")
         self.assertTrue(T.same_types(x, y, z))
 
     @attr.gpu


### PR DESCRIPTION
Backport of #5596