### PR TITLE
Fix python 3.5 incompatibility in Chainer X train_mnist.py example

### DIFF
--- a/chainerx_cc/examples/mnist_py/train_mnist.py
+++ b/chainerx_cc/examples/mnist_py/train_mnist.py
@@ -181,7 +181,6 @@ def get_mnist(path, name):
     with gzip.open(y_path, 'rb') as fy:
         fy.read(8)  # skip header
         y = np.frombuffer(fy.read(), dtype=np.uint8)
-        # y.flags.writeable = True  # TODO(beam2d): remove this workaround
 
     assert x.shape[0] == y.shape[0]
 

--- a/chainerx_cc/examples/mnist_py/train_mnist.py
+++ b/chainerx_cc/examples/mnist_py/train_mnist.py
@@ -168,20 +168,20 @@ def main():
 
 def get_mnist(path, name):
     path = pathlib.Path(path)
-    x_path = path / '{}-images-idx3-ubyte.gz'.format(name)
-    y_path = path / '{}-labels-idx1-ubyte.gz'.format(name)
+    x_path = str(path / '{}-images-idx3-ubyte.gz'.format(name))
+    y_path = str(path / '{}-labels-idx1-ubyte.gz'.format(name))
 
     with gzip.open(x_path, 'rb') as fx:
         fx.read(16)  # skip header
         # read/frombuffer is used instead of fromfile because fromfile does not
         # handle gzip file correctly
         x = np.frombuffer(fx.read(), dtype=np.uint8).reshape(-1, 784)
-        x.flags.writeable = True  # TODO(beam2d): remove this workaround
+        # x.flags.writeable = True  # TODO(beam2d): remove this workaround
 
     with gzip.open(y_path, 'rb') as fy:
         fy.read(8)  # skip header
         y = np.frombuffer(fy.read(), dtype=np.uint8)
-        y.flags.writeable = True  # TODO(beam2d): remove this workaround
+        # y.flags.writeable = True  # TODO(beam2d): remove this workaround
 
     assert x.shape[0] == y.shape[0]
 

--- a/chainerx_cc/examples/mnist_py/train_mnist.py
+++ b/chainerx_cc/examples/mnist_py/train_mnist.py
@@ -176,7 +176,6 @@ def get_mnist(path, name):
         # read/frombuffer is used instead of fromfile because fromfile does not
         # handle gzip file correctly
         x = np.frombuffer(fx.read(), dtype=np.uint8).reshape(-1, 784)
-        # x.flags.writeable = True  # TODO(beam2d): remove this workaround
 
     with gzip.open(y_path, 'rb') as fy:
         fy.read(8)  # skip header


### PR DESCRIPTION
Fixes #5925.
