### PR TITLE
Add Travis matrix for macOS ChainerX tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,14 @@ matrix:
       language: generic
       env:
       - CHAINER_TRAVIS_TEST="chainer"
+      - PYTHON_VERSION=3.5.1
+      - PYENV_ROOT=~/.pyenv
+      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+
+    - os: osx
+      language: generic
+      env:
+      - CHAINER_TRAVIS_TEST="chainer"
       - PYTHON_VERSION=2.7.10
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       - CHAINER_TRAVIS_TEST="chainer"
       - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
-    - name: "macOS Py27"
+    - name: "macOS Py35"
       os: osx
       language: generic
       env:
@@ -49,7 +49,8 @@ matrix:
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
 
-    - os: osx
+    - name: "macOS Py27"
+      os: osx
       language: generic
       env:
       - CHAINER_TRAVIS_TEST="chainer"

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,17 +70,6 @@ matrix:
       - SKIP_CHAINERX=1
       if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
 
-    - name: "macOS Py35"
-      os: osx
-      language: generic
-      env:
-      - CHAINER_TRAVIS_TEST="chainer"
-      - PYTHON_VERSION=3.5.1
-      - PYENV_ROOT=~/.pyenv
-      - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-      - MATRIX_EVAL="brew install gcc5 && CC=gcc-5 && CXX=g++-5"
-      if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
-
 before_install:
   - bash scripts/ci/travis/run-tests.sh before_install
 

--- a/scripts/ci/travis/run-tests.sh
+++ b/scripts/ci/travis/run-tests.sh
@@ -75,7 +75,6 @@ step_before_install_chainer_test() {
         pyenv global $PYTHON_VERSION
         python --version
 
-        brew cask uninstall oclint
         brew install hdf5
     fi
 }


### PR DESCRIPTION
Adds a new Travis matrix: macOS x ChainerX.

Only the native backend will be tested.

Note: Error fixes can be done in separate PRs I think. Specifically #5776 will be required.