### PR TITLE
Fix test of `F.rrelu`

### DIFF
--- a/chainer/functions/activation/rrelu.py
+++ b/chainer/functions/activation/rrelu.py
@@ -1,9 +1,10 @@
+import numpy as np
+
 import chainer
 from chainer.backends import cuda
 from chainer import function_node
 from chainer.utils import argument
 from chainer.utils import type_check
-import numpy as np
 
 
 def _kern():
@@ -87,14 +88,14 @@ class _RReLUGrad(function_node.FunctionNode):
 def rrelu(x, l=1. / 8, u=1. / 3, **kwargs):
     """rrelu(x, l=1. / 8, u=1. / 3, *, r=None, return_r=False)
 
-        Randomized Leaky Rectified Liner Unit function.
+    Randomized Leaky Rectified Liner Unit function.
 
     This function is expressed as
 
     .. math:: f(x)=\\max(x, ax),
 
-    where :math:`a` is a random number sampled \
-                from a uniform distribution :math:`U(l, u)`.
+    where :math:`a` is a random number sampled from a uniform distribution
+    :math:`U(l, u)`.
 
     See: https://arxiv.org/pdf/1505.00853.pdf
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -106,7 +106,7 @@ class TestRReLUR(unittest.TestCase):
         if r is None:
             assert out_r.shape == out.array.shape
         else:
-            if chainer.config.train:
+            if self.train:
                 assert out_r is r
 
     def test_cpu(self):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -56,8 +56,8 @@ class TestRReLU(unittest.TestCase):
 
     def check_backward(self, x_data, y_grad):
         xp = backend.get_array_module(x_data)
-        r = xp.random.uniform(self.l, self.u, x_data[
-                              0].shape).astype(x_data[0].dtype)
+        r = xp.random.uniform(self.l, self.u, x_data.shape).astype(
+            x_data.dtype)
 
         def f(x):
             return functions.rrelu(x, self.l, self.u, r=r)
@@ -93,8 +93,8 @@ class TestRReLUR(unittest.TestCase):
         self.u = numpy.random.uniform(0, 1)
         if self.l >= self.u:
             self.l, self.u = self.u, self.l
-        self.r = (numpy.random.uniform(
-            self.l, self.u, self.x[0].shape)).astype(self.x[0].dtype)
+        self.r = numpy.random.uniform(
+            self.l, self.u, self.x.shape).astype(self.x.dtype)
 
     def _check(self):
         r = self.r if self.specify_r else None

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -9,7 +9,6 @@ from chainer import functions
 from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
@@ -45,12 +44,10 @@ class TestRReLU(unittest.TestCase):
         testing.assert_allclose(
             expected, y.data, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.check_forward(cuda.to_gpu(self.x))
 
@@ -67,12 +64,10 @@ class TestRReLU(unittest.TestCase):
                 f, x_data, y_grad, dtype=numpy.float64,
                 **self.check_backward_options)
 
-    @condition.retry(10)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(10)
     def test_backward_gpu(self):
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -20,11 +20,11 @@ from chainer.testing import condition
 class TestRReLU(unittest.TestCase):
 
     def setUp(self):
-        # Avoid unstability of numeraical grad
+        # Avoid unstability of numerical grad
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.x[(-0.05 < self.x) & (self.x < 0.05)] = 0.5
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        # Asummption l < u
+        # Assumption l < u
         self.l = numpy.random.uniform(0, 1)
         self.u = numpy.random.uniform(0, 1)
         if self.l >= self.u:
@@ -88,7 +88,7 @@ class TestRReLUR(unittest.TestCase):
     def setUp(self):
         self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.x[(-0.05 < self.x) & (self.x < 0.05)] = 0.5
-        # Asummption l < u
+        # Assumption l < u
         self.l = numpy.random.uniform(0, 1)
         self.u = numpy.random.uniform(0, 1)
         if self.l >= self.u:
@@ -98,7 +98,7 @@ class TestRReLUR(unittest.TestCase):
 
     def _check(self):
         r = self.r if self.specify_r else None
-        with chainer.using_config('tarin', self.train):
+        with chainer.using_config('train', self.train):
             out, out_r = functions.rrelu(
                 self.x, self.l, self.u, r=r, return_r=True)
 


### PR DESCRIPTION
- Fix typos, including `'train'` config.
- The shape of `r` should be the same as the shape of `x`.
- Remove `retry` from tests.  I confirmed that the cpu tests pass with `repeat(10000)`.