### PR TITLE
Add optional property `finished` to trigger object

### DIFF
--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -300,7 +300,8 @@ class Trainer(object):
         # invoke initializer of each extension
         for _, entry in extensions:
             initializer = getattr(entry.extension, 'initialize', None)
-            if initializer:
+            finished = getattr(entry.trigger, 'finished', False)
+            if initializer and not finished:
                 initializer(self)
 
         update = self.updater.update

--- a/chainer/training/triggers/manual_schedule_trigger.py
+++ b/chainer/training/triggers/manual_schedule_trigger.py
@@ -19,9 +19,9 @@ class ManualScheduleTrigger(object):
             either ``'iteration'`` or ``'epoch'``.
 
     Attributes:
-        finished (bool): Flag that triggered when this trigger will never
-            called again. The flag helps decision to call
-            `Extension.initialize` or not in `trainer`.
+        finished (bool): Flag that indicates whether or not this trigger will
+        fire in the future. This flag is used to determine if the extension
+        should be initialized after resume.
 
     """
 

--- a/chainer/training/triggers/manual_schedule_trigger.py
+++ b/chainer/training/triggers/manual_schedule_trigger.py
@@ -61,8 +61,11 @@ class ManualScheduleTrigger(object):
                 previous_epoch_detail < p <= epoch_detail
                 for p in self.points)
 
-            if (fire or hasattr(self, '_finished_is_tmp')) and \
-               epoch_detail >= max(self.points):
+            if hasattr(self, '_finished_is_tmp'):
+                del self._finished_is_tmp
+                if epoch_detail >= max(self.points):
+                    self.finished = True
+            if fire and epoch_detail >= max(self.points):
                 self.finished = True
         else:
             iteration = updater.iteration
@@ -77,8 +80,11 @@ class ManualScheduleTrigger(object):
                 previous_iteration < p <= iteration
                 for p in self.points)
 
-            if (fire or hasattr(self, '_finished_is_tmp')) and \
-               iteration >= max(self.points):
+            if hasattr(self, '_finished_is_tmp'):
+                del self._finished_is_tmp
+                if iteration >= max(self.points):
+                    self.finished = True
+            if fire and iteration >= max(self.points):
                 self.finished = True
 
         # save current values

--- a/chainer/training/triggers/manual_schedule_trigger.py
+++ b/chainer/training/triggers/manual_schedule_trigger.py
@@ -87,6 +87,7 @@ class ManualScheduleTrigger(object):
         return fire
 
     def serialize(self, serializer):
+        self.finished = serializer('finished', self.finished)
         try:
             self._previous_iteration = serializer(
                 'previous_iteration', self._previous_iteration)

--- a/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import numpy as np
 import random
+import six
 import tempfile
 import unittest
 
@@ -11,48 +12,61 @@ from chainer.testing import condition
 from chainer import training
 
 
+def expected_finished(pos, num):
+    return [i >= pos for i in six.moves.range(num)]
+
+
 @testing.parameterize(
     # single iteration
     {
         'iter_per_epoch': 2, 'schedule': (2, 'iteration'), 'resume': 3,
         'expected': [False, True, False, False, False, False, False],
-        'finished': [False, True, True, True, True, True, True]},
+        'finished': expected_finished(1, 7)},
     # multiple iteration
     {
         'iter_per_epoch': 2, 'schedule': ([2, 4], 'iteration'), 'resume': 3,
-        'expected': [False, True, False, True, False, False, False]},
+        'expected': [False, True, False, True, False, False, False],
+        'finished': expected_finished(3, 7)},
     # single epoch
     {
         'iter_per_epoch': 3, 'schedule': (1, 'epoch'), 'resume': 3,
-        'expected': [False, False, True, False, False, False, False]},
+        'expected': [False, False, True, False, False, False, False],
+        'finished': expected_finished(2, 7)},
     # multiple epoch
     {
         'iter_per_epoch': 3, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
-        'expected': [False, False, True, False, False, True, False]},
+        'expected': [False, False, True, False, False, True, False],
+        'finished': expected_finished(5, 7)},
     # single fractional epoch
     {
         'iter_per_epoch': 2, 'schedule': (1.5, 'epoch'), 'resume': 4,
-        'expected': [False, False, True, False, False, False, False]},
+        'expected': [False, False, True, False, False, False, False],
+        'finished': expected_finished(2, 7)},
     # multiple fractional epoch
     {
         'iter_per_epoch': 2, 'schedule': ([1.5, 2.5], 'epoch'), 'resume': 4,
-        'expected': [False, False, True, False, True, False, False]},
+        'expected': [False, False, True, False, True, False, False],
+        'finished': expected_finished(4, 7)},
     # single unaligned epoch
     {
         'iter_per_epoch': 2.5, 'schedule': (1, 'epoch'), 'resume': 4,
-        'expected': [False, False, True, False, False, False, False]},
+        'expected': [False, False, True, False, False, False, False],
+        'finished': expected_finished(2, 7)},
     # multiple unaligned epoch
     {
         'iter_per_epoch': 2.5, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
-        'expected': [False, False, True, False, True, False, False]},
+        'expected': [False, False, True, False, True, False, False],
+        'finished': expected_finished(4, 7)},
     # single tiny epoch
     {
         'iter_per_epoch': 0.5, 'schedule': (1, 'epoch'), 'resume': 4,
-        'expected': [True, False, False, False, False, False, False]},
+        'expected': [True, False, False, False, False, False, False],
+        'finished': expected_finished(0, 7)},
     # multiple tiny epoch
     {
         'iter_per_epoch': 0.5, 'schedule': ([1, 2], 'epoch'), 'resume': 4,
-        'expected': [True, False, False, False, False, False, False]},
+        'expected': [True, False, False, False, False, False, False],
+        'finished': expected_finished(0, 7)},
 )
 class TestTrigger(unittest.TestCase):
 
@@ -70,16 +84,20 @@ class TestTrigger(unittest.TestCase):
             stop_trigger=None, iter_per_epoch=self.iter_per_epoch)
         with tempfile.NamedTemporaryFile(delete=False) as f:
             trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
-            for expected in self.expected[:self.resume]:
+            for expected, finished in zip(self.expected[:self.resume],
+                                          self.finished[:self.resume]):
                 trainer.updater.update()
                 self.assertEqual(trigger(trainer), expected)
+                self.assertEqual(trigger.finished, finished)
             serializers.save_npz(f.name, trigger)
 
             trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
             serializers.load_npz(f.name, trigger)
-            for expected in self.expected[self.resume:]:
+            for expected, finished in zip(self.expected[self.resume:],
+                                          self.finished[self.resume:]):
                 trainer.updater.update()
                 self.assertEqual(trigger(trainer), expected)
+                self.assertEqual(trigger.finished, finished)
 
     @condition.repeat(10)
     def test_trigger_sparse_call(self):
@@ -87,11 +105,12 @@ class TestTrigger(unittest.TestCase):
             stop_trigger=None, iter_per_epoch=self.iter_per_epoch)
         trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
         accumulated = False
-        for expected in self.expected:
+        for expected, finished in zip(self.expected, self.finished):
             trainer.updater.update()
             accumulated = accumulated or expected
             if random.randrange(2):
                 self.assertEqual(trigger(trainer), accumulated)
+                self.assertEqual(trigger.finished, finished)
                 accumulated = False
 
     @condition.repeat(10)
@@ -101,21 +120,25 @@ class TestTrigger(unittest.TestCase):
         accumulated = False
         with tempfile.NamedTemporaryFile(delete=False) as f:
             trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
-            for expected in self.expected[:self.resume]:
+            for expected, finished in zip(self.expected[:self.resume],
+                                          self.finished[:self.resume]):
                 trainer.updater.update()
                 accumulated = accumulated or expected
                 if random.randrange(2):
                     self.assertEqual(trigger(trainer), accumulated)
+                    self.assertEqual(trigger.finished, finished)
                     accumulated = False
             serializers.save_npz(f.name, trigger)
 
             trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
             serializers.load_npz(f.name, trigger)
-            for expected in self.expected[self.resume:]:
+            for expected, finished in zip(self.expected[self.resume:],
+                                          self.finished[self.resume:]):
                 trainer.updater.update()
                 accumulated = accumulated or expected
                 if random.randrange(2):
                     self.assertEqual(trigger(trainer), accumulated)
+                    self.assertEqual(trigger.finished, finished)
                     accumulated = False
 
     def test_resumed_trigger_backward_compat(self):
@@ -123,18 +146,22 @@ class TestTrigger(unittest.TestCase):
             stop_trigger=None, iter_per_epoch=self.iter_per_epoch)
         with tempfile.NamedTemporaryFile(delete=False) as f:
             trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
-            for expected in self.expected[:self.resume]:
+            for expected, finished in zip(self.expected[:self.resume],
+                                          self.finished[:self.resume]):
                 trainer.updater.update()
                 self.assertEqual(trigger(trainer), expected)
+                self.assertEqual(trigger.finished, finished)
             # old version does not save anything
             np.savez(f, dummy=0)
 
             trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
             with testing.assert_warns(UserWarning):
                 serializers.load_npz(f.name, trigger)
-            for expected in self.expected[self.resume:]:
+            for expected, finished in zip(self.expected[self.resume:],
+                                          self.finished[self.resume:]):
                 trainer.updater.update()
                 self.assertEqual(trigger(trainer), expected)
+                self.assertEqual(trigger.finished, finished)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
@@ -15,7 +15,8 @@ from chainer import training
     # single iteration
     {
         'iter_per_epoch': 2, 'schedule': (2, 'iteration'), 'resume': 3,
-        'expected': [False, True, False, False, False, False, False]},
+        'expected': [False, True, False, False, False, False, False],
+        'finished': [False, True, True, True, True, True, True]},
     # multiple iteration
     {
         'iter_per_epoch': 2, 'schedule': ([2, 4], 'iteration'), 'resume': 3,
@@ -59,9 +60,10 @@ class TestTrigger(unittest.TestCase):
         trainer = testing.get_trainer_with_mock_updater(
             stop_trigger=None, iter_per_epoch=self.iter_per_epoch)
         trigger = training.triggers.ManualScheduleTrigger(*self.schedule)
-        for expected in self.expected:
+        for expected, finished in zip(self.expected, self.finished):
             trainer.updater.update()
             self.assertEqual(trigger(trainer), expected)
+            self.assertEqual(trigger.finished, finished)
 
     def test_resumed_trigger(self):
         trainer = testing.get_trainer_with_mock_updater(


### PR DESCRIPTION
This PR is separated from #5565.
New optional property `finished` in `trigger` object helps to avoid unnecessary call of `Extension.initialize`.
The main target of this `finished` property is `once_trigger` in PR #5565, but the PR is now working.
So I first apply it to `manual_schedule_trigger` instead.

TODO:
- [ ] Add property `finished` to `once_trigger` in PR #5565