### PR TITLE
improve `F.group_normalization` via cuDNN call

### DIFF
--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -282,8 +282,16 @@ class _XHatGrad(function_node.FunctionNode):
         if 0 in indexes:
             # gx = inv_std * gx_std
             # dgx = dinv_std * gx_std + inv_std * dgx_std
+            #
             # -gx2l = (ggx * dinv_std * gx_std) / dx
-            # -gx_hat2r = (inv_std * ggx * dgx_std) / dx_hat
+            #       = mean(ggx * gx_std) * (dinv_std / dx)
+            #       = -mean(ggx * gx_std) * inv_std^2 * x_hat
+            #       = -inv_std * x_hat * mean(ggx * gx)
+            #
+            # By `gx_std = gx_hat - gx_hat_avg - x_hat * gx_hat_x_hat_avg`,
+            # -gx_hat2r = (ggx * inv_std * dgx_std) / dx_hat
+            #           = -inv_std * (ggx * mean(gx_hat * x_hat) +
+            #                         gx_hat * mean(ggx * x_hat))
 
             gx2l_std = x_hat * F.mean(ggx * gx, axis=1, keepdims=True)
             gx2l, = _MulInvStd(

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -35,12 +35,16 @@ class GroupNormalization(function_node.FunctionNode):
             beta_type.ndim == 1,
             gamma_type.dtype == x_type.dtype,
             beta_type.dtype == x_type.dtype,
-            x_type.shape[1] % self.groups == 0,
             x_type.shape[1] == gamma_type.shape[0],
             gamma_type.shape == beta_type.shape,
         )
 
     def forward(self, inputs):
+        if inputs[0].shape[1] % self.groups != 0:
+            raise ValueError('The number of channels {} is not divisible by '
+                             '\'groups\' argument {}.'
+                             .format(inputs[0].shape[1], self.groups))
+
         xp = backend.get_array_module(*inputs)
         if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
             return self.forward_cudnn(inputs)

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -15,16 +15,15 @@ if cuda.cudnn_enabled:
 
 class GroupNormalization(function_node.FunctionNode):
 
-    mean = None
-    inv_std = None
-    dummy_gamma = None
-
     def __init__(self, groups, eps=1e-5):
         if not isinstance(groups, int):
             raise TypeError('Argument: \'groups\' type must be (int).')
 
         self.groups = groups
         self.eps = eps
+        self.mean = None
+        self.inv_std = None
+        self.dummy_gamma = None
 
     def check_type_forward(self, in_types):
         type_check.expect(in_types.size() == 3)

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -122,7 +122,7 @@ class GroupNormalization(function_node.FunctionNode):
         x_hat, = _XHat(
             self.eps, self.mean, self.inv_std,
             self.dummy_gamma).apply((x,))
-        gx_hat, ggamma, gbeta = _GradHelper().apply((x_hat, gamma, gy))
+        gx_hat, ggamma, gbeta = _ScaleShiftGrad().apply((x_hat, gamma, gy))
         gx, = _XHatGrad(
             self.eps, self.mean, self.inv_std,
             self.dummy_gamma, x_hat.array).apply((x, gx_hat))
@@ -131,7 +131,7 @@ class GroupNormalization(function_node.FunctionNode):
         return gx, ggamma, gbeta
 
 
-class _GradHelper(function_node.FunctionNode):
+class _ScaleShiftGrad(function_node.FunctionNode):
 
     def forward(self, inputs):
         self.retain_inputs((0, 1, 2))

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -281,12 +281,13 @@ class _XHatGrad(function_node.FunctionNode):
         ret = []
 
         if 0 in indexes:
+            # -- sketch of gx2, which is grad of x through gx
             # gx = inv_std * gx_std
             # dgx = dinv_std * gx_std + inv_std * dgx_std
             #
             # -gx2l = (ggx * dinv_std * gx_std) / dx
-            #       = mean(ggx * gx_std) * (dinv_std / dx)
-            #       = -mean(ggx * gx_std) * inv_std^2 * x_hat
+            #       = sum(ggx * gx_std) * (dinv_std / dx)
+            #       = -sum(ggx * gx_std) * inv_std^2 * x_hat / N
             #       = -inv_std * x_hat * mean(ggx * gx)
             #
             # By `gx_std = gx_hat - gx_hat_avg - x_hat * gx_hat_x_hat_avg`,

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -1,10 +1,345 @@
-import warnings
+import numpy
 
