### PR TITLE
`FunctionNode` automatic fallback of array attributes in forward

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -435,7 +435,22 @@ Use apply() method instead.\
 
     def _make_chainerx_forward_fallback_class(self, device):
         # Creates a fabricated class based on the concerete FunctionNode class,
-        # equipped with the automatic attribute fallback.
+        # equipped with the automatic attribute fallback, which is enabled
+        # during the forward function.
+        #
+        # In the fallback mechanism, wnen an array with the fallback ndarray
+        # type (e.g. numpy.ndarray for ChainerX native devices) is assigned
+        # as an attribute, it's automatically converted to a ChainerX ndarray
+        # with the corresponding ChainerX device and stored in that form.
+        # Conversely, when an attribute with ChainerX ndarray type is queried,
+        # it's converted to the fallback ndarray before being returned.
+        # That way, concrete FunctionNode implementations can use attributes
+        # as ndarray storage, without converting from/to ChainerX manually.
+        #
+        # Note that it works only if the attribute has an ndarray type. If the
+        # array is wrapped in a tuple, for example, no automatic conversion
+        # will be taken place.
+
         fallback_device = device.fallback_device
         sup = super(FunctionNode, self)
         # Cache to avoid converting same arrays multiple times

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -438,7 +438,7 @@ Use apply() method instead.\
         # equipped with the automatic attribute fallback, which is enabled
         # during the forward function.
         #
-        # In the fallback mechanism, wnen an array with the fallback ndarray
+        # In the fallback mechanism, when an array with the fallback ndarray
         # type (e.g. numpy.ndarray for ChainerX native devices) is assigned
         # as an attribute, it's automatically converted to a ChainerX ndarray
         # with the corresponding ChainerX device and stored in that form.

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -457,8 +457,8 @@ Use apply() method instead.\
             if isinstance(value, fallback_device.xp.ndarray):
                 fallback_array_cache[name] = value
                 sup.__setattr__(name, backend.to_chainerx(value))
-                return value
-            return sup.__setattr__(name, value)
+                return
+            sup.__setattr__(name, value)
 
         # Return a fabricated FunctionNode class
         new_class = type(

--- a/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_gaussian.py
@@ -3,25 +3,38 @@ import unittest
 import numpy
 
 import chainer
-from chainer.backends import cuda
 from chainer import functions
 from chainer import gradient_check
 from chainer import testing
-from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'shape': [(3, 2), ()],
 }))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        # NumPy
+        {},
+        # CuPy
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+        # ChainerX
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
 class TestGaussian(unittest.TestCase):
 
     def setUp(self):
-        self.m = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.v = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggm = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggv = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        shape = self.shape
+        dtype = self.dtype
+        self.m = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        self.v = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        self.gy = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        self.ggm = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        self.ggv = numpy.random.uniform(-1, 1, shape).astype(dtype)
 
         self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
         self.check_double_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
@@ -29,107 +42,73 @@ class TestGaussian(unittest.TestCase):
             self.check_backward_options['dtype'] = numpy.float64
             self.check_double_backward_options['dtype'] = numpy.float64
 
-    def check_forward(self, m_data, v_data):
+    def test_forward(self, backend_config):
+        # TODO(niboshi): Support it
+        if backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
+
+        m_data, v_data = backend_config.get_array((self.m, self.v))
+
         m = chainer.Variable(m_data)
         v = chainer.Variable(v_data)
-        n = functions.gaussian(m, v)
 
-        # Only checks dtype and shape because its result contains noise
-        self.assertEqual(n.dtype, self.dtype)
-        self.assertEqual(n.shape, m.shape)
+        # Call forward without eps and retrieve it
+        n1, eps = functions.gaussian(m, v, return_eps=True)
 
-    def test_forward_cpu(self):
-        self.check_forward(self.m, self.v)
+        self.assertIsInstance(eps, backend_config.xp.ndarray)
+        self.assertEqual(n1.dtype, self.dtype)
+        self.assertEqual(n1.shape, m.shape)
+        self.assertEqual(eps.dtype, self.dtype)
+        self.assertEqual(eps.shape, m.shape)
 
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.m), cuda.to_gpu(self.v))
+        # Call again with retrieved eps
+        n2 = functions.gaussian(m, v, eps=eps)
+        self.assertEqual(n2.dtype, self.dtype)
+        self.assertEqual(n2.shape, m.shape)
+        testing.assert_allclose(n1.array, n2.array)
 
