### PR TITLE
Update style check tools to the versions compatible with pycodestyle 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,7 @@ install:
 
 script:
   - flake8
-  - autopep8 -r . --diff | tee check_autopep8
-  - test ! -s check_autopep8
+  - autopep8 -r . --diff --exit-code
   # To workaround Travis issue (https://github.com/travis-ci/travis-ci/issues/7261),
   # ignore DeprecationWarning raised in `site.py`.
   - python -Werror::DeprecationWarning -Wignore::DeprecationWarning:site -m compileall -f -q chainer chainermn examples tests docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 # TODO(niboshi): Fix violating code and remove E241 and E226
-ignore = E741,W503,E241,E226
+ignore = E741,W503,W504,E241,E226
 
 [pep8]
 exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ requirements = {
         'six>=1.9.0',
     ],
     'stylecheck': [
-        'autopep8==1.3.5',
-        'flake8==3.5.0',
+        'autopep8>=1.4,<1.5',
+        'flake8>=3.6,<3.7',
         'pbr==4.0.4',
-        'pycodestyle==2.3.1',
+        'pycodestyle>=2.4,<2.5',
     ],
     'test': [
         'pytest',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements = {
         'six>=1.9.0',
     ],
     'stylecheck': [
-        'autopep8>=1.4,<1.5',
+        'autopep8>=1.4.1,<1.5',
         'flake8>=3.6,<3.7',
         'pbr==4.0.4',
         'pycodestyle>=2.4,<2.5',


### PR DESCRIPTION
The newest flake8 (3.6.0) requires pycodestyle 2.4, which has the `W504` check.
It seems `W504` needs to be added to `ignore` in `setup.py`, while the check is disabled by default. 