+import chainer
 from chainer import backend
 from chainer.backends import cuda
-from chainer.functions.array import broadcast
-from chainer.functions.array import reshape
-from chainer.functions.normalization import batch_normalization
+from chainer import configuration
+from chainer import function_node
+from chainer.utils import type_check
+
+
+if cuda.cudnn_enabled:
+    cudnn = cuda.cudnn
+    libcudnn = cuda.cuda.cudnn
+
+
+class GroupNormalization(function_node.FunctionNode):
+
+    mean = None
+    inv_std = None
+    dummy_gamma = None
+
+    def __init__(self, groups, eps=1e-5):
+        if not isinstance(groups, int):
+            raise TypeError('Argument: \'groups\' type must be (int).')
+
+        self.groups = groups
+        self.eps = eps
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 3)
+        x_type, gamma_type, beta_type = in_types
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            x_type.ndim >= 2,
+            gamma_type.ndim == 1,
+            beta_type.ndim == 1,
+            gamma_type.dtype == x_type.dtype,
+            beta_type.dtype == x_type.dtype,
+            x_type.shape[1] % self.groups == 0,
+            x_type.shape[1] == gamma_type.shape[0],
+            gamma_type.shape == beta_type.shape,
+        )
+
+    def forward(self, inputs):
+        xp = backend.get_array_module(*inputs)
+        if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
+            return self.forward_cudnn(inputs)
+
+        self.retain_inputs((0, 1))
+        x, gamma, beta = inputs
+
+        orig_shape = x.shape
+        batch_size, channels = orig_shape[:2]
+        groups = self.groups
+        x = x.reshape((batch_size * groups, -1))
+
+        self.mean = x.mean(axis=1)
+        x_hat = x - self.mean[:, None]
+        var = (x_hat * x_hat).mean(axis=1)
+        var += self.eps
+        self.inv_std = var
+        del var
+        xp.sqrt(self.inv_std, out=self.inv_std)
+        xp.reciprocal(self.inv_std, out=self.inv_std)
+        x_hat *= self.inv_std[:, None]
+
+        y = x_hat.reshape((batch_size, channels, -1))
+        y *= gamma[:, None]
+        y += beta[:, None]
+
+        y = y.reshape(orig_shape)
+        return y,
+
+    def forward_cudnn(self, inputs):
+        if self.eps < libcudnn.CUDNN_BN_MIN_EPSILON:
+            raise RuntimeError(
+                'cuDNN does not allow an eps value '
+                'less than {}.'.format(libcudnn.CUDNN_BN_MIN_EPSILON))
+
+        self.retain_inputs((0, 1))
+        x, gamma, beta = inputs
+        xp = cuda.cupy
+
+        orig_shape = x.shape
+        batch_size, channels = orig_shape[:2]
+        groups = self.groups
+        x = x.reshape((1, batch_size * groups, -1, 1))
+
+        with cuda.get_device_from_array(x):
+            dummy_beta = xp.zeros(batch_size * groups, dtype=x.dtype)
+            self.dummy_gamma = xp.ones_like(dummy_beta)
+            self.mean = xp.empty_like(dummy_beta)
+            self.inv_std = xp.empty_like(dummy_beta)
+        x_hat = cudnn.batch_normalization_forward_training(
+            x, self.dummy_gamma, dummy_beta, dummy_beta, dummy_beta,
+            self.mean, self.inv_std, self.eps, 1.0,
+            True, libcudnn.CUDNN_BATCHNORM_SPATIAL,
+            configuration.config.debug)
+
+        y = x_hat.reshape((batch_size, channels, -1))
+        cuda.elementwise(
+            'T gamma, T beta', 'T y',
+            'y = y * gamma + beta',
+            'groupnorm_y')(gamma[:, None], beta[:, None], y)
+
+        y = y.reshape(orig_shape)
+        return y,
+
+    def backward(self, indexes, grad_outputs):
+        x, gamma = self.get_retained_inputs()
+        gy, = grad_outputs
+
+        orig_shape = x.shape
+        batch_size = orig_shape[0]
+        groups = self.groups
+        x = chainer.functions.reshape(x, (batch_size * groups, -1))
+
+        x_hat, = _XHat(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma).apply((x,))
+        gx_hat, ggamma, gbeta = _GradHelper().apply((x_hat, gamma, gy))
+        gx, = _XHatGrad(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma, x_hat.array).apply((x, gx_hat))
+
+        gx = gx.reshape(orig_shape)
+        return gx, ggamma, gbeta
+
+
+class _GradHelper(function_node.FunctionNode):
+
+    def forward(self, inputs):
+        self.retain_inputs((0, 1, 2))
+        x_hat, gamma, gy = inputs
+        xp = backend.get_array_module(x_hat)
+
+        x_hat_shape = x_hat.shape
+        batch_size, channels = gy.shape[:2]
+        x_hat = x_hat.reshape((batch_size, channels, -1))
+        gy = gy.reshape((batch_size, channels, -1))
+
+        gx_hat = gy * gamma[:, None]
+        if xp is numpy:
+            ggamma = (gy * x_hat).sum(axis=(0, 2))
+        else:
+            ggamma = cuda.reduce(
+                'T gy, T x_hat', 'T ggamma',
+                'gy * x_hat', 'a + b', 'ggamma = a', '0',
+                'groupnorm_ggamma')(gy, x_hat, axis=(0, 2))
+        gbeta = gy.sum(axis=(0, 2))
+
+        gx_hat = gx_hat.reshape(x_hat_shape)
+        return gx_hat, ggamma, gbeta
+
+    def backward(self, indexes, grad_outputs):
+        x_hat, gamma, gy = self.get_retained_inputs()
+        ggx_hat, gggamma, ggbeta = grad_outputs
+
+        x_hat_shape = x_hat.shape
+        orig_shape = gy.shape
+        batch_size, channels = gy.shape[:2]
+        x_hat = x_hat.reshape((batch_size, channels, -1))
+        gy = gy.reshape((batch_size, channels, -1))
+        ggx_hat = ggx_hat.reshape((batch_size, channels, -1))
+
+        gx_hat2 = gggamma[:, None] * gy
+        ggamma2 = chainer.functions.sum(ggx_hat * gy, axis=(0, 2))
+        ggy = (ggx_hat * gamma[:, None] + gggamma[:, None] * x_hat +
+               ggbeta[:, None])
+
+        gx_hat2 = chainer.functions.reshape(gx_hat2, x_hat_shape)
+        ggy = chainer.functions.reshape(ggy, orig_shape)
+        return gx_hat2, ggamma2, ggy
+
+
+class _XHat(function_node.FunctionNode):
+
+    def __init__(self, eps, mean, inv_std, dummy_gamma):
+        self.eps = eps
+        self.mean = mean
+        self.inv_std = inv_std
+        self.dummy_gamma = dummy_gamma
+
+    def forward_cpu(self, inputs):
+        self.retain_inputs((0,))
+        x, = inputs
+        x_hat = x - self.mean[:, None]
+        x_hat *= self.inv_std[:, None]
+        self.retain_outputs((0,))
+        return x_hat,
+
+    def forward_gpu(self, inputs):
+        self.retain_inputs((0,))
+        x, = inputs
+        x_hat = cuda.elementwise(
+            'T x, T mean, T inv_std', 'T x_hat',
+            'x_hat = (x - mean) * inv_std',
+            'groupnorm_x_hat')(x, self.mean[:, None], self.inv_std[:, None])
+        self.retain_outputs((0,))
+        return x_hat,
+
+    def backward(self, indexes, grad_outputs):
+        x, = self.get_retained_inputs()
+        x_hat, = self.get_retained_outputs()
+        gx_hat, = grad_outputs
+        return _XHatGrad(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma, x_hat.array).apply((x, gx_hat))
+
+
+class _XHatGrad(function_node.FunctionNode):
+
+    def __init__(self, eps, mean, inv_std, dummy_gamma, x_hat):
+        self.eps = eps
+        self.mean = mean
+        self.inv_std = inv_std
+        self.dummy_gamma = dummy_gamma
+        self.x_hat = x_hat
+
+    def forward(self, inputs):
+        xp = backend.get_array_module(*inputs)
+        if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000) and \
+                self.dummy_gamma is not None:
+            return self.forward_cudnn(inputs)
+
+        self.retain_inputs((0, 1))
+        _, gx_hat = inputs
+        x_hat = self.x_hat
+        self.x_hat = None
+
+        gx_hat_avg = gx_hat.mean(axis=1, keepdims=True)
+        gx_hat_x_hat_avg = (gx_hat * x_hat).mean(axis=1, keepdims=True)
+        gx_std = gx_hat - gx_hat_avg - x_hat * gx_hat_x_hat_avg
+        gx = self.inv_std[:, None] * gx_std
+
+        self.retain_outputs((0,))
+        return gx,
+
+    def forward_cudnn(self, inputs):
+        if self.eps < libcudnn.CUDNN_BN_MIN_EPSILON:
+            raise RuntimeError(
+                'cuDNN does not allow an eps value '
+                'less than {}.'.format(libcudnn.CUDNN_BN_MIN_EPSILON))
+
+        self.retain_inputs((0, 1))
+        x, gx_hat = inputs
+        self.x_hat = None
+
+        # `x[None, :, :, None]` is slower because it results in a different
+        # strides and cuDNN doesn't recognize it as a contiguous array.
+        reduced_shape = x.shape
+        cudnn_shape = (1,) + reduced_shape + (1,)
+        x = x.reshape(cudnn_shape)
+        gx_hat = gx_hat.reshape(cudnn_shape)
+
+        gx, _, _ = cudnn.batch_normalization_backward(
+            x, self.dummy_gamma, gx_hat,
+            self.mean, self.inv_std, self.eps,
+            True, libcudnn.CUDNN_BATCHNORM_SPATIAL,
+            configuration.config.debug)
+        gx = gx.reshape(reduced_shape)
+
+        self.retain_outputs((0,))
+        return gx,
+
+    def backward(self, indexes, grad_outputs):
+        F = chainer.functions
+        x, gx_hat = self.get_retained_inputs()
+        gx, = self.get_retained_outputs()
+        ggx, = grad_outputs
+
+        x_hat, = _XHat(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma).apply((x,))
+
+        ret = []
+
+        if 0 in indexes:
+            # gx = inv_std * gx_std
+            # dgx = dinv_std * gx_std + inv_std * dgx_std
+            # -gx2l = (ggx * dinv_std * gx_std) / dx
+            # -gx_hat2r = (inv_std * ggx * dgx_std) / dx_hat
+
+            gx2l_std = x_hat * F.mean(ggx * gx, axis=1, keepdims=True)
+            gx2l, = _MulInvStd(
+                self.eps, self.mean, self.inv_std,
+                self.dummy_gamma).apply((x, gx2l_std))
+
+            gx_hat2r_std = (
+                ggx * F.mean(gx_hat * x_hat, axis=1, keepdims=True) +
+                gx_hat * F.mean(ggx * x_hat, axis=1, keepdims=True))
+            gx_hat2r, = _MulInvStd(
+                self.eps, self.mean, self.inv_std,
+                self.dummy_gamma).apply((x, gx_hat2r_std))
+            gx2r, = _XHatGrad(
+                self.eps, self.mean, self.inv_std,
+                self.dummy_gamma, x_hat.array).apply((x, gx_hat2r))
+
+            gx2 = -(gx2l + gx2r)
+            ret.append(gx2)
+
+        if 1 in indexes:
+            ggx_hat, = _XHatGrad(
+                self.eps, self.mean, self.inv_std,
+                self.dummy_gamma, x_hat.array).apply((x, ggx))
+            ret.append(ggx_hat)
+
+        return ret
+
+
+class _MulInvStd(function_node.FunctionNode):
+
+    def __init__(self, eps, mean, inv_std, dummy_gamma):
+        self.eps = eps
+        self.mean = mean
+        self.inv_std = inv_std
+        self.dummy_gamma = dummy_gamma
+
+    def forward(self, inputs):
+        self.retain_inputs((0,))
+        _, y = inputs
+        z = self.inv_std[:, None] * y
+        self.retain_outputs((0,))
+        return z,
+
+    def backward(self, indexes, grad_outputs):
+        x, = self.get_retained_inputs()
+        z, = self.get_retained_outputs()
+        gz, = grad_outputs
+
+        x_hat, = _XHat(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma).apply((x,))
+        gx_std = x_hat * chainer.functions.mean(gz * z, axis=1, keepdims=True)
+        gx, = _MulInvStd(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma).apply((x, gx_std))
+        gy, = _MulInvStd(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma).apply((x, gz))
+
+        return gx, gy
 
 
 def group_normalization(x, groups, gamma, beta, eps=1e-5):
