### PR TITLE
Simplify `F.batch_renormalization` test 

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -140,7 +140,7 @@ class TestBatchRenormalizationForward(testing.FunctionTestCase):
         assert isinstance(gy, chainer.Variable)
 
         import chainerx
-        if isinstance(x.array, chainerx.ndarray):
+        if x.xp is chainerx:
             # TODO(niboshi): ChainerX does not support grad yet
             y.grad = gy.array.copy()
             y.backward()

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -1,142 +1,218 @@
-import unittest
-
 import numpy
 import six
 
 import chainer
-from chainer.backends import cuda
 from chainer.functions.normalization import batch_renormalization
-from chainer import gradient_check
 from chainer import testing
-from chainer.testing import attr
-from chainer.testing import condition
-
-
-def _batch_renormalization(expander, gamma, beta, x, mean, var, r, d):
-    mean = mean[expander]
-    std = numpy.sqrt(var)[expander]
-    y_expect = (gamma[expander] * ((x - mean) / std * r + d) + beta[expander])
-    return y_expect
 
 
 # naive implementation of differentiable batch renormalization
 def _naive_batch_renormalization(
-        x, gamma, beta, rmax, dmax, eps, avg_mean, avg_std, axis):
-    shape = x.shape
-    stat_shape = list(shape)
-    for i in axis:
-        stat_shape[i] = 1
-    stat_shape = tuple(stat_shape)
-    gamma = chainer.functions.reshape(gamma, stat_shape)
-    beta = chainer.functions.reshape(beta, stat_shape)
-    avg_mean = avg_mean.reshape(stat_shape)
-    avg_std = avg_std.reshape(stat_shape)
+        x, gamma, beta,  # variables
+        mean, var,  # variables
+        running_mean, running_var,  # arrays
+        rmax, dmax, eps, decay):
+    # If decay is not None, the running stats are updated.
 
