### PR TITLE
Support NumPy integers in `chainerx.ndarray.__getitem__`

### DIFF
--- a/chainerx_cc/chainerx/python/array_index.cc
+++ b/chainerx_cc/chainerx/python/array_index.cc
@@ -1,5 +1,10 @@
 #include "chainerx/python/array_index.h"
 
+#include <type_traits>
+#include <vector>
+
+#include <pybind11/pybind11.h>
+
 #include "chainerx/array_index.h"
 
 #include "chainerx/python/slice.h"
@@ -16,18 +21,26 @@ ArrayIndex MakeArrayIndex(py::handle handle) {
     if (handle.is_none()) {
         return ArrayIndex{NewAxis{}};
     }
-    if (py::int_::check_(handle)) {
+    if (py::isinstance<py::int_>(handle)) {
         return ArrayIndex{py::cast<int64_t>(handle)};
     }
-    if (py::slice::check_(handle)) {
+    if (py::isinstance<py::slice>(handle)) {
         return ArrayIndex{MakeSlice(py::cast<py::slice>(handle))};
+    }
+    // NumPy integer scalar
+    // numpy.integer is cached because it's time consuming to import each time.
+    // (py::handle is trivially destructible)
+    static py::handle numpy_integer = py::module::import("numpy").attr("integer");
+    static_assert(std::is_trivially_destructible<py::handle>::value, "");
+    if (py::isinstance(handle, numpy_integer)) {
+        return ArrayIndex{py::cast<int64_t>(handle)};
     }
     throw py::index_error{"only integers, slices (`:`), and chainerx.newaxis (`None`) are valid indices"};
 }
 
 std::vector<ArrayIndex> MakeArrayIndicesFromTuple(py::tuple tup) {
     std::vector<ArrayIndex> indicies;
-    for (auto& handle : tup) {
+    for (auto handle : tup) {
         indicies.emplace_back(MakeArrayIndex(handle));
     }
     return indicies;
@@ -36,7 +49,7 @@ std::vector<ArrayIndex> MakeArrayIndicesFromTuple(py::tuple tup) {
 }  // namespace
 
 std::vector<ArrayIndex> MakeArrayIndices(py::handle handle) {
-    if (py::tuple::check_(handle)) {
+    if (py::isinstance<py::tuple>(handle)) {
         return MakeArrayIndicesFromTuple(py::cast<py::tuple>(handle));
     }
     return {MakeArrayIndex(handle)};

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_indexing.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_indexing.py
@@ -21,6 +21,9 @@ from chainerx_tests import array_utils
     ((3,), -1),
     ((2, 3), 0),
     ((2, 3), 1),
+    ((2, 3), numpy.int8(-1)),
+    ((2, 3), numpy.int32(0)),
+    ((2, 3), numpy.uint64(1)),
     # integer indexining - tuple indexing
     ((3,), (0,)),
     ((3,), (1,)),


### PR DESCRIPTION
Fixes #5897

Before (using the script in #5897)
```
numpy array: 0.5639582940057153
cupy array: 2.305104177998146
chainerx (native) array: 84.79587393000838
chainerx (cuda) array: 101.06928799199522
genuine chainerx impl with shuffle (on cuda): 113.26358407300722
```

This PR
```
numpy array: 0.5752583239955129
cupy array: 2.019738340997719
chainerx (native) array: 2.341369660003693
chainerx (cuda) array: 2.20467715599807
genuine chainerx impl with shuffle (on cuda): 113.40527645299153
```