### PR TITLE
Enable ChainerX in docker image

### DIFF
--- a/docker/intel/python3/Dockerfile
+++ b/docker/intel/python3/Dockerfile
@@ -5,7 +5,14 @@ RUN apt-get update -y && \
     python3-dev \
     python3-pip \
     python3-wheel \
-    python3-setuptools && \
+    python3-setuptools \
+    git \
+    g++ \
+    make \
+    cmake \
+    libblas3 \
+    libblas-dev \
+    && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip3 install --no-cache-dir 'ideep4py<2.1' chainer==6.0.0b1
+RUN CHAINER_BUILD_CHAINERX=1 pip3 install --no-cache-dir 'ideep4py<2.1' chainer==6.0.0b1

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -5,7 +5,12 @@ RUN apt-get update -y && \
     python3-dev \
     python3-pip \
     python3-wheel \
-    python3-setuptools && \
+    python3-setuptools \
+    git \
+    cmake \
+    libblas3 \
+    libblas-dev \
+    && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip3 install --no-cache-dir cupy-cuda92==6.0.0b1 chainer==6.0.0b1
+RUN CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 pip3 install --no-cache-dir cupy-cuda92==6.0.0b1 chainer==6.0.0b1


### PR DESCRIPTION
Closes #5878.

Confirmed that:
* `python3 train_mnist.py --device cuda:0` work on CUDA container
* `python3 train_mnist.py --device native:0` work on Intel container