### PR TITLE
Fix scalar handling of `indices_and_sections` in `chainerx.split`

### DIFF
--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -410,6 +410,9 @@ void InitChainerxManipulation(pybind11::module& m) {
           py::arg("axis") = 0);
     m.def("split",
           [](const ArrayBodyPtr& ary, py::handle indices_or_sections, int8_t axis) {
+              // TODO(niboshi): Perhaps we would want more general approach to handle multi-type arguments like indices_or_sections to
+              // provide more helpful error message for users.
+
               auto split_sections = [](const ArrayBodyPtr& ary, int64_t sections, int8_t axis) {
                   return MoveArrayBodies(Split(Array{ary}, sections, axis));
               };

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -441,14 +441,14 @@ void InitChainerxManipulation(pybind11::module& m) {
               }
               // numpy.ndarray
               if (py::isinstance<py::array>(indices_or_sections)) {
-                  py::array np = py::cast<py::array>(indices_or_sections);
-                  if (np.ndim() >= 2) {
-                      throw py::value_error{std::string{"Too many dimensions of indices: "} + std::to_string(np.ndim())};
+                  py::array np_ios = py::cast<py::array>(indices_or_sections);
+                  if (np_ios.ndim() >= 2) {
+                      throw py::value_error{std::string{"Too many dimensions of indices: "} + std::to_string(np_ios.ndim())};
                   }
                   // sections: scalar
-                  if (np.ndim() == 0) {
+                  if (np_ios.ndim() == 0) {
                       int64_t sections{};
-                      py::object scalar_np = np.attr("tolist")();
+                      py::object scalar_np = np_ios.attr("tolist")();
                       if (py::isinstance<py::int_>(scalar_np)) {
                           sections = py::cast<int64_t>(scalar_np);
                       } else if (py::isinstance<py::float_>(scalar_np)) {
@@ -460,16 +460,16 @@ void InitChainerxManipulation(pybind11::module& m) {
                   }
 
                   // indices: (0,)-shape
-                  if (np.size() == 0) {
+                  if (np_ios.size() == 0) {
                       return split_indices(ary, {}, axis);
                   }
 
-                  if (np.dtype().kind() != 'i') {
+                  if (np_ios.dtype().kind() != 'i') {
                       throw py::type_error{std::string{"Indices must be integers."}};
                   }
                   // indices: non-scalar
                   std::vector<int64_t> indices{};
-                  py::list indices_pylist = np.attr("tolist")();
+                  py::list indices_pylist = np_ios.attr("tolist")();
                   for (py::handle item : indices_pylist) {
                       indices.emplace_back(py::cast<int64_t>(item));
                   }

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -419,6 +419,14 @@ def test_stack(xp, shapes, axis):
     ((2, 4, 6), [2, 8], 2),
     ((2, 4, 6), [4, 2], 2),
     ((2, 4, 6), [1, 3], -2),
+    ((6,), numpy.array([1, 2]), 0),  # indices with 1-d numpy array
+    ((6,), numpy.array([2]), 0),  # indices with (1,)-shape numpy array
+    ((6,), numpy.array(2), 0),  # sections numpy scalar
+    ((6,), numpy.array(2.0), 0),  # sections with numpy scalar, float
+    ((6,), 2.0, 0),  # float type sections, without fraction
+    # indices with empty numpy indices
+    ((6,), numpy.array([], numpy.int32), 0),
+    ((6,), numpy.array([], numpy.float64), 0),
 ])
 def test_split(xp, shape, indices_or_sections, axis):
     a = array_utils.create_dummy_ndarray(xp, shape, 'float32')
@@ -427,7 +435,8 @@ def test_split(xp, shape, indices_or_sections, axis):
 
 @chainerx.testing.numpy_chainerx_array_equal(
     accept_error=(
-        chainerx.DimensionError, IndexError, ValueError, ZeroDivisionError))
+        chainerx.DimensionError, IndexError, ValueError, TypeError,
+        ZeroDivisionError))
 @pytest.mark.parametrize('shape,indices_or_sections,axis', [
     ((), 1, 0),
     ((2,), 3, 0),
@@ -435,6 +444,17 @@ def test_split(xp, shape, indices_or_sections, axis):
     ((2, 4), -1, 1),
     ((2, 4), 1, 2),  # Axis out of range.
     ((2, 4), 3, 1),  # Uneven split.
+    ((6,), [2.0], 0),  # float type indices
+    ((6,), 2.1, 0),  # float type sections, with fraction
+    # indices with (1,)-shape numpy array, float
+    ((6,), numpy.array([2.0]), 0),
+    # sections with numpy scalar, float with fraction
+    ((6,), numpy.array(2.1), 0),
+    ((2,), [1, 2.0], 0),  # indices with mixed type
+    ((6,), '2', 0),  # Invalid type
+    # indices with empty numpy indices
+    ((6,), numpy.array([[], []], numpy.int32), 0),
+    ((6,), numpy.array([[], []], numpy.float64), 0),
 ])
 def test_split_invalid(xp, shape, indices_or_sections, axis):
     a = array_utils.create_dummy_ndarray(xp, shape, 'float32')


### PR DESCRIPTION
Fixes #5785 