### PR TITLE
Fix to use generator in `all` and `any` functions

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -170,15 +170,15 @@ def is_arrays_compatible(arrays):
     # TODO(niboshi): intel64.mdarray is not supported yet.
     # TODO(niboshi): Delegate array compatibility check to chainerx.
     if (chainerx.is_available()
-            and any([isinstance(arr, chainerx.ndarray) for arr in arrays])):
-        return not any([
-            isinstance(arr, backends.intel64.mdarray) for arr in arrays])
+            and any(isinstance(arr, chainerx.ndarray) for arr in arrays)):
+        return not any(
+            isinstance(arr, backends.intel64.mdarray) for arr in arrays)
 
     if isinstance(arrays[0], backends.cuda.ndarray):
         types = backends.cuda.ndarray
     else:
         types = get_cpu_array_types()
-    return all([isinstance(a, types) for a in arrays])
+    return all(isinstance(a, types) for a in arrays)
 
 
 global_config.debug = bool(int(os.environ.get('CHAINER_DEBUG', '0')))

--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -170,7 +170,7 @@ def get_array_module(*args):
                 for arg in args]
 
     if (chainerx.is_available()
-            and any([isinstance(a, chainerx.ndarray) for a in args])):
+            and any(isinstance(a, chainerx.ndarray) for a in args)):
         return chainerx
     elif cuda.available:
         return cuda.cupy.get_array_module(*args)

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -186,4 +186,4 @@ def inputs_all_ready(inputs, supported_ndim=(2, 4)):
               else x for x in inputs]
 
     return (ideep.check_ndim(inputs, supported_ndim)
-            and all([_is_supported_array_type(a) for a in inputs]))
+            and all(_is_supported_array_type(a) for a in inputs))

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -350,7 +350,7 @@ Use apply() method instead.\
 
         else:
             input_vars = [chainer.as_variable(x) for x in inputs]
-            requires_grad = any([x.requires_grad for x in input_vars])
+            requires_grad = any(x.requires_grad for x in input_vars)
 
             ret = tuple(
                 [variable.Variable(y, requires_grad=requires_grad)
@@ -709,9 +709,9 @@ Use apply() method instead.\
             (self._output_indexes_to_retain is None
              and len(retained_outputs) == 0)
             or (len(self._output_indexes_to_retain) == len(retained_outputs)))
-        assert all([
+        assert all(
             a is None or isinstance(a, chainerx.ndarray)
-            for a in grad_outputs])
+            for a in grad_outputs)
 
         self._chainerx_retained_inputs = tuple([
             variable.Variable(
@@ -736,7 +736,7 @@ Use apply() method instead.\
                     for gy in grad_outputs]))
 
         gx_arrs = [gx._data[0] for gx in gxs]
-        assert all([isinstance(gx, chainerx.ndarray) for gx in gx_arrs])
+        assert all(isinstance(gx, chainerx.ndarray) for gx in gx_arrs)
         return gx_arrs
 
     def _backward_target_inputs(self, target_input_indexes, grad_outputs):
@@ -1165,7 +1165,7 @@ def _extract_apply_in_data(inputs):
         if isinstance(x, variable.Variable) else x for x in inputs]
 
     if (chainerx.is_available()
-            and any([isinstance(arr, chainerx.ndarray) for arr in arrays])):
+            and any(isinstance(arr, chainerx.ndarray) for arr in arrays)):
         return True, tuple(backend.to_chainerx(arrays))
     return False, tuple(arrays)
 

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -19,7 +19,7 @@ class GetItem(function_node.FunctionNode):
 
     def __init__(self, slices):
         if isinstance(slices, list):
-            if all([isinstance(s, int) for s in slices]):
+            if all(isinstance(s, int) for s in slices):
                 slices = slices,
             slices = tuple(slices)
         elif not isinstance(slices, tuple):

--- a/chainer/functions/array/scatter_add.py
+++ b/chainer/functions/array/scatter_add.py
@@ -12,7 +12,7 @@ class ScatterAdd(function_node.FunctionNode):
 
     def __init__(self, slices):
         if isinstance(slices, list):
-            if all([isinstance(s, int) for s in slices]):
+            if all(isinstance(s, int) for s in slices):
                 slices = slices,
             slices = tuple(slices)
         elif not isinstance(slices, tuple):

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -91,7 +91,7 @@ class Convolution2DFunction(function_node.FunctionNode):
 
     def forward_chainerx(self, inputs):
         # TODO(hvy): Support mixed precision.
-        if any([arr.dtype != inputs[0].dtype for arr in inputs[1:]]):
+        if any(arr.dtype != inputs[0].dtype for arr in inputs[1:]):
             return chainer.Fallback
         # TODO(hvy): Support dilate > 1.
         if self.dy > 1 or self.dx > 1:

--- a/chainer/functions/connection/convolution_nd.py
+++ b/chainer/functions/connection/convolution_nd.py
@@ -56,7 +56,7 @@ class ConvolutionND(function_node.FunctionNode):
 
     def forward_chainerx(self, inputs):
         # TODO(hvy): Support mixed precision.
-        if any([arr.dtype != inputs[0].dtype for arr in inputs[1:]]):
+        if any(arr.dtype != inputs[0].dtype for arr in inputs[1:]):
             return chainer.Fallback
         # TODO(hvy): Support dilate > 1.
         if any(d != 1 for d in self.dilate):

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -54,10 +54,10 @@ def _check_outputs_and_grad_outputs(outputs, grad_outputs):
             'the number of output elements.\n'
             '{}'.format(
                 _make_outputs_props_in_error_message(outputs, grad_outputs)))
-    shapes_match = all([gy is None or y.shape == gy.shape
-                        for y, gy in zip(outputs, grad_outputs)])
-    dtypes_match = all([gy is None or y.dtype == gy.dtype
-                        for y, gy in zip(outputs, grad_outputs)])
+    shapes_match = all(gy is None or y.shape == gy.shape
+                       for y, gy in zip(outputs, grad_outputs))
+    dtypes_match = all(gy is None or y.dtype == gy.dtype
+                       for y, gy in zip(outputs, grad_outputs))
     if not (shapes_match and dtypes_match):
         raise ValueError(
             'Shapes and/or dtypes of outputs and output gradients do not '
@@ -165,9 +165,9 @@ def numerical_grad(
         x[i] = orig + delta
         y = _copy_arrays(f())
         assert len(y) == len(grad_outputs)
-        assert all([
+        assert all(
             gy is None or numpy.isscalar(gy) or y_.shape == gy.shape
-            for y_, gy in zip(y, grad_outputs)])
+            for y_, gy in zip(y, grad_outputs))
         x[i] = orig
         return y
 

--- a/chainer/utils/precision.py
+++ b/chainer/utils/precision.py
@@ -12,8 +12,8 @@ def _fp16_mixed_precision_helper(fn):
     """
     @functools.wraps(fn)
     def wrapper(self, in_data):
-        flag = all([x.dtype.kind != 'f' or x.dtype == numpy.float16
-                    for x in in_data])
+        flag = all(x.dtype.kind != 'f' or x.dtype == numpy.float16
+                   for x in in_data)
 
         in_data1 = []
         for x in in_data:


### PR DESCRIPTION
FIx to use `all` and `any` with generator expression instead of list. These functions have a functionality to abort iteration when the condition is (not) met like the following:

```python
>>> class A:
...   def __iter__(self):
...     for i in range(5):
...       print(i)
...       yield i
... 
>>> any(i > 0 for i in A())  # generator
0
1
True
>>> any([i > 0 for i in A()])  # list
0
1
2
3
4
True
```
