### PR TITLE
Fix clang-tidy warnings on clang-tidy 6

### DIFF
--- a/chainerx_cc/chainerx/context.cc
+++ b/chainerx_cc/chainerx/context.cc
@@ -74,11 +74,11 @@ Backend& Context::GetBackend(const std::string& backend_name) {
     std::unique_ptr<Backend, context_detail::BackendDeleter> backend;
     if (backend_name == native::NativeBackend::kDefaultName) {
         backend = std::unique_ptr<Backend, context_detail::BackendDeleter>{
-                new native::NativeBackend{*this}, context_detail::BackendDeleter{[](Backend* ptr) { delete ptr; }}};
+                new native::NativeBackend{*this}, context_detail::BackendDeleter{[](gsl::owner<Backend*> ptr) { delete ptr; }}};
 #ifdef CHAINERX_ENABLE_CUDA
     } else if (backend_name == cuda::CudaBackend::kDefaultName) {
         backend = std::unique_ptr<Backend, context_detail::BackendDeleter>{
-                new cuda::CudaBackend{*this}, context_detail::BackendDeleter{[](Backend* ptr) { delete ptr; }}};
+                new cuda::CudaBackend{*this}, context_detail::BackendDeleter{[](gsl::owner<Backend*> ptr) { delete ptr; }}};
 #endif  // CHAINERX_ENABLE_CUDA
     } else {
         // Load .so file

--- a/chainerx_cc/chainerx/context_testdata/backend0.cc
+++ b/chainerx_cc/chainerx/context_testdata/backend0.cc
@@ -15,6 +15,8 @@ public:
 
 }  // namespace
 
+// NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
 extern "C" chainerx::Backend* CreateBackend(chainerx::Context& ctx) { return new Backend0{ctx}; }
 
+// NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
 extern "C" void DestroyBackend(chainerx::Backend* backend) { delete backend; }

--- a/chainerx_cc/chainerx/context_testdata/backend1.cc
+++ b/chainerx_cc/chainerx/context_testdata/backend1.cc
@@ -15,6 +15,8 @@ public:
 
 }  // namespace
 
+// NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
 extern "C" chainerx::Backend* CreateBackend(chainerx::Context& ctx) { return new Backend1{ctx}; }
 
+// NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
 extern "C" void DestroyBackend(chainerx::Backend* backend) { delete backend; }

--- a/chainerx_cc/chainerx/cuda/cuda.cc
+++ b/chainerx_cc/chainerx/cuda/cuda.cc
@@ -3,11 +3,13 @@
 #include <mutex>
 #include <type_traits>
 
