### PR TITLE
support spatial_scale >= 1.0 in roi_average_align_2d.py

### DIFF
--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -222,6 +222,7 @@ class ROIAverageAlign2D(function.Function):
                     y_low, x_low, y_high, x_high, w1, w2, w3, w4 = \
                         _get_bilinear_interp_params(y, x, height, width)
                     if y_low is None:
+                        ix += 1
                         continue
 
                     v1 = bottom_data[roi_batch_ind, c, y_low, x_low]
@@ -404,6 +405,7 @@ class ROIAverageAlign2D(function.Function):
                     y_low, x_low, y_high, x_high, w1, w2, w3, w4 = \
                         _get_bilinear_interp_params(y, x, height, width)
                     if y_low is None:
+                        ix += 1
                         continue
 
                     g1 = top_diff_this_bin * w1 / count

--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -208,10 +208,10 @@ class ROIAverageAlign2D(function.Function):
             count = roi_bin_grid_h * roi_bin_grid_w
 
             output_val = 0.
-            for iy in range(roi_bin_grid_h):
+            for iy in six.moves.range(roi_bin_grid_h):
                 y = roi_start_h + ph * bin_size_h + \
                     (iy + .5) * bin_size_h / roi_bin_grid_h
-                for ix in range(roi_bin_grid_w):
+                for ix in six.moves.range(roi_bin_grid_w):
                     x = roi_start_w + pw * bin_size_w + \
                         (ix + .5) * bin_size_w / roi_bin_grid_w
 
@@ -385,10 +385,10 @@ class ROIAverageAlign2D(function.Function):
 
             count = roi_bin_grid_h * roi_bin_grid_w
 
-            for iy in range(roi_bin_grid_h):
+            for iy in six.moves.range(roi_bin_grid_h):
                 y = roi_start_h + ph * bin_size_h + \
                     (iy + .5) * bin_size_h / roi_bin_grid_h
-                for ix in range(roi_bin_grid_w):
+                for ix in six.moves.range(roi_bin_grid_w):
                     x = roi_start_w + pw * bin_size_w + \
                         (ix + .5) * bin_size_w / roi_bin_grid_w
 

--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -30,19 +30,19 @@ def _pair(x):
     return x, x
 
 
-def _get_bounds(i, limit):
-    if i < -1 or i > limit:
+def _get_bounds(p, limit):
+    if p < -1 or p > limit:
         # out of range, so it is empty
         return None, None, None
-    if i <= 0:
-        i = 0
-    i_low = int(numpy.floor(i))
-    if i_low >= limit - 1:
-        i_high = i_low = limit - 1
-        i = float(i_low)
+    if p <= 0:
+        p = 0
+    low = int(numpy.floor(p))
+    if low >= limit - 1:
+        high = low = limit - 1
+        p = float(low)
     else:
-        i_high = i_low + 1
-    return i, i_low, i_high
+        high = low + 1
+    return p, low, high
 
 
 def _get_bilinear_interp_params(y, x, y_low, x_low, y_high, x_high):
