### PR TITLE
Remove `parse_kwargs` from `Variable`

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -165,15 +165,20 @@ def get_array_module(*args):
         on the types of the arguments.
 
     """
-    if chainerx.is_available() or cuda.available:
-        args = [arg.data if isinstance(arg, chainer.variable.Variable) else arg
-                for arg in args]
+    is_chainerx_available = chainerx.is_available()
+    if is_chainerx_available or cuda.available:
+        arrays = []
+        for arg in args:
+            # Unwrap arrays
+            if isinstance(arg, chainer.variable.Variable):
+                array = arg.data
+            else:
+                array = arg
+            if is_chainerx_available and isinstance(array, chainerx.ndarray):
+                return chainerx
+            arrays.append(array)
 
-    if (chainerx.is_available()
-            and any([isinstance(a, chainerx.ndarray) for a in args])):
-        return chainerx
-    elif cuda.available:
-        return cuda.cupy.get_array_module(*args)
+        return cuda.cupy.get_array_module(*arrays)
     else:
         return numpy
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -177,15 +177,12 @@ class VariableNode(object):
     # by an old-style Function
     _old_style_grad_generator = None  # type: str
 
-    _unexpected_kwargs = {
-        "grad": 'unexpected keyword argument "grad": '
-                'pass the gradient to Variable instead'
-    }
-
     def __init__(self, variable, name, **kwargs):
         # type: (Variable, tp.Optional[str], **tp.Any) -> None
-        if kwargs:
-            argument.check_unexpected_kwargs(kwargs, **self._unexpected_kwargs)
+
+        if 'grad' in kwargs:
+            raise ValueError('unexpected keyword argument "grad": '
+                             'pass the gradient to Variable instead')
         self._variable = weakref.ref(variable)
         self.name = name
         self._requires_grad = variable.requires_grad
@@ -509,21 +506,16 @@ class Variable(object):
     # instance.
     _grad = None
 
-    _default_args = [
-        ('name', None),
-        ('grad', None),
-        ('requires_grad', True),
-    ]
-
-    _unexpected_kwargs = {
-        'volatile': 'volatile argument is not supported anymore. '
-                    'Use chainer.using_config'
-    }
-
     def __init__(self, data=None, **kwargs):
         # type: (types.NdArray, **tp.Any) -> None
-        name, grad, requires_grad = argument.parse_kwargs(
-            kwargs, *self._default_args, **self._unexpected_kwargs)
+
+        # retrieve keyword-only arguments
+        name = kwargs.get('name', None)
+        grad = kwargs.get('grad', None)
+        requires_grad = kwargs.get('requires_grad', True)
+        if 'volatile' in kwargs:
+            raise ValueError('volatile argument is not supported anymore. '
+                             'Use chainer.using_config')
         assert isinstance(requires_grad, bool)
         if data is not None:
             array_types = chainer.get_array_types()


### PR DESCRIPTION
`parse_kwargs` is useful functionality but generates non-trivial overhead especially in hotspots. This patch unrolls `parse_kwargs` and place it directly in `Variable`. It also fixes `get_array_module` to reduce the function calls.