### PR TITLE
Improve gradient mismatch error

### DIFF
--- a/chainerx_cc/chainerx/array_test.cc
+++ b/chainerx_cc/chainerx/array_test.cc
@@ -307,7 +307,7 @@ TEST_P(ArrayTest, InvalidSetGradMismatchedShape) {
     Array g = testing::BuildArray(mismatched_shape).WithData<T>({8, 4, 6});
     x.RequireGrad();
 
-    EXPECT_THROW(x.SetGrad(g), DimensionError);
+    EXPECT_THROW(x.SetGrad(g), GradientError);
 }
 
 // TODO(niboshi): Move to ArrayGradTest
@@ -320,7 +320,7 @@ TEST_P(ArrayTest, InvalidSetGradMismatchedDtype) {
     Array g = testing::BuildArray(shape).WithData<MismatchedT>({8, 4, 6, 3, 2, 1});
     x.RequireGrad();
 
-    EXPECT_THROW(x.SetGrad(g), DtypeError);
+    EXPECT_THROW(x.SetGrad(g), GradientError);
 }
 
 // TODO(niboshi): Move to ArrayGradTest
@@ -335,7 +335,7 @@ TEST_P(ArrayTest, InvalidSetGradMismatchedDevice) {
     Array g = testing::BuildArray(shape).WithData<T>({8, 4, 6, 3, 2, 1}).WithDevice(mismatched_device);
     x.RequireGrad();
 
-    EXPECT_THROW(x.SetGrad(g), DeviceError);
+    EXPECT_THROW(x.SetGrad(g), GradientError);
 }
 
 TEST_P(ArrayTest, ContiguousFill) {

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -20,8 +20,10 @@ namespace internal {
 class ArrayBody;
 class ArrayNode;
 
+// Throws GradientError in case of mismatch in gradient array props.
 void AccumulateGrad(nonstd::optional<Array>& target_grad, Array partial_grad, const Shape& shape, Dtype dtype, Device& device);
 
+// Throws GradientError in case of mismatch in gradient array props.
 void SetGrad(nonstd::optional<Array>& target_grad, Array grad, const Shape& shape, Dtype dtype, Device& device);
 
 }  // namespace internal

--- a/chainerx_cc/chainerx/backward_test.cc
+++ b/chainerx_cc/chainerx/backward_test.cc
@@ -2531,7 +2531,7 @@ TEST(BackpropGradValidationTest, InvalidGradShape) {
     y1.SetGrad(gy1_value, backprop_id);
 
     // The shape of the computed gradient of x1 is (2, 1) but the shape of x1 is (2,), thus an exception should be thrown.
-    EXPECT_THROW(Backward({y1}, backprop_id, DoubleBackpropOption::kDisable), DimensionError);
+    EXPECT_THROW(Backward({y1}, backprop_id, DoubleBackpropOption::kDisable), GradientError);
 }
 
 TEST(BackpropGradValidationTest, InvalidGradDtype) {
@@ -2568,7 +2568,7 @@ TEST(BackpropGradValidationTest, InvalidGradDtype) {
     y1.SetGrad(gy1_value, backprop_id);
 
     // The dtype of the computed gradient of x1 is float but the dtype of x1 is double, thus an exception should be thrown.
-    EXPECT_THROW(Backward({y1}, backprop_id, DoubleBackpropOption::kDisable), DtypeError);
+    EXPECT_THROW(Backward({y1}, backprop_id, DoubleBackpropOption::kDisable), GradientError);
 }
 
 TEST(BackpropGradValidationTest, InvalidGradDevice) {
@@ -2606,7 +2606,7 @@ TEST(BackpropGradValidationTest, InvalidGradDevice) {
     y1.SetGrad(gy1_value, backprop_id);
 
     // The device of the computed gradient of x1 is on a different device from the device of x1, thus an exception should be throws.
-    EXPECT_THROW(Backward({y1}, backprop_id, DoubleBackpropOption::kDisable), DeviceError);
+    EXPECT_THROW(Backward({y1}, backprop_id, DoubleBackpropOption::kDisable), GradientError);
 }
 
 }  // namespace

--- a/chainerx_cc/chainerx/error.h
+++ b/chainerx_cc/chainerx/error.h
@@ -87,6 +87,12 @@ public:
     using ChainerxError::ChainerxError;
 };
 
+// Error on mismatch gradient traits
+class GradientError : public ChainerxError {
+public:
+    using ChainerxError::ChainerxError;
+};
+
 // Error on failing gradient check
 class GradientCheckError : public ChainerxError {
 public:

--- a/chainerx_cc/chainerx/python/error.cc
+++ b/chainerx_cc/chainerx/python/error.cc
@@ -18,6 +18,7 @@ void InitChainerxError(pybind11::module& m) {
     py::register_exception<DimensionError>(m, "DimensionError");
     py::register_exception<DtypeError>(m, "DtypeError");
     py::register_exception<NotImplementedError>(m, "NotImplementedError");
+    py::register_exception<GradientError>(m, "GradientError");
     py::register_exception<GradientCheckError>(m, "GradientCheckError");
 }
 


### PR DESCRIPTION
If a fallback backward function returns gradients with mismatched dtype, shape, etc., it's extremely difficult to spot the erroneous code, as the stack trace does not go through any Python code.