@@ -38,43 +373,4 @@ def group_normalization(x, groups, gamma, beta, eps=1e-5):
 
     See: `Group Normalization <https://arxiv.org/abs/1803.08494>`_
     """
-    if x.ndim <= 2:
-        raise ValueError('Input dimension must be grater than 2, '
-                         'including batch size dimension '
-                         '(first dimension).')
-
-    if not isinstance(groups, int):
-        raise TypeError('Argument: \'groups\' type must be (int).')
-
-    xp = backend.get_array_module(x)
-
-    batch_size, channels = x.shape[:2]
-    original_shape = x.shape
-
-    if channels % groups != 0:
-        raise ValueError('Argument: \'groups\' must be a divisor '
-                         'of the number of channel.')
-
-    # By doing this reshaping, calling batch_normalization function becomes
-    # equivalent to Group Normalization.
-    # And redundant dimension is added in order to utilize ideep64/cuDNN.
-    x = reshape.reshape(x, (1, batch_size * groups, -1, 1))
-
-    with cuda.get_device_from_array(x.array):
-        dummy_gamma = xp.ones(batch_size * groups).astype(xp.float32)
-        dummy_beta = xp.zeros(batch_size * groups).astype(xp.float32)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        x = batch_normalization.batch_normalization(
-            x, dummy_gamma, dummy_beta, eps=eps)
-
-    x = reshape.reshape(x, original_shape)
-
-    target_shape = [1, channels] + [1] * (x.ndim - 2)
-    gamma_broadcast = broadcast.broadcast_to(
-        reshape.reshape(gamma, target_shape), x.shape)
-    beta_broadcast = broadcast.broadcast_to(
-        reshape.reshape(beta, target_shape), x.shape)
-
-    return x * gamma_broadcast + beta_broadcast
+    return GroupNormalization(groups, eps).apply((x, gamma, beta))[0]

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -92,13 +92,11 @@ class GroupNormalization(function_node.FunctionNode):
         with cuda.get_device_from_array(x):
             dummy_beta = xp.zeros(batch_size * groups, dtype=x.dtype)
             self.dummy_gamma = xp.ones_like(dummy_beta)
-            self.mean = xp.empty_like(dummy_beta)
-            self.inv_std = xp.empty_like(dummy_beta)
-        x_hat = cudnn.batch_normalization_forward_training(
-            x, self.dummy_gamma, dummy_beta, dummy_beta, dummy_beta,
-            self.mean, self.inv_std, self.eps, 1.0,
-            True, libcudnn.CUDNN_BATCHNORM_SPATIAL,
-            configuration.config.debug)
+        x_hat, self.mean, self.inv_std = \
+            cudnn.batch_normalization_forward_training(
+                x, self.dummy_gamma, dummy_beta, dummy_beta, dummy_beta,
+                self.eps, 1.0, True, libcudnn.CUDNN_BATCHNORM_SPATIAL,
+                configuration.config.debug)
 
         y = x_hat.reshape((batch_size, channels, -1))
         cuda.elementwise(

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -352,7 +352,7 @@ class _MulInvStd(function_node.FunctionNode):
             self.eps, self.mean, self.inv_std,
             self.dummy_gamma).apply((x, gz))
 
-        return gx, gy
+        return -gx, gy
 
 
 def group_normalization(x, groups, gamma, beta, eps=1e-5):

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -78,8 +78,8 @@ class GroupNormalization(link.Link):
 
         """
         if self.gamma.array is None:
