### PR TITLE
[backport] Fix doc of `F.softmax_cross_entropy` on output shape with `reduce=no`

### DIFF
--- a/chainer/functions/loss/sigmoid_cross_entropy.py
+++ b/chainer/functions/loss/sigmoid_cross_entropy.py
@@ -140,7 +140,8 @@ def sigmoid_cross_entropy(x, t, normalize=True, reduce='mean'):
     Returns:
         Variable: A variable object holding an array of the cross entropy.
         If ``reduce`` is ``'mean'``, it is a scalar array.
-        If ``reduce`` is ``'no'``, the shape is same as ``x``.
+        If ``reduce`` is ``'no'``, the shape is same as those of ``x`` and
+        ``t``.
 
     .. note::
 

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -351,7 +351,7 @@ def softmax_cross_entropy(
     Returns:
         ~chainer.Variable: A variable holding a scalar array of the cross
         entropy loss.  If ``reduce`` is ``'mean'``, it is a scalar array.
-        If ``reduce`` is ``'no'``, the shape is same as that of ``x``.
+        If ``reduce`` is ``'no'``, the shape is same as that of ``t``.
 
     .. note::
 


### PR DESCRIPTION
Backport of #5965