### PR TITLE
Improve `F.resize_images` speed

### DIFF
--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -203,10 +203,9 @@ class ResizeImages(function_node.FunctionNode):
 
         # Meshgrid-like operation. Meshgrid can cause
         # performance loss due to memory consumption.
-        v = xp.broadcast_to(v[:, None], (out_H, out_W))
-        u = xp.broadcast_to(u[None, :], (out_H, out_W))
-        vw = xp.broadcast_to(vw[:, None], (out_H, out_W))
-        uw = xp.broadcast_to(uw[None, :], (out_H, out_W))
+        # Note that numpy 1.9 doesn't support broadcast_to method.
+        v, u, vw, uw = xp.broadcast_arrays(
+            v[:, None], u[None, :], vw[:, None], uw[None, :])
 
         if xp is numpy:
             y = interpolate_bilinear_cpu(x, v, u, vw, uw)
@@ -254,10 +253,9 @@ class ResizeImagesGrad(function_node.FunctionNode):
 
         # Meshgrid-like operation. Meshgrid can cause
         # performance loss due to memory consumption.
-        v = xp.broadcast_to(v[:, None], (out_H, out_W))
-        u = xp.broadcast_to(u[None, :], (out_H, out_W))
-        vw = xp.broadcast_to(vw[:, None], (out_H, out_W))
-        uw = xp.broadcast_to(uw[None, :], (out_H, out_W))
+        # Note that numpy 1.9 doesn't support broadcast_to method.
+        v, u, vw, uw = xp.broadcast_arrays(
+            v[:, None], u[None, :], vw[:, None], uw[None, :])
 
         if xp is numpy:
             gx = interpolate_grad_bilinear_cpu(gy, v, u, vw, uw, H, W)

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -93,6 +93,32 @@ class TestResizeImagesForwardUpScale(unittest.TestCase):
             cuda.to_gpu(self.x), output_shape=self.output_shape[2:])
 
 
+class TestResizeImagesForwardMultiLines(unittest.TestCase):
+
+    in_shape = (1, 1, 987, 123)
+    output_shape = (1, 1, 765, 345)
+
+    def setUp(self):
+        self.x = numpy.arange(numpy.prod(self.in_shape), dtype=numpy.float32)
+        self.x = self.x.reshape(self.in_shape)
+
+        out_row = numpy.linspace(0, 123 - 1, 345, dtype=numpy.float32)
+        out_col = numpy.linspace(0, (987 - 1) * 123, 765, dtype=numpy.float32)
+        self.out = (out_row + out_col[:, None]).reshape(self.output_shape)
+
+    def check_forward(self, x, output_shape):
+        y = functions.resize_images(x, output_shape)
+        testing.assert_allclose(y.data, self.out)
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x, output_shape=self.output_shape[2:])
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(
+            cuda.to_gpu(self.x), output_shape=self.output_shape[2:])
+
+
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
     'output_shape': [(10, 5), (3, 4)]


### PR DESCRIPTION
The speed of `resize_images` improved about 1.5-3x on GPU and 0.5-3x on CPU depending on data (explained later.)

For GPU, I wrote custom kernel. Performance gain is consistent in any benchmark.

For CPU,

* Images are processed by each panel that consists of image rows. The size of a panel is chosen to fit in CPU cache. This optimization is especially useful when running multiple processes in parallel.
* Temporal objects and computations in the loop are minimized, so as to exploit the above cache memory optimization as much as possible.
*  `numpy.einsum` is used to for interpolation. Benchmark founds it is fast.
* `numpy.bincount` is used in backward, instead of `numpy.add.at`.

On CPU, I optimized to the data with small batch/channel size and multi processes. This is because

* Some users (including me) want to use this function for dataset loading,
* Resizing of a feature map with large channels isn't likely a bottleneck of CPU inference, and
* CPU inference doesn't use large batch size typically.

BTW I also tried hard to unify the routine and `spatial_transformer_sampler`, but I gave up because it is difficult to implement zero-padding while maintaining efficiency and simplicity.

The result of benchmark is as follows. It is conducted by a machine with Ryzen 2700X CPU, GTX 1080 Ti GPU and dual DDR4-3200 memories.

