### PR TITLE
Avoid deprecated `numpy.asscalar`

### DIFF
--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -48,8 +48,8 @@ def _chainerx_preprocess_const(x, value, label):
 
     if isinstance(value, (six.integer_types, float)):
         return value
-    if numpy.isscalar(value):
-        return numpy.asscalar(value)
+    if isinstance(value, numpy.generic):
+        return value.item()
     if isinstance(value, variable.Variable):
         value = variable.as_array(value)
     utils._check_arrays_forward_compatible((x, value), label)


### PR DESCRIPTION
`numpy.asscalar` was deprecated in NumPy 1.16.