@@ -60,20 +60,20 @@ def _get_bilinear_interp_params(y, x, y_low, x_low, y_high, x_high):
 _GET_BILINEAR_INTERP_KERNEL = '''
 __device__
 bool get_bounds(
-    T &i, const int limit, int &i_low, int &i_high) {
-    if (i < -1. || i > limit) {
+    T &p, const int limit, int &low, int &high) {
+    if (p < -1. || p > limit) {
         // empty
         return false;
     }
-    if (i <= 0) {
-        i = 0;
+    if (p <= 0) {
+        p = 0;
     }
-    i_low = (int)i;
-    if (i_low >= limit - 1) {
-        i_high = i_low = limit - 1;
-        i = (T)i_low;
+    low = (int)p;
+    if (low >= limit - 1) {
+        high = low = limit - 1;
+        p = (T)low;
     } else {
-        i_high = i_low + 1;
+        high = low + 1;
     }
     return true;
 }

--- a/chainer/functions/pooling/roi_average_align_2d.py
+++ b/chainer/functions/pooling/roi_average_align_2d.py
@@ -197,23 +197,21 @@ class ROIAverageAlign2D(function.Function):
             bin_size_w = roi_width / pooled_width
 
             if self.sampling_ratio[0] is None:
-                roi_bin_grid_h = numpy.ceil(roi_height / pooled_height)
+                roi_bin_grid_h = int(numpy.ceil(roi_height / pooled_height))
             else:
                 roi_bin_grid_h = self.sampling_ratio[0]
             if self.sampling_ratio[1] is None:
-                roi_bin_grid_w = numpy.ceil(roi_width / pooled_width)
+                roi_bin_grid_w = int(numpy.ceil(roi_width / pooled_width))
             else:
                 roi_bin_grid_w = self.sampling_ratio[1]
 
             count = roi_bin_grid_h * roi_bin_grid_w
 
             output_val = 0.
-            iy = 0
-            while iy < roi_bin_grid_h:
+            for iy in range(roi_bin_grid_h):
                 y = roi_start_h + ph * bin_size_h + \
                     (iy + .5) * bin_size_h / roi_bin_grid_h
-                ix = 0
-                while ix < roi_bin_grid_w:
+                for ix in range(roi_bin_grid_w):
                     x = roi_start_w + pw * bin_size_w + \
                         (ix + .5) * bin_size_w / roi_bin_grid_w
 
@@ -222,7 +220,6 @@ class ROIAverageAlign2D(function.Function):
                     y_low, x_low, y_high, x_high, w1, w2, w3, w4 = \
                         _get_bilinear_interp_params(y, x, height, width)
                     if y_low is None:
-                        ix += 1
                         continue
 
                     v1 = bottom_data[roi_batch_ind, c, y_low, x_low]
@@ -233,9 +230,6 @@ class ROIAverageAlign2D(function.Function):
                     output_val += w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4
 
                     # }}
-
-                    ix += 1
-                iy += 1
 
             output_val /= count
             top_data[n, c, ph, pw] = output_val
@@ -381,22 +375,20 @@ class ROIAverageAlign2D(function.Function):
             top_diff_this_bin = top_diff[n, c, ph, pw]
 
             if self.sampling_ratio[0] is None:
-                roi_bin_grid_h = numpy.ceil(roi_height / pooled_height)
+                roi_bin_grid_h = int(numpy.ceil(roi_height / pooled_height))
             else:
                 roi_bin_grid_h = self.sampling_ratio[0]
             if self.sampling_ratio[1] is None:
-                roi_bin_grid_w = numpy.ceil(roi_width / pooled_width)
+                roi_bin_grid_w = int(numpy.ceil(roi_width / pooled_width))
             else:
                 roi_bin_grid_w = self.sampling_ratio[1]
 
             count = roi_bin_grid_h * roi_bin_grid_w
 
-            iy = 0
-            while iy < roi_bin_grid_h:
+            for iy in range(roi_bin_grid_h):
                 y = roi_start_h + ph * bin_size_h + \
                     (iy + .5) * bin_size_h / roi_bin_grid_h
-                ix = 0
-                while ix < roi_bin_grid_w:
+                for ix in range(roi_bin_grid_w):
                     x = roi_start_w + pw * bin_size_w + \
                         (ix + .5) * bin_size_w / roi_bin_grid_w
 
@@ -405,7 +397,6 @@ class ROIAverageAlign2D(function.Function):
                     y_low, x_low, y_high, x_high, w1, w2, w3, w4 = \
                         _get_bilinear_interp_params(y, x, height, width)
                     if y_low is None:
-                        ix += 1
                         continue
 
                     g1 = top_diff_this_bin * w1 / count
@@ -421,9 +412,6 @@ class ROIAverageAlign2D(function.Function):
                         bottom_diff[roi_batch_ind, c, y_high, x_high] += g4
 
                     # }}
-
-                    ix += 1
-                iy += 1
 
         return bottom_diff, None, None
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_average_align_2d.py
@@ -20,6 +20,7 @@ def _pair(x):
 @testing.parameterize(*testing.product({
     'sampling_ratio': [None, 1, 2, (None, 3), (1, 2)],
     'outsize': [5, 7, (5, 7)],
+    'spatial_scale': [0.6, 1.0, 2.0],
 }))
 class TestROIAlign2D(unittest.TestCase):
 
@@ -40,7 +41,6 @@ class TestROIAlign2D(unittest.TestCase):
         ], dtype=numpy.float32)
         self.roi_indices = numpy.array([0, 2, 1, 0, 2], dtype=numpy.int32)
         n_rois = self.rois.shape[0]
-        self.spatial_scale = 0.6
         outsize = _pair(self.outsize)
         self.gy = numpy.random.uniform(
             -1, 1, (n_rois, n_channels,


### PR DESCRIPTION
currently, when `spatial_scale > 1.0` is given, the function hangs.