### PR TITLE
Update pybind dependency to v2.2.4

### DIFF
--- a/chainerx_cc/third_party/pybind11.cmake
+++ b/chainerx_cc/third_party/pybind11.cmake
@@ -4,7 +4,7 @@ project(pybind11-download NONE)
 include(ExternalProject)
 ExternalProject_Add(pybind11
     GIT_REPOSITORY    https://github.com/pybind/pybind11.git
-    GIT_TAG           5ef1af138dc3ef94c05274ae554e70d64cd589bf # 2.2.3 + #1371 merged
+    GIT_TAG           v2.2.4
     SOURCE_DIR        "${CMAKE_BINARY_DIR}/pybind11"
     BINARY_DIR        ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
v2.2.3 can cause deprecation warning for `PyThread_create_key` at `include/pybind11/detail/internals.h:82:34`.

(fixed in https://github.com/pybind/pybind11/pull/1454)