### PR TITLE
Fix `D.OneHotCategorical`

### DIFF
--- a/chainer/distributions/one_hot_categorical.py
+++ b/chainer/distributions/one_hot_categorical.py
@@ -9,6 +9,7 @@ def _stack(xp, xs, axis):
     try:
         return xp.stack(xs, axis)
     except AttributeError:
+        # in case numpy<1.10, which does not have numpy.stack
         return xp.concatenate(
             [xp.expand_dims(x, axis) for x in xs],
             axis=axis)
@@ -18,11 +19,13 @@ def _random_choice(xp, a, size, p):
     try:
         return xp.random.choice(a, size, p=p)
     except ValueError:
-        # Validate the sum as NumPy PR #6131 (numpy>=1.10)
+        # Validate the sum of the probabilities as NumPy PR #6131 (numpy>=1.10)
         tol = xp.finfo(p.dtype).eps ** 0.5
         p = p.astype(xp.float64)
         xp.testing.assert_allclose(p.sum(), 1, rtol=0, atol=tol)
 
+        # Normalize the probabilities as they satisfy the validation above, and
+        # generate samples again
         p /= p.sum()
         return xp.random.choice(a, size, p=p)
 

--- a/chainer/distributions/one_hot_categorical.py
+++ b/chainer/distributions/one_hot_categorical.py
@@ -5,6 +5,26 @@ from chainer.functions.math import exponential
 import chainer.functions.math.sum as sum_mod
 
 
+def _stack(xp, xs, axis):
+    try:
+        return xp.stack(xs, axis)
+    except AttributeError:
+        return xp.concatenate(
+            [xp.expand_dims(x, axis) for x in xs],
+            axis=axis)
+
+
+def _random_choice(xp, a, size, p):
+    try:
+        return xp.random.choice(a, size, p=p)
+    except ValueError:
+        xp.testing.assert_allclose(
+            p.sum(), 1, rtol=0, atol=10 * xp.finfo(p.dtype).eps)
+        p = p.astype(xp.float64)
+        p /= p.sum()
+        return xp.random.choice(a, size, p=p)
+
+
 class OneHotCategorical(distribution.Distribution):
 
     """OneHotCategorical Distribution.
@@ -45,9 +65,9 @@ class OneHotCategorical(distribution.Distribution):
         xp = cuda.get_array_module(self.p)
         obo_p = self.p.data.reshape((-1,) + self.event_shape)
         eye = xp.eye(self.event_shape[0])
-        eps = [xp.random.choice(
-            one_p.shape[0], size=(n,), p=one_p) for one_p in obo_p]
-        eps = xp.stack(eps).T.reshape((n,)+self.batch_shape)
+        eps = [_random_choice(xp, one_p.shape[0], size=(n,), p=one_p)
+               for one_p in obo_p]
+        eps = _stack(xp, eps, axis=1).reshape((n,)+self.batch_shape)
         eps = eye[eps]
         noise = chainer.Variable(eps)
         return noise

--- a/chainer/distributions/one_hot_categorical.py
+++ b/chainer/distributions/one_hot_categorical.py
@@ -19,7 +19,7 @@ def _random_choice(xp, a, size, p):
         return xp.random.choice(a, size, p=p)
     except ValueError:
         # Validate the sum as NumPy PR #6131 (numpy>=1.10)
-        tol = xp.finfo(p.dtype.eps) ** 0.5
+        tol = xp.finfo(p.dtype).eps ** 0.5
         p = p.astype(xp.float64)
         xp.testing.assert_allclose(p.sum(), 1, rtol=0, atol=tol)
 

--- a/chainer/distributions/one_hot_categorical.py
+++ b/chainer/distributions/one_hot_categorical.py
@@ -18,9 +18,9 @@ def _random_choice(xp, a, size, p):
     try:
         return xp.random.choice(a, size, p=p)
     except ValueError:
-        xp.testing.assert_allclose(
-            p.sum(), 1, rtol=0, atol=10 * xp.finfo(p.dtype).eps)
+        tol = 10 * xp.finfo(p.dtype.eps)
         p = p.astype(xp.float64)
+        xp.testing.assert_allclose(p.sum(), 1, rtol=0, atol=tol)
         p /= p.sum()
         return xp.random.choice(a, size, p=p)
 

--- a/chainer/distributions/one_hot_categorical.py
+++ b/chainer/distributions/one_hot_categorical.py
@@ -18,9 +18,11 @@ def _random_choice(xp, a, size, p):
     try:
         return xp.random.choice(a, size, p=p)
     except ValueError:
-        tol = 10 * xp.finfo(p.dtype.eps)
+        # Validate the sum as NumPy PR #6131 (numpy>=1.10)
+        tol = xp.finfo(p.dtype.eps) ** 0.5
         p = p.astype(xp.float64)
         xp.testing.assert_allclose(p.sum(), 1, rtol=0, atol=tol)
+
         p /= p.sum()
         return xp.random.choice(a, size, p=p)
 

--- a/tests/chainer_tests/distributions_tests/test_one_hot_categorical.py
+++ b/tests/chainer_tests/distributions_tests/test_one_hot_categorical.py
@@ -9,6 +9,7 @@ def _numpy_stack(xs, axis):
     try:
         return numpy.stack(xs, axis)
     except AttributeError:
+        # in case numpy<1.10, which does not have numpy.stack
         return numpy.concatenate(
             [numpy.expand_dims(x, axis) for x in xs],
             axis=axis)


### PR DESCRIPTION
- Old versions of NumPy do not have `stack` and `moveaxis`.
- Old versions of NumPy too strictly check `p.sum()`.