### PR TITLE
Fix pickling of ChainerX link

### DIFF
--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -20,6 +20,8 @@ if _available:
 
     from builtins import bool, int, float  # NOQA
 
+    from chainerx import _device  # NOQA
+
     from chainerx.creation.from_data import asanyarray  # NOQA
     from chainerx.creation.from_data import fromfile  # NOQA
     from chainerx.creation.from_data import fromfunction  # NOQA

--- a/chainerx/_device.py
+++ b/chainerx/_device.py
@@ -1,0 +1,11 @@
+import chainerx
+
+
+def _recover_device(backend_name, device_index):
+    # Recovers the device instance.
+    # This function is used together with chainerx.Device.__reduce__.
+    # TODO(niboshi): Save the context name and lookup the context with it.
+    context = chainerx.get_default_context()
+    backend = context.get_backend(backend_name)
+    device = backend.get_device(device_index)
+    return device

--- a/chainerx_cc/chainerx/python/array.cc
+++ b/chainerx_cc/chainerx/python/array.cc
@@ -146,6 +146,13 @@ void InitChainerxArray(pybind11::module& m) {
               std::shared_ptr<void> data{c_ptr, [base](void*) {}};
               return MoveArrayBody(FromData(ToShape(shape), GetDtype(dtype), data, ToStrides(strides), offset, GetDevice(device)));
           });
+    c.def(py::pickle(
+            [](const ArrayBodyPtr& self) -> py::tuple { return py::make_tuple(MakeNumpyArrayFromArray(self, true), self->device()); },
+            [](py::tuple state) -> ArrayBodyPtr {
+                py::array numpy_array = state[0];
+                Device& device = py::cast<Device&>(state[1]);
+                return MakeArrayFromNumpyArray(numpy_array, device);
+            }));
     c.def("__len__", [](const ArrayBodyPtr& self) -> size_t {
         // TODO(hvy): Do bounds cheking. For reference, Chainer throws an AttributeError.
         if (self->ndim() == 0) {

--- a/chainerx_cc/chainerx/python/device.cc
+++ b/chainerx_cc/chainerx/python/device.cc
@@ -55,6 +55,16 @@ private:
 
 void InitChainerxDevice(pybind11::module& m) {
     py::class_<Device> c{m, "Device"};
+    c.def("__reduce__", [m](Device& self) {
+        // Implements serialization of Device instance.
+        // Note that the deserialization function chainerx._device._recover_device() is implemented in .py code, because the function itself
+        // would be unpicklable if it were defined with pybind. (pybind-generated function cannot be pickled.)
+        // TODO(niboshi): Add context name
+        std::string backend_name = self.backend().GetName();
+        int device_index = self.index();
+        py::tuple args = py::make_tuple(backend_name, device_index);
+        return py::make_tuple(py::module::import("chainerx").attr("_device").attr("_recover_device"), args);
+    });
     c.def("__repr__", &Device::name);
     c.def("synchronize", &Device::Synchronize);
     c.def_property_readonly("name", &Device::name);

--- a/chainerx_cc/chainerx/python/device.cc
+++ b/chainerx_cc/chainerx/python/device.cc
@@ -55,7 +55,7 @@ private:
 
 void InitChainerxDevice(pybind11::module& m) {
     py::class_<Device> c{m, "Device"};
-    c.def("__reduce__", [m](Device& self) {
+    c.def("__reduce__", [](Device& self) {
         // Implements serialization of Device instance.
         // Note that the deserialization function chainerx._device._recover_device() is implemented in .py code, because the function itself
         // would be unpicklable if it were defined with pybind. (pybind-generated function cannot be pickled.)

--- a/tests/chainerx_tests/unit_tests/test_array.py
+++ b/tests/chainerx_tests/unit_tests/test_array.py
@@ -1,4 +1,6 @@
+import copy
 import math
+import pickle
 
 import numpy
 import pytest
@@ -697,3 +699,33 @@ def test_asarray_to_numpy_identity(device, slice1, slice2):
     z = chainerx.to_numpy(y)
     chainerx.testing.assert_array_equal_ex(x, y)
     chainerx.testing.assert_array_equal_ex(x, z, strides_check=False)
+
+
+# TODO(niboshi): Add pickle test involving context destruction and re-creation
+@pytest.mark.parametrize_device(['native:0', 'native:1', 'cuda:0'])
+def test_array_pickle(device):
+    arr = chainerx.array([1, 2], chainerx.float32, device=device)
+    s = pickle.dumps(arr)
+    del arr
+
+    arr2 = pickle.loads(s)
+    assert isinstance(arr2, chainerx.ndarray)
+    assert arr2.device is device
+    assert arr2.dtype == chainerx.float32
+    chainerx.testing.assert_array_equal(
+        arr2,
+        chainerx.array([1, 2], chainerx.float32))
+
+
+# TODO(niboshi): Add deepcopy test with arbitrary context
+@pytest.mark.parametrize_device(['native:0', 'native:1', 'cuda:0'])
+def test_array_deepcopy(device):
+    arr = chainerx.array([1, 2], chainerx.float32, device=device)
+    arr2 = copy.deepcopy(arr)
+
+    assert isinstance(arr2, chainerx.ndarray)
+    assert arr2.device is device
+    assert arr2.dtype == chainerx.float32
+    chainerx.testing.assert_array_equal(
+        arr2,
+        chainerx.array([1, 2], chainerx.float32))

--- a/tests/chainerx_tests/unit_tests/test_device.py
+++ b/tests/chainerx_tests/unit_tests/test_device.py
@@ -1,3 +1,6 @@
+import copy
+import pickle
+
 import pytest
 
 import chainerx
@@ -133,3 +136,18 @@ def test_using_device_with_name(device_instance1, device_instance2):
     with chainerx.using_device(device2.backend.name, device2.index) as scope:
         assert chainerx.get_default_device() == device2
         assert scope.device is device2
+
+
+# TODO(niboshi): Add pickle test involving context destruction and re-creation
+@pytest.mark.parametrize_device(['native:0', 'native:1', 'cuda:0'])
+def test_device_pickle(device):
+    s = pickle.dumps(device)
+    device2 = pickle.loads(s)
+    assert device is device2
+
+
+# TODO(niboshi): Add deepcopy test with arbitrary context
+@pytest.mark.parametrize_device(['native:0', 'native:1', 'cuda:0'])
+def test_device_deepcopy(device):
+    device2 = copy.deepcopy(device)
+    assert device is device2


### PR DESCRIPTION
Fixes #5916

Makes `chainerx.Device` and `chainerx.ndarray` picklable.