### PR TITLE
[backport] Accept splitting at the tail of dataset in `split_dataset`

### DIFF
--- a/chainer/datasets/sub_dataset.py
+++ b/chainer/datasets/sub_dataset.py
@@ -101,7 +101,7 @@ def split_dataset(dataset, split_at, order=None):
                         .format(type(split_at)))
     if split_at < 0:
         raise ValueError('split_at must be non-negative')
-    if split_at >= n_examples:
+    if split_at > n_examples:
         raise ValueError('split_at exceeds the dataset size')
     subset1 = SubDataset(dataset, 0, split_at, order)
     subset2 = SubDataset(dataset, split_at, n_examples, order)

--- a/tests/chainer_tests/datasets_tests/test_sub_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_sub_dataset.py
@@ -47,12 +47,24 @@ class TestSplitDataset(unittest.TestCase):
         self.assertEqual(subset2[1], 4)
         self.assertEqual(subset2[2], 5)
 
+    def test_split_dataset_head(self):
+        original = [1, 2, 3, 4, 5]
+        subset1, subset2 = datasets.split_dataset(original, 0)
+        self.assertEqual(len(subset1), 0)
+        self.assertEqual(len(subset2), 5)
+
+    def test_split_dataset_tail(self):
+        original = [1, 2, 3, 4, 5]
+        subset1, subset2 = datasets.split_dataset(original, 5)
+        self.assertEqual(len(subset1), 5)
+        self.assertEqual(len(subset2), 0)
+
     def test_split_dataset_invalid_position(self):
         original = [1, 2, 3, 4, 5]
         with self.assertRaises(ValueError):
             datasets.split_dataset(original, -1)
         with self.assertRaises(ValueError):
-            datasets.split_dataset(original, 5)
+            datasets.split_dataset(original, 6)
 
     def test_split_dataset_invalid_type(self):
         original = [1, 2, 3, 4, 5]


### PR DESCRIPTION
Backport of #5895