### PR TITLE
Add F.as_strided

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -24,7 +24,7 @@ from chainer.functions.activation.swish import swish  # NOQA
 from chainer.functions.activation.tanh import tanh  # NOQA
 from chainer.functions.activation.tree_lstm import tree_lstm  # NOQA
 
-from chainer.functions.array.as_strided import as_strided
+ from chainer.functions.array.as_strided import as_strided  # NOQA
 from chainer.functions.array.broadcast import broadcast  # NOQA
 from chainer.functions.array.broadcast import broadcast_to  # NOQA
 from chainer.functions.array.cast import cast  # NOQA

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -24,6 +24,7 @@ from chainer.functions.activation.swish import swish  # NOQA
 from chainer.functions.activation.tanh import tanh  # NOQA
 from chainer.functions.activation.tree_lstm import tree_lstm  # NOQA
 
+from chainer.functions.array.as_strided import as_strided
 from chainer.functions.array.broadcast import broadcast  # NOQA
 from chainer.functions.array.broadcast import broadcast_to  # NOQA
 from chainer.functions.array.cast import cast  # NOQA

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -24,7 +24,7 @@ from chainer.functions.activation.swish import swish  # NOQA
 from chainer.functions.activation.tanh import tanh  # NOQA
 from chainer.functions.activation.tree_lstm import tree_lstm  # NOQA
 
- from chainer.functions.array.as_strided import as_strided  # NOQA
+from chainer.functions.array.as_strided import as_strided  # NOQA
 from chainer.functions.array.broadcast import broadcast  # NOQA
 from chainer.functions.array.broadcast import broadcast_to  # NOQA
 from chainer.functions.array.cast import cast  # NOQA

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -376,10 +376,11 @@ def as_strided(x, shape, strides, storage_offset=None):
     """Create a new view of array with the given shape, strides, and offset.
 
     Args:
-        x (tuple of :class:`~chainer.Variable` or :class:`numpy.ndarray` or
+        x (tuple of :class:`~chainer.Variable` or :class:`numpy.ndarray` or \
         :class:`cupy.ndarray`):
             The array pointing a memory buffer. Its view is totally ignored.
-        shape (tuple of int): The shape of output.
+        shape (tuple of int):
+            The shape of output.
         strides (tuple of int):
             The strides of output, given in the unit of bytes.
         storage_offset (int):
@@ -405,6 +406,7 @@ def as_strided(x, shape, strides, storage_offset=None):
         :func:`numpy.lib.stride_tricks.as_strided`.
 
     .. admonition:: Example
+
         >>> from chainer import functions as F, Variable
         >>> x = Variable(np.arange(4, dtype=np.float32))
         >>> x

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -1,5 +1,5 @@
 from chainer.backends import cuda
-from chainer.function_node import FunctionNode
+from chainer import function_node
 from chainer.utils import type_check
 
 import numpy as np
@@ -211,7 +211,7 @@ class TensorGeometry(object):
         return len(self.shape)
 
 
-class AsStrided(FunctionNode):
+class AsStrided(function_node.FunctionNode):
     """Transportation of :func:`torch.Tensor.as_strided`.
     While :func:`torch.Tensor.as_strided` does not support nagative strides,
     this implementation does support it.
@@ -268,7 +268,7 @@ class AsStrided(FunctionNode):
                              self.storage_offset).apply(grad_outputs)
 
 
-class AsStridedGrad(FunctionNode):
+class AsStridedGrad(function_node.FunctionNode):
     """Backward of :func:`~chainer.functions.as_strided`.
     """
 

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -164,12 +164,8 @@ def _stride_array(array, shape, strides, storage_offset):
         return cuda.cupy.ndarray(shape, array.dtype, memptr, strides)
     elif isinstance(array, np.ndarray):
         base_array = _get_base_array(array)
-        if (max_index + 1) * base_array.itemsize > base_array.data.nbytes:
+        if (max_index + 1) * base_array.itemsize > base_array.nbytes:
             raise ValueError("Out of buffer: too large index was specified")
