### PR TITLE
Fix wording in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Chainer -- A flexible framework of neural networks
 
 .. toctree::
    :maxdepth: 2
-   :caption: Chainer Documents
+   :caption: Chainer Documentation
 
    glance
    install


### PR DESCRIPTION
Replaces "Documents" with "Documentation".