### PR TITLE
Add robots.txt to hide older versions from search results

### DIFF
--- a/docs/source/_static/robots.txt
+++ b/docs/source/_static/robots.txt
@@ -1,0 +1,4 @@
+User-Agent: *
+Allow: /en/stable/
+Allow: /en/latest/
+Disallow: /


### PR DESCRIPTION
After merging this we need to setup redirect from `/robots.txt` to `/en/latest/_static/robots.txt` in Cloudflare.