### PR TITLE
Fix `testing.BackendConfig` context for repeated use

### DIFF
--- a/chainer/testing/backend.py
+++ b/chainer/testing/backend.py
@@ -83,8 +83,6 @@ class BackendConfig(object):
         return self._device
 
     def __enter__(self):
-        if self._contexts is None:
-            self._contexts = []
         contexts = [
             chainer.using_config(
                 'use_cudnn', self.use_cudnn),

--- a/chainer/testing/backend.py
+++ b/chainer/testing/backend.py
@@ -83,7 +83,9 @@ class BackendConfig(object):
         return self._device
 
     def __enter__(self):
-        self._contexts = [
+        if self._contexts is None:
+            self._contexts = []
+        contexts = [
             chainer.using_config(
                 'use_cudnn', self.use_cudnn),
             chainer.using_config(
@@ -94,12 +96,14 @@ class BackendConfig(object):
                 'use_ideep', self.use_ideep),
             chainer.using_device(self.device),
         ]
-        for c in self._contexts:
+        for c in contexts:
             c.__enter__()
+        self._contexts.append(contexts)
         return self
 
     def __exit__(self, typ, value, traceback):
-        for c in reversed(self._contexts):
+        contexts = self._contexts.pop()
+        for c in reversed(contexts):
             c.__exit__(typ, value, traceback)
 
     def __repr__(self):


### PR DESCRIPTION
Fix `testing.BackendConfig` so that it can be used as a context manager multiple times.

Previously, the following code caused an error:
```
a = chainer.testing.BackendConfig({'use_cuda': True})
with a:
    with a:
        pass
```
```
...
  File "cupy/cuda/device.pyx", line 113, in cupy.cuda.device.Device.__exit__
IndexError: pop from empty list
```