### PR TITLE
improve cuDNN call performance by caching ndarray.ctypes objects

### DIFF
--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -16,6 +16,8 @@ if cuda.cudnn_enabled:
 
 
 _singleton_ndarray_ctypes_cache = {}
+
+
 def _singleton_ndarray_ctypes(v, dtype):
     if (v, dtype) in _singleton_ndarray_ctypes_cache:
         obj = _singleton_ndarray_ctypes_cache[(v, dtype)]

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -20,6 +20,8 @@ if cuda.cudnn_enabled:
 
 
 _singleton_ndarray_ctypes_cache = {}
+
+
 def _singleton_ndarray_ctypes(v, dtype):
     if (v, dtype) in _singleton_ndarray_ctypes_cache:
         obj = _singleton_ndarray_ctypes_cache[(v, dtype)]

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -21,6 +21,8 @@ if cuda.cudnn_enabled:
 
 
 _singleton_ndarray_ctypes_cache = {}
+
+
 def _singleton_ndarray_ctypes(v, dtype):
     if (v, dtype) in _singleton_ndarray_ctypes_cache:
         obj = _singleton_ndarray_ctypes_cache[(v, dtype)]

--- a/chainer/functions/pooling/pooling_2d.py
+++ b/chainer/functions/pooling/pooling_2d.py
@@ -13,6 +13,8 @@ if cuda.cudnn_enabled:
 
 
 _singleton_ndarray_ctypes_cache = {}
+
+
 def _singleton_ndarray_ctypes(v, dtype):
     if (v, dtype) in _singleton_ndarray_ctypes_cache:
         obj = _singleton_ndarray_ctypes_cache[(v, dtype)]

--- a/chainer/functions/pooling/pooling_nd.py
+++ b/chainer/functions/pooling/pooling_nd.py
@@ -14,6 +14,8 @@ if cuda.cudnn_enabled:
 
 
 _singleton_ndarray_ctypes_cache = {}
+
+
 def _singleton_ndarray_ctypes(v, dtype):
     if (v, dtype) in _singleton_ndarray_ctypes_cache:
         obj = _singleton_ndarray_ctypes_cache[(v, dtype)]


### PR DESCRIPTION
Retrieving `numpy.ndarray.ctypes` is slow because it imports `numpy.core._internal` module. I checked the behavior with numpy 1.14.5. 

Batchnorm and pooling routines uses the property for passing constants 0 and 1 to cuDNN. If CPU is bottleneck, this slows down training.

You can check the behavior by `cProfile` module and/or the following code that hooks imports.

```python
import builtins
ip_old = builtins.__import__
npi_count = 0
def ip(name, globals=None, locals=None, fromlist=(), level=0):
    global mp_count
    print(name)
    if name == 'numpy.core._internal':
        npi_count +=1
        if npi_count == 1000:
            raise
    return ip_old(name, globals, locals, fromlist, level)
builtins.__import__ = ip
```

I performed a benchmark for `chainer/examples/cifar` by the command below. The sample code is modified to disable snapshots.

```sh
python train_cifar.py --epoch 2 --batchsize 32
```

The results with i5-3550 CPU and GTX 1080 Ti GPU are as follows. If you have faster CPU or slower GPU, you may have to clock-down the CPU or decrease the number of filters. Though the difference is small, results have been consistent on several runs. I also confirmed ~5-10% speed-up on a real-world task.

Before:

```
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           2.44298     2.2634                0.112944       0.138578                  60.286
2           1.90411     1.77155               0.239937       0.295028                  118.455
```

After:

```
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           2.24371     1.88177               0.178003       0.242013                  59.4717
2           1.74626     1.54112               0.310559       0.3751                    116.899
```