-    mean = chainer.functions.mean(x, axis=axis, keepdims=True)
-    std = chainer.functions.sqrt(
-        eps +
-        chainer.functions.mean(
-            chainer.functions.square(x - mean),
-            axis=axis, keepdims=True))
-    r = (std.array / avg_std).clip(1./rmax, rmax)
-    d = ((mean.array - avg_mean) / avg_std).clip(-dmax, dmax)
-    xhat = ((x - mean) / std) * r + d
-    return gamma * xhat + beta
+    F = chainer.functions
+    assert isinstance(x, chainer.Variable)
+    assert isinstance(gamma, chainer.Variable)
+    assert isinstance(beta, chainer.Variable)
+    assert isinstance(mean, chainer.Variable)
+    assert isinstance(var, chainer.Variable)
+    assert isinstance(running_mean, chainer.get_array_types())
+    assert isinstance(running_var, chainer.get_array_types())
+    assert mean.shape == var.shape
+    assert mean.shape == running_mean.shape
+    assert mean.shape == running_var.shape
+    assert mean.shape == gamma.shape
+
+    dt = x.dtype.type
+    std = F.sqrt(var + dt(eps))
+    # r and d are gradient-stopped
+    running_std = numpy.sqrt(running_var + dt(eps))
+    r = (std.array / running_std).clip(1. / rmax, rmax)
+    d = ((mean.array - running_mean) / running_std).clip(-dmax, dmax)
+    xhat = (x - mean) / std * r + d
+    y = gamma * xhat + beta
+
+    # Update running stats
+    if decay is not None:
+        running_mean *= decay
+        running_mean += mean.array * dt(1. - decay)
+        # unbiased estimation
+        m = x.size // gamma.size
+        adjust = m / max(m - 1., 1.)
+        running_var *= decay
+        running_var += (var.array + dt(eps)) * dt((1. - decay) * adjust)
+
+    return y
 
 
-@testing.parameterize(*(testing.product({
-    'ndim': [0, 1, 2],
-    'eps': [2e-5, 1e-1],
-    'dtype': [numpy.float32],
-    'update_statistics': [True, False],
-}) + testing.product({
-    'ndim': [1],
-    'eps': [2e-5, 1e-1],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'update_statistics': [True, False],
-})))
-class TestBatchRenormalization(unittest.TestCase):
+def parameterize_batch_renormalization():
+    return testing.parameterize(*(testing.product({
+        'ndim': [0, 1, 2],
+        'eps': [2e-5, 1e-1],
+        'dtype': [numpy.float32],
+        'update_statistics': [True, False],
+    }) + testing.product({
+        'ndim': [1],
+        'eps': [2e-5, 1e-1],
+        'dtype': [numpy.float16, numpy.float32, numpy.float64],
+        'update_statistics': [True, False],
+    })))
+
+
+def inject_backend_tests_batch_renormalization():
+    return testing.inject_backend_tests(
+        None,
+        # CPU tests
+        [
+            {},
+            {'use_ideep': 'always'},
+        ]
+        # GPU tests
+        + [
+            {'use_cuda': True, 'cuda_device': 0},
+            {'use_cuda': True, 'cuda_device': 1},
+        ]
+        # ChainerX tests
+        + [
+            {'use_chainerx': True, 'chainerx_device': 'native:0'},
+            {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+            {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+        ])
+
+
+@parameterize_batch_renormalization()
+@inject_backend_tests_batch_renormalization()
+class TestBatchRenormalizationForward(testing.FunctionTestCase):
+    # As F.batch_renormalization includes a calculation in which the outcome
+    # depends on x but it's gradient-stopped w.r.t. x,
+    # gradient_check.check_backward cannot be used, because numerical
+    # gradients would not be calculated correctly.
+    # Instead of using gradient_check.check_backward, this test checks the
+    # backward gradients as a "forward" function.
+    # In addition, updated running_mean and running_var are also included in
+    # the outputs of the "forward" function.
+
+    skip_backward_test = True
+    skip_double_backward_test = True
+
+    rmax = 3
+    dmax = 5
 
     def setUp(self):
-        self.expander = (None, Ellipsis) + (None,) * self.ndim
-        self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
-        self.decay = 0.9
-
-        self.rmax = self.dtype(3)
-        self.dmax = self.dtype(5)
-
-        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(self.dtype)
-        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
-
         shape = (5, 3) + (2,) * self.ndim
-        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        aggr_shape = (3,)
+        self.running_mean = (
+            numpy.random.uniform(-1, 1, aggr_shape).astype(self.dtype))
+        self.running_var = (
+            numpy.random.uniform(1e-3, 1, aggr_shape).astype(self.dtype))
 
-        self.args = [self.x, self.gamma, self.beta]
-        self.mean = self.x.mean(axis=self.aggr_axes)
-        self.var = self.x.var(axis=self.aggr_axes) + self.eps
-        # Need to add some noise to running_mean and running_var,
-        # otherwise we will always get r=1, d=0
-        self.running_mean = self.mean + numpy.random.uniform(
-            -1, 1, self.mean.shape).astype(self.dtype)
-        self.running_var = numpy.abs(self.var + numpy.random.uniform(
-            -1, 1, self.var.shape).astype(self.dtype))
+        axis = (0,) + tuple(six.moves.range(2, self.ndim + 2))
+        expander = (None, Ellipsis) + (None,) * self.ndim
 
-        self.train = True
-        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_forward_options = {'atol': 0.02, 'rtol': 0.02}
 
-    def check_compare_naive(self, args, stats, y_grad):
-        def compute(f):
-            x, gamma, beta = [chainer.Variable(v.copy()) for v in args]
-            running_mean, running_var = [v.copy() for v in stats]
-            y = f(x, gamma, beta, running_mean, running_var)
-            y.grad = y_grad.copy()
+        self.shape = shape
+        self.aggr_shape = aggr_shape
+        self.axis = axis
+        self.expander = expander
+
+    def generate_inputs(self):
+        shape = self.shape
+        aggr_shape = self.aggr_shape
+        dtype = self.dtype
+
+        x = numpy.random.uniform(-10, 10, shape).astype(dtype)
+        gamma = numpy.random.uniform(.5, 1, aggr_shape).astype(dtype)
+        beta = numpy.random.uniform(-1, 1, aggr_shape).astype(dtype)
+        gy = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        return x, gamma, beta, gy
+
+    def _compute_backward(self, x, gamma, beta, y, gy):
+        assert isinstance(x, chainer.Variable)
+        assert isinstance(gamma, chainer.Variable)
+        assert isinstance(beta, chainer.Variable)
+        assert isinstance(y, chainer.Variable)
+        assert isinstance(gy, chainer.Variable)
+
+        import chainerx
+        if isinstance(x.array, chainerx.ndarray):
+            # TODO(niboshi): ChainerX does not support grad yet
+            y.grad = gy.array.copy()
             y.backward()
-            return y.array, x.grad, gamma.grad, beta.grad
+            gx = x.grad_var
+            ggamma = gamma.grad_var
+            gbeta = beta.grad_var
+        else:
+            gx, ggamma, gbeta = chainer.grad([y], [x, gamma, beta], [gy])
+        return gx.array, ggamma.array, gbeta.array
 
-        def f_tested(x, gamma, beta, running_mean, running_var):
-            return batch_renormalization.batch_renormalization(
-                x, gamma, beta, self.rmax, self.dmax,
-                eps=self.eps, running_mean=running_mean,
-                running_var=running_var,
-                update_statistics=self.update_statistics)
+    def forward(self, inputs, device):
+        x, gamma, beta, gy = inputs
+        running_mean = device.send(self.running_mean.copy())
+        running_var = device.send(self.running_var.copy())
+        y = batch_renormalization.batch_renormalization(
+            x, gamma, beta,
+            self.rmax, self.dmax,
+            eps=self.eps,
+            running_mean=running_mean,
+            running_var=running_var,
+            update_statistics=self.update_statistics)
 
-        def f_expected(x, gamma, beta, running_mean, running_var):
-            return _naive_batch_renormalization(
-                x, gamma, beta, self.rmax, self.dmax, self.eps,
-                avg_mean=running_mean,
-                avg_std=(self.eps + running_var) ** 0.5,
-                axis=self.aggr_axes)
+        # backward gradients
+        gx, ggamma, gbeta = self._compute_backward(x, gamma, beta, y, gy)
 
-        tested = compute(f_tested)
-        expected = compute(f_expected)
+        return (
+            y,
+            chainer.Variable(running_mean),
+            chainer.Variable(running_var),
+            chainer.Variable(gx),
+            chainer.Variable(ggamma),
+            chainer.Variable(gbeta),
+        )
 
-        # test forward
-        testing.assert_allclose(
-            tested[0], expected[0], **self.check_forward_options)
+    def forward_expected(self, inputs):
+        F = chainer.functions
+        expander = self.expander
+        axis = self.axis
 
-        # test backward
-        for g, g_expected in zip(tested[1:], expected[1:]):
-            testing.assert_allclose(
-                g, g_expected, **self.check_backward_options)
+        if self.update_statistics:
+            decay = 0.9  # defaut value of F.batch_renormalization
+        else:
+            decay = None
 
-    @condition.retry(3)
-    def test_compare_naive_cpu(self):
-        self.check_compare_naive(
-            self.args, [self.running_mean, self.running_var],
-            self.gy)
+        x_arr, gamma_arr, beta_arr, gy_arr = inputs
+        x = chainer.Variable(x_arr)
+        gamma = chainer.Variable(gamma_arr[expander])
+        beta = chainer.Variable(beta_arr[expander])
 
-    @attr.gpu
-    @condition.retry(3)
-    def test_compare_naive_gpu(self):
-        self.check_compare_naive(
-            [cuda.to_gpu(i) for i in self.args],
-            [cuda.to_gpu(i) for i in [self.running_mean, self.running_var]],
-            cuda.to_gpu(self.gy))
+        x_mean = F.mean(x, axis=axis, keepdims=True)
+        x_var = F.mean((x - x_mean) ** 2, axis=axis, keepdims=True)
+        running_mean = self.running_mean.copy()
+        running_var = self.running_var.copy()
+        y = _naive_batch_renormalization(
+            x, gamma, beta,
+            x_mean,
+            x_var,
+            running_mean[expander],
+            running_var[expander],
+            self.rmax, self.dmax, self.eps,
+            decay)
+
+        # backward gradients
+        gx, ggamma, gbeta = self._compute_backward(
+            x, gamma, beta, y, chainer.Variable(gy_arr))
+        ggamma = numpy.squeeze(ggamma, axis)
+        gbeta = numpy.squeeze(gbeta, axis)
+
+        return (
+            y.array,
+            running_mean, running_var,
+            gx, ggamma, gbeta)
 
 
 @testing.parameterize(*testing.product({
@@ -144,75 +220,49 @@ class TestBatchRenormalization(unittest.TestCase):
     'eps': [2e-5, 1e-1],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestFixedBatchRenormalization(unittest.TestCase):
+@inject_backend_tests_batch_renormalization()
+class TestFixedBatchRenormalization(testing.FunctionTestCase):
 
     def setUp(self):
-        self.gamma = numpy.random.uniform(.5, 1, (3,)).astype(self.dtype)
-        self.beta = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
-        self.expander = (None, Ellipsis) + (None,) * self.ndim
-
-        self.rmax = self.dtype(3)
-        self.dmax = self.dtype(5)
-
-        shape = (5, 3) + (2,) * self.ndim
-        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
-        self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
-
-        self.mean = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
-        self.var = numpy.random.uniform(
-            0.5, 1, (3,)).astype(self.dtype)
-        self.args = [self.x, self.gamma, self.beta, self.mean, self.var]
-        self.train = False
-        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'dtype': numpy.float64}
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
+            self.check_forward_options.update({'atol': 5e-3, 'rtol': 1e-2})
+            self.check_backward_options.update({'atol': 5e-3, 'rtol': 1e-2})
+            self.check_double_backward_options.update(
+                {'atol': 5e-3, 'rtol': 1e-2})
 
-    def _forward(self, *args):
+    def generate_inputs(self):
+        channels = 3
+        shape = (5, channels) + (2,) * self.ndim
+        dtype = self.dtype
+        x = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        gamma = numpy.random.uniform(.5, 1, (channels,)).astype(dtype)
+        beta = numpy.random.uniform(-1, 1, (channels,)).astype(dtype)
+        mean = numpy.random.uniform(-1, 1, (channels,)).astype(dtype)
+        var = numpy.random.uniform(0.5, 1, (channels,)).astype(dtype)
+        return x, gamma, beta, mean, var
+
+    def forward(self, inputs, device):
+        x, gamma, beta, mean, var = inputs
         with testing.assert_warns(DeprecationWarning):
-            return batch_renormalization.fixed_batch_renormalization(
-                *args, eps=self.eps)
+            y = batch_renormalization.fixed_batch_renormalization(
+                x, gamma, beta, mean, var, eps=self.eps)
+        return y,
 
-    def check_forward(self, args):
-        with chainer.using_config('train', self.train):
-            y = self._forward(*args)
-        self.assertEqual(y.data.dtype, self.dtype)
+    def forward_expected(self, inputs):
+        expander = (None, Ellipsis) + (None,) * self.ndim
 
-        y_expect = _batch_renormalization(
-            self.expander, self.gamma, self.beta, self.x, self.mean,
-            self.var + self.eps,
-            1, 0)
+        x_arr, gamma_arr, beta_arr, mean_arr, var_arr = inputs
+        x = chainer.Variable(x_arr)
+        gamma = chainer.Variable(gamma_arr[expander])
+        beta = chainer.Variable(beta_arr[expander])
 
-        testing.assert_allclose(
-            y_expect, y.data, **self.check_forward_options)
-
-    @condition.retry(3)
-    def test_forward_cpu(self):
-        self.check_forward(self.args)
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_gpu(self):
-        self.check_forward([cuda.to_gpu(i) for i in self.args])
-
-    def check_backward(self, args, y_grad):
-        with chainer.using_config('train', self.train):
-            gradient_check.check_backward(
-                self._forward,
-                args, y_grad, **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.args, self.gy)
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.check_backward(
-            [cuda.to_gpu(i) for i in self.args], cuda.to_gpu(self.gy))
+        y = _naive_batch_renormalization(
+            x, gamma, beta,
+            chainer.Variable(mean_arr[expander]),
+            chainer.Variable(var_arr[expander]),
+            mean_arr[expander], var_arr[expander],
+            1, 0, self.eps, None)
+        return y.array,
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -4,6 +4,7 @@ import six
 import chainer
 from chainer.functions.normalization import batch_renormalization
 from chainer import testing
+import chainerx
 
 
 # naive implementation of differentiable batch renormalization
@@ -139,7 +140,6 @@ class TestBatchRenormalizationForward(testing.FunctionTestCase):
         assert isinstance(y, chainer.Variable)
         assert isinstance(gy, chainer.Variable)
 
-        import chainerx
         if x.xp is chainerx:
             # TODO(niboshi): ChainerX does not support grad yet
             y.grad = gy.array.copy()


### PR DESCRIPTION
Applies the function test case https://github.com/chainer/chainer/pull/3499.

~`chainer.Function` also needs automatic attribute fallback #5745 for F.batch_renormalization to support ChainerX.~

`chainer.Function` attribute fallback is implemented in #5828.