### PR TITLE
Support custom initializer in links.CRF1d

### DIFF
--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -1,7 +1,7 @@
 from chainer.functions.loss import crf1d
+from chainer import initializers
 from chainer import link
 from chainer import variable
-from chainer import initializers
 
 
 class CRF1d(link.Link):

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -1,6 +1,7 @@
 from chainer.functions.loss import crf1d
 from chainer import link
 from chainer import variable
+from chainer import initializers
 
 
 class CRF1d(link.Link):
@@ -19,8 +20,11 @@ class CRF1d(link.Link):
         cost (~chainer.Variable): Transition cost parameter.
     """
 
-    def __init__(self, n_label, initialW=0):
+    def __init__(self, n_label, initialW=None):
         super(CRF1d, self).__init__()
+        if initialW is None:
+            initialW = initializers.constant.Zero()
+
         with self.init_scope():
             self.cost = variable.Parameter(initializer=initialW,
                                            shape=(n_label, n_label))

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -14,8 +14,9 @@ class CRF1d(link.Link):
     Args:
         n_label (int): Number of labels.
         initialW (:ref:`initializer <initializer>`): Initializer to
-            initialize the weight. When it is not specify,
-            the weight is initialized with zero.
+            initialize the transition cost matrix.
+            When it is not specify, the transition cost matrix
+            is initialized with zero.
 
     .. seealso:: :func:`~chainer.functions.crf1d` for more detail.
 

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -13,6 +13,9 @@ class CRF1d(link.Link):
 
     Args:
         n_label (int): Number of labels.
+        initialW (:ref:`initializer <initializer>`): Initializer to
+            initialize the weight. When it is not specify,
+            the weight is initialized with zero.
 
     .. seealso:: :func:`~chainer.functions.crf1d` for more detail.
 

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -19,10 +19,11 @@ class CRF1d(link.Link):
         cost (~chainer.Variable): Transition cost parameter.
     """
 
-    def __init__(self, n_label):
+    def __init__(self, n_label, initialW=0):
         super(CRF1d, self).__init__()
         with self.init_scope():
-            self.cost = variable.Parameter(0, (n_label, n_label))
+            self.cost = variable.Parameter(initializer=initialW,
+                                           shape=(n_label, n_label))
 
     def forward(self, xs, ys, reduce='mean'):
         return crf1d.crf1d(self.cost, xs, ys, reduce)

--- a/chainer/links/loss/crf1d.py
+++ b/chainer/links/loss/crf1d.py
@@ -13,10 +13,10 @@ class CRF1d(link.Link):
 
     Args:
         n_label (int): Number of labels.
-        initialW (:ref:`initializer <initializer>`): Initializer to
+        initial_cost (:ref:`initializer <initializer>`): Initializer to
             initialize the transition cost matrix.
-            When it is not specify, the transition cost matrix
-            is initialized with zero.
+            If this attribute is not specified,
+            the transition cost matrix is initialized with zeros.
 
     .. seealso:: :func:`~chainer.functions.crf1d` for more detail.
 
