### PR TITLE
Fix gitignore to avoid ignoring some necessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ build
 .eggs/
 _readthedocs_build
 /TAGS
-/docs/source/reference/**/generated
 /tags
 chainer.egg-info/
 dist/
@@ -24,7 +23,4 @@ docs/my.state
 docs/my_mnist.model
 docs/mnist_result
 docs/*.png
-docs/source/reference/core
-docs/source/reference/generated
-docs/source/reference/util
-docs/source/**/reference/generated
+/docs/source/**/reference/**/generated


### PR DESCRIPTION
Currently, `.gitignore` includes `docs/source/reference/util/*.rst` as files to be ignored.
