### PR TITLE
improve `F.elu` memory consumption by retaining output

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_elu.py
@@ -14,6 +14,7 @@ from chainer.testing import attr
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'alpha': [(-2.0, 0.0), 0.0, (0.0, 2.0)],
 }))
 @testing.fix_random()
 class TestELU(unittest.TestCase):
@@ -24,7 +25,8 @@ class TestELU(unittest.TestCase):
         self.x[(-0.01 < self.x) & (self.x < 0.01)] = 0.5
         self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         self.ggx = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.alpha = random.random()
+        if isinstance(self.alpha, tuple):
+            self.alpha = random.uniform(self.alpha[0], self.alpha[1])
         self.check_forward_options = {}
         self.check_backward_options = {}
         if self.dtype == numpy.float16:


### PR DESCRIPTION
When `alpha >= 0.0`, `F.elu` can modified to retain output. Gradient computation becomes easier.

It might degrade the precision of gradients, but it won't be worse than `F.sigmoid`, `F.tanh`, `F.swish` or `F.softplus`. [TF also computes gradients from the output.](https://github.com/tensorflow/tensorflow/blob/96237f7b7ae6b7b8a2cbcf6d64312906b96f060b/tensorflow/core/kernels/relu_op_functor.h#L149)