### PR TITLE
Adjust testing tolerance of F.connectionist_temporal_classification

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -30,7 +30,7 @@ class CTCTestBase(object):
             self.gy = numpy.random.uniform(-1, 1, (2,)).astype(self.dtype)
 
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 5e-3}
+            self.check_forward_options = {'atol': 1e-2}
             self.check_backward_options = {
                 'atol': 1e-3, 'dtype': numpy.float64}
         else:


### PR DESCRIPTION
This PR adjusts testing tolerance of `F.connectionist_temporal_classification` with `float16` data.