-            if x.ndim <= 2:
-                raise ValueError('Input dimension must be grater than 2, '
+            if x.ndim < 2:
+                raise ValueError('Input dimension must be at least 2, '
                                  'including batch size dimension '
                                  '(first dimension).')
             channels = x.shape[1]

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
@@ -1,23 +1,17 @@
 import six
-import unittest
 
 import numpy
 
-import chainer
-from chainer import backend
-from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
-from chainer.testing import attr
 
 
-def _simple_group_normalization(x, groups, gamma, beta, xp, eps=1e-5):
+def _simple_group_normalization(x, groups, gamma, beta, eps=1e-5):
     batch_size, channels = x.shape[:2]
     x_reshape = x.reshape(batch_size, groups, channels // groups, -1)
 
-    mean = xp.mean(x_reshape, axis=(2, 3), keepdims=True)
-    var = xp.var(x_reshape, axis=(2, 3), keepdims=True)
+    mean = numpy.mean(x_reshape, axis=(2, 3), keepdims=True)
+    var = numpy.var(x_reshape, axis=(2, 3), keepdims=True)
     std = numpy.sqrt(var + eps)
 
     x_hat = (x_reshape - mean) / std
@@ -25,8 +19,8 @@ def _simple_group_normalization(x, groups, gamma, beta, xp, eps=1e-5):
 
     for i in six.moves.xrange(x.ndim):
         if i != 1:  # except for channel dim
-            gamma = xp.expand_dims(gamma, i)
-            beta = xp.expand_dims(beta, i)
+            gamma = numpy.expand_dims(gamma, i)
+            beta = numpy.expand_dims(beta, i)
 
     return x_hat * gamma + beta
 
@@ -37,104 +31,48 @@ def _simple_group_normalization(x, groups, gamma, beta, xp, eps=1e-5):
     'dtype': [numpy.float32],
     'eps': [1e-5, 1e-1],
 })))
