### PR TITLE
[backport]  Fix `F.cast` gradient for casts between the same dtypes 

### DIFF
--- a/chainer/functions/array/cast.py
+++ b/chainer/functions/array/cast.py
@@ -52,5 +52,6 @@ def cast(x, typ):
 
     """
     if x.dtype == typ:
-        return chainer.as_variable(x)
+        if not chainer.config.enable_backprop:
+            return chainer.as_variable(x)
     return Cast(typ).apply((x,))[0]


### PR DESCRIPTION
Backport of #5811