### PR TITLE
Do not ignore FutureWarning other than experimental features

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ ignore = E741,W503,W504,E241,E226
 exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 
 [tool:pytest]
-filterwarnings= ignore::FutureWarning
+filterwarnings= ignore::FutureWarning:chainer\.utils\.experimental
                 error::DeprecationWarning
                 error::PendingDeprecationWarning
                 # importing old SciPy is warned because it tries to

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,8 @@ ignore = E741,W503,W504,E241,E226
 exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 
 [tool:pytest]
-filterwarnings= ignore::FutureWarning:chainer\.utils\.experimental
+filterwarnings= error::FutureWarning
+                ignore::FutureWarning:chainer\.utils\.experimental
                 error::DeprecationWarning
                 error::PendingDeprecationWarning
                 # importing old SciPy is warned because it tries to

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 
@@ -161,8 +162,12 @@ class TestSplitAxis(unittest.TestCase):
         }
 
     def _forward(self, x):
-        return functions.split_axis(
-            x, self.ys_section, self.axis, force_tuple=True)
+        with warnings.catch_warnings():
+            if not chainer.functions.array.split_axis._numpy_split_ok:
+                warnings.filterwarnings(
+                    'ignore', category=FutureWarning, module='numpy')
+            return functions.split_axis(
+                x, self.ys_section, self.axis, force_tuple=True)
 
     def check_forward(self, inputs, backend_config):
         inputs = backend_config.get_array(inputs)


### PR DESCRIPTION
This PR changes only tests, while defining `class ExperimentalWarning(FutureWarning): pass` might resolve some other issues.