### PR TITLE
Dtype blackout

### DIFF
--- a/chainer/functions/connection/embed_id.py
+++ b/chainer/functions/connection/embed_id.py
@@ -21,7 +21,7 @@ class EmbedIDFunction(function_node.FunctionNode):
             x_type.ndim >= 1,
         )
         type_check.expect(
-            w_type.dtype == numpy.float32,
+            w_type.dtype.kind == 'f',
             w_type.ndim == 2
         )
 
@@ -111,7 +111,7 @@ class EmbedIDGrad(function_node.FunctionNode):
 
         if self.ignore_label is not None:
             mask, zero, _ = xp.broadcast_arrays(
-                mask[..., None], xp.zeros((), 'f'), ggy.data)
+                mask[..., None], xp.zeros((), ggy.dtype), ggy.data)
             ggy = chainer.functions.where(mask, zero, ggy)
         return None, ggy
 
@@ -122,7 +122,7 @@ def embed_id(x, W, ignore_label=None):
     This function implements so called *word embeddings*. It takes two
     arguments: a set of IDs (words) ``x`` in :math:`B` dimensional integer
     vector, and a set of all ID (word) embeddings ``W`` in :math:`V \\times d`
-    float32 matrix. It outputs :math:`B \\times d` matrix whose ``i``-th
+    float matrix. It outputs :math:`B \\times d` matrix whose ``i``-th
     column is the ``x[i]``-th column of ``W``.
 
     This function is only differentiable on the input ``W``.

--- a/tests/chainer_tests/links_tests/loss_tests/test_black_out.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_black_out.py
@@ -7,9 +7,11 @@ from chainer.backends import cuda
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+}))
 class TestBlackOut(unittest.TestCase):
 
     batch_size = 5
@@ -18,15 +20,25 @@ class TestBlackOut(unittest.TestCase):
     n_samples = 7
 
     def setUp(self):
+        self._config_user = chainer.using_config('dtype', self.dtype)
+        self._config_user.__enter__()
+
         x_shape = (self.batch_size, self.in_size)
-        self.x = numpy.random.uniform(
-            -1, 1, x_shape).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
         self.t = numpy.random.randint(
             len(self.count), size=self.batch_size).astype(numpy.int32)
 
         self.link = links.BlackOut(self.in_size, self.count, self.n_samples)
         self.w = numpy.random.uniform(-1, 1, self.link.W.data.shape)
         self.link.W.data[:] = self.w
+
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-3}
+        else:
+            self.check_forward_options = {'atol': 1e-4}
+
+    def tearDown(self):
+        self._config_user.__exit__(None, None, None)
 
     def check_forward(self, x_data, t_data):
         x = chainer.Variable(x_data)
@@ -36,7 +48,7 @@ class TestBlackOut(unittest.TestCase):
             (self.batch_size, self.n_samples))
         y = self.link(x, t)
 
-        expect_y = numpy.empty((self.batch_size), dtype=numpy.float32)
+        expect_y = numpy.empty((self.batch_size), dtype=self.dtype)
         samples = cuda.to_cpu(self.link.sample_data)
         for b in range(self.batch_size):
             z = 0
@@ -53,14 +65,12 @@ class TestBlackOut(unittest.TestCase):
             expect_y[b] = l
 
         loss = -numpy.sum(expect_y) / self.batch_size
-        testing.assert_allclose(y.data, loss, atol=1.e-4)
+        testing.assert_allclose(y.data, loss, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x, self.t)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.link.to_gpu()
         self.check_forward(cuda.to_gpu(self.x), cuda.to_gpu(self.t))


### PR DESCRIPTION
Merge #5624 first.

`L.BlackOut` will work with the default dtype as it is after `F.embed_id`, on which `L.BlackOut` depends, will support all float dtypes in #5624.

This PR just adds tests for the default dtype in `L.BlackOut`.
