### PR TITLE
ignore chainerx reference generated doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/*.png
 docs/source/reference/core
 docs/source/reference/generated
 docs/source/reference/util
+docs/source/**/reference/generated


### PR DESCRIPTION
I made `docs/source/chainerx/reference` to be ignored.