### PR TITLE
Raise an appropriate error on cuDNN RNN backward in testing mode

### DIFF
--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -295,6 +295,10 @@ class BaseNStepRNN(function.Function):
             return hy, ys
 
     def backward(self, inputs, grads):
+        if not configuration.config.train:
+            raise RuntimeError('cuDNN does not support backward computation '
+                               'of RNN in testing mode')
+
         if self.use_cell:
             # LSTM
             hx, cx, w, xs = inputs

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -244,7 +244,7 @@ class TestNStepRNN(unittest.TestCase):
 
     def check_call_cudnn_backward_inference(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn), \
-             chainer.using_config('train', False):
+                chainer.using_config('train', False):
             hx = _wrap_variable(_to_gpu(self.hx))
             xs = _wrap_variable(_to_gpu(self.xs))
             ws = _wrap_variable(_to_gpu(self.ws))

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -227,7 +227,7 @@ class TestNStepRNN(unittest.TestCase):
         self.check_call_cudnn_forward_inference('never')
         self.check_call_cudnn_forward_inference('auto')
 
-    def check_call_cudnn_backward(self, use_cudnn):
+    def check_call_cudnn_backward_training(self, use_cudnn):
         with chainer.using_config('use_cudnn', use_cudnn):
             expect = chainer.should_use_cudnn('>=auto', 5000)
             hy, ys = self.call_forward(True)
@@ -237,10 +237,36 @@ class TestNStepRNN(unittest.TestCase):
             assert func.called == expect
 
     @attr.cudnn
-    def test_call_cudnn_backward(self):
-        self.check_call_cudnn_backward('always')
-        self.check_call_cudnn_backward('never')
-        self.check_call_cudnn_backward('auto')
+    def test_call_cudnn_backward_training(self):
+        self.check_call_cudnn_backward_training('always')
+        self.check_call_cudnn_backward_training('never')
+        self.check_call_cudnn_backward_training('auto')
+
+    def check_call_cudnn_backward_inference(self, use_cudnn):
+        with chainer.using_config('use_cudnn', use_cudnn), \
+             chainer.using_config('train', False):
+            hx = _wrap_variable(_to_gpu(self.hx))
+            xs = _wrap_variable(_to_gpu(self.xs))
+            ws = _wrap_variable(_to_gpu(self.ws))
+            bs = _wrap_variable(_to_gpu(self.bs))
+            hy, ys = functions.n_step_rnn(
+                self.n_layers, self.dropout, hx, ws, bs, xs)
+
+            hy.grad = _to_gpu(self.dhy)
+            if chainer.should_use_cudnn('>=auto', 5000):
+                with self.assertRaises(RuntimeError):
+                    hy.backward()
+            else:
+                with testing.patch('cupy.cudnn.rnn_backward_weights') as func:
+                    hy.backward()
+                assert not func.called
+
+    @attr.cudnn
+    def test_call_cudnn_backward_inference(self):
+        # see chainer/5943
+        self.check_call_cudnn_backward_inference('always')
+        self.check_call_cudnn_backward_inference('never')
+        self.check_call_cudnn_backward_inference('auto')
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Close #5943.

This PR fix `F.n_step_rnn` to raise an appropriate error on attempting backward computation in testing mode.
