### PR TITLE
[backport] Fix bug when CuPy not installed and cuda.fuse decorator used without parenthesis

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -590,6 +590,8 @@ def fuse(*args, **kwargs):
     """
     if available:
         return cupy.fuse(*args, **kwargs)
+    elif len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return args[0]
     else:
         return lambda f: f
 


### PR DESCRIPTION
Backport of #5809