### PR TITLE
Fix a couple of broken links from markdown files

### DIFF
--- a/chainerx_cc/README.md
+++ b/chainerx_cc/README.md
@@ -2,4 +2,4 @@
 
 This is the C++ code base for ChainerX including the Python bindings.
 
-For instructions how to build and install it, please refer to the [ChainerX contribution guide](docs/source/chainerx/contribution.rst).
+For instructions how to build and install it, please refer to the [ChainerX contribution guide](../docs/source/chainerx/contribution.rst).

--- a/examples/pix2pix/README.md
+++ b/examples/pix2pix/README.md
@@ -2,8 +2,6 @@
 chainer implementation of pix2pix
 https://phillipi.github.io/pix2pix/
 
-The Japanese readme can be found [here](README-ja.md).
-
 # Example result on CMP facade dataset
 <img src="https://github.com/mattya/chainer-pix2pix/blob/master/image/example.png?raw=true">
 From the left side: input, output, ground_truth


### PR DESCRIPTION
- Fixed a link from chainerx_cc/README.md.
- Removed a link to Japanese README. It seems there is
  https://github.com/pfnet-research/chainer-pix2pix/blob/master/README-ja.md
  but it'd be better to just drop the link as documents in
  other repositories can easily get stale.

I wrote an incomplete script so other markdown files are
probably OK.

https://github.com/shinh/test/blob/master/check_md_links.rb
