### PR TITLE
[backport] Support all float dtypes in `F.connectionist_temporal_classification`

### DIFF
--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -109,7 +109,8 @@ class ConnectionistTemporalClassification(function.Function):
 
     def __init__(self, blank_symbol, reduce='mean'):
         self.blank_symbol = blank_symbol
-        self.zero_padding = -10000000000.0
+        # Lazily initialized in the first forward computation for dtype
+        self.zero_padding = None
 
         if reduce not in ('mean', 'no'):
             raise ValueError(
@@ -129,7 +130,7 @@ class ConnectionistTemporalClassification(function.Function):
             t_type.ndim == 2,
             t_type.dtype == numpy.int32,
             x_type.ndim == 3,
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
         )
         n_batch = x_type.shape[1]
         type_check.expect(
@@ -144,10 +145,10 @@ class ConnectionistTemporalClassification(function.Function):
         else:
             create_recurrence_relation = cuda.elementwise(
                 'T x, T e', 'T y',
-                'y = x == 0 ? e : log(x)',
+                'y = x == 0 ? e : (T)log(x)',
                 'create_recurrence_relation')
             res = create_recurrence_relation(x, self.zero_padding)
-        return res.astype(numpy.float32, copy=False)
+        return res.astype(x.dtype, copy=False)
 
     # path probablity to label probability
     def label_probability(self, label_size, path, path_length,
@@ -190,7 +191,7 @@ class ConnectionistTemporalClassification(function.Function):
         if xp == numpy:
             n_batch, max_path_length = path.shape
             mat = xp.full(
-                (3, n_batch, max_path_length), self.zero_padding, 'f')
+                (3, n_batch, max_path_length), self.zero_padding, y.dtype)
             mat[0, :, :] = prev_prob
             mat[1, :, 1:] = prev_prob[:, :-1]
             mat[2, :, 2:] = prev_prob[:, :-2]
@@ -221,13 +222,13 @@ class ConnectionistTemporalClassification(function.Function):
                 int ind1[] = {b, t};
                 int ind2[] = {b, t - 1};
                 int ind3[] = {b, t - 2};
-                float f1 = prob[ind1];
-                float f2 = (0 <= t - 1) ? prob[ind2] : zero;
-                float f3 = (0 <= t - 2 && path[ind3] != path[ind1]) ?
+                T f1 = prob[ind1];
+                T f2 = (0 <= t - 1) ? prob[ind2] : zero;
+                T f3 = (0 <= t - 2 && path[ind3] != path[ind1]) ?
                   prob[ind3] : zero;
 
                 // calculates log-sum-exp
-                float m = max(f1, max(f2, f3));
+                T m = max(f1, max(f2, f3));
                 z = m + log(exp(f1 - m) + exp(f2 - m) + exp(f3 - m));
 
                 cum_prob += z;
@@ -248,7 +249,7 @@ class ConnectionistTemporalClassification(function.Function):
         assert path.shape == (n_batch, max_label_length * 2 + 1)
 
         forward_prob = xp.full(
-            (n_batch, max_path_length), self.zero_padding, dtype='f')
+            (n_batch, max_path_length), self.zero_padding, dtype=yseq.dtype)
         forward_prob[:, 0] = 0
         backward_prob = forward_prob
 
@@ -274,6 +275,12 @@ class ConnectionistTemporalClassification(function.Function):
     def forward(self, inputs):
         xp = backend.get_array_module(inputs[0])
         self.input_length, label_length, t, xs = inputs
+
+        if self.zero_padding is None:
+            if xs.dtype == numpy.float16:
+                self.zero_padding = -10000.0
+            else:
+                self.zero_padding = -10000000000.0
 
         if chainer.is_debug():
             assert len(xs) >= xp.max(self.input_length)

--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -16,7 +16,7 @@ from chainer.testing import condition
 class CTCTestBase(object):
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (4, 2, 3)).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, (4, 2, 3)).astype(self.dtype)
         self.t = numpy.array([[0, 1], [1, 0]]).astype(numpy.int32)
         self.l = numpy.array([[2, 0, 2, 1, 2],
                               [2, 1, 2, 0, 2]]).astype(numpy.int32)
