### PR TITLE
Fix visibility for pybind exception registration for macOS

### DIFF
--- a/chainerx_cc/chainerx/macro.h
+++ b/chainerx_cc/chainerx/macro.h
@@ -36,3 +36,11 @@
     } while (false)
 #endif  // NDEBUG
 #endif  // CHAINERX_NEVER_REACH
+
+#ifndef CHAINERX_VISIBILITY_HIDDEN
+#if defined(WIN32) || defined(_WIN32)
+#define CHAINERX_VISIBILITY_HIDDEN
+#else
+#define CHAINERX_VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
+#endif  // defined(WIN32) || defined(_WIN32)
+#endif  // CHAINERX_VISIBILITY_HIDDEN

--- a/chainerx_cc/chainerx/python/CMakeLists.txt
+++ b/chainerx_cc/chainerx/python/CMakeLists.txt
@@ -23,7 +23,7 @@ pybind11_add_module(_core.so MODULE
     )
 
 if(${APPLE})
-    target_link_libraries(_core.so PRIVATE chainerx)
+    target_link_libraries(_core.so PRIVATE "-Wl,-rpath,@loader_path" chainerx)
 else()
     target_link_libraries(_core.so PRIVATE "-Wl,-R,'$ORIGIN/.'" chainerx)
 endif()

--- a/chainerx_cc/chainerx/python/CMakeLists.txt
+++ b/chainerx_cc/chainerx/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(_core.so MODULE
+pybind11_add_module(_core.so MODULE
     core_module.cc
     array.cc
     array_index.cc
@@ -21,18 +21,17 @@ add_library(_core.so MODULE
     testing/device_buffer.cc
     testing/testing_module.cc
     )
+
 if(${APPLE})
-    target_link_libraries(_core.so
-        PRIVATE
-        "-flto" pybind11::module
-        chainerx)
+    target_link_libraries(_core.so PRIVATE chainerx)
 else()
-    target_link_libraries(_core.so
-        PRIVATE
-        "-Wl,-flto" pybind11::module
-        "-Wl,-R,'$ORIGIN/.'" chainerx)
+    target_link_libraries(_core.so PRIVATE "-Wl,-R,'$ORIGIN/.'" chainerx)
 endif()
+
+# Visibility (CXX_VISIBILITY_PRESET) must be set to "default" to register custom exceptions, overriding the visibility configured by pybind11_add_module.
+# Note however that this only seems to be an issue when building with libc++.
 set_target_properties(_core.so
     PROPERTIES
     PREFIX "${PYTHON_MODULE_PREFIX}"
-    SUFFIX "${PYTHON_MODULE_SUFFIX}")
+    SUFFIX "${PYTHON_MODULE_SUFFIX}"
+    CXX_VISIBILITY_PRESET "default")

--- a/chainerx_cc/chainerx/python/testing/device_buffer.cc
+++ b/chainerx_cc/chainerx/python/testing/device_buffer.cc
@@ -7,6 +7,7 @@
 
 #include "chainerx/device.h"
 #include "chainerx/error.h"
+#include "chainerx/macro.h"
 #include "chainerx/python/device.h"
 #include "chainerx/python/dtype.h"
 #include "chainerx/python/shape.h"
@@ -26,7 +27,7 @@ namespace py = pybind11;  // standard convention
 // (py::buffer_info only holds a raw pointer and does not manage the lifetime of the pointed data). Memoryviews created from this buffer
 // will also share ownership. Note that accessing the .obj attribute of a memoryview may increase the reference count and should thus be
 // avoided.
-class PYBIND11_EXPORT PyDeviceBuffer {
+class CHAINERX_VISIBILITY_HIDDEN PyDeviceBuffer {
 public:
     PyDeviceBuffer(std::shared_ptr<void> data, std::shared_ptr<py::buffer_info> info) : data_{std::move(data)}, info_{std::move(info)} {}
 

--- a/chainerx_cc/chainerx/python/testing/device_buffer.cc
+++ b/chainerx_cc/chainerx/python/testing/device_buffer.cc
@@ -26,7 +26,7 @@ namespace py = pybind11;  // standard convention
 // (py::buffer_info only holds a raw pointer and does not manage the lifetime of the pointed data). Memoryviews created from this buffer
 // will also share ownership. Note that accessing the .obj attribute of a memoryview may increase the reference count and should thus be
 // avoided.
-class PyDeviceBuffer {
+class PYBIND11_EXPORT PyDeviceBuffer {
 public:
     PyDeviceBuffer(std::shared_ptr<void> data, std::shared_ptr<py::buffer_info> info) : data_{std::move(data)}, info_{std::move(info)} {}
 


### PR DESCRIPTION
Fix that's required to correctly bind ChainerX custom exceptions on macOS (libc++).

More precisely, custom exceptions raised by the C++ code were treated as different types from the ones registered here https://github.com/chainer/chainer/blob/master/chainerx_cc/chainerx/python/error.cc due to the default visibility configuration of pybind11 which is `hidden` and set here https://github.com/pybind/pybind11/blob/master/include/pybind11/detail/common.h#L24. 

This PR changes the visibility to `default` and also includes changes to utilize `pybind11_add_module` which also seems to be required.

#### Reference
"Problems with C++ exceptions (please read!)" in https://gcc.gnu.org/wiki/Visibility