### PR TITLE
Overlap compute and transfer more

### DIFF
--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -305,7 +305,7 @@ class Conveyor(object):
 
     """Interface to handle asynchronous data transfer using double buffering.
 
-    An asynchrous data transfer is initiated by :meth:`put`, and the result,
+    An asynchronous data transfer is initiated by :meth:`put`, and the result,
     the array transferred to a target device, is obtained by :meth:`get`.
     You should call :meth:`put` followed by :meth:`get`.
 
@@ -327,7 +327,7 @@ class Conveyor(object):
         self._ret_array = []
 
     def put(self, array):
-        """Initiates asynchrous transfer of an array to a target device.
+        """Initiates asynchronous transfer of an array to a target device.
 
         This method assumes that the input array is a numpy array and
         on host memory without page-locked. So, it first copys the data
@@ -380,11 +380,11 @@ class Conveyor(object):
 
         If sync is ``True``, the data of returned array is available in GPU
         kernels. If sync is ``False``, the data of returned array might be
-        being transfered to GPU, so synchronizeaion must be done carefully by
+        being transferred to GPU, so synchronization must be done carefully by
         the calling function.
 
         Args:
-            sync (bool): If ``True``, global synchronizaton is used to ensure
+            sync (bool): If ``True``, global synchronization is used to ensure
                 completion of asynchronous data transfer for safer reason.
                 If ``False``, it assumes a caller function is handling
                 synchronization correctly hence does not use global

--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -204,12 +204,12 @@ class ConcatWithAsyncTransfer(object):
     Args:
         stream (cupy.cuda.Stream): CUDA stream. If ``None``, a stream is
             automatically created on the first call. Data transfer operation
-            is launched acynchrnously using the stream.
+            is launched asynchronously using the stream.
         compute_stream(cupy.cuda.Stream): CUDA stream used for compute kernels.
             If not ``None``, CUDA events are created/used to avoid global
             synchronization and overlap execution of compute kernels and data
             transfers as much as possible. If ``None``, global synchronization
-            is used instread.
+            is used instead.
     """
 
     def __init__(self, stream=None, compute_stream=None):


### PR DESCRIPTION
This PR aims to overlap GPU kernels and data transfer more.

Current `ConcatWithAsyncTransfer` implementation uses global synchronization to prevent a GPU kernel read arrays that might be still being transferred to GPU. This implementation is safe but it blocks a CPU thread to launch GPU kernels until data transfer to GPU is finished.   With this PR, the global synchronized is removed and CUDA events are used instead to further overlap GPU kernels and data transfers w/o blocking a CPU thread to launch GPU kernels. You should specify CUDA stream used for compute kernels by an argument `compute_stream` like below, or global synchronization is used as before.

    converter = dataset.ConcatWithAsyncTransfer(compute_stream=chainer.backends.cuda.Stream.null)