### PR TITLE
ChainerX backward w.r.t. inputs (C++ chainerx.grad) 

### DIFF
--- a/chainerx_cc/chainerx/backward.cc
+++ b/chainerx_cc/chainerx/backward.cc
@@ -529,8 +529,8 @@ void Backward(
 }
 
 void Backward(
-        const std::vector<ConstArrayRef>& inputs,
         const std::vector<ConstArrayRef>& outputs,
+        const std::vector<ConstArrayRef>& inputs,
         const nonstd::optional<BackpropId>& backprop_id,
         DoubleBackpropOption double_backprop) {
     if (inputs.empty() || outputs.empty()) {

--- a/chainerx_cc/chainerx/backward.cc
+++ b/chainerx_cc/chainerx/backward.cc
@@ -78,10 +78,8 @@ void PushNodeIfNotSeen(std::vector<std::shared_ptr<T>>& nodes, const std::shared
             std::is_same<T, ArrayNode>::value || std::is_same<T, OpNode>::value, "Only ArrayNodes or OpNodes are allowed to be pushed.");
     CHAINERX_ASSERT(node != nullptr);
 
-    T* raw_node = node.get();
-    if (seen_nodes.find(raw_node) == seen_nodes.end()) {
+    if (seen_nodes.emplace(node.get()).second) {
         nodes.emplace_back(node);
-        seen_nodes.emplace(raw_node);
     }
 }
 

--- a/chainerx_cc/chainerx/backward.cc
+++ b/chainerx_cc/chainerx/backward.cc
@@ -103,7 +103,7 @@ std::unordered_map<OpNode*, std::vector<uint8_t>> CreateSubgraph(
         forward_op_nodes.emplace(array_node.get(), nullptr);  // Outputs have no forward op nodes.
         const std::shared_ptr<OpNode>& op_node = array_node->creator_op_node();
         if (op_node != nullptr) {
-            PushNodeIfNotSeen(candidate_op_nodes, array_node->creator_op_node(), seen_op_nodes);
+            PushNodeIfNotSeen(candidate_op_nodes, op_node, seen_op_nodes);
         }
     }
 

--- a/chainerx_cc/chainerx/backward.cc
+++ b/chainerx_cc/chainerx/backward.cc
@@ -562,14 +562,12 @@ std::vector<nonstd::optional<Array>> Grad(
     if (inputs.empty()) {
         return {};
     }
+    if (outputs.empty()) {
+        return std::vector<nonstd::optional<Array>>(inputs.size(), nonstd::nullopt);
+    }
 
     std::vector<nonstd::optional<Array>> input_grads;
     input_grads.reserve(inputs.size());
-
-    if (outputs.empty()) {
-        input_grads.resize(inputs.size(), nonstd::nullopt);
-        return input_grads;
-    }
 
     BackpropId actual_backprop_id = internal::GetArrayBackpropId(outputs.front().get(), backprop_id);
 

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -26,7 +26,7 @@ void SetGrad(nonstd::optional<Array>& target_grad, Array grad, const Shape& shap
 
 }  // namespace internal
 
-// Computes the gradients by back propagation.
+// Updates the gradients held by the input arrays using backpropagation.
 //
 // This functions is not thread safe.
 void Backward(
@@ -34,10 +34,19 @@ void Backward(
         const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
 
-// Computes the gradients by back propagation.
+// Updates the gradients held by the input arrays using backpropagation.
 //
 // This functions is not thread safe.
 void Backward(
+        const std::vector<ConstArrayRef>& outputs,
+        const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
+        DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
+
+// Updates the gradients held by the input arrays using backpropagation.
+//
+// This functions is not thread safe.
+void Backward(
+        const std::vector<ConstArrayRef>& inputs,
         const std::vector<ConstArrayRef>& outputs,
         const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -46,8 +46,8 @@ void Backward(
 //
 // This functions is not thread safe.
 void Backward(
-        const std::vector<ConstArrayRef>& inputs,
         const std::vector<ConstArrayRef>& outputs,
+        const std::vector<ConstArrayRef>& inputs,
         const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
 

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -51,4 +51,11 @@ void Backward(
         const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
 
+// Returns gradient arrays for all inputs.
+std::vector<Array> Grad(
+        const std::vector<ConstArrayRef>& outputs,
+        const std::vector<ConstArrayRef>& inputs,
+        const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
+        DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
+
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -42,15 +42,6 @@ void Backward(
         const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
 
-// Updates the gradients held by the input arrays using backpropagation.
-//
-// This functions is not thread safe.
-void Backward(
-        const std::vector<ConstArrayRef>& outputs,
-        const std::vector<ConstArrayRef>& inputs,
-        const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,
-        DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
-
 // Returns gradient arrays for all inputs.
 std::vector<nonstd::optional<Array>> Grad(
         const std::vector<ConstArrayRef>& outputs,

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -52,7 +52,7 @@ void Backward(
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
 
 // Returns gradient arrays for all inputs.
-std::vector<Array> Grad(
+std::vector<nonstd::optional<Array>> Grad(
         const std::vector<ConstArrayRef>& outputs,
         const std::vector<ConstArrayRef>& inputs,
         const nonstd::optional<BackpropId>& backprop_id = nonstd::nullopt,

--- a/chainerx_cc/chainerx/backward_context.cc
+++ b/chainerx_cc/chainerx/backward_context.cc
@@ -40,6 +40,12 @@ GradRef::GradRef(ArrayNode& array_node) : original_grad_owner_body_{array_node.w
 
 GradRef::GradRef(nonstd::nullopt_t /*nullopt*/) : temporary_grad_{std::make_unique<nonstd::optional<Array>>()} {}
 
+GradRef::GradRef(nonstd::optional<Array>* grad) : original_grad_ptr_{std::move(grad)} {
+    if (original_grad_ptr_->has_value()) {
+        original_grad_owner_body_ = internal::GetArrayBody(**grad);
+    }
+}
+
 nonstd::optional<Array>& GradRef::get() {
     if (original_grad_ptr_ == nullptr) {
         if (temporary_grad_ == nullptr) {

--- a/chainerx_cc/chainerx/backward_context.cc
+++ b/chainerx_cc/chainerx/backward_context.cc
@@ -40,7 +40,7 @@ GradRef::GradRef(ArrayNode& array_node) : original_grad_owner_body_{array_node.w
 
 GradRef::GradRef(nonstd::nullopt_t /*nullopt*/) : temporary_grad_{std::make_unique<nonstd::optional<Array>>()} {}
 
-GradRef::GradRef(nonstd::optional<Array>* grad) : original_grad_ptr_{std::move(grad)} {
+GradRef::GradRef(nonstd::optional<Array>* grad) : original_grad_ptr_{grad} {
     if (original_grad_ptr_->has_value()) {
         original_grad_owner_body_ = internal::GetArrayBody(**grad);
     }

--- a/chainerx_cc/chainerx/backward_context.h
+++ b/chainerx_cc/chainerx/backward_context.h
@@ -35,6 +35,8 @@ public:
     // Initialize with a temporary grad without value.
     explicit GradRef(nonstd::nullopt_t);
 
+    explicit GradRef(nonstd::optional<Array>* grad);
+
     GradRef(const GradRef&) = delete;
     GradRef(GradRef&&) = default;
     GradRef& operator=(const GradRef&) = delete;

--- a/chainerx_cc/chainerx/backward_test.cc
+++ b/chainerx_cc/chainerx/backward_test.cc
@@ -984,7 +984,36 @@ TEST_F(BackpropTest, NoReferenceToOuterGraphsUnlessArraysAreRetained) {
     }
 }
 
-TEST_F(BackpropTest, BackwardWithInputsOnlyRequiresGrad) {
+TEST_F(BackpropTest, GradWithSingleArrayNode) {
+    BackpropScope backprop_scope1{"bp1"};
+    BackpropId backprop_id_1 = backprop_scope1.backprop_id();
+
+    Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
+    Array x1_initial_grad = Full({1}, 4.0f);
+
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+
+    std::vector<nonstd::optional<Array>> grads = Grad({x1}, {x1}, backprop_id_1);
+
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 1U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 1.0f), *grads.at(0));
+}
+
+TEST_F(BackpropTest, GradWithSingleArrayNodeNoRequiresGrad) {
+    BackpropScope backprop_scope1{"bp1"};
+    BackpropId backprop_id_1 = backprop_scope1.backprop_id();
+
+    Array x1 = Full({1}, 2.0f);
+
+    EXPECT_THROW(Grad({x1}, {x1}, backprop_id_1), ChainerxError);
+}
+
+TEST_F(BackpropTest, GradOnlyRequiresGrad) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
@@ -998,13 +1027,17 @@ TEST_F(BackpropTest, BackwardWithInputsOnlyRequiresGrad) {
 
     std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1}, backprop_id_1);
 
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 1U);
     EXPECT_TRUE(grads.at(0).has_value());
     EXPECT_ARRAY_EQ(Full({1}, 3.0f), *grads.at(0));
-    EXPECT_ARRAY_EQ(*x1.GetGrad(backprop_id_1), x1_initial_grad);
-    EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
 }
 
-TEST_F(BackpropTest, BackwardWithInputsMixedRequiresGrad) {
+TEST_F(BackpropTest, GradMixedRequiresGrad) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
@@ -1018,74 +1051,150 @@ TEST_F(BackpropTest, BackwardWithInputsMixedRequiresGrad) {
 
     std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1, x2}, backprop_id_1);
 
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 2U);
     EXPECT_TRUE(grads.at(0).has_value());
     EXPECT_ARRAY_EQ(Full({1}, 3.0f), *grads.at(0));
     EXPECT_FALSE(grads.at(1).has_value());
-    EXPECT_ARRAY_EQ(*x1.GetGrad(backprop_id_1), x1_initial_grad);
-    EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
 }
 
-TEST_F(BackpropTest, BackwardWithInputsOnlyRequiresGradButSpecifySubset) {
+TEST_F(BackpropTest, GradOnlyRequiresGradButSpecifySubset) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
     Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
     Array x2 = Full({1}, 3.0f).RequireGrad(backprop_id_1);
 
+    Array x1_initial_grad = Full({1}, 4.0f);
+    Array x2_initial_grad = Full({1}, 5.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+    x2.SetGrad(x2_initial_grad, backprop_id_1);
+
     Array y = x1 * x2;
 
-    Backward({y}, {x1}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1}, backprop_id_1);
 
-    EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
-    EXPECT_FALSE(x2.GetGrad(backprop_id_1));
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x2_initial_grad, *x2.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 1U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 3.0f), *grads.at(0));
 }
 
-TEST_F(BackpropTest, BackwardWithInputsMultipleSameInputs) {
+TEST_F(BackpropTest, GradMultipleSameInputs) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
     Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
     Array x2 = Full({1}, 3.0f);
+
+    Array x1_initial_grad = Full({1}, 4.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
 
     Array y = x1 * x1 * x2;
 
-    Backward({y}, {x1}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1}, backprop_id_1);
 
-    EXPECT_ARRAY_EQ(Full({1}, 12.0f), *x1.GetGrad(backprop_id_1));
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 1U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 12.0f), *grads.at(0));
 }
 
-TEST_F(BackpropTest, BackwardWithInputsNoInputs) {
+TEST_F(BackpropTest, GradNoInputs) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
     Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
     Array x2 = Full({1}, 3.0f);
 
+    Array x1_initial_grad = Full({1}, 4.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+
     Array y = x1 * x2;
 
-    Backward({y}, {}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {}, backprop_id_1);
 
-    EXPECT_FALSE(x1.GetGrad(backprop_id_1));
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+
+    EXPECT_TRUE(grads.empty());
 }
 
-TEST_F(BackpropTest, BackwardWithInputsNoOutputs) {
+TEST_F(BackpropTest, GradNoOutputs) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
     Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
     Array x2 = Full({1}, 3.0f);
 
+    Array x1_initial_grad = Full({1}, 4.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+
     Array y = x1 * x2;
 
-    Backward({}, {x1, x2}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({}, {x1, x2}, backprop_id_1);
 
-    EXPECT_FALSE(x1.GetGrad(backprop_id_1));
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 2U);
+    EXPECT_FALSE(grads.at(0).has_value());
+    EXPECT_FALSE(grads.at(1).has_value());
 }
 
-TEST_F(BackpropTest, BackwardWithInputsNonTrivialGraph) {
+TEST_F(BackpropTest, GradDisjointInputs) {
+    BackpropScope backprop_scope1{"bp1"};
+    BackpropId backprop_id_1 = backprop_scope1.backprop_id();
+
+    Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
+    Array x2 = Full({1}, 3.0f).RequireGrad(backprop_id_1);
+    Array x3 = Full({1}, 4.0f).RequireGrad(backprop_id_1);
+
+    Array x1_initial_grad = Full({1}, 5.0f);
+    Array x2_initial_grad = Full({1}, 6.0f);
+    Array x3_initial_grad = Full({1}, 7.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+    x2.SetGrad(x2_initial_grad, backprop_id_1);
+    x3.SetGrad(x3_initial_grad, backprop_id_1);
+
+    Array y = x1 * x2;
+
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1, x2, x3}, backprop_id_1);
+
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x2.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x3.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x2_initial_grad, *x2.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x3_initial_grad, *x3.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 3U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_TRUE(grads.at(1).has_value());
+    EXPECT_FALSE(grads.at(2).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 3.0f), *grads.at(0));
+    EXPECT_ARRAY_EQ(Full({1}, 2.0f), *grads.at(1));
+}
+
+TEST_F(BackpropTest, GradNonTrivialGraph) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
@@ -1094,27 +1203,47 @@ TEST_F(BackpropTest, BackwardWithInputsNonTrivialGraph) {
     Array x3 = Full({1}, 3.0f).RequireGrad(backprop_id_1);
     Array x4 = Full({1}, 4.0f);
 
+    Array x1_initial_grad = Full({1}, 4.0f);
+    Array x2_initial_grad = Full({1}, 5.0f);
+    Array x3_initial_grad = Full({1}, 6.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+    x2.SetGrad(x2_initial_grad, backprop_id_1);
+    x3.SetGrad(x3_initial_grad, backprop_id_1);
+
     Array y1 = x1 * x2;
     Array y2 = x3 + 4;
     Array y3 = x4 - 3;
     Array z1 = y1 * 2;
     Array z2 = y2 / y3;
 
-    Backward({z1, z2}, {x2, x3}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({z1, z2}, {x2, x3}, backprop_id_1);
 
-    EXPECT_FALSE(x1.GetGrad(backprop_id_1));
-    EXPECT_ARRAY_EQ(Full({1}, 2.0f), *x2.GetGrad(backprop_id_1));  // 2 * x1
-    EXPECT_ARRAY_EQ(Full({1}, 1.0f), *x3.GetGrad(backprop_id_1));  // 1 / (x4 - 3)
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x2.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x3.IsGradRequired(backprop_id_1));
     EXPECT_FALSE(x4.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x2_initial_grad, *x2.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x3_initial_grad, *x3.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 2U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_TRUE(grads.at(1).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 2.0f), *grads.at(0));  // 2 * x1
+    EXPECT_ARRAY_EQ(Full({1}, 1.0f), *grads.at(1));  // 1 / (x4 - 3)
 }
 
-TEST_F(BackpropTest, BackwardWithInputsSomeOutputsOmitted) {
+TEST_F(BackpropTest, GradSomeOutputsOmitted) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
 
     Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
     Array y1{};
     Array y2{};
+
+    Array x1_initial_grad = Full({1}, 6.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
 
     auto forward = [](const Array& x1, Array& y1, Array& y2) {
         y1 = x1.AsGradStopped() * x1.AsGradStopped();
@@ -1131,9 +1260,12 @@ TEST_F(BackpropTest, BackwardWithInputsSomeOutputsOmitted) {
     y1.SetGrad(FullLike(y1, 2), backprop_id_1);
     y2.SetGrad(FullLike(y2, 3), backprop_id_1);
 
-    Backward({y2}, {x1}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({y2}, {x1}, backprop_id_1);
 
-    EXPECT_ARRAY_EQ(Full({1}, 40.0f), *x1.GetGrad(backprop_id_1));
+    EXPECT_EQ(grads.size(), 1U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 40.0f), *grads.at(0));
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
 }
 
 class BackpropFunctionTest : public ::testing::TestWithParam<DoubleBackpropOption> {};

--- a/chainerx_cc/chainerx/backward_test.cc
+++ b/chainerx_cc/chainerx/backward_test.cc
@@ -993,7 +993,7 @@ TEST_F(BackpropTest, BackwardWithInputsOnlyRequiresGrad) {
 
     Array y = x1 * x2;
 
-    Backward({x1}, {y}, backprop_id_1);
+    Backward({y}, {x1}, backprop_id_1);
 
     EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
@@ -1008,7 +1008,7 @@ TEST_F(BackpropTest, BackwardWithInputsMixedRequiresGrad) {
 
     Array y = x1 * x2;
 
-    Backward({x1, x2}, {y}, backprop_id_1);
+    Backward({y}, {x1, x2}, backprop_id_1);
 
     EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
@@ -1023,7 +1023,7 @@ TEST_F(BackpropTest, BackwardWithInputsOnlyRequiresGradButSpecifySubset) {
 
     Array y = x1 * x2;
 
-    Backward({x1}, {y}, backprop_id_1);
+    Backward({y}, {x1}, backprop_id_1);
 
     EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
     EXPECT_FALSE(x2.GetGrad(backprop_id_1));
@@ -1038,7 +1038,7 @@ TEST_F(BackpropTest, BackwardWithInputsMultipleSameInputs) {
 
     Array y = x1 * x1 * x2;
 
-    Backward({x1}, {y}, backprop_id_1);
+    Backward({y}, {x1}, backprop_id_1);
 
     EXPECT_ARRAY_EQ(Full({1}, 12.0f), *x1.GetGrad(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
@@ -1053,7 +1053,7 @@ TEST_F(BackpropTest, BackwardWithInputsNoInputs) {
 
     Array y = x1 * x2;
 
-    Backward({}, {y}, backprop_id_1);
+    Backward({y}, {}, backprop_id_1);
 
     EXPECT_FALSE(x1.GetGrad(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
@@ -1068,7 +1068,7 @@ TEST_F(BackpropTest, BackwardWithInputsNoOutputs) {
 
     Array y = x1 * x2;
 
-    Backward({x1, x2}, {}, backprop_id_1);
+    Backward({}, {x1, x2}, backprop_id_1);
 
     EXPECT_FALSE(x1.GetGrad(backprop_id_1));
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
@@ -1089,7 +1089,7 @@ TEST_F(BackpropTest, BackwardWithInputsNonTrivialGraph) {
     Array z1 = y1 * 2;
     Array z2 = y2 / y3;
 
-    Backward({x2, x3}, {z1, z2}, backprop_id_1);
+    Backward({z1, z2}, {x2, x3}, backprop_id_1);
 
     EXPECT_FALSE(x1.GetGrad(backprop_id_1));
     EXPECT_ARRAY_EQ(Full({1}, 2.0f), *x2.GetGrad(backprop_id_1));  // 2 * x1
@@ -1120,7 +1120,7 @@ TEST_F(BackpropTest, BackwardWithInputsSomeOutputsOmitted) {
     y1.SetGrad(FullLike(y1, 2), backprop_id_1);
     y2.SetGrad(FullLike(y2, 3), backprop_id_1);
 
-    Backward({x1}, {y2}, backprop_id_1);
+    Backward({y2}, {x1}, backprop_id_1);
 
     EXPECT_ARRAY_EQ(Full({1}, 40.0f), *x1.GetGrad(backprop_id_1));
 }

--- a/chainerx_cc/chainerx/backward_test.cc
+++ b/chainerx_cc/chainerx/backward_test.cc
@@ -991,11 +991,17 @@ TEST_F(BackpropTest, BackwardWithInputsOnlyRequiresGrad) {
     Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
     Array x2 = Full({1}, 3.0f);
 
+    Array x1_initial_grad = Full({1}, 4.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+
     Array y = x1 * x2;
 
-    Backward({y}, {x1}, backprop_id_1);
+    // Backward({y}, {x1}, backprop_id_1);
+    std::vector<Array> grads = Grad({y}, {x1}, backprop_id_1);
 
-    EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
+    // EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(Full({1}, 3.0f), grads.at(0));
+    EXPECT_ARRAY_EQ(*x1.GetGrad(backprop_id_1), x1_initial_grad);
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
 }
 

--- a/chainerx_cc/chainerx/backward_test.cc
+++ b/chainerx_cc/chainerx/backward_test.cc
@@ -996,11 +996,10 @@ TEST_F(BackpropTest, BackwardWithInputsOnlyRequiresGrad) {
 
     Array y = x1 * x2;
 
-    // Backward({y}, {x1}, backprop_id_1);
-    std::vector<Array> grads = Grad({y}, {x1}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1}, backprop_id_1);
 
-    // EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
-    EXPECT_ARRAY_EQ(Full({1}, 3.0f), grads.at(0));
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 3.0f), *grads.at(0));
     EXPECT_ARRAY_EQ(*x1.GetGrad(backprop_id_1), x1_initial_grad);
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
 }
@@ -1012,11 +1011,17 @@ TEST_F(BackpropTest, BackwardWithInputsMixedRequiresGrad) {
     Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
     Array x2 = Full({1}, 3.0f);
 
+    Array x1_initial_grad = Full({1}, 4.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+
     Array y = x1 * x2;
 
-    Backward({y}, {x1, x2}, backprop_id_1);
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1, x2}, backprop_id_1);
 
-    EXPECT_ARRAY_EQ(Full({1}, 3.0f), *x1.GetGrad(backprop_id_1));
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 3.0f), *grads.at(0));
+    EXPECT_FALSE(grads.at(1).has_value());
+    EXPECT_ARRAY_EQ(*x1.GetGrad(backprop_id_1), x1_initial_grad);
     EXPECT_FALSE(x2.IsGradRequired(backprop_id_1));
 }
 

--- a/chainerx_cc/chainerx/backward_test.cc
+++ b/chainerx_cc/chainerx/backward_test.cc
@@ -1268,6 +1268,35 @@ TEST_F(BackpropTest, GradSomeOutputsOmitted) {
     EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
 }
 
+TEST_F(BackpropTest, GradSameInputToDifferentOpNodes) {
+    BackpropScope backprop_scope1{"bp1"};
+    BackpropId backprop_id_1 = backprop_scope1.backprop_id();
+
+    Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
+    Array x2 = Full({1}, 3.0f).RequireGrad(backprop_id_1);
+
+    Array x1_initial_grad = Full({1}, 5.0f);
+    Array x2_initial_grad = Full({1}, 6.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+    x2.SetGrad(x2_initial_grad, backprop_id_1);
+
+    Array y = x1 * x2 * x1 * x2;
+
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1, x2}, backprop_id_1, DoubleBackpropOption::kDisable);
+
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x2_initial_grad, *x2.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 2U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_TRUE(grads.at(1).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 36.0f), *grads.at(0));
+    EXPECT_ARRAY_EQ(Full({1}, 24.0f), *grads.at(1));
+}
+
 class BackpropFunctionTest : public ::testing::TestWithParam<DoubleBackpropOption> {};
 
 TEST_P(BackpropFunctionTest, OneToOneFunc) {

--- a/chainerx_cc/chainerx/backward_test.cc
+++ b/chainerx_cc/chainerx/backward_test.cc
@@ -1263,6 +1263,36 @@ TEST_F(BackpropTest, GradNonTrivialGraph) {
     EXPECT_ARRAY_EQ(Full({1}, 1.0f), *grads.at(1));  // 1 / (x4 - 3)
 }
 
+TEST_F(BackpropTest, GradFromIntermediate) {
+    BackpropScope backprop_scope1{"bp1"};
+    BackpropId backprop_id_1 = backprop_scope1.backprop_id();
+
+    Array x1 = Full({1}, 1.0f).RequireGrad(backprop_id_1);
+    Array x2 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
+
+    Array x1_initial_grad = Full({1}, 4.0f);
+    Array x2_initial_grad = Full({1}, 5.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+    x2.SetGrad(x2_initial_grad, backprop_id_1);
+
+    Array y1 = x1 * x2;
+    Array z1 = y1 * x1;
+
+    std::vector<nonstd::optional<Array>> grads = Grad({y1}, {x1, x2}, backprop_id_1);
+
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x2_initial_grad, *x2.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 2U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_TRUE(grads.at(1).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 2.0f), *grads.at(0));
+    EXPECT_ARRAY_EQ(Full({1}, 1.0f), *grads.at(1));
+}
+
 TEST_F(BackpropTest, GradSomeOutputsOmitted) {
     BackpropScope backprop_scope1{"bp1"};
     BackpropId backprop_id_1 = backprop_scope1.backprop_id();
@@ -1295,6 +1325,43 @@ TEST_F(BackpropTest, GradSomeOutputsOmitted) {
     EXPECT_TRUE(grads.at(0).has_value());
     EXPECT_ARRAY_EQ(Full({1}, 40.0f), *grads.at(0));
     EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+}
+
+TEST_F(BackpropTest, GradDoubleBackwardWithBackward) {
+    BackpropScope backprop_scope1{"bp1"};
+    BackpropId backprop_id_1 = backprop_scope1.backprop_id();
+
+    Array x1 = Full({1}, 2.0f).RequireGrad(backprop_id_1);
+    Array x2 = Full({1}, 3.0f).RequireGrad(backprop_id_1);
+
+    Array x1_initial_grad = Full({1}, 5.0f);
+    Array x2_initial_grad = Full({1}, 6.0f);
+    x1.SetGrad(x1_initial_grad, backprop_id_1);
+    x2.SetGrad(x2_initial_grad, backprop_id_1);
+
+    Array y = x1 * x2 * x1 * x2;
+
+    std::vector<nonstd::optional<Array>> grads = Grad({y}, {x1, x2}, backprop_id_1, DoubleBackpropOption::kEnable);
+
+    EXPECT_TRUE(x1.IsGradRequired(backprop_id_1));
+    EXPECT_TRUE(x2.IsGradRequired(backprop_id_1));
+
+    EXPECT_ARRAY_EQ(x1_initial_grad, *x1.GetGrad(backprop_id_1));
+    EXPECT_ARRAY_EQ(x2_initial_grad, *x2.GetGrad(backprop_id_1));
+
+    EXPECT_EQ(grads.size(), 2U);
+    EXPECT_TRUE(grads.at(0).has_value());
+    EXPECT_TRUE(grads.at(1).has_value());
+    EXPECT_ARRAY_EQ(Full({1}, 36.0f), *grads.at(0));
+    EXPECT_ARRAY_EQ(Full({1}, 24.0f), *grads.at(1));
+
+    const Array& gx1 = *grads.at(0);
+    const Array& gx2 = *grads.at(1);
+
+    Backward({gx1, gx2}, backprop_id_1);
+
+    EXPECT_ARRAY_EQ(Full({1}, 47.0f), *x1.GetGrad(backprop_id_1));  // (Initial 5) + 18 + 24
+    EXPECT_ARRAY_EQ(Full({1}, 38.0f), *x2.GetGrad(backprop_id_1));  // (Initial 6) + 24 + 8
 }
 
 class BackpropFunctionTest : public ::testing::TestWithParam<DoubleBackpropOption> {};


### PR DESCRIPTION
This PR introduces `void Backward(const std::vector<ConstArrayRef>& inputs, ...)` which is similar to `chainer.grad` but does not return anything but instead sets the gradients of the specified inputs. It's better keep the behavior consistent with the previous `Backward` since a graph is consumed, in contrast to Chainer which allows repeated backprops. Basically, a function to extract a subgraph is introduced and this subgraph is checked for at certain places in backward to skip computations that are not required.

1. Traverse backwards (from given outputs) to create an ArrayNode -> OpNode mapping where the ArrayNode is an input to the OpNode.
2. Traverse forwards (from given inputs) to extract a subgraph (OpNode -> boolean "input included in subgraph" flags).
3. Then standard `Backward` but
3.a. A backward entry is skipped if none of the inputs are involved in the subgraph.
3.b After a backward entry is backproped, gradients are ignored if it is not included in the subgraph.
3.c. There are no optimizations **within** a backward entry. This would e.g. require some additional index arguments to the backward lambdas.

1 and 2 are similar to the Chainer implementation of `chainer.grad`.

The signature of the new `Backward` is open for discussion. `inputs` should maybe be the second/last argument?