The worst degradation (0.53x) is observed when the setting `B=16, C=256: 13 x 13 -> 26 x 26`, (simulating upsampling layer in the CNN) is run by CPU in a single process. When the batch size is set to 1 or the number of processes increased to 16, 0.59x or 0.95x degradation observed.

In the all other experiments, the new implementation outperformed the old one. I think the new implementation performs better in most real workloads. 

Before:

```
=== forward ===                                           
resize image B=1, C=3: 1920 x 1080 -> 736 x 416                            
CPU: 26.691821798158344 ms, avg of 10 runs, single process
CPU: 58.3756480125885 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 14.872294664382935 ms, avg of 10 runs                
resize image B=1, C=3: 300 x 300 -> 512 x 512                             
CPU: 22.749565800768323 ms, avg of 10 runs, single process
CPU: 106.85483475626825 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 4.729868793487549 ms, avg of 10 runs                
resize image B=1, C=256: 13 x 13 -> 26 x 26                                
CPU: 0.7389972990495153 ms, avg of 10 runs, single process                 
CPU: 6.624079518496728 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 4.671692895889282 ms, avg of 10 runs           
resize image B=16, C=256: 13 x 13 -> 26 x 26              
CPU: 18.51114509627223 ms, avg of 10 runs, single process                  
CPU: 137.61708643814927 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 4.785724830627442 ms, avg of 10 runs         
=== backward ===                                          
resize image grad B=1, C=3: 1920 x 1080 -> 736 x 416                       
CPU: 259.442993097764 ms, avg of 10 runs, single process
CPU: 441.9108092307397 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 4.477715158462525 ms, avg of 10 runs                
resize image grad B=1, C=3: 300 x 300 -> 512 x 512                         
CPU: 217.0542143008788 ms, avg of 10 runs, single process
CPU: 370.3624082684655 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 4.356169605255127 ms, avg of 10 runs                
resize image grad B=1, C=256: 13 x 13 -> 26 x 26                           
CPU: 41.45520479505649 ms, avg of 10 runs, single process                  
CPU: 69.43192750022718 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 4.442115116119385 ms, avg of 10 runs         
resize image grad B=16, C=256: 13 x 13 -> 26 x 26         
CPU: 663.2762717999867 ms, avg of 10 runs, single process                 
CPU: 1253.7040110001726 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 4.686790418624878 ms, avg of 10 runs 
```

After:

```
=== forward ===                                                            
resize image B=1, C=3: 1920 x 1080 -> 736 x 416          
CPU: 20.45501230022637 ms, avg of 10 runs, single process                  
CPU: 31.312923219957156 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 11.668041777610778 ms, avg of 10 runs                                
resize image B=1, C=3: 300 x 300 -> 512 x 512       
CPU: 15.048598102293909 ms, avg of 10 runs, single process
CPU: 31.39626003758167 ms, avg of 10 runs, avg of 16 processes in parallel 
GPU: 1.4476064085960387 ms, avg of 10 runs                                 
resize image B=1, C=256: 13 x 13 -> 26 x 26       
CPU: 1.2483462021918967 ms, avg of 10 runs, single process
CPU: 2.4135381940141087 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 1.1990272045135497 ms, avg of 10 runs              
resize image B=16, C=256: 13 x 13 -> 26 x 26                              
CPU: 34.67513090145076 ms, avg of 10 runs, single process
CPU: 143.83816199369903 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 2.3886464118957518 ms, avg of 10 runs               
=== backward ===                                                          
resize image grad B=1, C=3: 1920 x 1080 -> 736 x 416     
CPU: 54.4332204022794 ms, avg of 10 runs, single process                   
CPU: 298.46999800693084 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 1.529529595375061 ms, avg of 10 runs                                 
resize image grad B=1, C=3: 300 x 300 -> 512 x 512
CPU: 28.015225402486976 ms, avg of 10 runs, single process
CPU: 159.3188028867189 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 1.4265375852584838 ms, avg of 10 runs                                 
resize image grad B=1, C=256: 13 x 13 -> 26 x 26
CPU: 3.170811999007128 ms, avg of 10 runs, single process   
CPU: 19.724836263230827 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 1.1780479967594146 ms, avg of 10 runs                               
resize image grad B=16, C=256: 13 x 13 -> 26 x 26
CPU: 95.04309819749324 ms, avg of 10 runs, single process
CPU: 338.28351716847465 ms, avg of 10 runs, avg of 16 processes in parallel
GPU: 2.1786527752876284 ms, avg of 10 runs    
```

