### PR TITLE
Set grad of `F.clip` 1 at `x_min` and `x_max`

### DIFF
--- a/chainer/functions/math/clip.py
+++ b/chainer/functions/math/clip.py
@@ -38,7 +38,7 @@ class Clip(function_node.FunctionNode):
 class ClipGrad(function_node.FunctionNode):
 
     def __init__(self, x, x_min, x_max):
-        self.cond = (x_min < x) * (x < x_max)
+        self.cond = (x_min <= x) * (x <= x_max)
 
     def check_type_forward(self, in_types):
         type_check._argname(in_types, ('gy',))
@@ -63,6 +63,8 @@ def clip(x, x_min, x_max):
 
     Given an interval ``[x_min, xmax]``, elements outside the interval are
     clipped to the interval edges.
+
+    Its gradients at ``x_min`` and ``x_max`` are regarded as 1.
 
     Args:
         x (~chainer.Variable): Input variable to be clipped.


### PR DESCRIPTION
Chainer's `F.clip` hasn't propagate gradient at `x_min` and `x_max`. This behavior is different to TF and recent PyTorch's. (https://github.com/pytorch/pytorch/issues/7002). This PR makes it consistent with TF and PyTorch. I also added docstrings and tests.

Note that `F.clip` has retained input, though it could retain output. This PR makes it necessary that `F.clip` retains input.