### PR TITLE
[backport] Add `hasattr` check to user-specified `flush` call to file-like objects.

### DIFF
--- a/chainer/datasets/pickle_dataset.py
+++ b/chainer/datasets/pickle_dataset.py
@@ -41,7 +41,8 @@ class PickleDatasetWriter(object):
         self._positions.append(position)
 
     def flush(self):
-        self._writer.flush()
+        if hasattr(self._writer, 'flush'):
+            self._writer.flush()
 
 
 class PickleDataset(dataset_mixin.DatasetMixin):

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -152,7 +152,8 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
                 function_name, used_bytes, acquired_bytes, occurrence)
             file.write(line)
             file.write('\n')
-        file.flush()
+        if hasattr(file, 'flush'):
+            file.flush()
 
 
 class CupyMemoryCumulativeHook(MemoryHook):

--- a/chainer/function_hooks/debug_print.py
+++ b/chainer/function_hooks/debug_print.py
@@ -80,7 +80,7 @@ class PrintHook(function_hook.FunctionHook):
                     v = variable.Variable(xp.zeros_like(d, dtype=d.dtype))
                     v.grad = d
                 self._print(v.debug_print())
-        if self.flush:
+        if self.flush and hasattr(self.file, 'flush'):
             self.file.flush()
 
     def forward_preprocess(self, function, in_data):

--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -137,4 +137,5 @@ class TimerHook(function_hook.FunctionHook):
             line = template.format(function_name, elapsed_time, occurrence)
             file.write(line)
             file.write('\n')
-        file.flush()
+        if hasattr(file, 'flush'):
+            file.flush()

--- a/chainer/training/extensions/progress_bar.py
+++ b/chainer/training/extensions/progress_bar.py
@@ -111,7 +111,8 @@ class ProgressBar(extension.Extension):
                 util.set_console_cursor_position(0, -4)
             else:
                 out.write('\033[4A')
-            out.flush()
+            if hasattr(out, 'flush'):
+                out.flush()
 
             if len(recent_timing) > 100:
                 del recent_timing[0]
@@ -123,4 +124,5 @@ class ProgressBar(extension.Extension):
             util.erase_console(0, 0)
         else:
             out.write('\033[J')
-        out.flush()
+        if hasattr(out, 'flush'):
+            out.flush()


### PR DESCRIPTION
Backport of #5794