### PR TITLE
Fix broken `F.leaky_relu` grad when slope = 0

### DIFF
--- a/chainer/functions/activation/leaky_relu.py
+++ b/chainer/functions/activation/leaky_relu.py
@@ -12,7 +12,7 @@ def _get_kern():
     if _kern is None:
         _kern = cuda.elementwise(
             'T cond, T x, T slope', 'T y',
-            'y = cond >= 0 ? x : (T)(slope * x)', 'lrelu')
+            'y = cond <= 0 ? (T)(slope * x) : x', 'lrelu')
     return _kern
 
 
@@ -35,7 +35,7 @@ class LeakyReLU(function_node.FunctionNode):
 
         x, = inputs
         y = x.copy()
-        y[x < 0] *= self.slope
+        y[x <= 0] *= self.slope
         if self.slope >= 0:
             self.retain_outputs((0,))
         else:
@@ -46,7 +46,6 @@ class LeakyReLU(function_node.FunctionNode):
         x, = inputs
         y = intel64.ideep.relu.Forward(
             intel64.ideep.array(x), self.slope)
-
         if self.slope >= 0:
             self.retain_outputs((0,))
         else:
@@ -64,20 +63,17 @@ class LeakyReLU(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         if self.slope >= 0:
-            x = None
-            y = self.get_retained_outputs()[0].data
+            cond = self.get_retained_outputs()[0].array
         else:
-            x = self.get_retained_inputs()[0].data
-            y = None
-        return _LeakyReLUGrad(x, y, self.slope).apply(grad_outputs)
+            cond = self.get_retained_inputs()[0].array
+        return _LeakyReLUGrad(cond, self.slope).apply(grad_outputs)
 
 
 class _LeakyReLUGrad(function_node.FunctionNode):
 
-    def __init__(self, x, y, slope):
+    def __init__(self, cond, slope):
+        self.cond = cond
         self.slope = slope
-        self.x = x
-        self.y = y
 
     def forward_cpu(self, inputs):
         if (intel64.should_use_ideep('>=auto')
@@ -86,35 +82,23 @@ class _LeakyReLUGrad(function_node.FunctionNode):
 
         gy, = inputs
         gy = gy.copy()
-        if self.slope >= 0:
-            gy[self.y < 0] *= self.slope
-        else:
-            gy[self.x < 0] *= self.slope
+        gy[self.cond <= 0] *= self.slope
         return gy,
 
     def forward_ideep(self, inputs):
         gy, = inputs
-
-        if self.slope >= 0:
-            gy = intel64.ideep.relu.Backward(
-                intel64.ideep.array(self.y),
-                intel64.ideep.array(gy), self.slope)
-        else:
-            gy = intel64.ideep.relu.Backward(
-                intel64.ideep.array(self.x),
-                intel64.ideep.array(gy), self.slope)
+        gy = intel64.ideep.relu.Backward(
+            intel64.ideep.array(self.cond),
+            intel64.ideep.array(gy), self.slope)
         return gy,
 
     def forward_gpu(self, inputs):
         gy, = inputs
-        if self.slope >= 0:
-            gy = _get_kern()(self.y, gy, self.slope)
-        else:
-            gy = _get_kern()(self.x, gy, self.slope)
+        gy = _get_kern()(self.cond, gy, self.slope)
         return gy,
 
     def backward(self, indexes, grad_outputs):
-        return _LeakyReLUGrad(self.x, self.y, self.slope).apply(grad_outputs)
+        return _LeakyReLUGrad(self.cond, self.slope).apply(grad_outputs)
 
 
 def leaky_relu(x, slope=0.2):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_leaky_relu.py
@@ -14,6 +14,7 @@ from chainer.testing import backend
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'slope': ['random', 0.0],
 }))
 @testing.fix_random()
 @backend.inject_backend_tests(
@@ -36,7 +37,8 @@ class TestLeakyReLU(unittest.TestCase):
         self.x[(-0.05 < self.x) & (self.x < 0.05)] = 0.5
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.ggx = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.slope = random.random()
+        if self.slope == 'random':
+            self.slope = random.random()
         self.check_forward_options = {}
         self.check_backward_options = {}
         self.check_double_backward_options = {}


### PR DESCRIPTION
When slope = 0, `F.leaky_relu` backpropagated all gradients, even at x < 0. This PR fixes this.

The following script shows the problem.

```python
import chainer
import chainer.functions as F
import numpy as np
x = np.arange(-5, 5, dtype=np.float32)
v = chainer.Variable(x)
l = F.sum(F.leaky_relu(v, slope=0.0))
l.backward()
print(v.grad)
```

```output
[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
```

Note that this PR is not about the behavior at `x = 0`, contrary to #5876 #5877. 