### PR TITLE
Raise CuPy not available error early in `cuda.GpuDevice` initialization

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -158,8 +158,8 @@ _integer_types = six.integer_types + (numpy.integer,)
 class GpuDevice(_backend.Device):
 
     def __init__(self, device):
-        assert isinstance(device, Device)
         check_cuda_available()
+        assert isinstance(device, Device)
 
         super(GpuDevice, self).__init__()
         self.device = device


### PR DESCRIPTION
If CuPy is not available, `Device` is not defined, causing a bit difficult to understand error.