### PR TITLE
Warn if `reset` method is not implemented in an iterator

### DIFF
--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -202,9 +202,9 @@ class Evaluator(extension.Extension):
             iterator.reset()
             it = iterator
         else:
-            warnings.warn('This iterator does not have the reset method.' +
-                          'Evaluator copies the iterator instead of' +
-                          'resetting. This behavior is deprecated.' +
+            warnings.warn('This iterator does not have the reset method. '
+                          'Evaluator copies the iterator instead of '
+                          'resetting. This behavior is deprecated. '
                           'Please implement the reset method.',
                           DeprecationWarning)
             it = copy.copy(iterator)

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -202,11 +202,11 @@ class Evaluator(extension.Extension):
             iterator.reset()
             it = iterator
         else:
-            warnings.warn('This iterator does not have the reset method. '
-                          'Evaluator copies the iterator instead of '
-                          'resetting. This behavior is deprecated. '
-                          'Please implement the reset method.',
-                          DeprecationWarning)
+            warnings.warn(
+                'This iterator does not have the reset method. Evaluator '
+                'copies the iterator instead of resetting. This behavior is '
+                'deprecated. Please implement the reset method.',
+                DeprecationWarning)
             it = copy.copy(iterator)
 
         summary = reporter_module.DictSummary()

--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -202,6 +202,11 @@ class Evaluator(extension.Extension):
             iterator.reset()
             it = iterator
         else:
+            warnings.warn('This iterator does not have the reset method.' +
+                          'Evaluator copies the iterator instead of' +
+                          'resetting. This behavior is deprecated.' +
+                          'Please implement the reset method.',
+                          DeprecationWarning)
             it = copy.copy(iterator)
 
         summary = reporter_module.DictSummary()

--- a/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
@@ -7,6 +7,7 @@ from chainer import dataset
 from chainer import iterators
 from chainer import testing
 from chainer.training import extensions
+from chainer.iterators._statemachine import IteratorState
 
 
 class DummyModel(chainer.Chain):
@@ -38,6 +39,9 @@ class DummyIterator(dataset.Iterator):
     def __init__(self, return_values):
         self.iterator = iter(return_values)
         self.finalized = False
+
+    def reset(self):
+        self._state = IteratorState(0, 0, False, None)
 
     def __next__(self):
         return next(self.iterator)

--- a/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_evaluator.py
@@ -7,7 +7,6 @@ from chainer import dataset
 from chainer import iterators
 from chainer import testing
 from chainer.training import extensions
-from chainer.iterators._statemachine import IteratorState
 
 
 class DummyModel(chainer.Chain):
@@ -39,9 +38,10 @@ class DummyIterator(dataset.Iterator):
     def __init__(self, return_values):
         self.iterator = iter(return_values)
         self.finalized = False
+        self.return_values = return_values
 
     def reset(self):
-        self._state = IteratorState(0, 0, False, None)
+        self.iterator = iter(self.return_values)
 
     def __next__(self):
         return next(self.iterator)


### PR DESCRIPTION
Adding a comment for reset, as part of clarifying #5793 