@@ -24,13 +24,13 @@ class CRF1d(link.Link):
         cost (~chainer.Variable): Transition cost parameter.
     """
 
-    def __init__(self, n_label, initialW=None):
+    def __init__(self, n_label, initial_cost=None):
         super(CRF1d, self).__init__()
-        if initialW is None:
-            initialW = initializers.constant.Zero()
+        if initial_cost is None:
+            initial_cost = initializers.constant.Zero()
 
         with self.init_scope():
-            self.cost = variable.Parameter(initializer=initialW,
+            self.cost = variable.Parameter(initializer=initial_cost,
                                            shape=(n_label, n_label))
 
     def forward(self, xs, ys, reduce='mean'):

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -64,7 +64,8 @@ class TestCRF1d(unittest.TestCase):
     def check_forward(self, x_data, t_data):
         x = self.link(x_data, t_data)
         t = self._crf1d(self.link.cost.data, x_data, t_data)
-        testing.assert_allclose(x.data, t)
+        testing.assert_allclose(x.data, t,
+                                **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -48,7 +48,7 @@ class TestCRF1d(unittest.TestCase):
                    for b in self.batches]
         self.ys = [numpy.random.randint(
             0, self.n_labels, (b,)).astype(numpy.int32)
-                   for b in self.batches]
+            for b in self.batches]
 
         self.link = links.CRF1d(n_label=self.n_labels)
         self.cost_shape = (self.n_labels, self.n_labels)

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -1,5 +1,6 @@
 import unittest
 
+import itertools
 import numpy
 
 import chainer
@@ -8,26 +9,46 @@ from chainer import initializers
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
+from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'initial_cost': ['random', None],
 }))
 class TestCRF1d(unittest.TestCase):
+    def _calc_score(self, batch, ys):
+        cost = self.link.cost.data
+        return sum(x[batch, y] for x, y in zip(self.xs, ys)) + \
+            sum(cost[y1, y2] for y1, y2 in zip(ys[:-1], ys[1:]))
 
-    n_labels = 3
+    def _crf1d(self, cost_data, xs_data, ys_data):
+        z = numpy.zeros((self.batches[0],), numpy.float32)
+        for b, length in enumerate(self.lengths):
+            for ys in itertools.product(range(self.n_labels), repeat=length):
+                z[b] += numpy.exp(self._calc_score(b, ys))
+
+        score = numpy.zeros((self.batches[0],), numpy.float32)
+        for b, length in enumerate(self.lengths):
+            ys = [self.ys[i][b] for i in range(length)]
+            score[b] = self._calc_score(b, ys)
+
+        loss = -(score - numpy.log(z))
+        return numpy.sum(loss) / self.batches[0]
 
     def setUp(self):
         self._config_user = chainer.using_config('dtype', self.dtype)
         self._config_user.__enter__()
+        self.n_labels = 3
 
-        self.xs = [numpy.array([[1, 0, 0], [1, 0, 0]], self.dtype),
-                   numpy.array([[0, 1, 0], [0, 1, 0]], self.dtype),
-                   numpy.array([[0, 1, 0]], self.dtype)]
+        self.lengths = [3, 3]
+        self.batches = [2, 2, 2]
 
-        self.ts = [numpy.array([0, 0], numpy.int32),
-                   numpy.array([1, 1], numpy.int32),
-                   numpy.array([2], numpy.int32)]
+        self.xs = [numpy.random.uniform(-1, 1, (b, 3)).astype(self.dtype)
+                   for b in self.batches]
+        self.ys = [numpy.random.randint(
+            0, self.n_labels, (b,)).astype(numpy.int32)
+                   for b in self.batches]
 
         self.link = links.CRF1d(n_label=self.n_labels)
         self.cost_shape = (self.n_labels, self.n_labels)
@@ -41,29 +62,65 @@ class TestCRF1d(unittest.TestCase):
         self._config_user.__exit__(None, None, None)
 
     def check_forward(self, x_data, t_data):
-        self.link(x_data, t_data)
+        x = self.link(x_data, t_data)
+        t = self._crf1d(self.link.cost.data, x_data, t_data)
+        testing.assert_allclose(x.data, t)
 
+    @condition.retry(3)
     def test_forward_cpu(self):
-        print(self.xs, self.ts)
-        self.check_forward(self.xs, self.ts)
+        self.check_forward(self.xs, self.ys)
 
     @attr.gpu
+    @condition.retry(3)
     def test_forward_gpu(self):
         self.link.to_gpu()
-        self.check_forward(cuda.to_gpu(self.xs), cuda.to_gpu(self.ts))
+        self.check_forward(cuda.to_gpu(self.xs), cuda.to_gpu(self.ys))
 
-    def test_zeroinit(self):
-        link = links.CRF1d(n_label=self.n_labels)
-        x = link.cost.data
-        t = link.xp.zeros(self.cost_shape, dtype=link.xp.float32)
-        self.assertTrue(link.xp.array_equal(x, t))
 
-    def test_xavierinit(self):
-        link = links.CRF1d(n_label=self.n_labels,
-                           initial_cost=initializers.GlorotUniform())
-        x = link.cost.data
-        t = link.xp.zeros(self.cost_shape, dtype=link.xp.float32)
-        self.assertFalse(link.xp.array_equal(x, t))
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'initializer': ['random', None]
+}))
+class TestInitialization(unittest.TestCase):
+
+    def setUp(self):
+        self.n_labels = 3
+
+        if self.initializer is None:
+            self.initial_cost = None
+
+        elif self.initializer == 'random':
+            self.initial_cost = initializers.GlorotUniform()
+
+        with chainer.using_config('dtype', self.dtype):
+            self.link = links.CRF1d(
+                self.n_labels,
+                initial_cost=self.initial_cost)
+
+    def check_param(self):
+        link = self.link
+        dtype = self.dtype
+        assert link.cost.dtype == dtype
+
+        if self.initializer is None:
+            cost = numpy.empty(
+                (self.n_labels, self.n_labels), dtype=self.dtype)
+            initial_cost = initializers.constant.Zero()
+            initial_cost(cost)
+            testing.assert_allclose(cost, link.cost.data)
+
+        elif self.initializer == 'random':
+            zeros = link.xp.zeros(
+                (self.n_labels, self.n_labels), dtype=self.dtype)
+            assert not (zeros == link.cost.data).all()
+
+    def test_param_cpu(self):
+        self.check_param()
+
+    @attr.gpu
+    def test_param_gpu(self):
+        self.link.to_gpu()
+        self.check_param()
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -25,7 +25,7 @@ class TestCRF1d(unittest.TestCase):
     def _crf1d(self, cost_data, xs_data, ys_data):
         z = numpy.zeros((self.batches[0],), numpy.float32)
         for b, length in enumerate(self.lengths):
-            for ys in itertools.product(range(self.n_labels), repeat=length):
+            for ys in itertools.product(range(self.n_label), repeat=length):
                 z[b] += numpy.exp(self._calc_score(b, ys))
 
         score = numpy.zeros((self.batches[0],), numpy.float32)
@@ -39,7 +39,7 @@ class TestCRF1d(unittest.TestCase):
     def setUp(self):
         self._config_user = chainer.using_config('dtype', self.dtype)
         self._config_user.__enter__()
-        self.n_labels = 3
+        self.n_label = 3
 
         self.lengths = [3, 3]
         self.batches = [2, 2, 2]
@@ -47,11 +47,11 @@ class TestCRF1d(unittest.TestCase):
         self.xs = [numpy.random.uniform(-1, 1, (b, 3)).astype(self.dtype)
                    for b in self.batches]
         self.ys = [numpy.random.randint(
-            0, self.n_labels, (b,)).astype(numpy.int32)
+            0, self.n_label, (b,)).astype(numpy.int32)
             for b in self.batches]
 
-        self.link = links.CRF1d(n_label=self.n_labels)
-        self.cost_shape = (self.n_labels, self.n_labels)
+        self.link = links.CRF1d(n_label=self.n_label)
+        self.cost_shape = (self.n_label, self.n_label)
 
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-3}
@@ -85,7 +85,7 @@ class TestCRF1d(unittest.TestCase):
 class TestInitialization(unittest.TestCase):
 
     def setUp(self):
-        self.n_labels = 3
+        self.n_label = 3
 
         if self.initializer is None:
             self.initial_cost = None
@@ -95,7 +95,7 @@ class TestInitialization(unittest.TestCase):
 
         with chainer.using_config('dtype', self.dtype):
             self.link = links.CRF1d(
-                self.n_labels,
+                self.n_label,
                 initial_cost=self.initial_cost)
 
     def check_param(self):
@@ -105,14 +105,14 @@ class TestInitialization(unittest.TestCase):
 
         if self.initializer is None:
             cost = numpy.empty(
-                (self.n_labels, self.n_labels), dtype=self.dtype)
+                (self.n_label, self.n_label), dtype=self.dtype)
             initial_cost = initializers.constant.Zero()
             initial_cost(cost)
             testing.assert_allclose(cost, link.cost.data)
 
         elif self.initializer == 'random':
             zeros = link.xp.zeros(
-                (self.n_labels, self.n_labels), dtype=self.dtype)
+                (self.n_label, self.n_label), dtype=self.dtype)
             assert not (zeros == link.cost.data).all()
 
     def test_param_cpu(self):

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -1,0 +1,69 @@
+import unittest
+
+import numpy
+
+import chainer
+from chainer.backends import cuda
+from chainer import initializers
+from chainer import links
+from chainer import testing
+from chainer.testing import attr
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64]
+}))
+class TestCRF1d(unittest.TestCase):
+
+    n_labels = 3
+
+    def setUp(self):
+        self._config_user = chainer.using_config('dtype', self.dtype)
+        self._config_user.__enter__()
+
+        self.xs = [numpy.array([[1, 0, 0], [1, 0, 0]], self.dtype),
+                   numpy.array([[0, 1, 0], [0, 1, 0]], self.dtype),
+                   numpy.array([[0, 1, 0]], self.dtype)]
+
+        self.ts = [numpy.array([0, 0], numpy.int32),
+                   numpy.array([1, 1], numpy.int32),
+                   numpy.array([2], numpy.int32)]
+
+        self.link = links.CRF1d(n_label=self.n_labels)
+        self.cost_shape = (self.n_labels, self.n_labels)
+
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-3}
+        else:
+            self.check_forward_options = {'atol': 1e-4}
+
+    def tearDown(self):
+        self._config_user.__exit__(None, None, None)
+
+    def check_forward(self, x_data, t_data):
+        self.link(x_data, t_data)
+
+    def test_forward_cpu(self):
+        print(self.xs, self.ts)
+        self.check_forward(self.xs, self.ts)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.link.to_gpu()
+        self.check_forward(cuda.to_gpu(self.xs), cuda.to_gpu(self.ts))
+
+    def test_zeroinit(self):
+        link = links.CRF1d(n_label=self.n_labels)
+        x = link.cost.data
+        t = link.xp.zeros(self.cost_shape, dtype=link.xp.float32)
+        self.assertTrue(link.xp.array_equal(x, t))
+
+    def test_xavierinit(self):
+        link = links.CRF1d(n_label=self.n_labels,
+                           initial_cost=initializers.GlorotUniform())
+        x = link.cost.data
+        t = link.xp.zeros(self.cost_shape, dtype=link.xp.float32)
+        self.assertFalse(link.xp.array_equal(x, t))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -25,7 +25,7 @@ class TestCRF1d(unittest.TestCase):
         z = numpy.zeros((self.batches[0],), numpy.float32)
         for b, length in enumerate(self.lengths):
             for ys in itertools.product(range(self.n_label), repeat=length):
-                z[b] += numpy.exp(self._calc_score(b, ys))
+                z[b] += numpy.exp(chainer.cuda.to_cpu(self._calc_score(b, ys)))
 
         score = numpy.zeros((self.batches[0],), numpy.float32)
         for b, length in enumerate(self.lengths):

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -101,15 +101,9 @@ class TestInitialization(unittest.TestCase):
         link = self.link
         dtype = self.dtype
         assert link.cost.dtype == dtype
-
-        if self.initializer is None:
-            cost = numpy.empty(
-                (self.n_label, self.n_label), dtype=self.dtype)
-            testing.assert_allclose(cost, link.cost.array, atol=0, rtol=0)
-
-        elif self.initializer == 'random':
-            testing.assert_allclose(link.cost.array, self.initial_cost,
-                                    atol=0, rtol=0)
+        testing.assert_allclose(link.cost.array,
+                                self.initial_cost,
+                                atol=0, rtol=0)
 
     def test_param_cpu(self):
         self.check_param()

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -63,7 +63,7 @@ class TestCRF1d(unittest.TestCase):
     def check_forward(self, x_data, t_data):
         x = self.link(x_data, t_data)
         t = self._crf1d(self.link.cost.array, x_data, t_data)
-        testing.assert_allclose(x.data, t,
+        testing.assert_allclose(x.array, t,
                                 **self.check_forward_options)
 
     def test_forward_cpu(self):

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -110,7 +110,7 @@ class TestInitialization(unittest.TestCase):
             testing.assert_allclose(cost, link.cost.array, atol=0, rtol=0)
 
         elif self.initializer == 'random':
-            testing.assert_allclose(link.cost.data, self.initial_cost,
+            testing.assert_allclose(link.cost.array, self.initial_cost,
                                     atol=0, rtol=0)
 
     def test_param_cpu(self):

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -83,16 +83,16 @@ class TestInitialization(unittest.TestCase):
 
     def setUp(self):
         self.n_label = 3
+        self.initial_cost = numpy.empty((self.n_label, self.n_label),
+                                        dtype=self.dtype)
 
         if self.initializer is None:
-            self.initial_cost = None
+            initializer = initializers.constant.Zero()
 
         elif self.initializer == 'random':
             initializer = initializers.GlorotUniform()
-            self.initial_cost = numpy.empty((self.n_label, self.n_label),
-                                            dtype=self.dtype)
-            initializer(self.initial_cost)
 
+        initializer(self.initial_cost)
         with chainer.using_config('dtype', self.dtype):
             self.link = links.CRF1d(self.n_label,
                                     initial_cost=self.initial_cost)
@@ -105,8 +105,6 @@ class TestInitialization(unittest.TestCase):
         if self.initializer is None:
             cost = numpy.empty(
                 (self.n_label, self.n_label), dtype=self.dtype)
-            initial_cost = initializers.constant.Zero()
-            initial_cost(cost)
             testing.assert_allclose(cost, link.cost.array, atol=0, rtol=0)
 
         elif self.initializer == 'random':

--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -107,7 +107,7 @@ class TestInitialization(unittest.TestCase):
                 (self.n_label, self.n_label), dtype=self.dtype)
             initial_cost = initializers.constant.Zero()
             initial_cost(cost)
-            testing.assert_allclose(cost, link.cost.data, atol=0, rtol=0)
+            testing.assert_allclose(cost, link.cost.array, atol=0, rtol=0)
 
         elif self.initializer == 'random':
             testing.assert_allclose(link.cost.data, self.initial_cost,


### PR DESCRIPTION
Currently, the parameter of CRF1d is initialized by zero.
But this parameter could be initialized randomly.
There are some example using normal distribution ([1]) and uniform distribution ([2] and [3]).

So, in this PR, I change links.loss.CRF such that it accept the attribute `initialW`.

---
[1]: http://pages.cs.wisc.edu/~jerryzhu/cs769/CRF.pdf
[2]: https://github.com/glample/tagger/blob/master/model.py#L285
[3]: https://github.com/glample/tagger/blob/master/utils.py#L44
[ 1 ]: http://pages.cs.wisc.edu/~jerryzhu/cs769/CRF.pdf