### PR TITLE
Fix `inject_backend_tests` `multi_gpu` test mark

### DIFF
--- a/chainer/testing/backend.py
+++ b/chainer/testing/backend.py
@@ -185,7 +185,7 @@ def _test_case_generator(base, method_names, params):
 
             # Apply test marks
             for mark in marks:
-                mark(new_method)
+                new_method = mark(new_method)
 
             return new_method
 


### PR DESCRIPTION
#5904 has caused `testing.attr.multi_gpu` (put by `inject_backend_tests`) to ignore `CHAINER_TEST_GPU_LIMIT` environment variable. This PR fixes it.

(just for reference)
Another fix would be to change `unittest.skipIf` to `pytest.mark.skipif` at this line (I don't know why):
https://github.com/chainer/chainer/blob/9f243e66fc5b6a337273d965b431644d846a9cc7/chainer/testing/attr.py#L60