### PR TITLE
Remove unnecessary cast in `F.huber_loss`

### DIFF
--- a/chainer/functions/loss/huber_loss.py
+++ b/chainer/functions/loss/huber_loss.py
@@ -48,8 +48,7 @@ class HuberLoss(function_node.FunctionNode):
         x0, x1 = self.get_retained_inputs()
         gy, = grad_outputs
         diff = x0 - x1
-        # `functions.clip` only accepts float value.
-        delta = float(self.delta)
+        delta = self.delta
 
         gx = chainer.functions.clip(diff, -delta, delta)
 


### PR DESCRIPTION
Removes an unnecessary cast pointed out at https://github.com/chainer/chainer/issues/5812#issuecomment-445548380

Rel. #5813