The following script is used for the benchmark.

```python
import multiprocessing
import time

import numpy as np
import chainer
from chainer.backends import cuda


class TaskResizeImages():
    from chainer.functions.array.resize_images import ResizeImages

    def __init__(self, B, C, H, W, out_H, out_W):
        self.name = 'resize image B={}, C={}: {} x {} -> {} x {}'.format(B, C, W, H, out_W, out_H)
        self.images = np.arange(B * C * H * W, dtype=np.float32).reshape((B, C, H, W))
        self.B = B
        self.C = C
        self.H = H
        self.W = W
        self.out_H = out_H
        self.out_W = out_W

    def to_gpu(self):
        self.images = cuda.cupy.asarray(self.images)

    def __call__(self):
        self.ResizeImages((self.out_H, self.out_W)).apply((self.images,))


class TaskResizeImagesGrad():
    from chainer.functions.array.resize_images import ResizeImagesGrad

    def __init__(self, B, C, H, W, out_H, out_W):
        self.name = 'resize image grad B={}, C={}: {} x {} -> {} x {}'.format(B, C, W, H, out_W, out_H)
        self.grads = np.random.normal(size=(B, C, out_H, out_W)).astype(np.float32)
        self.B = B
        self.C = C
        self.H = H
        self.W = W
        self.out_H = out_H
        self.out_W = out_W

    def to_gpu(self):
        self.grads = cuda.cupy.asarray(self.grads)

    def __call__(self):
        self.ResizeImagesGrad((self.B, self.C, self.H, self.W), (self.out_H, self.out_W)).apply((self.grads,))


def f(args):
    runs, task = args
    cum_ms = 0
    for _ in range(runs):
        start = time.perf_counter()
        task()
        end = time.perf_counter()
        cum_ms += (end - start) * 1000
    return cum_ms


def run_task(task):
    runs = 10
    processes = 16
    print(task.name)

    cum_ms = f((runs, task))
    print('CPU: {} ms, avg of {} runs, single process'.format(cum_ms / runs, runs))

    with multiprocessing.Pool(processes) as pool:
        cum_mss = pool.map(f, ((runs, task) for _ in range(processes)), 1)
        cum_ms = sum(cum_mss) / processes
        print('CPU: {} ms, avg of {} runs, avg of {} processes in parallel'.format(cum_ms / runs, runs, processes))

    stream = cuda.Stream.null
    task.to_gpu()

    cum_ms = 0
    for _ in range(runs):
        time.sleep(0.1)
        start = stream.record()
        task()
        end = stream.record()
        end.synchronize()
        cum_ms += cuda.cupy.cuda.get_elapsed_time(start, end)
    print('GPU: {} ms, avg of {} runs'.format(cum_ms / runs, runs))


cuda.get_device_from_id(0).use()
task1 = TaskResizeImages(1, 3, 1080, 1920, 416, 736)
task2 = TaskResizeImages(1, 3, 300, 300, 512, 512)
task3 = TaskResizeImages(1, 256, 13, 13, 26, 26)
task4 = TaskResizeImages(16, 256, 13, 13, 26, 26)
task5 = TaskResizeImagesGrad(1, 3, 1080, 1920, 416, 736)
task6 = TaskResizeImagesGrad(1, 3, 300, 300, 512, 512)
task7 = TaskResizeImagesGrad(1, 256, 13, 13, 26, 26)
task8 = TaskResizeImagesGrad(16, 256, 13, 13, 26, 26)
print("=== forward ===")
run_task(task1)
run_task(task2)
run_task(task3)
run_task(task4)
print("=== backward ===")
run_task(task5)
run_task(task6)
run_task(task7)
run_task(task8)
```