@@ -25,9 +25,17 @@ class CTCTestBase(object):
         self.l_length = numpy.full((len(self.t),), len(self.t[0]), dtype='i')
         self.use_length = True
         if self.reduce == 'mean':
-            self.gy = numpy.random.uniform(-1, 1, ()).astype(numpy.float32)
+            self.gy = numpy.random.uniform(-1, 1, ()).astype(self.dtype)
         else:
-            self.gy = numpy.random.uniform(-1, 1, (2,)).astype(numpy.float32)
+            self.gy = numpy.random.uniform(-1, 1, (2,)).astype(self.dtype)
+
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 5e-3}
+            self.check_backward_options = {
+                'atol': 1e-3, 'dtype': numpy.float64}
+        else:
+            self.check_forward_options = {}
+            self.check_backward_options = {'atol': 1e-4}
 
     # recursive forward computation.
     def alpha(self, x, l, t, u):
@@ -77,7 +85,7 @@ class CTCTestBase(object):
                 xt[b][t] = numpy.exp(xt[b][t]) / numpy.sum(numpy.exp(xt[b][t]))
         batch_size = xt.shape[0]
         path_length = 2 * l_length + 1
-        loss_expect = xp.zeros((batch_size,), dtype=xp.float32)
+        loss_expect = xp.zeros((batch_size,), dtype=self.dtype)
         for i in range(batch_size):
             xtb, lb, xlb, plb = xt[i], self.l[i], x_length[i], path_length[i]
             loss_expect[i] = -math.log(
@@ -85,7 +93,8 @@ class CTCTestBase(object):
                 self.alpha(xtb, lb, int(xlb - 1), int(plb - 2)))
         if self.reduce == 'mean':
             loss_expect = xp.mean(loss_expect)
-        testing.assert_allclose(loss_expect, loss)
+        testing.assert_allclose(
+            loss_expect, loss, **self.check_forward_options)
 
     def test_forward_cpu(self):
         self.check_forward(self.t, tuple(self.x),
@@ -119,7 +128,7 @@ class CTCTestBase(object):
 
         gradient_check.check_backward(
             f, (x_length, l_length, t_data) + xs_data, gy_data,
-            eps=1e-2, atol=1e-4)
+            eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -137,20 +146,20 @@ class CTCTestBase(object):
                             cuda.to_gpu(self.gy))
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTC(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
         CTCTestBase.setUp(self)
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithoutLength(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -158,10 +167,10 @@ class TestCTCWithoutLength(unittest.TestCase, CTCTestBase):
         self.use_length = False
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithLabelPadding(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -169,10 +178,10 @@ class TestCTCWithLabelPadding(unittest.TestCase, CTCTestBase):
         self.l_length[0] = 1
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithInputPadding(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -180,10 +189,10 @@ class TestCTCWithInputPadding(unittest.TestCase, CTCTestBase):
         self.x_length[0] = 3
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithAllPadding(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -192,10 +201,10 @@ class TestCTCWithAllPadding(unittest.TestCase, CTCTestBase):
         self.l_length[...] = 1
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCWithRepeatedLabel(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
@@ -206,10 +215,10 @@ class TestCTCWithRepeatedLabel(unittest.TestCase, CTCTestBase):
         self.l_length = numpy.full((len(self.t),), len(self.t[0]), dtype='i')
 
 
-@testing.parameterize(
-    {'reduce': 'mean'},
-    {'reduce': 'no'}
-)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'reduce': ['mean', 'no'],
+}))
 class TestCTCBlankSymbol(unittest.TestCase, CTCTestBase):
 
     def setUp(self):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_ctc.py
@@ -223,7 +223,7 @@ class TestCTCBlankSymbol(unittest.TestCase, CTCTestBase):
 
     def setUp(self):
         CTCTestBase.setUp(self)
-        self.x = numpy.random.uniform(-1, 1, (4, 2, 4)).astype(numpy.float32)
+        self.x = numpy.random.uniform(-1, 1, (4, 2, 4)).astype(self.dtype)
         self.l = numpy.array([[3, 0, 3, 1, 3],
                               [3, 1, 3, 0, 3]]).astype(numpy.int32)
         self.blank_symbol = 3


### PR DESCRIPTION
Backport of #5680