### PR TITLE
Remove @overload annotations outside the stub files

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -1179,17 +1179,7 @@ class ChainList(Link, collections_abc.MutableSequence):
                 ' within a "with chainlist.init_scope():" block.')
         super(ChainList, self).__setattr__(name, value)
 
-    @tp.overload  # NOQA
-    def __setitem__(self, key, value):
-        # type: (int, Link) -> None
-        pass
-
-    @tp.overload  # NOQA
-    def __setitem__(self, key, value):
-        # type: (slice, tp.Iterable[Link]) -> None
-        pass
-
-    def __setitem__(self, index, value):  # NOQA
+    def __setitem__(self, index, value):
         # type: (tp.Union[int, slice], tp.Union[Link, tp.Iterable[Link]]) -> None # NOQA
 
         if isinstance(index, int):
@@ -1205,18 +1195,7 @@ class ChainList(Link, collections_abc.MutableSequence):
                 'ChainList indices must be integers or slices, not %s' %
                 type(index).__name__)
 
-    @tp.overload  # NOQA
-    def __getitem__(self, key):
-        # type: (int) -> Link
-        pass
-
-    @tp.overload  # NOQA
-    def __getitem__(self, key):
-        # type: (slice) -> collections_abc.MutableSequence[Link]
-        pass
-
-    def __getitem__(self, index):  # NOQA
-        # type: (tp.Union[int, slice]) -> tp.Union[Link, collections_abc.MutableSequence[Link]] # NOQA
+    def __getitem__(self, index):
         """Returns the child at given index.
 
         Args:


### PR DESCRIPTION
Remove `@overload` annotations outside the stub files because it isn't supported in Python 3.5.1. It fixes #5959.

```bash
$ pyenv local 3.5.1
$ pip install typing typing_extensions
$ python
Python 3.5.1 (default, Nov 15 2018, 17:50:51) 
[GCC 5.5.0 20171010] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import chainer
>>> 
$ pyenv local 3.6.6
$ pip install typing typing_extensions
$ python
Python 3.6.6 (default, Jul 26 2018, 11:12:32) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import chainer
>>> 
```
