### PR TITLE
[v5] Fix pytest plugin version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,9 @@ requirements = {
         '-r stylecheck',
         '-r test',
         '-r docs',
-        # pytest-timeout>=1.3.0 requires pytest>=3.6.
-        # TODO(niboshi): Consider upgrading pytest to >=3.6
+        # pytest-timeout>=1.3.0 and pytest-cov>=2.6.1 requires pytest>=3.6.
         'pytest-timeout<1.3.0',
-        'pytest-cov',
+        'pytest-cov<2.6.1',
         'theano',
         'h5py',
         'pillow',


### PR DESCRIPTION
Travis tests for v5 are failing because pytest-cov 2.6.1 requires pytest>=3.6