### PR TITLE
Change link.add_hook to return self

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -759,6 +759,9 @@ class Link(object):
                 among link hooks registered to this link. If ``None``,
                 the default name of the link hook is used.
 
+        Returns:
+            self
+
         """
         if not isinstance(hook, link_hook.LinkHook):
             raise TypeError('Hook must be of type LinkHook')
@@ -769,6 +772,7 @@ class Link(object):
             raise KeyError('Hook %s already exists' % name)
         hooks[name] = hook
         hook.added(self)
+        return self
 
     def delete_hook(self, name):
         """Unregisters the link hook.

--- a/tests/chainer_tests/test_link_hook.py
+++ b/tests/chainer_tests/test_link_hook.py
@@ -179,11 +179,11 @@ class TestLinkHook(unittest.TestCase):
     def test_local_hook_unnamed(self):
         self._check_local_hook(None, 'MyLinkHook')
 
-    def test_link_addhook(self):
+    def test_addhook_returns_self(self):
         model, x, dot = self._create_model_and_data()
         hook = MyLinkHook()
-        model = model.add_hook(hook)
-        assert model is not None and isinstance(model, chainer.Chain)
+        ret = model.add_hook(hook)
+        assert ret is model
 
     def test_global_hook_delete(self):
         # Deleted hook should not be called

--- a/tests/chainer_tests/test_link_hook.py
+++ b/tests/chainer_tests/test_link_hook.py
@@ -179,6 +179,12 @@ class TestLinkHook(unittest.TestCase):
     def test_local_hook_unnamed(self):
         self._check_local_hook(None, 'MyLinkHook')
 
+    def test_link_addhook(self):
+        model, x, dot = self._create_model_and_data()
+        hook = MyLinkHook()
+        model = model.add_hook(hook)
+        assert model is not None and isinstance(model, chainer.Chain)
+
     def test_global_hook_delete(self):
         # Deleted hook should not be called
 


### PR DESCRIPTION
This change makes it easier to define original models when their links have `LinkHook`.

One expected usage is below.

```python
class MyModel(chainer.Chain):
    def __init__(self, *args, **kwargs):
        super(MyModel, self).__init__()
        with self.init_scope():
            self.linear = L.Linear(10).add_hook(SomeLinkHook)
            self.conv = L.Convolution2D(10, 3, 1, pad=1).add_hook(AnotherLinkHook)
...
```
