### PR TITLE
Encode parameters in parameterized class name

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -13,7 +13,7 @@ def _parameterize_test_case_generator(base, params):
     # Defines the logic to generate parameterized test case classes.
 
     for i, param in enumerate(params):
-        cls_name = '%s_param_%d' % (base.__name__, i)
+        cls_name = '{}_param_{}_{}'.format(base.__name__, i, param)
 
         def __str__(self):
             name = base.__str__(self)


### PR DESCRIPTION
Previously parameterized class names are difficult to interpret.

Previous:
```
tests/chainer_tests/test_variable.py::TestBackwardAccumulate_param_0::test_backward_accumulate_cpu
```

This PR:
```
tests/chainer_tests/test_variable.py::TestBackwardAccumulate_param_0_{'in0_isvar_hasgrad': (False, False), 'in1_isvar_hasgrad': (False, False), 'in2_isvar_hasgrad': (False, False), 'var_mapping': (0, 1, 2)}::test_backward_accumulate_cpu
```

Note that Python classes and functions can have any name represented by a string (including spaces, symbols, etc.), with unlimited length.