### PR TITLE
Do not overwrite CMAKE_CXX_FLAGS a user specified

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -85,7 +85,7 @@ set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)  # ref. https://texus.me/2015/09/06/cm
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|Intel")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
-    set(CMAKE_CXX_FLAGS "-g -Wall -Wextra -fPIC -pthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -fPIC -pthread")
     set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")  # cmake -DCMAKE_BUILD_TYPE=Release
     set(CMAKE_CXX_FLAGS_DEBUG "-O0")  # cmake -DCMAKE_BUILD_TYPE=Debug
     if (${CUDA_FOUND})


### PR DESCRIPTION
I'd like to specify `-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0` to avoid ABI conflict with other libraries.