### PR TITLE
Correct the stable version in master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more details of Chainer, see the documents and resources listed above and jo
 
 ## Stable version
 
-The stable version of current Chainer is separated in here: [v4](https://github.com/chainer/chainer/tree/v4).
+The stable version of current Chainer is separated in here: [v5](https://github.com/chainer/chainer/tree/v5).
 
 ## Installation
 


### PR DESCRIPTION
It seems that the stable version is wrong in the `README.md` file of `master` branch, though it is actually correct in the `v5` branch.

Just a simple fix.