### PR TITLE
Converter decorator for ChainerX device support

### DIFF
--- a/chainer/dataset/__init__.py
+++ b/chainer/dataset/__init__.py
@@ -1,6 +1,7 @@
 # import classes and functions
 from chainer.dataset.convert import concat_examples  # NOQA
 from chainer.dataset.convert import ConcatWithAsyncTransfer  # NOQA
+from chainer.dataset.convert import converter  # NOQA
 from chainer.dataset.convert import to_device  # NOQA
 from chainer.dataset.dataset_mixin import DatasetMixin  # NOQA
 from chainer.dataset.download import cache_or_load_file  # NOQA

--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 
 import numpy
 import six
@@ -6,6 +7,81 @@ import six
 import chainer
 from chainer import backend
 from chainer.backends import cuda
+
+
+def converter():
+    """Decorator to make a converter function.
+
+    The target converter must be a callable that accepts two positional
+    arguments: a batch and a device, and returns a converted batch.
+
+    The type of the device argument is :class:`chainer.backend.Device`.
+
+    The types and values of the batches (the first argument and the return
+    value) are not specified: they depend on how the converter is used (e.g.
+    by updaters).
+
+    .. admonition:: Example
+
+        >>> @chainer.dataset.converter()
+        ... def custom_converter(batch, device):
+        ...     assert isinstance(device, chainer.backend.Device)
+        ...     # do something with batch...
+        ...     return device.send(batch)
+
+    This decorator puts a mark on the target converter function so that
+    Chainer can recognize that it accepts :class:`chainer.backend.Device` as
+    the device argument. For backward compatibility, the decorator also wraps
+    the function so that if the converter is called with the device argument
+    with ``int`` type, it is converted to a :class:`chainer.backend.Device`
+    instance before calling the original function. The ``int`` value indicates
+    the CUDA device of the cupy backend.
+
+    Without the decorator, the converter cannot support ChainerX devices.
+    If the batch were requested to be converted to ChainerX with such
+    converters, :class:`RuntimeError` will be raised.
+
+    """
+
+    def wrap(func):
+        func.__is_decorated_converter = True
+
+        @functools.wraps(func)
+        def wrap_call(*args, **kwargs):
+            # Normalize the 'device' argument
+            if len(args) >= 2:
+                # specified as a positional argument
+                args = list(args)
+                args[1] = _get_device(args[1])
+            elif 'device' in kwargs:
+                kwargs['device'] = _get_device(kwargs['device'])
+            return func(*args, **kwargs)
+
+        return wrap_call
+
+    return wrap
+
+
+def _call_converter(converter, batch, device):
+    # Calls the converter.
+    # Converter can be either new-style (accepts chainer.backend.Device) or
+    # old-style (accepts int as device).
+    assert device is None or isinstance(device, backend.Device)
+
+    if getattr(converter, '__is_decorated_converter', False):
+        # New-style converter
+        return converter(batch, device)
+
+    # Old-style converter
+    if device is None:
+        return converter(batch, None)
+    if device.xp is numpy:
+        return converter(batch, -1)
+    if device.xp is cuda.cupy:
+        return converter(batch, device.device.id)
+    raise RuntimeError(
+        'Converter does not support ChainerX. '
+        'Use chainer.dataset.converter decorator.')
 
 
 def to_device(device, x):
@@ -33,22 +109,33 @@ def to_device(device, x):
         Converted array.
 
     """
+    device = _get_device(device)
+
     if device is None:
         return x
-
-    # For backward compatibilities
-    if isinstance(device, six.integer_types):
-        if device < 0:
-            device = backend.CpuDevice()
-        else:
-            device = backend.get_device(cuda.Device(device))
-    else:
-        device = backend.get_device(device)
-
     return device.send(x)
 
 
+def _get_device(device_spec):
+    # Converts device specificer to a chainer.Device instance.
+    # Additionally to chainer.get_device,
+    # this function supports the following conversions:
+    # - None: returns None
+    # - negative integer: returns CpuDevice
+    # - non-negative integer: returns GpuDevice
+    if device_spec is None:
+        return None
+
+    # For backward compatibilities
+    if isinstance(device_spec, six.integer_types):
+        if device_spec < 0:
+            return backend.CpuDevice()
+        return backend.get_device(cuda.Device(device_spec))
+    return backend.get_device(device_spec)
+
+
 # TODO(hvy): Write unit tests where batch elements contain Python lists.
+@converter()
 def concat_examples(batch, device=None, padding=None):
     """Concatenates a list of examples into array(s).
 
@@ -130,6 +217,7 @@ def concat_examples(batch, device=None, padding=None):
         on the type of each example in the batch.
 
     """
+    assert device is None or isinstance(device, backend.Device)
     if len(batch) == 0:
         raise ValueError('batch is empty')
 

--- a/docs/source/reference/datasets.rst
+++ b/docs/source/reference/datasets.rst
@@ -50,6 +50,8 @@ Batch Conversion Function
    :toctree: generated/
    :nosignatures:
 
+   chainer.dataset.converter
+
    chainer.dataset.concat_examples
    chainer.dataset.ConcatWithAsyncTransfer
    chainer.dataset.to_device


### PR DESCRIPTION
~Introduces `chainer.dataset.Converter` class.~
Introduces `chainer.dataset.converter` decorator.

In the existing converter convention, users can make their custom converters by defining a function with two arguments: a batch and a device, where "device" is an integer specifying either CPU (-1) or CUDA devices (>=0).

Now Chainer has introduced `chainer.Device` class.
To support this, a new interface for converters is required becaue existing converter functions can't handle this class.

In this PR, a new decorator `chainer.dataset.converter` is being introduced. This decorator marks the subject converter to indicate that it supports `chainer.backend.Device` argument. If `int` is given when the converter is being called, the decorator converts the argument to `chainer.backend.Device` instance and passed to the subject converter.

##### (obsolete description)
~In this PR, a new class `chainer.dataset.Converter` is being introduced for Chainer to be able to distinguish between the existing converters and those aware of `chainer.Device`.~

~For ease of defining custom converters, a decorator `chainer.dataset.converter` is also being introduced.~