-    def check_backward(self, m_data, v_data, y_grad):
-        # Instantiate the FunctionNode object outside the function that is
-        # tested in order to reuse the same noise for the numerical gradient
-        # computations (the noise is generated once during its first forward
-        # pass, then reused)
-        # TODO(hvy): Do no expose internals of the tested function using
-        # e.g. numpy.random.RandomState
-        gaussian = functions.noise.gaussian.Gaussian()
+    def test_backward(self, backend_config):
+        # TODO(niboshi): Support it
+        if backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
+
+        m_data, v_data = backend_config.get_array((self.m, self.v))
+        y_grad = backend_config.get_array(self.gy)
+        eps = backend_config.get_array(
+            numpy.random.uniform(-1, 1, self.shape).astype(self.dtype))
 
         def f(m, v):
             # In case numerical gradient computation is held in more precise
             # dtype than that of backward computation, cast the eps to reuse
             # before the numerical computation.
-            if gaussian.eps is not None and gaussian.eps.dtype != m.dtype:
-                gaussian.eps = gaussian.eps.astype(m.dtype)
-            return gaussian.apply((m, v))[0]
+            eps_ = eps.astype(m.dtype)
+            return functions.gaussian(m, v, eps=eps_)
 
         gradient_check.check_backward(
             f, (m_data, v_data), y_grad, **self.check_backward_options)
 
-    def test_backward_cpu(self):
-        self.check_backward(self.m, self.v, self.gy)
+    def test_double_backward(self, backend_config):
+        # TODO(niboshi): Support it
+        if backend_config.use_chainerx and self.dtype == numpy.float16:
+            raise unittest.SkipTest('ChainerX does not support float16')
 
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.m),
-                            cuda.to_gpu(self.v),
-                            cuda.to_gpu(self.gy))
-
-    def check_double_backward(self, m_data, v_data, y_grad, m_grad_grad,
-                              v_grad_grad):
-        gaussian = functions.noise.gaussian.Gaussian()
+        m_data, v_data = backend_config.get_array((self.m, self.v))
+        y_grad = backend_config.get_array(self.gy)
+        m_grad_grad, v_grad_grad = (
+            backend_config.get_array((self.ggm, self.ggv)))
+        eps = backend_config.get_array(
+            numpy.random.uniform(-1, 1, self.shape).astype(self.dtype))
 
         def f(m, v):
-            if gaussian.eps is not None and gaussian.eps.dtype != m.dtype:
-                gaussian.eps = gaussian.eps.astype(m.dtype)
-            return gaussian.apply((m, v))
+            # In case numerical gradient computation is held in more precise
+            # dtype than that of backward computation, cast the eps to reuse
+            # before the numerical computation.
+            eps_ = eps.astype(m.dtype)
+            return functions.gaussian(m, v, eps=eps_)
 
         gradient_check.check_double_backward(
             f, (m_data, v_data), y_grad, (m_grad_grad, v_grad_grad),
             **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.m, self.v, self.gy, self.ggm, self.ggv)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(cuda.to_gpu(self.m),
-                                   cuda.to_gpu(self.v),
-                                   cuda.to_gpu(self.gy),
-                                   cuda.to_gpu(self.ggm),
-                                   cuda.to_gpu(self.ggv))
-
-
-@testing.parameterize(*testing.product({
-    'specify_eps': [True, False],
-}))
-class TestGaussianEps(unittest.TestCase):
-
-    def setUp(self):
-        self.m = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
-        self.v = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
-        self.eps = numpy.random.uniform(-1, 1, (3, 2)).astype(numpy.float32)
-
-    def _check(self):
-        eps = self.eps if self.specify_eps else None
-        out, out_eps = functions.gaussian(
-            self.m, self.v, eps=eps, return_eps=True)
-        assert isinstance(out_eps, type(out.array))
-        if eps is None:
-            assert out_eps.shape == out.array.shape
-        else:
-            assert out_eps is eps
-        out2 = functions.gaussian(self.m, self.v, eps=out_eps)
-        testing.assert_allclose(out.array, out2.array)
-
-    def test_cpu(self):
-        self._check()
-
-    @attr.gpu
-    def test_gpu(self):
-        self.m = cuda.to_gpu(self.m)
-        self.v = cuda.to_gpu(self.v)
-        self.eps = cuda.to_gpu(self.eps)
-        self._check()
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
In ChainerX FunctionNode fallback, type mismatch will happen if the function assigns an array as its attribute.
This PR implements automatic conversion of such attributes.