### PR TITLE
 Avoid `cudaMemcpyAsync` for pinned memory for faster host-to-device transfer

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device.cc
@@ -1,6 +1,8 @@
 #include "chainerx/cuda/cuda_device.h"
 
+#include <memory>
 #include <mutex>
+#include <utility>
 
 #include <cublas_v2.h>
 #include <cuda_runtime.h>
@@ -12,6 +14,50 @@
 
 namespace chainerx {
 namespace cuda {
+namespace cuda_internal {
+
+MemoryKeeper::~MemoryKeeper() {
+    while (!queue_.empty()) {
+        const std::pair<cudaEvent_t, std::shared_ptr<void>>& pair = queue_.front();
+        cudaEventDestroy(pair.first);
+        queue_.pop();
+    }
+}
+
+void MemoryKeeper::Add(cudaStream_t stream, std::shared_ptr<void> memory) {
+    // TODO(niboshi): Currently only the default stream is supported.
+    CHAINERX_ASSERT(stream == nullptr);
+
+    cudaEvent_t event{};
+    CheckCudaError(cudaEventCreate(&event));
+    CheckCudaError(cudaEventRecord(event, stream));
+
+    std::lock_guard<std::mutex> lock{mutex_};
+    queue_.emplace(event, std::move(memory));
+}
+
+void MemoryKeeper::Collect() {
+    if (queue_.empty()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock{mutex_};
+
+    while (true) {
+        if (queue_.empty()) {
+            break;
+        }
+        std::pair<cudaEvent_t, std::shared_ptr<void>>& pair = queue_.front();
+        if (cudaSuccess != cudaEventQuery(pair.first)) {
+            break;
+        }
+
+        CheckCudaError(cudaEventDestroy(pair.first));
+        queue_.pop();
+    }
+}
+
+}  // namespace cuda_internal
 
 CudaDevice::~CudaDevice() {
     if (cublas_handle_ != nullptr) {

--- a/chainerx_cc/chainerx/cuda/cuda_device.h
+++ b/chainerx_cc/chainerx/cuda/cuda_device.h
@@ -34,7 +34,7 @@ class MemoryKeeper {
 public:
     ~MemoryKeeper();
 
-    // Registers a memory.
+    // Registers a pointer to a memory chunk.
     // The memory is only freed after all preceding CUDA operations in the stream are finished.
     // TODO(niboshi): Currently only the default stream is supported.
     void Add(cudaStream_t stream, std::shared_ptr<void> memory);

--- a/chainerx_cc/chainerx/cuda/cuda_device.h
+++ b/chainerx_cc/chainerx/cuda/cuda_device.h
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <queue>
+#include <utility>
 
 #include <nonstd/optional.hpp>
 
@@ -25,6 +27,25 @@ namespace cuda {
 namespace cuda_internal {
 
 class CudaConvTest;  // for unit-tests
+
+// Keeps any memory from being freed before CUDA asynchronous operations are finished.
+// Operations in this class are thread safe.
+class MemoryKeeper {
+public:
+    ~MemoryKeeper();
+
+    // Registers a memory.
+    // The memory is only freed after all preceding CUDA operations in the stream are finished.
+    // TODO(niboshi): Currently only the default stream is supported.
+    void Add(cudaStream_t stream, std::shared_ptr<void> memory);
+
+    // Checks for recorded events and frees the associated memories.
+    void Collect();
+
+private:
+    std::mutex mutex_{};
+    std::queue<std::pair<cudaEvent_t, std::shared_ptr<void>>> queue_{};
+};
 
 }  // namespace cuda_internal
 
@@ -210,6 +231,9 @@ private:
 
     // TODO(hvy): Consider checking if pinned memory is available by querying canMapHostMemory.
     std::shared_ptr<MemoryPool> pinned_memory_pool_;
+
+    // Memory keeper.
+    cuda_internal::MemoryKeeper memory_keeper_{};
 
     std::mutex cublas_handle_mutex_;
     cublasHandle_t cublas_handle_{};

--- a/chainerx_cc/chainerx/cuda/cuda_device/memory.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/memory.cc
@@ -35,14 +35,19 @@ std::shared_ptr<void> CudaDevice::AllocatePinnedMemory(size_t bytesize) {
 }
 
 void CudaDevice::MemoryCopyFromHostAsync(void* dst, const void* src, size_t bytesize) {
-    std::shared_ptr<void> pinned_src_ptr = AllocatePinnedMemory(bytesize);
-
     CudaSetDeviceScope scope{index()};
 
-    // cudaMemcpyAsync is slightly faster than cudaMemcpy, although both should be synchronous involving not page-locked regions.
-    CheckCudaError(cudaMemcpyAsync(pinned_src_ptr.get(), src, bytesize, cudaMemcpyHostToHost));
+    memory_keeper_.Collect();
 
+    // Allocate a pinned memory and copy the host data.
+    std::shared_ptr<void> pinned_src_ptr = AllocatePinnedMemory(bytesize);
+    std::memcpy(pinned_src_ptr.get(), src, bytesize);
+
+    // Transfer from the pinned memory to the device.
     CheckCudaError(cudaMemcpyAsync(dst, pinned_src_ptr.get(), bytesize, cudaMemcpyHostToDevice));
+
+    // Register the pinned memory to the keeper to prevent it from being freed before host-to-device transfer is finished.
+    memory_keeper_.Add(nullptr, std::move(pinned_src_ptr));
 }
 
 std::shared_ptr<void> CudaDevice::MakeDataFromForeignPointer(const std::shared_ptr<void>& data) {


### PR DESCRIPTION
For transfer from the host memory to the pinned memory, `std::memcpy` is faster than `cudaMemcpyAsync`.
To prevent the pinned memory from being freed before asynchronous operations are finished, `MemoryKeeper` is introduced. 


### Measurements

```
x = [numpy.zeros((10000,), numpy.float32)] * 100
```

* ChainerX (before)
1445us: `chainerx.asarray(x, device='cuda:0')`

* ChainerX (this PR)
1095us: `chainerx.asarray(x, device='cuda:0')`

* (For reference) CuPy
1088us: `cupy.asarray(x)`
