### PR TITLE
Disable clang-tidy modernize-use-auto

### DIFF
--- a/chainerx_cc/.clang-tidy
+++ b/chainerx_cc/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:          '-*,boost-*,bugprone-*,cert-*,cppcoreguidelines-*,clang-analyzer-*,google-*,misc-*,modernize-*,performance-*,readability-*,-google-runtime-references,-cppcoreguidelines-pro-bounds-pointer-arithmetic'
+Checks:          '-*,boost-*,bugprone-*,cert-*,cppcoreguidelines-*,clang-analyzer-*,google-*,misc-*,modernize-*,performance-*,readability-*,-google-runtime-references,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-modernize-use-auto'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^chainerx/chainerx/.*'
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
Often it does not necessarily improve readability.
