### PR TITLE
Allow skipping linkcode in docs with environment variable

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -449,6 +449,8 @@ def _get_sourcefile_and_linenumber(obj):
 def linkcode_resolve(domain, info):
     if domain != 'py' or not info['module']:
         return None
+    if 1 == int(os.environ.get('CHAINER_DOCS_SKIP_LINKCODE', 0)):
+        return None
 
     # Import the object from module path
     obj = _import_object_from_name(info['module'], info['fullname'])


### PR DESCRIPTION
Currently docs cannot be built in non-editable installation.

This fix allows that by setting an environment variable.

```
$ cd docs
$ CHAINER_DOCS_SKIP_LINKCODE=1 make html
```