### PR TITLE
Update third-party.cmake to follow the recent way

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -141,7 +141,7 @@ endif()
 # gsl-lite
 # gsl-lite is a header-only library, we do not need to build and run tests
 get_third_party(gsl-lite)
-include_directories(${CMAKE_BINARY_DIR}/gsl-lite/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/gsl-lite/include)
 # ref. https://github.com/martinmoene/gsl-lite#api-macro
 # As default, functions (methods) are decorated with __host__ __device__ for the CUDA platform.
 # We want to stop it because we get many warnings with nvcc.
@@ -152,15 +152,15 @@ endif()
 
 # optional-lite
 get_third_party(optional-lite)
-include_directories(${CMAKE_BINARY_DIR}/optional-lite/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/optional-lite/include)
 
 # Test
 # TODO(niboshi): Remove gtest dependency from testing
 get_third_party(gtest)
-add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
     ${CMAKE_BINARY_DIR}/googletest-build
     EXCLUDE_FROM_ALL)
-include_directories(${CMAKE_BINARY_DIR}/googletest-src/googletest/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include)
 if(${CHAINERX_BUILD_TEST})
     enable_testing()
 endif()

--- a/chainerx_cc/cmake/third-party.cmake
+++ b/chainerx_cc/cmake/third-party.cmake
@@ -5,13 +5,13 @@ function(get_third_party name)
     configure_file("third_party/${name}.cmake" "${name}-download/CMakeLists.txt")
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
         RESULT_VARIABLE result
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/${name}-download")
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${name}-download")
     if(result)
         message(FATAL_ERROR "CMake step for ${name} failed: ${result}")
     endif()
     execute_process(COMMAND ${CMAKE_COMMAND} --build .
         RESULT_VARIABLE result
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/${name}-download")
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${name}-download")
     if(result)
         message(FATAL_ERROR "Build step for ${name} failed: ${result}")
     endif()

--- a/chainerx_cc/third_party/gsl-lite.cmake
+++ b/chainerx_cc/third_party/gsl-lite.cmake
@@ -5,7 +5,7 @@ include(ExternalProject)
 ExternalProject_Add(gsl-lite
         GIT_REPOSITORY    https://github.com/martinmoene/gsl-lite
         GIT_TAG           v0.32.0
-        SOURCE_DIR        "${CMAKE_BINARY_DIR}/gsl-lite"
+        SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/gsl-lite"
         BINARY_DIR        ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND     ""

--- a/chainerx_cc/third_party/gtest.cmake
+++ b/chainerx_cc/third_party/gtest.cmake
@@ -6,8 +6,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
     GIT_TAG           release-1.8.0
-    SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-    BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+    BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""
     INSTALL_COMMAND   ""

--- a/chainerx_cc/third_party/optional-lite.cmake
+++ b/chainerx_cc/third_party/optional-lite.cmake
@@ -5,7 +5,7 @@ include(ExternalProject)
 ExternalProject_Add(optional-lite
     GIT_REPOSITORY    https://github.com/martinmoene/optional-lite
     GIT_TAG           v2.3.0
-    SOURCE_DIR        "${CMAKE_BINARY_DIR}/optional-lite"
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/optional-lite"
     BINARY_DIR        ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""

--- a/chainerx_cc/third_party/pybind11.cmake
+++ b/chainerx_cc/third_party/pybind11.cmake
@@ -5,7 +5,7 @@ include(ExternalProject)
 ExternalProject_Add(pybind11
     GIT_REPOSITORY    https://github.com/pybind/pybind11.git
     GIT_TAG           v2.2.4
-    SOURCE_DIR        "${CMAKE_BINARY_DIR}/pybind11"
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/pybind11"
     BINARY_DIR        ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND     ""


### PR DESCRIPTION
suggested by gtest:

https://github.com/google/googletest/commit/c45631823c983935d228557b124eff05263b2660

This change makes it possible for other projects to use
ChainerX as a cmake sub-directory.
