### PR TITLE
fix usage of downsample_fb in resnet

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -616,7 +616,7 @@ class BottleneckA(link.Chain):
         # In the original MSRA ResNet, stride=2 is on 1x1 convolution.
         # In Facebook ResNet, stride=2 is on 3x3 convolution.
 
-        stride_1x1, stride_3x3 = (stride, 1) if downsample_fb else (1, stride)
+        stride_1x1, stride_3x3 = (1, stride) if downsample_fb else (stride, 1)
         with self.init_scope():
             self.conv1 = Convolution2D(
                 in_channels, mid_channels, 1, stride_1x1, 0, initialW=initialW,


### PR DESCRIPTION
This fixes #5700.

Test `tests/chainer_tests/links_tests/model_tests/test_vision.py` passes regardless of this fix.
Is there any good idea to add test without need of pretrained model and image?
