### PR TITLE
Support all float dtypes in `F.connectionist_temporal_classification`

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -16,7 +16,7 @@ from chainer.testing import condition
 class CTCTestBase(object):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (4, 2, 3)).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, (4, 2, 3)).astype(self.dtype)
         self.t = numpy.array([[0, 1], [1, 0]]).astype(numpy.int32)
         self.l = numpy.array([[2, 0, 2, 1, 2],
                               [2, 1, 2, 0, 2]]).astype(numpy.int32)
@@ -25,9 +25,17 @@ class CTCTestBase(object):
         self.l_length = numpy.full((len(self.t),), len(self.t[0]), dtype='i')
         self.use_length = True
         if self.reduce == 'mean':
-            self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)
+            self.gy = numpy.random.uniform(-1, 1, ()).astype(self.dtype)
         else:
-            self.gy = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
+            self.gy = numpy.random.uniform(-1, 1, (2,)).astype(self.dtype)
+
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-3}
+            self.check_backward_options = {
+                'atol': 1e-3, 'dtype': numpy.float64}
+        else:
+            self.check_forward_options = {}
+            self.check_backward_options = {'atol': 1e-4}
 
     # recursive forward computation.
     def alpha(self, x, l, t, u):
@@ -77,7 +85,7 @@ class CTCTestBase(object):
                 xt[b][t] = numpy.exp(xt[b][t]) / numpy.sum(numpy.exp(xt[b][t]))
         batch_size = xt.shape[0]
         path_length = 2 * l_length + 1
-        loss_expect = xp.zeros((batch_size,), dtype=xp.float32)
+        loss_expect = xp.zeros((batch_size,), dtype=self.dtype)
         for i in range(batch_size):
             xtb, lb, xlb, plb = xt[i], self.l[i], x_length[i], path_length[i]
             loss_expect[i] = -math.log(
@@ -85,7 +93,8 @@ class CTCTestBase(object):
                 self.alpha(xtb, lb, int(xlb - 1), int(plb - 2)))
         if self.reduce == 'mean':
             loss_expect = xp.mean(loss_expect)
-        testing.assert_allclose(loss_expect, loss)
+        testing.assert_allclose(
+            loss_expect, loss, **self.check_forward_options)
 
     def test_forward_cpu(self):
         self.check_forward(self.t, tuple(self.x),
@@ -119,7 +128,7 @@ class CTCTestBase(object):
 
         gradient_check.check_backward(
             f, (x_length, l_length, t_data) + xs_data, gy_data,
-            eps=1e-2, atol=1e-4)
+            eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -137,20 +146,20 @@ class CTCTestBase(object):
                             cuda.to_gpu(self.gy))
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTC(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
         CTCTestBase.setUp(self)
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithoutLength(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -158,10 +167,10 @@ class TestCTCWithoutLength(unittest.TestCase, CTCTestBase):
         self.use_length = False
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithLabelPadding(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -169,10 +178,10 @@ class TestCTCWithLabelPadding(unittest.TestCase, CTCTestBase):
         self.l_length[0] = 1
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithInputPadding(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -180,10 +189,10 @@ class TestCTCWithInputPadding(unittest.TestCase, CTCTestBase):
         self.x_length[0] = 3
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithAllPadding(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -192,10 +201,10 @@ class TestCTCWithAllPadding(unittest.TestCase, CTCTestBase):
         self.l_length[...] = 1
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithRepeatedLabel(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -206,10 +215,10 @@ class TestCTCWithRepeatedLabel(unittest.TestCase, CTCTestBase):
         self.l_length = numpy.full((len(self.t),), len(self.t[0]), dtype='i')
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCBlankSymbol(unittest.TestCase, CTCTestBase):
 
     def setUp(self):


### PR DESCRIPTION
This PR follows #4582, generalize `F.connectionist_temporal_classification` to support all float dtypes.