### PR TITLE
Change `.data` to `.array` in Guides and Examples docs

### DIFF
--- a/docs/source/examples/mnist.rst
+++ b/docs/source/examples/mnist.rst
@@ -286,7 +286,7 @@ Evaluation using the snapshot of a model is as easy as what explained in the :do
 
     y = model(x[None, ...])
 
-    print('predicted_label:', y.data.argmax(axis=1)[0])
+    print('predicted_label:', y.array.argmax(axis=1)[0])
 
 .. image:: ../../image/trainer/mnist_output.png
 

--- a/docs/source/examples/train_loop.rst
+++ b/docs/source/examples/train_loop.rst
@@ -257,7 +257,7 @@ The training loop code is as follows:
 
             # Display the training loss
             print('epoch:{:02d} train_loss:{:.04f} '.format(
-                train_iter.epoch, float(to_cpu(loss.data))), end='')
+                train_iter.epoch, float(to_cpu(loss.array))), end='')
 
             test_losses = []
             test_accuracies = []
@@ -270,12 +270,12 @@ The training loop code is as follows:
 
                 # Calculate the loss
                 loss_test = F.softmax_cross_entropy(prediction_test, target_test)
-                test_losses.append(to_cpu(loss_test.data))
+                test_losses.append(to_cpu(loss_test.array))
 
                 # Calculate the accuracy
                 accuracy = F.accuracy(prediction_test, target_test)
                 accuracy.to_cpu()
-                test_accuracies.append(accuracy.data)
+                test_accuracies.append(accuracy.array)
 
                 if test_iter.is_new_epoch:
                     test_iter.epoch = 0
@@ -365,8 +365,8 @@ The saved test image looks like:
     # Forward calculation of the model by sending X
     y = model(x)
 
-    # The result is given as Variable, then we can take a look at the contents by the attribute, .data.
-    y = y.data
+    # The result is given as Variable, then we can take a look at the contents by the attribute, .array.
+    y = y.array
 
     # Look up the most probable digit number using argmax
     pred_label = y.argmax(axis=1)

--- a/docs/source/guides/functions.rst
+++ b/docs/source/guides/functions.rst
@@ -415,7 +415,7 @@ You will need to check the value of the boolean flag ``chainer.config.train`` an
 For example, consider the following simple dropout function::
 
   def dropout(x):
-      xp = backend.get_array_module(x.data)
+      xp = backend.get_array_module(x.array)
       mask = 2 * (xp.random.rand(*x.shape) > 0.5).astype(x.dtype)
       return x * mask
 
@@ -427,7 +427,7 @@ We can fix it as follows::
       if not chainer.config.train:
           return x
 
-      xp = backend.get_array_module(x.data)
+      xp = backend.get_array_module(x.array)
       mask = 2 * (xp.random.rand(*x.shape) > 0.5).astype(x.dtype)
       return x * mask
 
@@ -566,9 +566,9 @@ This is a test example of :func:`functions.relu` function
            y.backward()
 
            def f():
-               return F.relu(x).data,
+               return F.relu(x).array,
 
-           gx, = gradient_check.numerical_grad(f, (x.data,), (y.grad,))
+           gx, = gradient_check.numerical_grad(f, (x.array,), (y.grad,))
            testing.assert_allclose(gx, x.grad)
 
 

--- a/docs/source/guides/links.rst
+++ b/docs/source/guides/links.rst
@@ -30,10 +30,10 @@ This is the preferred way to initialize these parameters.
 
 .. doctest::
 
-   >>> f.W.data
+   >>> f.W.array
    array([[ 1.0184761 ,  0.23103087,  0.5650746 ],
           [ 1.2937803 ,  1.0782351 , -0.56423163]], dtype=float32)
-   >>> f.b.data
+   >>> f.b.array
    array([0., 0.], dtype=float32)
 
 An instance of the Linear link acts like a usual function:
@@ -42,7 +42,7 @@ An instance of the Linear link acts like a usual function:
 
    >>> x = Variable(np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32))
    >>> y = f(x)
-   >>> y.data
+   >>> y.array
    array([[3.1757617, 1.7575557],
           [8.619507 , 7.1809077]], dtype=float32)
 


### PR DESCRIPTION
I found that `.data` is discouraged but is used in many places in the doc.

Hence I just changed them to `.array`, in `Guides` and `Examples` documentation. Hope this can help improve the consistency of the doc.