### PR TITLE
[backport] Support default dtype in `L.BinaryHierarchicalSoftmax`

### DIFF
--- a/chainer/links/loss/hierarchical_softmax.py
+++ b/chainer/links/loss/hierarchical_softmax.py
@@ -3,6 +3,7 @@ import copy
 import numpy
 import six
 
+import chainer
 from chainer.backends import cuda
 from chainer import function
 from chainer.initializers import uniform
@@ -13,8 +14,9 @@ from chainer import variable
 
 class TreeParser(object):
 
-    def __init__(self):
+    def __init__(self, dtype):
         self.next_id = 0
+        self.dtype = dtype
 
     def size(self):
         return self.next_id
@@ -58,7 +60,7 @@ class TreeParser(object):
         else:
             # leaf node
             self.paths[node] = numpy.array(self.path, dtype=numpy.int32)
-            self.codes[node] = numpy.array(self.code, dtype=numpy.float32)
+            self.codes[node] = numpy.array(self.code, dtype=self.dtype)
 
 
 class BinaryHierarchicalSoftmaxFunction(function.Function):
@@ -77,8 +79,8 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
 
     """
 
-    def __init__(self, tree):
-        parser = TreeParser()
+    def __init__(self, tree, dtype):
+        parser = TreeParser(dtype)
         parser.parse(tree)
         paths = parser.get_paths()
         codes = parser.get_codes()
@@ -102,12 +104,12 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
         x_type, t_type, w_type = in_types
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
             x_type.ndim == 2,
             t_type.dtype == numpy.int32,
             t_type.ndim == 1,
             x_type.shape[0] == t_type.shape[0],
-            w_type.dtype == numpy.float32,
+            w_type.dtype == x_type.dtype,
             w_type.ndim == 2,
             w_type.shape[0] == self.parser_size,
             w_type.shape[1] == x_type.shape[1],
@@ -129,7 +131,7 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
     def forward_cpu(self, inputs):
         x, t, W = inputs
 
-        loss = numpy.float32(0.0)
+        loss = x.dtype.type(0.0)
         for ix, it in six.moves.zip(x, t):
             loss += self._forward_cpu_one(ix, it, W)
         return numpy.array(loss),
@@ -174,7 +176,7 @@ class BinaryHierarchicalSoftmaxFunction(function.Function):
         max_length = cuda.to_cpu(max_length)[()]
 
         length = max_length * x.shape[0]
-        ls = cuda.cupy.empty((length,), dtype=numpy.float32)
+        ls = cuda.cupy.empty((length,), dtype=x.dtype)
         n_in = x.shape[1]
         wxy = cuda.cupy.empty_like(ls)
         cuda.elementwise(
@@ -262,7 +264,7 @@ class BinaryHierarchicalSoftmax(link.Link):
     It costs only :math:`O(\\log(n))` time where :math:`n` is the vocabulary
     size in average.
 
-    At first a user need to prepare a binary tree whose each leaf is
+    At first a user needs to prepare a binary tree whose each leaf is
     corresponding to a word in a vocabulary.
     When a word :math:`x` is given, exactly one path from the root of the tree
     to the leaf of the word exists.
@@ -288,6 +290,7 @@ class BinaryHierarchicalSoftmax(link.Link):
     Args:
         in_size (int): Dimension of input vectors.
         tree: A binary tree made with tuples like `((1, 2), 3)`.
+        dtype (numpy.dtype): Type to use in computing.
 
     Attributes:
         W (~chainer.Variable): Weight parameter matrix.
@@ -297,10 +300,11 @@ class BinaryHierarchicalSoftmax(link.Link):
 
     """
 
-    def __init__(self, in_size, tree):
+    def __init__(self, in_size, tree, dtype=None):
         # This function object is copied on every forward computation.
         super(BinaryHierarchicalSoftmax, self).__init__()
-        self._func = BinaryHierarchicalSoftmaxFunction(tree)
+        dtype = chainer.get_dtype(dtype)
+        self._func = BinaryHierarchicalSoftmaxFunction(tree, dtype)
 
         with self.init_scope():
             self.W = variable.Parameter(uniform.Uniform(1),


### PR DESCRIPTION
Backport of #5648