### PR TITLE
Allow doctest to run in single-GPU environment

### DIFF
--- a/chainer/links/theano/theano_function.py
+++ b/chainer/links/theano/theano_function.py
@@ -39,8 +39,7 @@ class TheanoFunction(link.Link):
 
     .. doctest::
        # See chainer/chainer#5997
-       :skipif: os.environ.get('READTHEDOCS') != 'True' \
-           and chainer.testing.is_requires_satisfied( \
+       :skipif: doctest_helper.skipif_requires_satisfied( \
                'Theano<=1.0.3', 'numpy>=1.16.0')
 
        >>> import theano

--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -3,7 +3,6 @@ from chainer.testing.backend import BackendConfig  # NOQA
 from chainer.testing.backend import inject_backend_tests  # NOQA
 from chainer.testing.distribution_test import distribution_unittest  # NOQA
 from chainer.testing.helper import assert_warns  # NOQA
-from chainer.testing.helper import is_requires_satisfied  # NOQA
 from chainer.testing.helper import patch  # NOQA
 from chainer.testing.helper import with_requires  # NOQA
 from chainer.testing.helper import without_requires  # NOQA

--- a/chainer/testing/doctest_helper.py
+++ b/chainer/testing/doctest_helper.py
@@ -1,0 +1,26 @@
+import os
+import pkg_resources
+
+
+_gpu_limit = int(os.getenv('CHAINER_TEST_GPU_LIMIT', '-1'))
+
+
+def skipif(condition):
+    # In the readthedocs build, doctest should never be skipped, because
+    # otherwise the code would disappear from the documentation.
+    if os.environ.get('READTHEDOCS') == 'True':
+        return False
+    return condition
+
+
+def skipif_requires_satisfied(*requirements):
+    ws = pkg_resources.WorkingSet()
+    try:
+        ws.require(*requirements)
+    except pkg_resources.ResolutionError:
+        return False
+    return skipif(True)
+
+
+def skipif_not_enough_cuda_devices(device_count):
+    return skipif(0 <= _gpu_limit < device_count)

--- a/chainer/testing/helper.py
+++ b/chainer/testing/helper.py
@@ -76,24 +76,6 @@ def without_requires(*requirements):
     return unittest.skipIf(skip, msg)
 
 
-def is_requires_satisfied(*requirements):
-    """Returns whether the given requirments are satisfied.
-
-    Args:
-    requirements: A list of string representing the requirements.
-
-    Returns:
-        bool: A boolean indicating whether the given requirements are
-            satisfied.
-    """
-    ws = pkg_resources.WorkingSet()
-    try:
-        ws.require(*requirements)
-    except pkg_resources.ResolutionError:
-        return False
-    return True
-
-
 @contextlib.contextmanager
 def assert_warns(expected):
     with warnings.catch_warnings(record=True) as w:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -354,6 +354,7 @@ from chainer import datasets, iterators, optimizers, serializers
 from chainer import Link, Chain, ChainList
 import chainer.functions as F
 import chainer.links as L
+from chainer.testing import doctest_helper
 from chainer.training import extensions
 import chainerx
 np.random.seed(0)

--- a/docs/source/guides/gpu.rst
+++ b/docs/source/guides/gpu.rst
@@ -23,15 +23,6 @@ After reading this section, you will be able to:
 
    import cupy
 
-.. testcode::
-   :hide:
-
-   try:
-       with cupy.cuda.Device(1):
-           pass
-   except cupy.cuda.runtime.CUDARuntimeError:
-       raise RuntimeError('doctest in this documentation requires 2 GPUs') from None
-
 Relationship between Chainer and CuPy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -76,6 +67,7 @@ The allocation takes place on the current device by default.
 The current device can be changed by :class:`cupy.cuda.Device` object as follows:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    with cupy.cuda.Device(1):
        x_on_gpu1 = cupy.array([1, 2, 3, 4, 5])
@@ -87,6 +79,7 @@ Chainer provides some convenient functions to automatically switch and choose th
 For example, the :func:`chainer.backends.cuda.to_gpu` function copies a :class:`numpy.ndarray` object to a specified device:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    x_cpu = np.ones((5, 4, 3), dtype=np.float32)
    x_gpu = cuda.to_gpu(x_cpu, device=1)
@@ -94,6 +87,7 @@ For example, the :func:`chainer.backends.cuda.to_gpu` function copies a :class:`
 It is equivalent to the following code using CuPy:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    x_cpu = np.ones((5, 4, 3), dtype=np.float32)
    with cupy.cuda.Device(1):
@@ -102,12 +96,14 @@ It is equivalent to the following code using CuPy:
 Moving a device array to the host can be done by :func:`chainer.backends.cuda.to_cpu` as follows:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    x_cpu = cuda.to_cpu(x_gpu)
 
 It is equivalent to the following code using CuPy:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    with x_gpu.device:
        x_cpu = x_gpu.get()
@@ -129,6 +125,7 @@ The dummy device object also supports *with* statements like the above example b
 Here are some other examples:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    cuda.get_device_from_id(1).use()
    x_gpu1 = cupy.empty((4, 3), dtype=cupy.float32)
@@ -371,6 +368,7 @@ The :meth:`Link.to_gpu` method runs in place, so we cannot use it to make a copy
 In order to make a copy, we can use :meth:`Link.copy` method.
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    model_1 = model_0.copy()
    model_0.to_gpu(0)
@@ -382,6 +380,7 @@ The :meth:`Link.copy` method copies the link into another instance.
 Then, set up an optimizer:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    optimizer = optimizers.SGD()
    optimizer.setup(model_0)
@@ -392,6 +391,7 @@ Before its update, gradients of ``model_1`` must be aggregated to those of ``mod
 Then, we can write a data-parallel learning loop as follows:
 
 .. testcode::
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    batchsize = 100
    datasize = len(x_train)
@@ -423,6 +423,7 @@ Then, we can write a data-parallel learning loop as follows:
 
 .. testoutput::
    :hide:
+   :skipif: doctest_helper.skipif_not_enough_cuda_devices(2)
 
    epoch 0
    ...


### PR DESCRIPTION
Currently doctest can't be run on a single-GPU environment.
As we have increased the required sphinx version in #6001, we can use `:skipif:` option now.

I think `testing.is_requires_satisfied()` can be removed in favor of `doctest_helper.skipif_requires_satisfied()`. It has not been released yet.
