### PR TITLE
Fix error message of `testing.assert_allclose`

### DIFF
--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -33,15 +33,18 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
             '  shape: {} {}\n'.format(x.shape, y.shape) +
             '  dtype: {} {}\n'.format(x.dtype, y.dtype))
         if x.shape == y.shape:
-            xx = x if x.ndim != 0 else x.reshape((1,))
-            yy = y if y.ndim != 0 else y.reshape((1,))
+            xx = numpy.atleast_1d(x)
+            yy = numpy.atleast_1d(y)
             err = numpy.abs(xx - yy)
-            i = numpy.unravel_index(numpy.argmax(err), err.shape)
+            tol_err = atol + rtol * numpy.abs(yy).astype(numpy.float64)
+            i = numpy.unravel_index(
+                numpy.argmax(err.astype(numpy.float64) - tol_err), err.shape)
             f.write(
                 '  i: {}\n'.format(i) +
                 '  x[i]: {}\n'.format(xx[i]) +
                 '  y[i]: {}\n'.format(yy[i]) +
-                '  err[i]: {}\n'.format(err[i]))
+                '  relative error[i]: {}\n'.format(err[i] / numpy.abs(yy[i])) +
+                '  absolute error[i]: {}\n'.format(err[i]))
         opts = numpy.get_printoptions()
         try:
             numpy.set_printoptions(threshold=10000)

--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -39,11 +39,15 @@ def assert_allclose(x, y, atol=1e-5, rtol=1e-4, verbose=True):
             tol_err = atol + rtol * numpy.abs(yy).astype(numpy.float64)
             i = numpy.unravel_index(
                 numpy.argmax(err.astype(numpy.float64) - tol_err), err.shape)
+            if yy[i] == 0:
+                rel_err = 'inf'
+            else:
+                rel_err = err[i] / numpy.abs(yy[i])
             f.write(
                 '  i: {}\n'.format(i) +
                 '  x[i]: {}\n'.format(xx[i]) +
                 '  y[i]: {}\n'.format(yy[i]) +
-                '  relative error[i]: {}\n'.format(err[i] / numpy.abs(yy[i])) +
+                '  relative error[i]: {}\n'.format(rel_err) +
                 '  absolute error[i]: {}\n'.format(err[i]))
         opts = numpy.get_printoptions()
         try:

--- a/tests/chainer_tests/testing_tests/test_array.py
+++ b/tests/chainer_tests/testing_tests/test_array.py
@@ -1,0 +1,25 @@
+import unittest
+
+import numpy
+import pytest
+
+from chainer import testing
+
+
+# TODO(niboshi): Add more assert_allclose tests
+
+
+class TestAssertAllClose(unittest.TestCase):
+
+    def test_no_zero_division(self):
+        # No zero-division should occur when the relative error is inf (y=0).
+        # That would cause FloatingPointError with
+        # numpy.errstate(divide='raise').
+        with numpy.errstate(divide='raise'):
+            with pytest.raises(AssertionError):
+                x = numpy.array([1], numpy.float32)
+                y = numpy.array([0], numpy.float32)
+                testing.assert_allclose(x, y)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
Currently `testing.assert_allclose` can show an error that is within the tolerance.
That's because the element to show is chosen by using `numpy.argmax(err)`, taking only the absolute error into account.

This PR also improves the message so that both relative and absolute errors are shown.