### PR TITLE
[WIP] Raise TypeError if None is applied to FunctionNode

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -223,6 +223,10 @@ Use apply() method instead.\
             A tuple of output :class:`~chainer.Variable` objects.
 
         """
+        if any([x is None for x in inputs]):
+            raise TypeError(
+                'inputs to FunctionNode.apply contain None')
+
         input_vars = [chainer.as_variable(x) for x in inputs]
         in_data = tuple([x.data for x in input_vars])
         requires_grad = any([x.requires_grad for x in input_vars])

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -285,6 +285,11 @@ Actual: 1 < 2"""
                                    msg):
             f.apply((v,))
 
+    def test_apply_none(self):
+        f = chainer.FunctionNode()
+        with six.assertRaisesRegex(self, TypeError, 'None'):
+            f.apply((None,))
+
 
 class TestFunctionNodeInconsistentBackends(unittest.TestCase):
 


### PR DESCRIPTION
Make `Func(...).apply((None,))` immediately fail.

The motivation is the following issue I claimed. (https://chainer.slack.com/archives/C5P26TUR1)/p1542017121027400
> ```
> >>> chainer.as_variable(None)
> variable(None)
> ```
> Is this intended?
> `Func().apply((None,))` don't fail immediately because of this

Other possible fixes
- (More compatible, but hardly effective) Just warn it at `forward` and raise an error at `backward`
- (Less compatible, and possibly fixes other issues) Return `None` for `as_variable(None)`
