### PR TITLE
Update gsl-lite to v0.32.0

### DIFF
--- a/chainerx_cc/third_party/gsl-lite.cmake
+++ b/chainerx_cc/third_party/gsl-lite.cmake
@@ -4,7 +4,7 @@ project(gsl-lite-download NONE)
 include(ExternalProject)
 ExternalProject_Add(gsl-lite
         GIT_REPOSITORY    https://github.com/martinmoene/gsl-lite
-        GIT_TAG           v0.26.0
+        GIT_TAG           v0.32.0
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/gsl-lite"
         BINARY_DIR        ""
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
Updates gsl-lite, which is required for OSX (AppleClang) support.