### PR TITLE
[backport] Ignore h5py is warned by Python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ filterwarnings= ignore::FutureWarning
                 # ``collections.MutableSequence`` in protobuf is warned by
                 # Python 3.7.
                 ignore::DeprecationWarning:google\.protobuf\.internal\.containers
+                # Importing abcs from ``collections`` in h5py is warned by
+                # Python 3.7.
+                ignore::DeprecationWarning:h5py\._hl\.base
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test


### PR DESCRIPTION
Backport of #5691