### PR TITLE
Import testing/backend.py definitions in testing/__init__.py

### DIFF
--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -1,4 +1,6 @@
 from chainer.testing.array import assert_allclose  # NOQA
+from chainer.testing.backend import BackendConfig  # NOQA
+from chainer.testing.backend import inject_backend_tests  # NOQA
 from chainer.testing.distribution_test import distribution_unittest  # NOQA
 from chainer.testing.helper import assert_warns  # NOQA
 from chainer.testing.helper import patch  # NOQA


### PR DESCRIPTION
Fixes #5632 .

Tests using for instance `inject_backend_tests` may be updated but I chose not to widen the scope of this PR.