### PR TITLE
Support batched update of weights by optimizer

### DIFF
--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -1,8 +1,9 @@
+import numpy as np
+
 from chainer import backend
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import optimizer
-
 
 _default_hyperparam = optimizer.Hyperparameter()
 _default_hyperparam.lr = 0.01
@@ -72,6 +73,129 @@ class MomentumSGDRule(optimizer.UpdateRule):
         MomentumSGDRule._kernel(
             grad, self.hyperparam.lr, self.hyperparam.momentum, param.data,
             self.state['v'])
+
+    def batched_update(self, params, loss_scale=None):
+        if loss_scale is None:
+            loss_scale = 1.0
+        lr = cuda.cupy.array(self.hyperparam.lr / loss_scale, dtype=np.float32)
+        momentum = cuda.cupy.array(self.hyperparam.momentum, dtype=np.float32)
+        pinfo = ParamsInfo(params)
+        n_threads = 128
+        n_blocks = (pinfo.n_elems + n_threads - 1) // n_threads
+        _cupy_batched_momentum_sgd()(
+            (n_blocks, ), (n_threads, ),
+            (pinfo.data_ptr, pinfo.data_dtype, pinfo.grad_ptr, pinfo.v_ptr,
+             pinfo.fp32_data_ptr, pinfo.size_csum, pinfo.n_params,
+             pinfo.n_elems, lr, momentum))
+
+
+def _cupy_batched_momentum_sgd():
+    return cuda.cupy.RawKernel(r'''
+#include <cuda_fp16.h>
+#define FLOAT16  6
+#define FLOAT32  7
+    extern "C" __global__
+    void cupy_batched_momentum_sgd(
+            unsigned long *data_ptr, const int *data_dtype,
+            const unsigned long *grad_ptr,
+            unsigned long *v_ptr,
+            unsigned long *fp32_data_ptr,
+            const int *size_csum, int n_params, int n_elems,
+            const float *lr, const float *momentum)
+    {
+        int tid = threadIdx.x + blockIdx.x * blockDim.x;
+        if (tid >= n_elems) return;
+        int j_min = 0;
+        int j_max = n_params - 1;
+        int j;
+        while (1) {
+            j = (j_min + j_max) / 2;
+            if (tid < size_csum[j]) {
+                j_max = j - 1;
+                continue;
+            }
+            if (tid >= size_csum[j+1]){
+                j_min = j + 1;
+                continue;
+            }
+            break;
+        }
+        int idx = tid - size_csum[j];
+        if (fp32_data_ptr[j] != 0) {
+            // fp32 update
+            float *fp32_data = (float*)(fp32_data_ptr[j]) + idx;
+            float *v = (float*)(v_ptr[j]) + idx;
+            half *data = (half*)(data_ptr[j]) + idx;
+            half *grad = (half*)(grad_ptr[j]) + idx;
+            v[0] = v[0] * momentum[0] - (float)grad[0] * lr[0];
+            fp32_data[0] += v[0];
+            data[0] = (half)fp32_data[0];
+        }
+        else if (data_dtype[j] == FLOAT16) {
+            half *data = (half*)(data_ptr[j]) + idx;
+            half *v = (half*)(v_ptr[j]) + idx;
+            half *grad = (half*)(grad_ptr[j]) + idx;
+            v[0] = v[0] * (half)momentum[0] - grad[0] * (half)lr[0];
+            data[0] += v[0];
+        }
+        else if (data_dtype[j] == FLOAT32) {
+            float *data = (float*)(data_ptr[j]) + idx;
+            float *v = (float*)(v_ptr[j]) + idx;
+            float *grad = (float*)(grad_ptr[j]) + idx;
+            v[0] = v[0] * momentum[0] - grad[0] * lr[0];
+            data[0] += v[0];
+        }
+    }
+
+    ''', 'cupy_batched_momentum_sgd')
+
+
+class ParamsInfo(object):
+    def __init__(self, params):
+        n_params = len(params)
+        data_ptr = np.empty(n_params, dtype=np.int64)
+        grad_ptr = np.empty(n_params, dtype=np.int64)
+        v_ptr = np.empty(n_params, dtype=np.int64)
+        fp32_data_ptr = np.empty(n_params, dtype=np.int64)
+        data_dtype = np.empty(n_params, dtype=np.int32)
+        size_csum = np.empty(n_params+1, dtype=np.int32)
+        size_csum[0] = 0
+        for i, param in enumerate(params):
+            data = param.data
+            grad = param.grad
+            v = param.update_rule.state['v']
+            data_ptr[i] = data.data.ptr
+            grad_ptr[i] = grad.data.ptr
+            v_ptr[i] = v.data.ptr
+            assert(data.dtype == grad.dtype)
+            data_dtype[i] = _get_dtype_id(data.dtype)
+            if param.update_rule._fp32_param is None:
+                fp32_data_ptr[i] = 0
+            else:
+                fp32_data = param.update_rule._fp32_param.data
+                assert(fp32_data.dtype == np.float32)
+                assert(v.dtype == np.float32)
+                assert(data.dtype == np.float16)
+                fp32_data_ptr[i] = fp32_data.data.ptr
+            size_csum[i+1] = size_csum[i] + data.size
+        self.n_elems = size_csum[n_params]
+        self.n_params = n_params
+        self.data_ptr = cuda.cupy.asarray(data_ptr)
+        self.grad_ptr = cuda.cupy.asarray(grad_ptr)
+        self.v_ptr = cuda.cupy.asarray(v_ptr)
+        self.fp32_data_ptr = cuda.cupy.asarray(fp32_data_ptr)
+        self.data_dtype = cuda.cupy.asarray(data_dtype)
+        self.size_csum = cuda.cupy.asarray(size_csum)
+
+
+def _get_dtype_id(dtype):
+    if dtype == np.float16:
+        return 6  # nccl.NCCL_FLOAT16
+    elif dtype == np.float32:
+        return 7  # nccl.NCCL_FLOAT32
+    else:
+        raise ValueError(
+            'dtype must be float16 or float32.')
 
 
 class MomentumSGD(optimizer.GradientMethod):


### PR DESCRIPTION
This PR aims to support a batched update of weights by optimizer.

Current optimizers in Chainer update weights in DL model in layer-by-layer, more specifically, parameter-by-parameter. This is good when mini-batch size is big enough, but this could be a problem in terms of performance when mini-batch size is small and CPU is a performance limiter, because lots of GPU kernels are launched with current parameter-by-parameter update approach.

The purpose of this PR is to mitigate this problem by updating whole weights in the DL model by a single GPU kernel, in other words, batched GPU kernel. With this PR, whole weights are updated in batched way by just adding a line below (after optimizer setup) in your training script.

    optimizer.use_batched_update()

Please note that "batched update" is enabled only when a optimizer has a method `batched_update()`. Currently, `batched_update()` is implemented only in momentum sgd. So, you cannot try this feature with other optimizers for now.