### PR TITLE
Enforce `Link.__init__` in subclasses

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -141,6 +141,7 @@ class Link(object):
     """
 
     _local_link_hooks = None  # type: tp.Optional[collections.OrderedDict[str, chainer.LinkHook]] # NOQA
+    __init_done = False
 
     def __init__(self, **params):
         # type: (**tp.Any) -> None
@@ -151,9 +152,16 @@ class Link(object):
         self._within_init_scope = False  # type: bool
         self.name = None  # type: tp.Optional[str]
 
+        # This flag has to be set before calling add_param().
+        self.__init_done = True
+
         for name, value in six.iteritems(params):
             shape, dtype = _ensure_shape_dtype(value)
             self.add_param(name, shape, dtype=dtype)
+
+    def __check_init_done(self):
+        if not self.__init_done:
+            raise RuntimeError('Link.__init__() has not been called.')
 
     @property
     def local_link_hooks(self):
@@ -238,6 +246,9 @@ class Link(object):
                           self.b = chainer.Parameter(0, (5,))
 
         """
+        # super().__init__ must be called before init_scope().
+        self.__check_init_done()
+
         old_flag = self.within_init_scope
         self._within_init_scope = True
         try:
@@ -247,6 +258,7 @@ class Link(object):
 
     def __call__(self, *args, **kwargs):
         # type: (*tp.Any, **tp.Any) -> tp.Any # NOQA
+        self.__check_init_done()
 
         # TODO(niboshi): Support link hooks for other forward methods.
         hooks = chainer._get_link_hooks()

--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -79,6 +79,8 @@ Please install theano to activate theano function.
   $ pip install theano'''
             raise RuntimeError(msg)
 
+        super(TheanoFunction, self).__init__()
+
         inputs = _to_var_tuple(inputs)
         outputs = _to_var_tuple(outputs)
 


### PR DESCRIPTION
When implementing a link, it's very easy to forget `super().__init__()`, and that results in difficult to understand errors (the error could be delayed, to make things worse).

```py
import chainer
import numpy


class A(chainer.Link):
    def __init__(self):
        #super().__init__()
        with self.init_scope():
            self.a = chainer.Parameter(1, (2, 3))

    def forward(self, x):
        return x * self.a


l = A()
x = numpy.ones((2, 3), numpy.float32)
y = l(x)
```
```
AttributeError: 'A' object has no attribute '_device'
```

This PR turns the errors into more easy to understand one, and raise it earlier. 

```
RuntimeError: Link.__init__() has not been called.
```