+#include <gsl/gsl>
+
 namespace chainerx {
 namespace cuda {
 namespace cuda_internal {
 
-std::mutex* g_mutex = new std::mutex{};  // NOLINT(cert-err58-cpp)
+gsl::owner<std::mutex*> g_mutex = new std::mutex{};  // NOLINT(cert-err58-cpp)
 static_assert(std::is_pod<decltype(g_mutex)>::value, "");
 
 }  // namespace cuda_internal

--- a/chainerx_cc/chainerx/cuda/cuda.h
+++ b/chainerx_cc/chainerx/cuda/cuda.h
@@ -2,6 +2,8 @@
 
 #include <mutex>
 
+#include <gsl/gsl>
+
 namespace chainerx {
 namespace cuda {
 namespace cuda_internal {
@@ -10,7 +12,7 @@ namespace cuda_internal {
 // Those variables will be moved to CudaDevice, and similarly the g_mutex.
 // Delete this file and cuda.cc after that.
 
-extern std::mutex* g_mutex;
+extern gsl::owner<std::mutex*> g_mutex;
 
 }  // namespace cuda_internal
 }  // namespace cuda

--- a/chainerx_cc/chainerx/cuda/cuda_backend.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_backend.cc
@@ -1,12 +1,13 @@
 #include "chainerx/cuda/cuda_backend.h"
 
-#include <cuda_runtime.h>
-
 #include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+
+#include <cuda_runtime.h>
+#include <gsl/gsl>
 
 #include "chainerx/backend.h"
 #include "chainerx/context.h"
@@ -23,7 +24,7 @@ constexpr const char* CudaBackend::kCudnnMaxWorkspaceSizeEnvVarName;
 
 namespace cuda_internal {
 
-CudaDevice* CreateDevice(CudaBackend& backend, int index) { return new CudaDevice{backend, index}; }
+gsl::owner<CudaDevice*> CreateDevice(CudaBackend& backend, int index) { return new CudaDevice{backend, index}; }
 
 }  // namespace cuda_internal
 

--- a/chainerx_cc/chainerx/cuda/cuda_backend.h
+++ b/chainerx_cc/chainerx/cuda/cuda_backend.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include <gsl/gsl>
 #include <nonstd/optional.hpp>
 
 #include "chainerx/backend.h"
@@ -21,7 +22,7 @@ namespace cuda_internal {
 // This function is meant to be used from the backend class. Never use it for other purpose.
 // This is defined in cuda_internal namespace in order to make it a friend of CudaDevice
 // class.
-CudaDevice* CreateDevice(CudaBackend& backend, int index);
+gsl::owner<CudaDevice*> CreateDevice(CudaBackend& backend, int index);
 
 }  // namespace cuda_internal
 

--- a/chainerx_cc/chainerx/float16_test.cc
+++ b/chainerx_cc/chainerx/float16_test.cc
@@ -74,7 +74,7 @@ TEST(NativeFloat16Test, Float16Zero) {
 }
 
 TEST(NativeFloat16Test, Float16Normalized) {
-    for (double x = 1e-3; x < 1e3; x *= 1.01) {  // NOLINT(clang-analyzer-security.FloatLoopCounter)
+    for (double x = 1e-3; x < 1e3; x *= 1.01) {  // NOLINT(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
         EXPECT_NE(Half{x}.data() & 0x7c00, 0);
         CheckToHalfFromHalfNear(x, 1e-3);
         CheckToHalfFromHalfNear(-x, 1e-3);
@@ -86,7 +86,7 @@ TEST(NativeFloat16Test, Float16Normalized) {
 }
 
 TEST(NativeFloat16Test, Float16Denormalized) {
-    for (double x = 1e-7; x < 1e-5; x += 1e-7) {  // NOLINT(clang-analyzer-security.FloatLoopCounter)
+    for (double x = 1e-7; x < 1e-5; x += 1e-7) {  // NOLINT(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
         // Check if the underflow gap around zero is filled with denormal number.
         EXPECT_EQ(Half{x}.data() & 0x7c00, 0x0000);
         EXPECT_NE(Half{x}.data() & 0x03ff, 0x0000);

--- a/chainerx_cc/chainerx/native/native_backend.cc
+++ b/chainerx_cc/chainerx/native/native_backend.cc
@@ -13,7 +13,7 @@ constexpr const char* NativeBackend::kDefaultName;
 
 namespace native_internal {
 
-NativeDevice* CreateDevice(NativeBackend& backend, int index) { return new NativeDevice{backend, index}; }
+gsl::owner<NativeDevice*> CreateDevice(NativeBackend& backend, int index) { return new NativeDevice{backend, index}; }
 
 }  // namespace native_internal
 

--- a/chainerx_cc/chainerx/python/chainer_interop.cc
+++ b/chainerx_cc/chainerx/python/chainer_interop.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <gsl/gsl>
 #include <nonstd/optional.hpp>
 
 #include "chainerx/array.h"
@@ -68,7 +69,7 @@ void InitChainerxChainerInterop(pybind11::module& m) {
               // Insert backward function
               BackwardBuilder bb{"chainer_function", std::move(input_array_refs), std::move(output_array_refs)};
               if (BackwardBuilder::Target bt = bb.CreateTarget()) {
-                  auto function_node_ptr = std::make_shared<py::object>(std::move(function_node), [](py::object* ptr) {
+                  auto function_node_ptr = std::make_shared<py::object>(std::move(function_node), [](gsl::owner<py::object*> ptr) {
                       py::gil_scoped_acquire acquire;
                       delete ptr;
                   });

--- a/chainerx_cc/chainerx/python/core_module.cc
+++ b/chainerx_cc/chainerx/python/core_module.cc
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <pybind11/pybind11.h>
+#include <gsl/gsl>
 
 #include "chainerx/python/array.h"
 #include "chainerx/python/array_index.h"
@@ -67,7 +68,8 @@ void InitChainerxModule(pybind11::module& m) {
         }
 
         // std::malloc should be used here, since pybind uses std::free to free ml_doc.
-        auto* c_docstring = static_cast<char*>(std::malloc(docstring.size() + 1));
+        // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
+        gsl::owner<char*> c_docstring = static_cast<char*>(std::malloc(docstring.size() + 1));
         if (c_docstring == nullptr) {
             return;
         }

--- a/chainerx_cc/scripts/run-clang-tidy.sh
+++ b/chainerx_cc/scripts/run-clang-tidy.sh
@@ -66,6 +66,7 @@ else
         -cert-err58-cpp  # on TEST, etc.
         -modernize-use-equals-default  # on TEST, etc.
         -modernize-use-equals-delete  # on TEST, etc.
+        -cppcoreguidelines-owning-memory  # on TEST, etc.
     )
 fi
 


### PR DESCRIPTION
Fixes warnings on clang-tidy 6.0.0.

* We started to use `gsl::owner` for raw pointers.
* `cppcoreguidelines-owning-memory` is ignored for test files, because googletest causes errors.