### PR TITLE
Fix thread safety of CUDA memory pool FreeUnusedBlocks

### DIFF
--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -178,6 +178,8 @@ MemoryPool::~MemoryPool() {
 void MemoryPool::FreeUnusedBlocks() {
     CudaSetDeviceScope scope{device_index_};
 
+    std::lock_guard<std::mutex> lock{free_bins_mutex_};
+
     // Frees unused memory blocks
     for (FreeBinsMap::value_type& pair : free_bins_) {
         FreeList& free_list = pair.second;


### PR DESCRIPTION
Fixes the first problem of #5991