-
-        if not base_array.data.c_contiguous:
-            raise ValueError(
-                "Non-contiguous array: only contiguous array is accepted")
 
         return np.ndarray(shape, base_array.dtype, base_array.data,
                           storage_offset, strides)

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -1,0 +1,427 @@
+from chainer.backends import cuda
+from chainer.function_node import FunctionNode 
+from chainer.utils import type_check
+
+import numpy as np
+from six.moves import range
+from functools import reduce
+
+index_dtype = {t().itemsize: t for t in np.sctypes['int']}
+
+
+def _byte2step(iterable, itemsize):
+    for i in iterable:
+        assert i % itemsize == 0
+    return tuple((i // itemsize for i in iterable))
+
+
+def _step2byte(iterable, itemsize):
+    return tuple((i * itemsize for i in iterable))
+
+
+def _maybe_overlapping_memory(shape: tuple, strides: tuple):
+    """Returns bool value indicating the array with such shape and strides
+    might have overlapping memory.
+
+    Args:
+    shape (tuple of int): The shape of output.
+    strides (tuple of int): The strides of output, given in the unit of steps.
+    storage_offset (int):
+        The offset between the head of allocated memory and the pointer of
+        first element, given in the unit of steps.
+
+    Returns:
+        bool: Existence of the overlapping memory
+    """
+    max_ptr_in_slice = 0
+    for stride, size in sorted(zip((abs(s) for s in strides), shape)):
+        if stride <= max_ptr_in_slice:
+            return True
+        max_ptr_in_slice += stride * (size - 1)
+    return False
+
+
+def _min_index(shape, strides, storage_offset):
+    """Returns the leftest index in the array (in the unit-steps)
+
+    Args:
+        shape (tuple of int): The shape of output.
+        strides (tuple of int):
+            The strides of output, given in the unit of steps.
+        storage_offset (int):
+            The offset between the head of allocated memory and the pointer of
+            first element, given in the unit of steps.
+
+    Returns:
+        int: The leftest pointer in the array
+    """
+    ndim = len(shape)
+    shape_negative = [shape[i] for i in range(ndim) if strides[i] < 0]
+    strides_negative = [strides[i] for i in range(ndim) if strides[i] < 0]
+    if len(strides_negative) == 0:
+        return storage_offset
+    else:
+        return storage_offset + \
+               reduce(lambda base, shape_strides:
+                      base + (shape_strides[0] - 1) * shape_strides[1],
+                      zip(shape_negative, strides_negative), 0)
+
+
+def _max_index(shape, strides, storage_offset):
+    """Returns the rightest index in the array
+
+    Args:
+        shape (tuple of int): The shape of output.
+        strides (tuple of int): The strides of output, given in unit-steps.
+        storage_offset (int):
+            The offset between the head of allocated memory and the pointer of
+            first element, given in the unit of steps.
+
+    Returns:
+        int: The rightest pointer in the array
+    """
+    ndim = len(shape)
+    shape_positive = [shape[i] for i in range(ndim) if strides[i] > 0]
+    strides_positive = [strides[i] for i in range(ndim) if strides[i] > 0]
+    if len(strides_positive) == 0:
+        return storage_offset
+    else:
+        return storage_offset + reduce(
+            lambda base, shape_strides: base + (shape_strides[0] - 1) *
+                                        shape_strides[1],
+            zip(shape_positive, strides_positive), 0)
+
+
+def _index_add(augend, indices, addend):
+    """Wrapper of :func:`cupyx.scatter_add` and :func:`numpy.add.at`
+
+    Args:
+        augend (:class:`numpy.ndarray` or :class:`cupy.ndarray`):
+            The array modified in-place.
+        indices (:class:`numpy.ndarray` or :class:`cupy.ndarray`):
+            The indices of ``augend``. The shape is the same to the ``addend``.
+        addend (:class:`numpy.ndarray` or :class:`cupy.ndarray`):
+            The array to be added.
+
+    Returns:
+        None
+    """
+    if isinstance(augend, cuda.ndarray):
+        cuda.cupyx.scatter_add(augend, indices, addend)
+    elif isinstance(augend, np.ndarray):
+        np.add.at(augend, indices, addend)
+
+
+def _get_base_array(array):
+    """Get the founder of :class:`numpy.ndarray`.
+
+    Args:
+        array (:class:`numpy.ndarray`):
+            The view of the base array.
+
+    Returns:
+        :class:`numpy.ndarray`:
+            The base array.
+    """
+    base_array_candidate = array
+    while base_array_candidate.base is not None:
+        base_array_candidate = base_array_candidate.base
+    return base_array_candidate
+
+
+def _stride_array(array, shape, strides, storage_offset):
+    """Wrapper of :func:`numpy.lib.stride_tricks.as_strided`.
+
+    .. note:
+        ``strides`` and ``storage_offset`` is given in the unit of steps
+        instead the unit of bytes. This specification differs from that of
+        :func:`numpy.lib.stride_tricks.as_strided`.
+
+    Args:
+        array (:class:`numpy.ndarray` of :class:`cupy.ndarray`):
+            The base array for the returned view.
+        shape (tuple of int):
+            The shape of the returned view.
+        strides (tuple of int):
+            The strides of the returned view, given in the unit of steps.
+        storage_offset (int):
+            The offset from the leftest pointer of allocated memory to
+            the first element of returned view, given in the unit of steps.
+
+    Returns:
+        :class:`numpy.ndarray` or :class:`cupy.ndarray`:
+            The new view for the base array.
+    """
+
+    min_index = _min_index(shape, strides, storage_offset)
+    max_index = _max_index(shape, strides, storage_offset)
+
+    strides = _step2byte(strides, array.itemsize)
+    storage_offset, = _step2byte((storage_offset,), array.itemsize)
+
+    if min_index < 0:
+        raise ValueError("Out of buffer: too small index was specified")
+
+    if isinstance(array, cuda.ndarray):
+        pooled_memory = array.data.mem
+        if (max_index + 1) * array.itemsize > pooled_memory.size:
+            raise ValueError("Out of buffer: too large index was specified")
+
+        memptr = cuda.cupy.cuda.memory.MemoryPointer(pooled_memory,
+                                                     storage_offset)
+        return cuda.cupy.ndarray(shape, array.dtype, memptr, strides)
+    elif isinstance(array, np.ndarray):
+        base_array = _get_base_array(array)
+        if (max_index + 1) * base_array.itemsize > base_array.data.nbytes:
+            raise ValueError("Out of buffer: too large index was specified")
+
+        if not base_array.data.c_contiguous:
+            raise ValueError(
+                "Non-contiguous array: only contiguous array is accepted")
+
+        return np.ndarray(shape, base_array.dtype, base_array.data,
+                          storage_offset, strides)
+    else:
+        raise TypeError("Only (np|cp).ndarray is accepted")
+
+
+class TensorGeometry(object):
+    def __init__(self, array: np.ndarray):
+        """Information about the view of array
+
+        Args:
+            array (:class:`numpy.ndarray` or :class:`cupy.ndarray`): base array
+        """
+        self.shape = array.shape
+        self.strides = _byte2step(array.strides, array.itemsize)
+        if isinstance(array, np.ndarray):
+            base_array = _get_base_array(array)
+            array_ptr = array.__array_interface__['data'][0]
+            base_array_ptr = base_array.__array_interface__['data'][0]
+            offset_bytes = base_array_ptr - array_ptr
+        elif isinstance(array, cuda.ndarray):
+            offset_bytes = array.data.ptr - array.data.mem.ptr
+        else:
+            raise ValueError("only (np|cp).ndarray is supported")
+        self.storage_offset, = _byte2step((offset_bytes,), array.itemsize)
+        self.itemsize = array.itemsize
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+
+class AsStrided(FunctionNode):
+    """Transportation of :func:`torch.Tensor.as_strided`.
+    While :func:`torch.Tensor.as_strided` does not support nagative strides,
+    this implementation does support it.
+    """
+
+    def __init__(self, shape, strides, storage_offset=None):
+        """
+        .. note:
+            ``strides`` and ``storage_offset`` is given in the unit of steps
+            instead the unit of bytes. This specification differs from that in
+            :func:`numpy.lib.stride_tricks.as_strided`.
+
+        Args:
+            array (:class:`numpy.ndarray` of :class:`cupy.ndarray`):
+                The base array for the returned view.
+            shape (tuple of int):
+                The shape of the returned view.
+            strides (tuple of int):
+                The strides of the returned view, given in the unit of steps.
+            storage_offset (int):
+                The offset from the leftest pointer of allocated memory to
+                the first element of returned view, given in the unit of steps.
+        """
+        self.shape = shape
+        self.strides = strides
+        self.storage_offset = storage_offset
+        self.input_geometry = None
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 1)
+
+    def forward(self, inputs):
+        assert len(inputs) > 0
+
+        x = inputs[0]
+
+        self.input_geometry = TensorGeometry(x)
+
+        if self.storage_offset is None:
+            self.storage_offset = self.input_geometry.storage_offset
+
+        return _stride_array(x, self.shape, self.strides, self.storage_offset),
+
+    def backward(self, _, grad_outputs):
+        """Backward computation which calls :class:`AsStridedGrad`.
+
+        .. note:
+            While this implementation is based on *New-Style Function
+            Implementation*, the backward computation does not support
+            double-backpropagation due to *layout agnostic* algorithm (
+            originally named in the note of pytorch).
+        """
+        return AsStridedGrad(self.input_geometry, self.shape, self.strides,
+                             self.storage_offset).apply(grad_outputs)
+
+
+class AsStridedGrad(FunctionNode):
+    """Backward of :func:`~chainer.functions.as_strided`.
+    """
+
+    def __init__(self, input_geometry, shape, strides, storage_offset):
+        """
+
+        Args:
+            input_geometry (:class:`~chainer.functions.array.as_strided.\
+            TensorGeometry):
+                The geometry of `gy` (i.e. the input of :func:`as_strided`).
+            shape (tuple of int): The shape of ``gx``.
+            strides (tuple of int): The strides of ``gx``.
+            storage_offset (int): The storage offset of ``gx``.
+        """
+        self.input_geometry = input_geometry
+        self.shape = shape
+        self.strides = strides
+        self.storage_offset = storage_offset
+
+    def forward(self, grads):
+        assert len(grads) > 0
+        gy = grads[0]
+
+        if gy.dtype not in np.sctypes['float']:
+            raise TypeError('Only float is supported for back propagation')
+
+        xp = cuda.get_array_module(gy)
+        input_geometry: TensorGeometry = self.input_geometry
+        itemsize = input_geometry.itemsize
+
+        if 0 in input_geometry.shape:
+            return xp.zeros(input_geometry.shape)
+
+        #  1. remove redundant axis from input/output
+        #  [redundant axis]
+        #  axis with shape==0, shape==1 or strides==0
+        if 0 in gy.shape:
+            return cuda.get_array_module(gy).zeros(input_geometry.shape)
+        else:
+            out_shape = tuple((self.shape[i] for i in range(gy.ndim) if
+                               self.shape[i] != 1 and self.strides[i] != 0))
+            out_strides = tuple((self.strides[i] for i in range(gy.ndim) if
+                                 self.shape[i] != 1 and self.strides[i] != 0))
+            gy = gy.sum(
+                tuple((i for i in range(gy.ndim) if self.strides[i] == 0)))
+            gy = gy.squeeze()
+
+        out_storage_offset = self.storage_offset
+
+        inp_shape = tuple(
+            (input_geometry.shape[i] for i in range(input_geometry.ndim) if
+             input_geometry.shape[i] != 1))
+        inp_strides = tuple(
+            (input_geometry.strides[i] for i in range(input_geometry.ndim) if
+             input_geometry.shape[i] != 1))
+        inp_storage_offset = input_geometry.storage_offset
+
+        #  2. calculate minimum required storage for gradient computation
+        inp_min_ptr = _min_index(inp_shape, inp_strides,
+                                 input_geometry.storage_offset)
+        out_min_ptr = _min_index(out_shape, out_strides, self.storage_offset)
+        common_min_ptr = min(inp_min_ptr, out_min_ptr)
+
+        inp_max_ptr = _max_index(inp_shape, inp_strides,
+                                 input_geometry.storage_offset)
+        out_max_ptr = _max_index(out_shape, out_strides, self.storage_offset)
+        common_max_ptr = max(inp_max_ptr, out_max_ptr)
+
+        base_size = (common_max_ptr - common_min_ptr) + 1
+
+        storage = xp.zeros(base_size, dtype=gy.dtype)
+        flatten_full_indices = xp.arange(base_size,
+                                         dtype=index_dtype[itemsize])
+
+        out_maybe_overlap = _maybe_overlapping_memory(out_shape, out_strides)
+
+        if out_maybe_overlap:
+            out_indices = _stride_array(flatten_full_indices, out_shape,
+                                        out_strides,
+                                        out_storage_offset - common_min_ptr)
+            _index_add(storage, out_indices, gy)
+        else:
+            storage_view = _stride_array(storage, out_shape, out_strides,
+                                         out_storage_offset - common_min_ptr)
+            storage_view[:] = gy[:]
+
+        inp_maybe_overlap = _maybe_overlapping_memory(inp_shape, inp_strides)
+        if inp_maybe_overlap:
+            count = xp.zeros_like(storage)
+            inp_indices = _stride_array(flatten_full_indices, inp_shape,
+                                        inp_strides,
+                                        inp_storage_offset - common_min_ptr)
+            _index_add(count, inp_indices, xp.ones(1))
+            with np.errstate(divide='ignore', invalid='ignore'):
+                storage /= count
+
+        return _stride_array(storage, inp_shape, inp_strides,
+                             inp_storage_offset - common_min_ptr),
+
+    def backward(self, target_input_indexes, grad_outputs):
+        raise NotImplementedError
+
+
+def as_strided(x, shape, strides, storage_offset=None):
+    """Create a new view of array with the given shape, strides, and offset.
+
+    Args:
+        x (tuple of :class:`~chainer.Variable` or :class:`numpy.ndarray` or
+        :class:`cupy.ndarray`):
+            The array pointing a memory buffer. Its view is totally ignored.
+        shape (tuple of int): The shape of output.
+        strides (tuple of int):
+            The strides of output, given in the unit of bytes.
+        storage_offset (int):
+            The offset between the head of allocated memory and the pointer of
+            first element, given in the unit of bytes.
+
+    Returns:
+        ~chainer.Variable: The strided variable.
+
+    .. warning::
+        Users should be aware that this function potentially causes unintended
+        side effects. See `numpy.lib.stride_tricks.as_strided`_ for the detail.
+
+    .. note::
+        The backward algorithm is borrowed from `torch.Tensor.as_strided`.
+        Therefore, the returned gradient of ``backward`` is *layout-agnostic*
+        when ``x`` contains memory overlap. See notes in pytorch's source
+        code (as_strided Backward and layout-aware/agnostic autograd) too.
+
+    .. note::
+        In this function ``strides`` and ``storage_offset`` are given in the
+        unit of steps instead of bytes. This specification differs from
+        :func:`numpy.lib.stride_tricks.as_strided`.
+
+    .. admonition:: Example
+        >>> from chainer import functions as F, Variable
+        >>> x = Variable(np.arange(4, dtype=np.float32))
+        >>> x
+        variable([0., 1., 2., 3.])
+        >>> y = F.as_strided(x, (3, 2), (4, 4), 0)
+        >>> y
+        variable([[0., 1.],
+                  [1., 2.],
+                  [2., 3.]])
+        >>> y.grad = np.ones((3, 2), dtype=np.float32)
+        >>> y.backward()
+        >>> x.grad
+        array([1., 2., 2., 1.], dtype=float32)
+
+    .. _numpy.lib.stride_tricks.as_strided:
+        https://docs.scipy.org/doc/numpy/reference/generated/\
+        numpy.lib.stride_tricks.as_strided.html
+
+    """
+    return AsStrided(shape, strides, storage_offset).apply((x,))[0]

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -179,11 +179,6 @@ def _stride_array(array, shape, strides, storage_offset):
 
 class TensorGeometry(object):
     def __init__(self, array):
-        # """Information about the view of array
-        #
-        # Args:
-        #     array (:class:`numpy.ndarray` or :class:`cupy.ndarray`): base array
-        # """
         self.shape = array.shape
         self.strides = _byte2step(array.strides, array.itemsize)
         if isinstance(array, np.ndarray):
@@ -210,23 +205,6 @@ class AsStrided(function_node.FunctionNode):
     """
 
     def __init__(self, shape, strides, storage_offset=None):
-        # """
-        # .. note:
-        #     ``strides`` and ``storage_offset`` is given in the unit of steps
-        #     instead the unit of bytes. This specification differs from that in
-        #     :func:`numpy.lib.stride_tricks.as_strided`.
-        #
-        # Args:
-        #     array (:class:`numpy.ndarray` of :class:`cupy.ndarray`):
-        #         The base array for the returned view.
-        #     shape (tuple of int):
-        #         The shape of the returned view.
-        #     strides (tuple of int):
-        #         The strides of the returned view, given in the unit of steps.
-        #     storage_offset (int):
-        #         The offset from the leftest pointer of allocated memory to
-        #         the first element of returned view, given in the unit of steps.
-        # """
         self.shape = shape
         self.strides = strides
         self.storage_offset = storage_offset
@@ -265,16 +243,6 @@ class AsStridedGrad(function_node.FunctionNode):
     """
 
     def __init__(self, input_geometry, shape, strides, storage_offset):
-        # """
-        #
-        # Args:
-        #     input_geometry (:class:`~chainer.functions.array.as_strided.\
-        #     TensorGeometry):
-        #         The geometry of `gy` (i.e. the input of :func:`as_strided`).
-        #     shape (tuple of int): The shape of ``gx``.
-        #     strides (tuple of int): The strides of ``gx``.
-        #     storage_offset (int): The storage offset of ``gx``.
-        # """
         self.input_geometry = input_geometry
         self.shape = shape
         self.strides = strides

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -369,7 +369,7 @@ def as_strided(x, shape, strides, storage_offset=None):
         >>> x = Variable(np.arange(4, dtype=np.float32))
         >>> x
         variable([0., 1., 2., 3.])
-        >>> y = F.as_strided(x, (3, 2), (4, 4), 0)
+        >>> y = F.as_strided(x, (3, 2), (1, 1), 0)
         >>> y
         variable([[0., 1.],
                   [1., 2.],

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -12,11 +12,11 @@ index_dtype = {t().itemsize: t for t in np.sctypes['int']}
 def _byte2step(iterable, itemsize):
     for i in iterable:
         assert i % itemsize == 0
-    return tuple((i // itemsize for i in iterable))
+    return tuple([i // itemsize for i in iterable])
 
 
 def _step2byte(iterable, itemsize):
-    return tuple((i * itemsize for i in iterable))
+    return tuple([i * itemsize for i in iterable])
 
 
 def _maybe_overlapping_memory(shape: tuple, strides: tuple):
@@ -34,7 +34,7 @@ def _maybe_overlapping_memory(shape: tuple, strides: tuple):
         bool: Existence of the overlapping memory
     """
     max_ptr_in_slice = 0
-    for stride, size in sorted(zip((abs(s) for s in strides), shape)):
+    for stride, size in sorted(zip([abs(s) for s in strides], shape)):
         if stride <= max_ptr_in_slice:
             return True
         max_ptr_in_slice += stride * (size - 1)
@@ -308,22 +308,22 @@ class AsStridedGrad(function_node.FunctionNode):
         if 0 in gy.shape:
             return cuda.get_array_module(gy).zeros(input_geometry.shape)
         else:
-            out_shape = tuple((self.shape[i] for i in range(gy.ndim) if
-                               self.shape[i] != 1 and self.strides[i] != 0))
-            out_strides = tuple((self.strides[i] for i in range(gy.ndim) if
-                                 self.shape[i] != 1 and self.strides[i] != 0))
+            out_shape = tuple([self.shape[i] for i in range(gy.ndim) if
+                               self.shape[i] != 1 and self.strides[i] != 0])
+            out_strides = tuple([self.strides[i] for i in range(gy.ndim) if
+                                 self.shape[i] != 1 and self.strides[i] != 0])
             gy = gy.sum(
-                tuple((i for i in range(gy.ndim) if self.strides[i] == 0)))
+                tuple([i for i in range(gy.ndim) if self.strides[i] == 0]))
             gy = gy.squeeze()
 
         out_storage_offset = self.storage_offset
 
         inp_shape = tuple(
-            (input_geometry.shape[i] for i in range(input_geometry.ndim) if
-             input_geometry.shape[i] != 1))
+            [input_geometry.shape[i] for i in range(input_geometry.ndim) if
+             input_geometry.shape[i] != 1])
         inp_strides = tuple(
-            (input_geometry.strides[i] for i in range(input_geometry.ndim) if
-             input_geometry.shape[i] != 1))
+            [input_geometry.strides[i] for i in range(input_geometry.ndim) if
+             input_geometry.shape[i] != 1])
         inp_storage_offset = input_geometry.storage_offset
 
         #  2. calculate minimum required storage for gradient computation

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -19,7 +19,7 @@ def _step2byte(iterable, itemsize):
     return tuple([i * itemsize for i in iterable])
 
 
-def _maybe_overlapping_memory(shape: tuple, strides: tuple):
+def _maybe_overlapping_memory(shape, strides):
     """Returns bool value indicating the array with such shape and strides
     might have overlapping memory.
 

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -382,10 +382,10 @@ def as_strided(x, shape, strides, storage_offset=None):
         shape (tuple of int):
             The shape of output.
         strides (tuple of int):
-            The strides of output, given in the unit of bytes.
+            The strides of output, given in the unit of steps.
         storage_offset (int):
             The offset between the head of allocated memory and the pointer of
-            first element, given in the unit of bytes.
+            first element, given in the unit of steps.
 
     Returns:
         ~chainer.Variable: The strided variable.

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -76,7 +76,7 @@ def _max_index(shape, strides, storage_offset):
     Returns:
         int: The rightest pointer in the array
     """
-    sh_st_pos = [sh_st for sh_st in zip(shape, strides) if sh_st[1] < 0]
+    sh_st_pos = [sh_st for sh_st in zip(shape, strides) if sh_st[1] > 0]
     if len(sh_st_pos) == 0:
         return storage_offset
     else:
@@ -185,7 +185,7 @@ class TensorGeometry(object):
             base_array = _get_base_array(array)
             array_ptr = array.__array_interface__['data'][0]
             base_array_ptr = base_array.__array_interface__['data'][0]
-            offset_bytes = base_array_ptr - array_ptr
+            offset_bytes = array_ptr - base_array_ptr
         elif isinstance(array, cuda.ndarray):
             offset_bytes = array.data.ptr - array.data.mem.ptr
         else:

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -296,7 +296,7 @@ class AsStridedGrad(FunctionNode):
             raise TypeError('Only float is supported for back propagation')
 
         xp = cuda.get_array_module(gy)
-        input_geometry: TensorGeometry = self.input_geometry
+        input_geometry = self.input_geometry
         itemsize = input_geometry.itemsize
 
         if 0 in input_geometry.shape:

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -1,5 +1,5 @@
 from chainer.backends import cuda
-from chainer.function_node import FunctionNode 
+from chainer.function_node import FunctionNode
 from chainer.utils import type_check
 
 import numpy as np
@@ -61,10 +61,10 @@ def _min_index(shape, strides, storage_offset):
     if len(strides_negative) == 0:
         return storage_offset
     else:
-        return storage_offset + \
-               reduce(lambda base, shape_strides:
-                      base + (shape_strides[0] - 1) * shape_strides[1],
-                      zip(shape_negative, strides_negative), 0)
+        return storage_offset + reduce(
+            lambda base, shape_strides:
+            base + (shape_strides[0] - 1) * shape_strides[1],
+            zip(shape_negative, strides_negative), 0)
 
 
 def _max_index(shape, strides, storage_offset):
@@ -87,8 +87,8 @@ def _max_index(shape, strides, storage_offset):
         return storage_offset
     else:
         return storage_offset + reduce(
-            lambda base, shape_strides: base + (shape_strides[0] - 1) *
-                                        shape_strides[1],
+            lambda base, shape_strides:
+            base + (shape_strides[0] - 1) * shape_strides[1],
             zip(shape_positive, strides_positive), 0)
 
 

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -179,11 +179,11 @@ def _stride_array(array, shape, strides, storage_offset):
 
 class TensorGeometry(object):
     def __init__(self, array):
-        """Information about the view of array
-
-        Args:
-            array (:class:`numpy.ndarray` or :class:`cupy.ndarray`): base array
-        """
+        # """Information about the view of array
+        #
+        # Args:
+        #     array (:class:`numpy.ndarray` or :class:`cupy.ndarray`): base array
+        # """
         self.shape = array.shape
         self.strides = _byte2step(array.strides, array.itemsize)
         if isinstance(array, np.ndarray):
@@ -210,23 +210,23 @@ class AsStrided(function_node.FunctionNode):
     """
 
     def __init__(self, shape, strides, storage_offset=None):
-        """
-        .. note:
-            ``strides`` and ``storage_offset`` is given in the unit of steps
-            instead the unit of bytes. This specification differs from that in
-            :func:`numpy.lib.stride_tricks.as_strided`.
-
-        Args:
-            array (:class:`numpy.ndarray` of :class:`cupy.ndarray`):
-                The base array for the returned view.
-            shape (tuple of int):
-                The shape of the returned view.
-            strides (tuple of int):
-                The strides of the returned view, given in the unit of steps.
-            storage_offset (int):
-                The offset from the leftest pointer of allocated memory to
-                the first element of returned view, given in the unit of steps.
-        """
+        # """
+        # .. note:
+        #     ``strides`` and ``storage_offset`` is given in the unit of steps
+        #     instead the unit of bytes. This specification differs from that in
+        #     :func:`numpy.lib.stride_tricks.as_strided`.
+        #
+        # Args:
+        #     array (:class:`numpy.ndarray` of :class:`cupy.ndarray`):
+        #         The base array for the returned view.
+        #     shape (tuple of int):
+        #         The shape of the returned view.
+        #     strides (tuple of int):
+        #         The strides of the returned view, given in the unit of steps.
+        #     storage_offset (int):
+        #         The offset from the leftest pointer of allocated memory to
+        #         the first element of returned view, given in the unit of steps.
+        # """
         self.shape = shape
         self.strides = strides
         self.storage_offset = storage_offset
@@ -265,16 +265,16 @@ class AsStridedGrad(function_node.FunctionNode):
     """
 
     def __init__(self, input_geometry, shape, strides, storage_offset):
-        """
-
-        Args:
-            input_geometry (:class:`~chainer.functions.array.as_strided.\
-            TensorGeometry):
-                The geometry of `gy` (i.e. the input of :func:`as_strided`).
-            shape (tuple of int): The shape of ``gx``.
-            strides (tuple of int): The strides of ``gx``.
-            storage_offset (int): The storage offset of ``gx``.
-        """
+        # """
+        #
+        # Args:
+        #     input_geometry (:class:`~chainer.functions.array.as_strided.\
+        #     TensorGeometry):
+        #         The geometry of `gy` (i.e. the input of :func:`as_strided`).
+        #     shape (tuple of int): The shape of ``gx``.
+        #     strides (tuple of int): The strides of ``gx``.
+        #     storage_offset (int): The storage offset of ``gx``.
+        # """
         self.input_geometry = input_geometry
         self.shape = shape
         self.strides = strides

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -55,16 +55,12 @@ def _min_index(shape, strides, storage_offset):
     Returns:
         int: The leftest pointer in the array
     """
-    ndim = len(shape)
-    shape_negative = [shape[i] for i in range(ndim) if strides[i] < 0]
-    strides_negative = [strides[i] for i in range(ndim) if strides[i] < 0]
-    if len(strides_negative) == 0:
+    sh_st_neg = [sh_st for sh_st in zip(shape, strides) if sh_st[1] < 0]
+    if len(sh_st_neg) == 0:
         return storage_offset
     else:
         return storage_offset + reduce(
-            lambda base, shape_strides:
-            base + (shape_strides[0] - 1) * shape_strides[1],
-            zip(shape_negative, strides_negative), 0)
+            lambda base, sh_st: base + (sh_st[0] - 1) * sh_st[1], sh_st_neg, 0)
 
 
 def _max_index(shape, strides, storage_offset):
@@ -80,16 +76,12 @@ def _max_index(shape, strides, storage_offset):
     Returns:
         int: The rightest pointer in the array
     """
-    ndim = len(shape)
-    shape_positive = [shape[i] for i in range(ndim) if strides[i] > 0]
-    strides_positive = [strides[i] for i in range(ndim) if strides[i] > 0]
-    if len(strides_positive) == 0:
+    sh_st_pos = [sh_st for sh_st in zip(shape, strides) if sh_st[1] < 0]
+    if len(sh_st_pos) == 0:
         return storage_offset
     else:
         return storage_offset + reduce(
-            lambda base, shape_strides:
-            base + (shape_strides[0] - 1) * shape_strides[1],
-            zip(shape_positive, strides_positive), 0)
+            lambda base, sh_st: base + (sh_st[0] - 1) * sh_st[1], sh_st_pos, 0)
 
 
 def _index_add(augend, indices, addend):

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -3,8 +3,8 @@ from chainer import function_node
 from chainer.utils import type_check
 
 import numpy as np
-from six.moves import range
-from functools import reduce
+
+from six import moves
 
 index_dtype = {t().itemsize: t for t in np.sctypes['int']}
 
@@ -59,7 +59,7 @@ def _min_index(shape, strides, storage_offset):
     if len(sh_st_neg) == 0:
         return storage_offset
     else:
-        return storage_offset + reduce(
+        return storage_offset + moves.reduce(
             lambda base, sh_st: base + (sh_st[0] - 1) * sh_st[1], sh_st_neg, 0)
 
 
@@ -80,7 +80,7 @@ def _max_index(shape, strides, storage_offset):
     if len(sh_st_pos) == 0:
         return storage_offset
     else:
-        return storage_offset + reduce(
+        return storage_offset + moves.reduce(
             lambda base, sh_st: base + (sh_st[0] - 1) * sh_st[1], sh_st_pos, 0)
 
 
@@ -264,22 +264,24 @@ class AsStridedGrad(function_node.FunctionNode):
         if 0 in gy.shape:
             return cuda.get_array_module(gy).zeros(input_geometry.shape)
         else:
-            out_shape = tuple([self.shape[i] for i in range(gy.ndim) if
+            out_shape = tuple([self.shape[i] for i in moves.range(gy.ndim) if
                                self.shape[i] != 1 and self.strides[i] != 0])
-            out_strides = tuple([self.strides[i] for i in range(gy.ndim) if
-                                 self.shape[i] != 1 and self.strides[i] != 0])
+            out_strides = tuple([self.strides[i] for i in moves.range(gy.ndim)
+                                 if self.shape[i] != 1
+                                 and self.strides[i] != 0])
             gy = gy.sum(
-                tuple([i for i in range(gy.ndim) if self.strides[i] == 0]))
+                tuple([i for i in moves.range(gy.ndim)
+                       if self.strides[i] == 0]))
             gy = gy.squeeze()
 
         out_storage_offset = self.storage_offset
 
-        inp_shape = tuple(
-            [input_geometry.shape[i] for i in range(input_geometry.ndim) if
-             input_geometry.shape[i] != 1])
-        inp_strides = tuple(
-            [input_geometry.strides[i] for i in range(input_geometry.ndim) if
-             input_geometry.shape[i] != 1])
+        inp_shape = tuple([input_geometry.shape[i]
+                           for i in moves.range(input_geometry.ndim)
+                           if input_geometry.shape[i] != 1])
+        inp_strides = tuple([input_geometry.strides[i]
+                             for i in moves.range(input_geometry.ndim)
+                             if input_geometry.shape[i] != 1])
         inp_storage_offset = input_geometry.storage_offset
 
         #  2. calculate minimum required storage for gradient computation

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -178,7 +178,7 @@ def _stride_array(array, shape, strides, storage_offset):
 
 
 class TensorGeometry(object):
-    def __init__(self, array: np.ndarray):
+    def __init__(self, array):
         """Information about the view of array
 
         Args:

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -80,6 +80,7 @@ Array manipulations
    :toctree: generated/
    :nosignatures:
 
+   chainer.functions.as_strided
    chainer.functions.broadcast
    chainer.functions.broadcast_to
    chainer.functions.cast

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -42,7 +42,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_gpu(self):
-                self.check_broadcast(cuda.cupy)
+        self.check_broadcast(cuda.cupy)
 
     def check_unstride(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -55,7 +55,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_gpu(self):
-                self.check_unstride(cuda.cupy)
+        self.check_unstride(cuda.cupy)
 
     def check_general_stride(self, xp):
         x = xp.arange(8, dtype=self.dtype)
@@ -73,7 +73,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_gpu(self):
-                self.check_general_stride(cuda.cupy)
+        self.check_general_stride(cuda.cupy)
 
     def check_invalid_negative_index(self, xp):
         x = xp.arange(8, dtype=self.dtype)
@@ -85,7 +85,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_invalid_negative_index_gpu(self):
-                self.check_invalid_negative_index(cuda.cupy)
+        self.check_invalid_negative_index(cuda.cupy)
 
 
 @testing.parameterize(
@@ -109,7 +109,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_forward_gpu(self):
-                self.check_flip_forward(cuda.cupy)
+        self.check_flip_forward(cuda.cupy)
 
     def check_broadcast_forward(self, xp):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
@@ -123,7 +123,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_forward_gpu(self):
-                self.check_broadcast_forward(cuda.cupy)
+        self.check_broadcast_forward(cuda.cupy)
 
     def check_unstride_forward(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -137,7 +137,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_forward_gpu(self):
-                self.check_unstride_forward(cuda.cupy)
+        self.check_unstride_forward(cuda.cupy)
 
     def check_general_stride(self, xp):
         x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
@@ -154,7 +154,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_forward_gpu(self):
-                self.check_general_stride(cuda.cupy)
+        self.check_general_stride(cuda.cupy)
 
 
 @testing.parameterize(
@@ -176,7 +176,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
-                self.check_flip_backward(cuda.cupy)
+        self.check_flip_backward(cuda.cupy)
 
     def check_broadcast_backward(self, xp):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
@@ -192,7 +192,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
-                self.check_broadcast_backward(cuda.cupy)
+        self.check_broadcast_backward(cuda.cupy)
 
     def check_unstride_backward(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -207,7 +207,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
-                self.check_unstride_backward(cuda.cupy)
+        self.check_unstride_backward(cuda.cupy)
 
     def check_general_stride_backward(self, xp):
         x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
@@ -230,7 +230,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
-                self.check_general_stride_backward(cuda.cupy)
+        self.check_general_stride_backward(cuda.cupy)
 
 
 @testing.parameterize(
@@ -252,7 +252,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
-                self.check_flip_backward(cuda.cupy)
+        self.check_flip_backward(cuda.cupy)
 
     def check_broadcast_backward(self, xp):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
@@ -267,7 +267,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
-                self.check_broadcast_backward(cuda.cupy)
+        self.check_broadcast_backward(cuda.cupy)
 
     def check_unstride_backward(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -282,7 +282,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
-                self.check_unstride_backward(cuda.cupy)
+        self.check_unstride_backward(cuda.cupy)
 
     def check_general_stride_backward(self, xp):
         x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
@@ -299,7 +299,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
-                self.check_general_stride_backward(cuda.cupy)
+        self.check_general_stride_backward(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -20,7 +20,7 @@ class TestStrideArray(unittest.TestCase):
     def check_flip(self, xp):
         x = xp.arange(4, dtype=self.dtype)
         y = _stride_array(x, (4,), (-1,), 3)  # [3, 2, 1, 0]
-        y_expected = xp.flip(x, axis=0)
+        y_expected = x[::-1]
         testing.assert_allclose(y, y_expected)
 
     def test_flip_cpu(self):
@@ -45,7 +45,7 @@ class TestStrideArray(unittest.TestCase):
         self.check_broadcast(cuda.cupy)
 
     def check_unstride(self, xp):
-        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4))[::-1]
         y = _stride_array(x, (12,), (1,), 0)
         y_expected = xp.arange(12, dtype=self.dtype)
         testing.assert_allclose(y, y_expected)
@@ -101,7 +101,7 @@ class TestAsStridedForward(unittest.TestCase):
         x = xp.arange(4, dtype=self.dtype)
         v = Variable(x)
         y = as_strided(v, (4,), (-1,), 3)
-        y_expected = xp.flip(x, axis=0)
+        y_expected = x[::-1]
         testing.assert_allclose(y.array, y_expected)
 
     def test_flip_forward_cpu(self):
@@ -126,7 +126,7 @@ class TestAsStridedForward(unittest.TestCase):
         self.check_broadcast_forward(cuda.cupy)
 
     def check_unstride_forward(self, xp):
-        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4))[::-1]
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
         y_expected = xp.arange(12, dtype=self.dtype)
@@ -195,7 +195,7 @@ class TestAsStridedBackward(unittest.TestCase):
         self.check_broadcast_backward(cuda.cupy)
 
     def check_unstride_backward(self, xp):
-        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4))[::-1]
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
         y.grad = xp.ones((12,), dtype=self.dtype)
@@ -270,7 +270,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
         self.check_broadcast_backward(cuda.cupy)
 
     def check_unstride_backward(self, xp):
-        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4))[::-1]
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
         y.grad = xp.ones((12,), dtype=self.dtype)

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -32,7 +32,8 @@ class TestStrideArray(unittest.TestCase):
         assert (y == y_expected).all()
 
     def test_broadcast_cpu(self):
-        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()  # [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
+        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        # [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
         y = _stride_array(x, (2, 3, 4), (0, 4, 1), 0)
         y_expected = np.broadcast_to(x, (2, 3, 4))
         assert (y == y_expected).all()
@@ -152,7 +153,8 @@ class TestAsStridedForward(unittest.TestCase):
         v = Variable(x)
         y = as_strided(v, (3, 3), (1, 2), 0)
         # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y_expected = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (1, 2), 0)
+        y_expected = _stride_array(np.arange(8, dtype=self.dtype),
+                                   (3, 3), (1, 2), 0)
         assert (y.array == y_expected).all()
 
     @testing.attr.gpu
@@ -162,7 +164,8 @@ class TestAsStridedForward(unittest.TestCase):
         v = Variable(x)
         y = as_strided(v, (3, 3), (1, 2), 0)
         # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y_expected = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (1, 2), 0)
+        y_expected = _stride_array(cp.arange(8, dtype=self.dtype),
+                                   (3, 3), (1, 2), 0)
         assert (y.array == y_expected).all()
 
 
@@ -231,7 +234,11 @@ class TestAsStridedBackward(unittest.TestCase):
         # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
         y.grad = np.ones(y.shape, dtype=self.dtype)
         gx, = grad((y,), (v,))
-        assert (gx.array == np.array([[0.5, 0.5, 0.], [2., 2., 1.], [1., 0.5, 0.5]])).all()
+        assert (gx.array == np.array([
+            [0.5, 0.5, 0.],
+            [2., 2., 1.],
+            [1., 0.5, 0.5]
+        ])).all()
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
@@ -242,7 +249,11 @@ class TestAsStridedBackward(unittest.TestCase):
         # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
         y.grad = cp.ones(y.shape, dtype=self.dtype)
         gx, = grad((y,), (v,))
-        assert (gx.array == cp.array([[0.5, 0.5, 0.], [2., 2., 1.], [1., 0.5, 0.5]])).all()
+        assert (gx.array == cp.array([
+            [0.5, 0.5, 0.],
+            [2., 2., 1.],
+            [1., 0.5, 0.5]
+        ])).all()
 
 
 @testing.parameterize(

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -17,84 +17,80 @@ from chainer.functions.array.as_strided import _stride_array
     {'dtype': np.int64}
 )
 class TestStrideArray(unittest.TestCase):
-    def test_flip_cpu(self):
-        x = np.arange(4, dtype=self.dtype)
+    def check_flip(self, xp):
+        x = xp.arange(4, dtype=self.dtype)
         y = _stride_array(x, (4,), (-1,), 3)  # [3, 2, 1, 0]
-        y_expected = np.flip(x, axis=0)
-        assert (y == y_expected).all()
+        y_expected = xp.flip(x, axis=0)
+        testing.assert_allclose(y, y_expected)
+
+    def test_flip_cpu(self):
+        self.check_flip(np)
 
     @testing.attr.gpu
     def test_flip_gpu(self):
         import cupy as cp
-        x = cp.arange(4, dtype=self.dtype)
-        y = _stride_array(x, (4,), (-1,), 3)
-        y_expected = cp.flip(x, axis=0)
-        assert (y == y_expected).all()
+        self.check_flip(cp)
 
-    def test_broadcast_cpu(self):
-        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+    def check_broadcast(self, xp):
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         # [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
         y = _stride_array(x, (2, 3, 4), (0, 4, 1), 0)
-        y_expected = np.broadcast_to(x, (2, 3, 4))
-        assert (y == y_expected).all()
+        y_expected = xp.broadcast_to(x, (2, 3, 4))
+        testing.assert_allclose(y, y_expected)
+
+    def test_broadcast_cpu(self):
+        self.check_broadcast(np)
 
     @testing.attr.gpu
     def test_broadcast_gpu(self):
         import cupy as cp
-        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
-        y = _stride_array(x, (2, 3, 4), (0, 4, 1), 0)
-        y_expected = cp.broadcast_to(x, (2, 3, 4))
-        assert (y == y_expected).all()
+        self.check_broadcast(cp)
+
+    def check_unstride(self, xp):
+        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        y = _stride_array(x, (12,), (1,), 0)
+        y_expected = xp.arange(12, dtype=self.dtype)
+        testing.assert_allclose(y, y_expected)
 
     def test_unstride_cpu(self):
-        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
-        y = _stride_array(x, (12,), (1,), 0)
-        y_expected = np.arange(12, dtype=self.dtype)
-        assert (y == y_expected).all()
+        self.check_unstride(np)
 
     @testing.attr.gpu
     def test_unstride_gpu(self):
         import cupy as cp
-        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
-        y = _stride_array(x, (12,), (1,), 0)
-        y_expected = cp.arange(12, dtype=self.dtype)
-        assert (y == y_expected).all()
+        self.check_unstride(cp)
 
-    def test_general_stride_cpu(self):
-        x = np.arange(8, dtype=self.dtype)
+    def check_general_stride(self, xp):
+        x = xp.arange(8, dtype=self.dtype)
         y = _stride_array(x, (3, 3), (-1, 2), 3)
-        y_expected = np.array(
+        y_expected = xp.array(
             [[3, 5, 7],
              [2, 4, 6],
              [1, 3, 5]],
             dtype=self.dtype
         )
-        assert (y == y_expected).all()
+        testing.assert_allclose(y, y_expected)
+
+    def test_general_stride_cpu(self):
+        self.check_general_stride(np)
 
     @testing.attr.gpu
     def test_general_stride_gpu(self):
         import cupy as cp
-        x = cp.arange(8, dtype=self.dtype)
-        y = _stride_array(x, (3, 3), (-1, 2), 3)
-        y_expected = cp.array(
-            [[3, 5, 7],
-             [2, 4, 6],
-             [1, 3, 5]],
-            dtype=self.dtype
-        )
-        assert (y == y_expected).all()
+        self.check_general_stride(cp)
 
-    def test_invalid_negative_index_cpu(self):
-        x = np.arange(8, dtype=self.dtype)
+    def check_invalid_negative_index(self, xp):
+        x = xp.arange(8, dtype=self.dtype)
         with self.assertRaises(ValueError):
             _stride_array(x, (3, 3), (-1, 2), 1)
+
+    def test_invalid_negative_index_cpu(self):
+        self.check_invalid_negative_index(np)
 
     @testing.attr.gpu
     def test_invalid_negative_index_gpu(self):
         import cupy as cp
-        x = cp.arange(8, dtype=self.dtype)
-        with self.assertRaises(ValueError):
-            _stride_array(x, (3, 3), (-1, 2), 1)
+        self.check_invalid_negative_index(cp)
 
 
 @testing.parameterize(
@@ -106,75 +102,68 @@ class TestStrideArray(unittest.TestCase):
     {'dtype': np.int64}
 )
 class TestAsStridedForward(unittest.TestCase):
-    def test_flip_forward_cpu(self):
-        x = np.arange(4, dtype=self.dtype)
+    def check_flip_forward(self, xp):
+        x = xp.arange(4, dtype=self.dtype)
         v = Variable(x)
         y = as_strided(v, (4,), (-1,), 3)
-        y_expected = np.flip(x, axis=0)
-        assert (y.array == y_expected).all()
+        y_expected = xp.flip(x, axis=0)
+        testing.assert_allclose(y.array, y_expected)
+
+    def test_flip_forward_cpu(self):
+        self.check_flip_forward(np)
 
     @testing.attr.gpu
     def test_flip_forward_gpu(self):
         import cupy as cp
-        x = cp.arange(4, dtype=self.dtype)
-        v = Variable(x)
-        y = as_strided(v, (4,), (-1,), 3)
-        y_expected = cp.flip(x, axis=0)
-        assert (y.array == y_expected).all()
+        self.check_flip_forward(cp)
 
-    def test_broadcast_forward_cpu(self):
-        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+    def check_broadcast_forward(self, xp):
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         v = Variable(x)
         y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
-        y_expected = np.broadcast_to(x, (2, 3, 4))
-        assert (y.array == y_expected).all()
+        y_expected = xp.broadcast_to(x, (2, 3, 4))
+        testing.assert_allclose(y.array, y_expected)
+
+    def test_broadcast_forward_cpu(self):
+        self.check_broadcast_forward(np)
 
     @testing.attr.gpu
     def test_broadcast_forward_gpu(self):
         import cupy as cp
-        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
-        v = Variable(x)
-        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
-        y_expected = cp.broadcast_to(x, (2, 3, 4))
-        assert (y.array == y_expected).all()
+        self.check_broadcast_forward(cp)
 
-    def test_unstride_forward_cpu(self):
-        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+    def check_unstride_forward(self, xp):
+        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
-        y_expected = np.arange(12, dtype=self.dtype)
-        assert (y.array == y_expected).all()
+        y_expected = xp.arange(12, dtype=self.dtype)
+        testing.assert_allclose(y.array, y_expected)
+
+    def test_unstride_forward_cpu(self):
+        self.check_unstride_forward(np)
 
     @testing.attr.gpu
     def test_unstride_forward_gpu(self):
         import cupy as cp
-        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
-        v = Variable(x)
-        y = as_strided(v, (12,), (1,), 0)
-        y_expected = cp.arange(12, dtype=self.dtype)
-        assert (y.array == y_expected).all()
+        self.check_unstride_forward(cp)
 
-    def test_general_stride_forward_cpu(self):
-        x = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+    def check_general_stride(self, xp):
+        x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
         # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
         v = Variable(x)
         y = as_strided(v, (3, 3), (1, 2), 0)
         # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y_expected = _stride_array(np.arange(8, dtype=self.dtype),
+        y_expected = _stride_array(xp.arange(8, dtype=self.dtype),
                                    (3, 3), (1, 2), 0)
         assert (y.array == y_expected).all()
+
+    def test_general_stride_forward_cpu(self):
+        self.check_general_stride(np)
 
     @testing.attr.gpu
     def test_general_stride_forward_gpu(self):
         import cupy as cp
-        x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
-        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
-        v = Variable(x)
-        y = as_strided(v, (3, 3), (1, 2), 0)
-        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y_expected = _stride_array(cp.arange(8, dtype=self.dtype),
-                                   (3, 3), (1, 2), 0)
-        assert (y.array == y_expected).all()
+        self.check_general_stride(cp)
 
 
 @testing.parameterize(
@@ -183,89 +172,78 @@ class TestAsStridedForward(unittest.TestCase):
     {'dtype': np.float64}
 )
 class TestAsStridedBackward(unittest.TestCase):
-    def test_flip_backward_cpu(self):
-        x = np.arange(4, dtype=self.dtype)
+    def check_flip_backward(self, xp):
+        x = xp.arange(4, dtype=self.dtype)
         v = Variable(x)
         y = as_strided(v, (4,), (-1,), 3)
-        y.grad = np.ones((4,), dtype=self.dtype)
+        y.grad = xp.ones((4,), dtype=self.dtype)
         gx, = grad((y,), (v,))
-        assert (gx.array == np.ones((4,), dtype=self.dtype)).all()
+        testing.assert_allclose(gx.array, xp.ones((4,), dtype=self.dtype))
+
+    def test_flip_backward_cpu(self):
+        self.check_flip_backward(np)
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
         import cupy as cp
-        x = cp.arange(4, dtype=self.dtype)
-        v = Variable(x)
-        y = as_strided(v, (4,), (-1,), 3)
-        y.grad = cp.ones((4,), dtype=self.dtype)
-        gx, = grad((y,), (v,))
-        assert (gx.array == cp.ones((4,), dtype=self.dtype)).all()
+        self.check_flip_backward(cp)
 
-    def test_broadcast_backward_cpu(self):
-        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+    def check_broadcast_backward(self, xp):
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         v = Variable(x)
         y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
-        y.grad = np.ones((2, 3, 4), dtype=self.dtype)
+        y.grad = xp.ones((2, 3, 4), dtype=self.dtype)
         gx, = grad((y,), (v,))
-        assert (gx.array == np.ones(x.shape, dtype=self.dtype) * 2).all()
+        testing.assert_allclose(gx.array,
+                                xp.ones(x.shape, dtype=self.dtype) * 2)
+
+    def test_broadcast_backward_cpu(self):
+        self.check_broadcast_backward(np)
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
         import cupy as cp
-        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
-        v = Variable(x)
-        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
-        y.grad = cp.ones((2, 3, 4), dtype=self.dtype)
-        gx, = grad((y,), (v,))
-        assert (gx.array == cp.ones(x.shape, dtype=self.dtype) * 2).all()
+        self.check_broadcast_backward(cp)
 
-    def test_unstride_backward_cpu(self):
-        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+    def check_unstride_backward(self, xp):
+        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
-        y.grad = np.ones((12,), dtype=self.dtype)
+        y.grad = xp.ones((12,), dtype=self.dtype)
         gx, = grad((y,), (v,))
-        assert (gx.array == np.ones(x.shape, dtype=self.dtype)).all()
+        testing.assert_allclose(gx.array, xp.ones(x.shape, dtype=self.dtype))
+
+    def test_unstride_backward_cpu(self):
+        self.check_unstride_backward(np)
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
         import cupy as cp
-        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
-        v = Variable(x)
-        y = as_strided(v, (12,), (1,), 0)
-        y.grad = cp.ones((12,), dtype=self.dtype)
-        gx, = grad((y,), (v,))
-        assert (gx.array == cp.ones(x.shape, dtype=self.dtype)).all()
+        self.check_unstride_backward(cp)
 
-    def test_general_stride_backward_cpu(self):
-        x = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+    def check_general_stride_backward(self, xp):
+        x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
         # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
         v = Variable(x)
         y = as_strided(v, (3, 3), (1, 2), 0)
         # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y.grad = np.ones(y.shape, dtype=self.dtype)
+        y.grad = xp.ones(y.shape, dtype=self.dtype)
         gx, = grad((y,), (v,))
-        assert (gx.array == np.array([
-            [0.5, 0.5, 0.],
-            [2., 2., 1.],
-            [1., 0.5, 0.5]
-        ])).all()
+        testing.assert_allclose(gx.array,
+                                xp.array([
+                                    [0.5, 0.5, 0.],
+                                    [2., 2., 1.],
+                                    [1., 0.5, 0.5]
+                                ], dtype=self.dtype)
+                                )
+
+    def test_general_stride_backward_cpu(self):
+        self.check_general_stride_backward(np)
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
         import cupy as cp
-        x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
-        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
-        v = Variable(x)
-        y = as_strided(v, (3, 3), (1, 2), 0)
-        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y.grad = cp.ones(y.shape, dtype=self.dtype)
-        gx, = grad((y,), (v,))
-        assert (gx.array == cp.array([
-            [0.5, 0.5, 0.],
-            [2., 2., 1.],
-            [1., 0.5, 0.5]
-        ])).all()
+        self.check_general_stride_backward(cp)
 
 
 @testing.parameterize(
@@ -274,81 +252,71 @@ class TestAsStridedBackward(unittest.TestCase):
     {'dtype': np.int64}
 )
 class TestAsStridedBackwardInvalidType(unittest.TestCase):
-    def test_flip_backward_cpu(self):
-        x = np.arange(4, dtype=self.dtype)
+    def check_flip_backward(self, xp):
+        x = xp.arange(4, dtype=self.dtype)
         v = Variable(x)
         y = as_strided(v, (4,), (-1,), 3)
-        y.grad = np.ones((4,), dtype=self.dtype)
+        y.grad = xp.ones((4,), dtype=self.dtype)
         with self.assertRaises(TypeError):
             gx, = grad((y,), (v,))
+
+    def test_flip_backward_cpu(self):
+        self.check_flip_backward(np)
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
         import cupy as cp
-        x = cp.arange(4, dtype=self.dtype)
+        self.check_flip_backward(cp)
+
+    def check_broadcast_backward(self, xp):
+        x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         v = Variable(x)
-        y = as_strided(v, (4,), (-1,), 3)
-        y.grad = cp.ones((4,), dtype=self.dtype)
+        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
+        y.grad = xp.ones((2, 3, 4), dtype=self.dtype)
         with self.assertRaises(TypeError):
             gx, = grad((y,), (v,))
 
     def test_broadcast_backward_cpu(self):
-        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
-        v = Variable(x)
-        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
-        y.grad = np.ones((2, 3, 4), dtype=self.dtype)
-        with self.assertRaises(TypeError):
-            gx, = grad((y,), (v,))
+        self.check_broadcast_backward(np)
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
         import cupy as cp
-        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        self.check_broadcast_backward(cp)
+
+    def check_unstride_backward(self, xp):
+        x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
         v = Variable(x)
-        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
-        y.grad = cp.ones((2, 3, 4), dtype=self.dtype)
+        y = as_strided(v, (12,), (1,), 0)
+        y.grad = xp.ones((12,), dtype=self.dtype)
         with self.assertRaises(TypeError):
             gx, = grad((y,), (v,))
 
     def test_unstride_backward_cpu(self):
-        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
-        v = Variable(x)
-        y = as_strided(v, (12,), (1,), 0)
-        y.grad = np.ones((12,), dtype=self.dtype)
-        with self.assertRaises(TypeError):
-            gx, = grad((y,), (v,))
+        self.check_unstride_backward(np)
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
         import cupy as cp
-        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        self.check_unstride_backward(cp)
+
+    def check_general_stride_backward(self, xp):
+        x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
         v = Variable(x)
-        y = as_strided(v, (12,), (1,), 0)
-        y.grad = cp.ones((12,), dtype=self.dtype)
+        y = as_strided(v, (3, 3), (1, 2), 0)
+        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
+        y.grad = xp.ones(y.shape, dtype=self.dtype)
         with self.assertRaises(TypeError):
             gx, = grad((y,), (v,))
 
     def test_general_stride_backward_cpu(self):
-        x = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
-        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
-        v = Variable(x)
-        y = as_strided(v, (3, 3), (1, 2), 0)
-        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y.grad = np.ones(y.shape, dtype=self.dtype)
-        with self.assertRaises(TypeError):
-            gx, = grad((y,), (v,))
+        self.check_general_stride_backward(np)
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
         import cupy as cp
-        x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
-        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
-        v = Variable(x)
-        y = as_strided(v, (3, 3), (1, 2), 0)
-        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
-        y.grad = cp.ones(y.shape, dtype=self.dtype)
-        with self.assertRaises(TypeError):
-            gx, = grad((y,), (v,))
+        self.check_general_stride_backward(cp)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -3,7 +3,7 @@ import unittest
 from chainer import testing, Variable, grad
 
 import numpy as np
-import cupy as cp
+import chainer.backends.cuda.cupy as cp
 
 from chainer.functions import as_strided
 from chainer.functions.array.as_strided import _stride_array

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -1,6 +1,6 @@
 import unittest
 
-from chainer import testing, Variable, grad
+from chainer import testing, Variable, grad, cuda
 
 import numpy as np
 
@@ -28,8 +28,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_gpu(self):
-        import cupy as cp
-        self.check_flip(cp)
+        self.check_flip(cuda.cupy)
 
     def check_broadcast(self, xp):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
@@ -43,8 +42,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_gpu(self):
-        import cupy as cp
-        self.check_broadcast(cp)
+                self.check_broadcast(cuda.cupy)
 
     def check_unstride(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -57,8 +55,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_gpu(self):
-        import cupy as cp
-        self.check_unstride(cp)
+                self.check_unstride(cuda.cupy)
 
     def check_general_stride(self, xp):
         x = xp.arange(8, dtype=self.dtype)
@@ -76,8 +73,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_gpu(self):
-        import cupy as cp
-        self.check_general_stride(cp)
+                self.check_general_stride(cuda.cupy)
 
     def check_invalid_negative_index(self, xp):
         x = xp.arange(8, dtype=self.dtype)
@@ -89,8 +85,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_invalid_negative_index_gpu(self):
-        import cupy as cp
-        self.check_invalid_negative_index(cp)
+                self.check_invalid_negative_index(cuda.cupy)
 
 
 @testing.parameterize(
@@ -114,8 +109,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_forward_gpu(self):
-        import cupy as cp
-        self.check_flip_forward(cp)
+                self.check_flip_forward(cuda.cupy)
 
     def check_broadcast_forward(self, xp):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
@@ -129,8 +123,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_forward_gpu(self):
-        import cupy as cp
-        self.check_broadcast_forward(cp)
+                self.check_broadcast_forward(cuda.cupy)
 
     def check_unstride_forward(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -144,8 +137,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_forward_gpu(self):
-        import cupy as cp
-        self.check_unstride_forward(cp)
+                self.check_unstride_forward(cuda.cupy)
 
     def check_general_stride(self, xp):
         x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
@@ -162,8 +154,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_forward_gpu(self):
-        import cupy as cp
-        self.check_general_stride(cp)
+                self.check_general_stride(cuda.cupy)
 
 
 @testing.parameterize(
@@ -185,8 +176,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
-        import cupy as cp
-        self.check_flip_backward(cp)
+                self.check_flip_backward(cuda.cupy)
 
     def check_broadcast_backward(self, xp):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
@@ -202,8 +192,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
-        import cupy as cp
-        self.check_broadcast_backward(cp)
+                self.check_broadcast_backward(cuda.cupy)
 
     def check_unstride_backward(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -218,8 +207,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
-        import cupy as cp
-        self.check_unstride_backward(cp)
+                self.check_unstride_backward(cuda.cupy)
 
     def check_general_stride_backward(self, xp):
         x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
@@ -242,8 +230,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
-        import cupy as cp
-        self.check_general_stride_backward(cp)
+                self.check_general_stride_backward(cuda.cupy)
 
 
 @testing.parameterize(
@@ -265,8 +252,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
-        import cupy as cp
-        self.check_flip_backward(cp)
+                self.check_flip_backward(cuda.cupy)
 
     def check_broadcast_backward(self, xp):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
@@ -281,8 +267,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
-        import cupy as cp
-        self.check_broadcast_backward(cp)
+                self.check_broadcast_backward(cuda.cupy)
 
     def check_unstride_backward(self, xp):
         x = xp.flip(xp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
@@ -297,8 +282,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
-        import cupy as cp
-        self.check_unstride_backward(cp)
+                self.check_unstride_backward(cuda.cupy)
 
     def check_general_stride_backward(self, xp):
         x = _stride_array(xp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
@@ -315,8 +299,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
-        import cupy as cp
-        self.check_general_stride_backward(cp)
+                self.check_general_stride_backward(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -1,0 +1,327 @@
+import unittest
+
+from chainer import testing, Variable, grad
+
+import numpy as np
+import cupy as cp
+
+from chainer.functions import as_strided
+from chainer.functions.array.as_strided import _stride_array
+
+
+@testing.parameterize(
+    {'dtype': np.float16},
+    {'dtype': np.float32},
+    {'dtype': np.float64},
+    {'dtype': np.int16},
+    {'dtype': np.int32},
+    {'dtype': np.int64}
+)
+class TestStrideArray(unittest.TestCase):
+    def test_flip_cpu(self):
+        x = np.arange(4, dtype=self.dtype)
+        y = _stride_array(x, (4,), (-1,), 3)  # [3, 2, 1, 0]
+        y_expected = np.flip(x, axis=0)
+        assert (y == y_expected).all()
+
+    @testing.attr.gpu
+    def test_flip_gpu(self):
+        x = cp.arange(4, dtype=self.dtype)
+        y = _stride_array(x, (4,), (-1,), 3)
+        y_expected = cp.flip(x, axis=0)
+        assert (y == y_expected).all()
+
+    def test_broadcast_cpu(self):
+        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()  # [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
+        y = _stride_array(x, (2, 3, 4), (0, 4, 1), 0)
+        y_expected = np.broadcast_to(x, (2, 3, 4))
+        assert (y == y_expected).all()
+
+    @testing.attr.gpu
+    def test_broadcast_gpu(self):
+        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        y = _stride_array(x, (2, 3, 4), (0, 4, 1), 0)
+        y_expected = cp.broadcast_to(x, (2, 3, 4))
+        assert (y == y_expected).all()
+
+    def test_unstride_cpu(self):
+        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        y = _stride_array(x, (12,), (1,), 0)
+        y_expected = np.arange(12, dtype=self.dtype)
+        assert (y == y_expected).all()
+
+    @testing.attr.gpu
+    def test_unstride_gpu(self):
+        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        y = _stride_array(x, (12,), (1,), 0)
+        y_expected = cp.arange(12, dtype=self.dtype)
+        assert (y == y_expected).all()
+
+    def test_general_stride_cpu(self):
+        x = np.arange(8, dtype=self.dtype)
+        y = _stride_array(x, (3, 3), (-1, 2), 3)
+        y_expected = np.array(
+            [[3, 5, 7],
+             [2, 4, 6],
+             [1, 3, 5]],
+            dtype=self.dtype
+        )
+        assert (y == y_expected).all()
+
+    @testing.attr.gpu
+    def test_general_stride_gpu(self):
+        x = cp.arange(8, dtype=self.dtype)
+        y = _stride_array(x, (3, 3), (-1, 2), 3)
+        y_expected = cp.array(
+            [[3, 5, 7],
+             [2, 4, 6],
+             [1, 3, 5]],
+            dtype=self.dtype
+        )
+        assert (y == y_expected).all()
+
+    def test_invalid_negative_index_cpu(self):
+        x = np.arange(8, dtype=self.dtype)
+        with self.assertRaises(ValueError):
+            _stride_array(x, (3, 3), (-1, 2), 1)
+
+    @testing.attr.gpu
+    def test_invalid_negative_index_gpu(self):
+        x = cp.arange(8, dtype=self.dtype)
+        with self.assertRaises(ValueError):
+            _stride_array(x, (3, 3), (-1, 2), 1)
+
+
+@testing.parameterize(
+    {'dtype': np.float16},
+    {'dtype': np.float32},
+    {'dtype': np.float64},
+    {'dtype': np.int16},
+    {'dtype': np.int32},
+    {'dtype': np.int64}
+)
+class TestAsStridedForward(unittest.TestCase):
+    def test_flip_forward_cpu(self):
+        x = np.arange(4, dtype=self.dtype)
+        v = Variable(x)
+        y = as_strided(v, (4,), (-1,), 3)
+        y_expected = np.flip(x, axis=0)
+        assert (y.array == y_expected).all()
+
+    @testing.attr.gpu
+    def test_flip_forward_gpu(self):
+        x = cp.arange(4, dtype=self.dtype)
+        v = Variable(x)
+        y = as_strided(v, (4,), (-1,), 3)
+        y_expected = cp.flip(x, axis=0)
+        assert (y.array == y_expected).all()
+
+    def test_broadcast_forward_cpu(self):
+        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        v = Variable(x)
+        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
+        y_expected = np.broadcast_to(x, (2, 3, 4))
+        assert (y.array == y_expected).all()
+
+    @testing.attr.gpu
+    def test_broadcast_forward_gpu(self):
+        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        v = Variable(x)
+        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
+        y_expected = cp.broadcast_to(x, (2, 3, 4))
+        assert (y.array == y_expected).all()
+
+    def test_unstride_forward_cpu(self):
+        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        v = Variable(x)
+        y = as_strided(v, (12,), (1,), 0)
+        y_expected = np.arange(12, dtype=self.dtype)
+        assert (y.array == y_expected).all()
+
+    @testing.attr.gpu
+    def test_unstride_forward_gpu(self):
+        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        v = Variable(x)
+        y = as_strided(v, (12,), (1,), 0)
+        y_expected = cp.arange(12, dtype=self.dtype)
+        assert (y.array == y_expected).all()
+
+    def test_general_stride_forward_cpu(self):
+        x = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
+        v = Variable(x)
+        y = as_strided(v, (3, 3), (1, 2), 0)
+        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
+        y_expected = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (1, 2), 0)
+        assert (y.array == y_expected).all()
+
+    @testing.attr.gpu
+    def test_general_stride_forward_gpu(self):
+        x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
+        v = Variable(x)
+        y = as_strided(v, (3, 3), (1, 2), 0)
+        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
+        y_expected = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (1, 2), 0)
+        assert (y.array == y_expected).all()
+
+
+@testing.parameterize(
+    {'dtype': np.float16},
+    {'dtype': np.float32},
+    {'dtype': np.float64}
+)
+class TestAsStridedBackward(unittest.TestCase):
+    def test_flip_backward_cpu(self):
+        x = np.arange(4, dtype=self.dtype)
+        v = Variable(x)
+        y = as_strided(v, (4,), (-1,), 3)
+        y.grad = np.ones((4,), dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == np.ones((4,), dtype=self.dtype)).all()
+
+    @testing.attr.gpu
+    def test_flip_backward_gpu(self):
+        x = cp.arange(4, dtype=self.dtype)
+        v = Variable(x)
+        y = as_strided(v, (4,), (-1,), 3)
+        y.grad = cp.ones((4,), dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == cp.ones((4,), dtype=self.dtype)).all()
+
+    def test_broadcast_backward_cpu(self):
+        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        v = Variable(x)
+        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
+        y.grad = np.ones((2, 3, 4), dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == np.ones(x.shape, dtype=self.dtype) * 2).all()
+
+    @testing.attr.gpu
+    def test_broadcast_backward_gpu(self):
+        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        v = Variable(x)
+        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
+        y.grad = cp.ones((2, 3, 4), dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == cp.ones(x.shape, dtype=self.dtype) * 2).all()
+
+    def test_unstride_backward_cpu(self):
+        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        v = Variable(x)
+        y = as_strided(v, (12,), (1,), 0)
+        y.grad = np.ones((12,), dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == np.ones(x.shape, dtype=self.dtype)).all()
+
+    @testing.attr.gpu
+    def test_unstride_backward_gpu(self):
+        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        v = Variable(x)
+        y = as_strided(v, (12,), (1,), 0)
+        y.grad = cp.ones((12,), dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == cp.ones(x.shape, dtype=self.dtype)).all()
+
+    def test_general_stride_backward_cpu(self):
+        x = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
+        v = Variable(x)
+        y = as_strided(v, (3, 3), (1, 2), 0)
+        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
+        y.grad = np.ones(y.shape, dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == np.array([[0.5, 0.5, 0.], [2., 2., 1.], [1., 0.5, 0.5]])).all()
+
+    @testing.attr.gpu
+    def test_general_stride_backward_gpu(self):
+        x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
+        v = Variable(x)
+        y = as_strided(v, (3, 3), (1, 2), 0)
+        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
+        y.grad = cp.ones(y.shape, dtype=self.dtype)
+        gx, = grad((y,), (v,))
+        assert (gx.array == cp.array([[0.5, 0.5, 0.], [2., 2., 1.], [1., 0.5, 0.5]])).all()
+
+
+@testing.parameterize(
+    {'dtype': np.int16},
+    {'dtype': np.int32},
+    {'dtype': np.int64}
+)
+class TestAsStridedBackwardInvalidType(unittest.TestCase):
+    def test_flip_backward_cpu(self):
+        x = np.arange(4, dtype=self.dtype)
+        v = Variable(x)
+        y = as_strided(v, (4,), (-1,), 3)
+        y.grad = np.ones((4,), dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+    @testing.attr.gpu
+    def test_flip_backward_gpu(self):
+        x = cp.arange(4, dtype=self.dtype)
+        v = Variable(x)
+        y = as_strided(v, (4,), (-1,), 3)
+        y.grad = cp.ones((4,), dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+    def test_broadcast_backward_cpu(self):
+        x = np.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        v = Variable(x)
+        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
+        y.grad = np.ones((2, 3, 4), dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+    @testing.attr.gpu
+    def test_broadcast_backward_gpu(self):
+        x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
+        v = Variable(x)
+        y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
+        y.grad = cp.ones((2, 3, 4), dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+    def test_unstride_backward_cpu(self):
+        x = np.flip(np.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        v = Variable(x)
+        y = as_strided(v, (12,), (1,), 0)
+        y.grad = np.ones((12,), dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+    @testing.attr.gpu
+    def test_unstride_backward_gpu(self):
+        x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
+        v = Variable(x)
+        y = as_strided(v, (12,), (1,), 0)
+        y.grad = cp.ones((12,), dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+    def test_general_stride_backward_cpu(self):
+        x = _stride_array(np.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
+        v = Variable(x)
+        y = as_strided(v, (3, 3), (1, 2), 0)
+        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
+        y.grad = np.ones(y.shape, dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+    @testing.attr.gpu
+    def test_general_stride_backward_gpu(self):
+        x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
+        # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
+        v = Variable(x)
+        y = as_strided(v, (3, 3), (1, 2), 0)
+        # [[0., 2., 4.], [1., 3., 5.,], [2., 4., 6.]]
+        y.grad = cp.ones(y.shape, dtype=self.dtype)
+        with self.assertRaises(TypeError):
+            gx, = grad((y,), (v,))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -3,7 +3,6 @@ import unittest
 from chainer import testing, Variable, grad
 
 import numpy as np
-import chainer.backends.cuda.cupy as cp
 
 from chainer.functions import as_strided
 from chainer.functions.array.as_strided import _stride_array
@@ -26,6 +25,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_gpu(self):
+        import cupy as cp
         x = cp.arange(4, dtype=self.dtype)
         y = _stride_array(x, (4,), (-1,), 3)
         y_expected = cp.flip(x, axis=0)
@@ -40,6 +40,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_gpu(self):
+        import cupy as cp
         x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         y = _stride_array(x, (2, 3, 4), (0, 4, 1), 0)
         y_expected = cp.broadcast_to(x, (2, 3, 4))
@@ -53,6 +54,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_gpu(self):
+        import cupy as cp
         x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
         y = _stride_array(x, (12,), (1,), 0)
         y_expected = cp.arange(12, dtype=self.dtype)
@@ -71,6 +73,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_gpu(self):
+        import cupy as cp
         x = cp.arange(8, dtype=self.dtype)
         y = _stride_array(x, (3, 3), (-1, 2), 3)
         y_expected = cp.array(
@@ -88,6 +91,7 @@ class TestStrideArray(unittest.TestCase):
 
     @testing.attr.gpu
     def test_invalid_negative_index_gpu(self):
+        import cupy as cp
         x = cp.arange(8, dtype=self.dtype)
         with self.assertRaises(ValueError):
             _stride_array(x, (3, 3), (-1, 2), 1)
@@ -111,6 +115,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_forward_gpu(self):
+        import cupy as cp
         x = cp.arange(4, dtype=self.dtype)
         v = Variable(x)
         y = as_strided(v, (4,), (-1,), 3)
@@ -126,6 +131,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_forward_gpu(self):
+        import cupy as cp
         x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         v = Variable(x)
         y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
@@ -141,6 +147,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_forward_gpu(self):
+        import cupy as cp
         x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
@@ -159,6 +166,7 @@ class TestAsStridedForward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_forward_gpu(self):
+        import cupy as cp
         x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
         # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
         v = Variable(x)
@@ -185,6 +193,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
+        import cupy as cp
         x = cp.arange(4, dtype=self.dtype)
         v = Variable(x)
         y = as_strided(v, (4,), (-1,), 3)
@@ -202,6 +211,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
+        import cupy as cp
         x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         v = Variable(x)
         y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
@@ -219,6 +229,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
+        import cupy as cp
         x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
@@ -242,6 +253,7 @@ class TestAsStridedBackward(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
+        import cupy as cp
         x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
         # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
         v = Variable(x)
@@ -272,6 +284,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_flip_backward_gpu(self):
+        import cupy as cp
         x = cp.arange(4, dtype=self.dtype)
         v = Variable(x)
         y = as_strided(v, (4,), (-1,), 3)
@@ -289,6 +302,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_broadcast_backward_gpu(self):
+        import cupy as cp
         x = cp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         v = Variable(x)
         y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
@@ -306,6 +320,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_unstride_backward_gpu(self):
+        import cupy as cp
         x = cp.flip(cp.arange(12, dtype=self.dtype).reshape((3, 4)), 0)
         v = Variable(x)
         y = as_strided(v, (12,), (1,), 0)
@@ -325,6 +340,7 @@ class TestAsStridedBackwardInvalidType(unittest.TestCase):
 
     @testing.attr.gpu
     def test_general_stride_backward_gpu(self):
+        import cupy as cp
         x = _stride_array(cp.arange(8, dtype=self.dtype), (3, 3), (-1, 2), 3)
         # [[3., 5., 7.], [2., 4., 6.], [1., 3., 5.]]
         v = Variable(x)

--- a/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_as_strided.py
@@ -8,6 +8,14 @@ from chainer.functions import as_strided
 from chainer.functions.array.as_strided import _stride_array
 
 
+def _broadcast_to(xp, x, shape):
+    if hasattr(xp, 'broadcast_to'):
+        return xp.broadcast_to(x, shape)
+    else:
+        dummy = xp.empty(shape)
+        return xp.broadcast_arrays(x, dummy)[0]
+
+
 @testing.parameterize(
     {'dtype': np.float16},
     {'dtype': np.float32},
@@ -34,7 +42,7 @@ class TestStrideArray(unittest.TestCase):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         # [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
         y = _stride_array(x, (2, 3, 4), (0, 4, 1), 0)
-        y_expected = xp.broadcast_to(x, (2, 3, 4))
+        y_expected = _broadcast_to(xp, x, (2, 3, 4))
         testing.assert_allclose(y, y_expected)
 
     def test_broadcast_cpu(self):
@@ -115,7 +123,7 @@ class TestAsStridedForward(unittest.TestCase):
         x = xp.arange(12, dtype=self.dtype).reshape((3, 4)).copy()
         v = Variable(x)
         y = as_strided(v, (2, 3, 4), (0, 4, 1), 0)
-        y_expected = xp.broadcast_to(x, (2, 3, 4))
+        y_expected = _broadcast_to(xp, x, (2, 3, 4))
         testing.assert_allclose(y.array, y_expected)
 
     def test_broadcast_forward_cpu(self):


### PR DESCRIPTION
This PR is for #5036 and #5796.

This feature (F.as_strided) strides array like `numpy.lib.stride_tricks.as_strided`, but this function is itemsize-agnostic (i.e. stride size is given in unit of steps, not bytes).

This is a transported code from pytorch. The algorithm and API is the same.

This feature will be helpful in the implementation of F.stft.

If this feature would be accepted, I will create a PR of F.stft.