### PR TITLE
Fix bug when CuPy not installed and cuda.fuse decorator used without parenthesis

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -670,6 +670,8 @@ def fuse(*args, **kwargs):
     """
     if available:
         return cupy.fuse(*args, **kwargs)
+    elif len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return args[0]
     else:
         return lambda f: f
 


### PR DESCRIPTION
On an environment CuPy is not installed, the following code has caused error.

```python
import numpy as np
from chainer.backends import cuda

@cuda.fuse
def f(x, y):
    return x + y

x = np.array([1,2,3])
y = np.array([1,2,3])
print(f(x, y))
```

```
Traceback (most recent call last):
  File "fusesample.py", line 10, in <module>
    print(f(x, y))
TypeError: <lambda>() takes 1 positional argument but 2 were given
```