### PR TITLE
ChainerX seq2seq example

### DIFF
--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -9,6 +9,7 @@ from chainer.functions.array import stack
 from chainer.functions.connection import linear
 from chainer.functions.connection import n_step_rnn
 from chainer.utils import argument
+import chainerx
 
 
 if cuda.cudnn_enabled:
@@ -412,7 +413,11 @@ def n_step_lstm_base(
 
     xp = backend.get_array_module(hx, hx.data)
 
-    if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
+    # TODO(imanishi): Support ChainerX n_step_rnn
+    use_cuda = xp is cuda.cupy or (
+        xp is chainerx and hx.device.device.backend.name == 'cuda')
+
+    if use_cuda and chainer.should_use_cudnn('>=auto', 5000):
         states = cuda.get_cudnn_dropout_states()
         states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]

--- a/docs/source/examples/seq2seq.rst
+++ b/docs/source/examples/seq2seq.rst
@@ -369,8 +369,8 @@ After the pre-processing the dataset, let's make dataset objects:
 
 .. literalinclude:: ../../../examples/seq2seq/seq2seq.py
    :language: python
-   :start-after: parser.parse_args
-   :end-before: Setup model
+   :start-after: chainerx._cuda.cupy_share_allocator()
+   :end-before: # Set the current device
    :caption: seq2seq.py
    :dedent: 4
 
@@ -422,7 +422,7 @@ Instantiate ``Seq2seq`` model.
 .. literalinclude:: ../../../examples/seq2seq/seq2seq.py
    :language: python
    :start-after: Setup model
-   :end-before: args.gpu
+   :end-before: model.to_device(device)
    :caption: seq2seq.py
    :dedent: 4
 

--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -270,7 +270,7 @@ def main():
     parser.add_argument('--validation-interval', type=int, default=4000,
                         help='number of iteration to evlauate the model '
                         'with validation dataset')
-    parser.add_argument('--device', '-d', type=str, default='native',
+    parser.add_argument('--device', '-d', type=str, default='-1',
                         help='Device specifier. Either ChainerX device '
                         'specifier or an integer. If non-negative integer, '
                         'CuPy arrays with specified device id are used. If '


### PR DESCRIPTION
Fixes the seq2seq example to enable ChainerX devices.

~Depends on #5832.~