### PR TITLE
[backport] Fix regex of protobuf modules warned by Python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ filterwarnings= ignore::FutureWarning
                 ignore::DeprecationWarning:theano\.gof\.cmodule
                 # ``collections.MutableSequence`` in protobuf is warned by
                 # Python 3.7.
-                ignore::DeprecationWarning:google\.protobuf\.internal\.containers
+                ignore::DeprecationWarning:google\.protobuf\.internal
                 # Importing abcs from ``collections`` in h5py is warned by
                 # Python 3.7.
                 ignore::DeprecationWarning:h5py\._hl\.base


### PR DESCRIPTION
Backport of #5642