-class TestGroupNormalization(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+        {'use_ideep': 'always'},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestGroupNormalization(testing.FunctionTestCase):
 
     def setUp(self):
+        self.check_forward_options.update({'atol': 1e-4, 'rtol': 1e-3})
+        self.check_backward_options.update({'atol': 1e-3, 'rtol': 1e-2})
+        self.check_double_backward_options.update({'atol': 1e-3, 'rtol': 1e-2})
+
+    def generate_inputs(self):
         x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         gamma = numpy.random.uniform(-1, 1, self.shape[1]).astype(self.dtype)
         beta = numpy.random.uniform(-1, 1, self.shape[1]).astype(self.dtype)
-        self.args = [x, gamma, beta]
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx = [numpy.random.uniform(-1, 1, arg.shape).astype(arg.dtype)
-                    for arg in self.args]
+        return x, gamma, beta
 
-        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
-        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+    def forward(self, inputs, device):
+        x, gamma, beta = inputs
+        y = functions.group_normalization(x, self.groups, gamma, beta,
+                                          eps=self.eps)
+        return y,
 
-    def check_forward(self, args):
-        xp = backend.get_array_module(*args)
-
-        def func(*args_):
-            return functions.group_normalization(
-                args_[0], self.groups, args_[1], args_[2], eps=self.eps)
-
-        y = func(*args)
-        self.assertEqual(y.data.dtype, self.dtype)
-
-        # Verify that implementation using batch normalization is correct
-        y_simple_gn = _simple_group_normalization(
-            args[0], self.groups, args[1], args[2], xp, eps=self.eps)
-        testing.assert_allclose(
-            y.data, y_simple_gn, **self.check_forward_options)
-
-        # Verify that forward isn't be affected by batch size
-        if self.shape[0] > 1:
-            y_one_each = chainer.functions.concat(
-                [func(*[xp.expand_dims(one_x, axis=0), args[1], args[2]])
-                 for one_x in args[0]], axis=0)
-            testing.assert_allclose(
-                y.data, y_one_each.data, **self.check_forward_options)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.args)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward([cuda.to_gpu(arg) for arg in self.args])
-
-    def check_backward(self, args, y_grad):
-        def func(*args_):
-            return functions.group_normalization(
-                args_[0], self.groups, args_[1], args_[2], eps=self.eps)
-
-        gradient_check.check_backward(
-            func, args, y_grad,
-            eps=1e-2, **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.args, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(
-            [cuda.to_gpu(arg) for arg in self.args], cuda.to_gpu(self.gy))
-
-    def check_double_backward(self, args, y_grad, x_grad_grad):
-        def func(*args_):
-            return functions.group_normalization(
-                args_[0], self.groups, args_[1], args_[2], eps=self.eps)
-
-        gradient_check.check_double_backward(
-            func, args, y_grad, x_grad_grad,
-            eps=1e-2, **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.args, self.gy, self.ggx)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(
-            [cuda.to_gpu(arg) for arg in self.args],
-            cuda.to_gpu(self.gy), [cuda.to_gpu(ggx_) for ggx_ in self.ggx])
-
-
-@testing.parameterize(*(testing.product({
-    'shape': [(20, 15)],
-    'dtype': [numpy.float32],
-    'eps': [1e-5, 1e-1],
-})))
-class TestInvStd(unittest.TestCase):
-
-    def setUp(self):
-        x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        mean = xp.mean(x, axis=1)
-        var = xp.var(x, axis=1)
-        std = 
-
-
-    def check_forward(self, args):
-        eps = 
+    def forward_expected(self, inputs):
+        x, gamma, beta = inputs
+        y = _simple_group_normalization(x, self.groups, gamma, beta,
+                                        eps=self.eps)
+        return y,
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -10,7 +10,6 @@ from chainer import links
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
-from chainer.utils import type_check
 
 
 @testing.parameterize(*(testing.product({
@@ -176,7 +175,7 @@ class TestInvalidInitialize(unittest.TestCase):
 
     def test_invalid_groups(self):
         self.link = links.GroupNormalization(groups=3)
-        with self.assertRaises(type_check.InvalidType):
+        with self.assertRaises(ValueError):
             self.link(self.x)
 
     def test_invalid_type_groups(self):

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -14,7 +14,7 @@ from chainer.utils import type_check
 
 
 @testing.parameterize(*(testing.product({
-    'shape': [(1, 4, 5, 5), (5, 4, 15)],
+    'shape': [(1, 4, 5, 5), (5, 4, 15), (3, 8)],
     'groups': [1, 2, 4],
     'dtype': [numpy.float32],
 })))
@@ -150,7 +150,7 @@ class TestDefaultInitializer(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(2,), (2, 3)],
+    'shape': [(2,), ()],
 }))
 class TestInvalidInput(unittest.TestCase):
 

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -10,6 +10,7 @@ from chainer import links
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing import condition
+from chainer.utils import type_check
 
 
 @testing.parameterize(*(testing.product({
@@ -175,7 +176,7 @@ class TestInvalidInitialize(unittest.TestCase):
 
     def test_invalid_groups(self):
         self.link = links.GroupNormalization(groups=3)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(type_check.InvalidType):
             self.link(self.x)
 
     def test_invalid_type_groups(self):


### PR DESCRIPTION
Memory consumption reduced and speed slightly improved.

* cuDNN's batch normalization routine is directly called to simplify computation graph.
* `x_hat = (x - mean) / std` is re-computed at backward phase to reduce memory consumption.
* Some `ElementwiseKernel` and `ReductionKernel` are used to reduce kernel calls.

Note that if we cache `x_hat`, speed can be further improved. But I think memory consumption is more crucial, because Group Normalization is particularly useful when batch size can't be increased due to memory limit.

Regarding speed, time to train ResNet50 with 224 x 224 input images becomes 94.5%. Validation was done at each epoch, and train/valid split ratio was 8/2. Batch size was 32. The benchmark environment is as follows.

* CPU: Ryzen7 2700X
* GPU: ZOTAC GTX 1080 Ti Amp Edition
* DRAM: DDR4-3200 8GiB x 2 dual channel
* SSD: WD Black NVMe 1TB
* OS: Linux 64bit
* CUDA version: 10.0.130
* cuDNN version: 7.4.1.5

Add to that, as Group Normalization is a generalization of Layer Normalization and Instance Normalization, current `F.layer_normalization` implementation can be replaced in future.
