### PR TITLE
Fix clang-tidy error

### DIFF
--- a/chainerx_cc/chainerx/routines/math.cc
+++ b/chainerx_cc/chainerx/routines/math.cc
@@ -394,7 +394,7 @@ Array AMax(const Array& a, const OptionalAxes& axis, bool keepdims) {
             Array reshaped_out{};
             if (keepdims) {
                 reshaped_gout = gout;
-                reshaped_out = std::move(out);
+                reshaped_out = out;
             } else {
                 // Add broadcastable dimensions to out and gout
                 // for each one that was reduced in the forward operation


### PR DESCRIPTION
`out` is a `const` variable (because it's a capture).
clang-tidy complains about moving from `const`.

Introduced in #5800.