### PR TITLE
Stop using unified memory by default

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_backend_test.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_backend_test.cc
@@ -26,7 +26,9 @@ namespace {
 
 template <typename T>
 std::shared_ptr<void> ToHost(const Device& from_device, const std::shared_ptr<void>& mem, size_t size) {
-    if (nullptr != dynamic_cast<native::NativeBackend*>(&from_device.backend())) return mem;
+    if (nullptr != dynamic_cast<native::NativeBackend*>(&from_device.backend())) {
+        return mem;
+    }
     std::shared_ptr<void> host_mem = std::make_unique<T[]>(size);
     cudaMemcpy(host_mem.get(), mem.get(), sizeof(T) * size, cudaMemcpyDeviceToHost);
     return host_mem;

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -14,7 +14,7 @@ namespace chainerx {
 namespace cuda {
 
 MallocStatus DeviceMemoryAllocator::Malloc(void** ptr, size_t bytesize) {
-    cudaError_t status = cudaMallocManaged(ptr, bytesize, cudaMemAttachGlobal);
+    cudaError_t status = cudaMalloc(ptr, bytesize);
     switch (status) {
         case cudaSuccess:
             return MallocStatus::kSuccess;

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -14,6 +14,9 @@ namespace chainerx {
 namespace cuda {
 
 MallocStatus DeviceMemoryAllocator::Malloc(void** ptr, size_t bytesize) {
+    // Note: Unified memory is not used since using it by default
+    // can cause slowdown for some workload. See
+    // https://github.com/chainer/chainer/pull/5912 for the details.
     cudaError_t status = cudaMalloc(ptr, bytesize);
     switch (status) {
         case cudaSuccess:


### PR DESCRIPTION
Though we have not clarified the difference between unified
memory and normal GPU memory, a couple of performance
regressions were observed:

- A significant regression was observed when GPU memory usage
  is close to the limit. It looked like some GPU memory was
  migrated to the host even though GPU should have enough
  memory.
- A tiny regression was also observed for simple element-wise
  ops even when GPU memory usage is low.

The latter can be reproduced by

https://github.com/shinh/test/blob/master/unified_mem_perf.sh
https://github.com/shinh/test/blob/master/unified_mem_perf.py

on both p100 and v100.

We might eventually re-consider enabling unified memory, but
we are using no unified memory specific feature yet and I
guess this should be an opt-in feature like cupy's.
