### PR TITLE
Add `Variable._init_unchecked()` static method for faster instantiation

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -177,9 +177,8 @@ def get_array_module(*args):
             if is_chainerx_available and isinstance(array, chainerx.ndarray):
                 return chainerx
             arrays.append(array)
-        else:
-            if cuda.available:
-                return cuda.cupy.get_array_module(*arrays)
+        if cuda.available:
+            return cuda.cupy.get_array_module(*arrays)
     return numpy
 
 

--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -165,15 +165,20 @@ def get_array_module(*args):
         on the types of the arguments.
 
     """
-    if chainerx.is_available() or cuda.available:
-        args = [arg.data if isinstance(arg, chainer.variable.Variable) else arg
-                for arg in args]
+    is_chainerx_available = chainerx.is_available()
+    if is_chainerx_available or cuda.available:
+        arrays = []
+        for arg in args:
+            # Unwrap arrays
+            if isinstance(arg, chainer.variable.Variable):
+                array = arg.data
+            else:
+                array = arg
+            if is_chainerx_available and isinstance(array, chainerx.ndarray):
+                return chainerx
+            arrays.append(array)
 
-    if (chainerx.is_available()
-            and any([isinstance(a, chainerx.ndarray) for a in args])):
-        return chainerx
-    elif cuda.available:
-        return cuda.cupy.get_array_module(*args)
+        return cuda.cupy.get_array_module(*arrays)
     else:
         return numpy
 

--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -177,10 +177,10 @@ def get_array_module(*args):
             if is_chainerx_available and isinstance(array, chainerx.ndarray):
                 return chainerx
             arrays.append(array)
-
-        return cuda.cupy.get_array_module(*arrays)
-    else:
-        return numpy
+        else:
+            if cuda.available:
+                return cuda.cupy.get_array_module(*arrays)
+    return numpy
 
 
 def get_device_from_array(*arrays):

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -273,7 +273,7 @@ Use apply() method instead.\
                 # Supported. Wrap with variables and return
                 assert isinstance(outputs, tuple)
                 return tuple([
-                    variable.Variable(
+                    variable.ChainerxVariable(
                         y, requires_grad=y.is_backprop_required())
                     for y in outputs])
 

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -273,8 +273,9 @@ Use apply() method instead.\
                 # Supported. Wrap with variables and return
                 assert isinstance(outputs, tuple)
                 return tuple([
-                    variable.ChainerxVariable(
-                        y, requires_grad=y.is_backprop_required())
+                    variable.UnsafeVariable(
+                        y, requires_grad=y.is_backprop_required(),
+                        is_chainerx_array=True)
                     for y in outputs])
 
             # Fall back to FunctionNode.forward()

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -273,7 +273,7 @@ Use apply() method instead.\
                 # Supported. Wrap with variables and return
                 assert isinstance(outputs, tuple)
                 return tuple([
-                    variable._unsafe_variable(
+                    variable.Variable._init_unchecked(
                         y, requires_grad=y.is_backprop_required(),
                         is_chainerx_array=True)
                     for y in outputs])

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -273,7 +273,7 @@ Use apply() method instead.\
                 # Supported. Wrap with variables and return
                 assert isinstance(outputs, tuple)
                 return tuple([
-                    variable.UnsafeVariable(
+                    variable._unsafe_variable(
                         y, requires_grad=y.is_backprop_required(),
                         is_chainerx_array=True)
                     for y in outputs])

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -305,7 +305,8 @@ class UpdateRule(object):
             param._chainerx_fallback_array = backend.from_chainerx(
                 param.array)
 
-        temp_param = variable.Variable(param._chainerx_fallback_array)
+        temp_param = variable.NonChainerxVariable(
+            param._chainerx_fallback_array)
 
         if grad_array is not None:
             temp_param._set_grad_without_check(

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -305,8 +305,8 @@ class UpdateRule(object):
             param._chainerx_fallback_array = backend.from_chainerx(
                 param.array)
 
-        temp_param = variable.NonChainerxVariable(
-            param._chainerx_fallback_array)
+        temp_param = variable.UnsafeVariable(
+            param._chainerx_fallback_array, is_chainerx_array=False)
 
         if grad_array is not None:
             temp_param._set_grad_without_check(

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -305,7 +305,7 @@ class UpdateRule(object):
             param._chainerx_fallback_array = backend.from_chainerx(
                 param.array)
 
-        temp_param = variable.UnsafeVariable(
+        temp_param = variable._unsafe_variable(
             param._chainerx_fallback_array, is_chainerx_array=False)
 
         if grad_array is not None:

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -305,7 +305,7 @@ class UpdateRule(object):
             param._chainerx_fallback_array = backend.from_chainerx(
                 param.array)
 
-        temp_param = variable._unsafe_variable(
+        temp_param = variable.Variable._init_unchecked(
             param._chainerx_fallback_array, is_chainerx_array=False)
 
         if grad_array is not None:

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -538,7 +538,10 @@ class Variable(object):
 
         self._init_attrs(data, name, grad, requires_grad, None)
 
-    def _init_attrs(self, data, name, grad, requires_grad, is_chainerx_array):
+    def _init_attrs(self,
+                    data, name, grad, requires_grad, is_chainerx_array):
+        # type: (tp.Optional[types.NdArray], tp.Optional[str], tp.Optional[types.NdArray], bool, tp.Optional[bool]) -> Variable # NOQA
+
         # Use a list as a data structure to hold the data array indirectly to
         # abstract its initialized/uninitialized state.
 
@@ -1597,24 +1600,24 @@ def _backprop_to_all(outputs, retain_grad, loss_scale):
     grads.assert_no_grads()
 
 
-class UnsafeVariable(Variable):
-    """A :class:`Variable` without the validations for optimizing performance.
+def _unsafe_variable(data, name=None, grad=None, requires_grad=True,
+                     is_chainerx_array=None):
+    # type: (tp.Optional[types.NdArray], tp.Optional[str], tp.Optional[types.NdArray], bool, tp.Optional[bool]) -> Variable # NOQA
+    """Create a new :class:`Variable` without the validations for optimizing
+    performance.
 
-    This is implementation details in the framework. You MUST use Variable
-    instead.
+    This is implementation details in the framework. You MUST use Variable's
+    constructor instead.
     """
-    def __init__(self, data=None, name=None, grad=None, requires_grad=True,
-                 is_chainerx_array=None):
-        # type: (tp.Optional[types.NdArray], tp.Optional[str], tp.Optional[types.NdArray], bool, tp.Optional[bool]) -> None # NOQA
 
-        # This is a specialized constructor which skips the validations.
-        self._init_attrs(data, name, grad, requires_grad, is_chainerx_array)
+    # Create a Variable without invoking __init__
+    var = Variable.__new__(Variable)
+    var._init_attrs(data, name, grad, requires_grad, is_chainerx_array)
 
-    def __copy__(self):
-        return self._copy_to(UnsafeVariable())
+    return var
 
 
-class Parameter(UnsafeVariable):
+class Parameter(Variable):
 
     """Parameter variable that can be registered to a link.
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1498,6 +1498,19 @@ class Variable(object):
 
 
 class ChainerxVariable(Variable):
+    """A :class:`Variable` for ChainerX arrays.
+
+    This is implementation details in the framework. The constructor of
+    Variable generates it when you pass :class:`chainerx.ndarray` to
+    data argument. You SHOULD NOT use it directly.
+    """
+
+    # Use the default implementation explicitly to increase the performance
+    def __new__(cls, *args, **kwargs):
+        # type: (tp.Type["ChainerxVariable"], *tp.Any, **tp.Any) -> "ChainerxVariable" # NOQA
+
+        return super(Variable, cls).__new__(cls)
+
     def __init__(self, data=None, name=None, grad=None, requires_grad=True):
         # type: (tp.Optional[chainerx.ndarray], tp.Optional[str], tp.Optional[chainerx.ndarray], bool) -> None # NOQA
 
@@ -1675,6 +1688,12 @@ class Parameter(Variable):
     initializer = None  # type: tp.Optional[tp.Union[tp.Optional[types.AbstractInitializer], types.NdArray]] # NOQA
     # TODO(okapies): fix the behavior when shape is None and remove NdArray
     _grad_initializer = None  # type: tp.Optional[types.AbstractInitializer]
+
+    # Use the default implementation explicitly to increase the performance
+    def __new__(cls, *args, **kwargs):
+        # type: (tp.Type["Parameter"], *tp.Any, **tp.Any) -> "Parameter" # NOQA
+
+        return super(Variable, cls).__new__(cls)
 
     def __init__(self, initializer=None, shape=None, name=None):
         # type: (tp.Optional[types.InitializerSpec], tp.Optional[types.ShapeSpec], tp.Optional[str]) -> None # NOQA

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -531,11 +531,8 @@ class Variable(object):
     def _init_unchecked(data=None, name=None, grad=None, requires_grad=True,
                         is_chainerx_array=None):
         # type: (tp.Optional[types.NdArray], tp.Optional[str], tp.Optional[types.NdArray], bool, tp.Optional[bool]) -> Variable # NOQA
-        """Create a new :class:`Variable` without the validations for
+        """Creates a new :class:`Variable` without the validations for
         optimizing performance.
-
-        This is implementation details in the framework. You MUST use
-        the Variable's constructor instead.
         """
 
         # Create a Variable without invoking __init__

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -540,7 +540,7 @@ class Variable(object):
 
     def _init_attrs(self,
                     data, name, grad, requires_grad, is_chainerx_array):
-        # type: (tp.Optional[types.NdArray], tp.Optional[str], tp.Optional[types.NdArray], bool, tp.Optional[bool]) -> Variable # NOQA
+        # type: (tp.Optional[types.NdArray], tp.Optional[str], tp.Optional[types.NdArray], bool, tp.Optional[bool]) -> None # NOQA
 
         # Use a list as a data structure to hold the data array indirectly to
         # abstract its initialized/uninitialized state.
@@ -558,7 +558,7 @@ class Variable(object):
                 raise ValueError(
                     'Cannot initialize a variable with gradients if the '
                     'require_grad argument is False.')
-            self._set_chainerx_array(data, grad)
+            self._set_chainerx_array(data, grad)  # type: ignore
 
             # ChainerX itself has own node objects, but not exposed to python.
             self._node = None  # type: tp.Optional[VariableNode]

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -211,15 +211,15 @@ class TestVariable(unittest.TestCase):
 
     def test_unsafe_init(self):
         a = np.asarray(self.x)
-        x = chainer.variable.UnsafeVariable(a)
+        x = chainer.variable._unsafe_variable(a)
         np.testing.assert_array_equal(x.array, a)
-        assert isinstance(x.node(), chainer.variable.VariableNode)
+        assert isinstance(x.node, chainer.variable.VariableNode)
 
     def test_unsafe_init_explicit(self):
         a = np.asarray(self.x)
-        x = chainer.variable.UnsafeVariable(a, is_chainerx_array=False)
+        x = chainer.variable._unsafe_variable(a, is_chainerx_array=False)
         np.testing.assert_array_equal(x.array, a)
-        assert isinstance(x.node(), chainer.variable.VariableNode)
+        assert isinstance(x.node, chainer.variable.VariableNode)
 
     @attr.chainerx
     def test_chainerx_init(self):
@@ -227,23 +227,23 @@ class TestVariable(unittest.TestCase):
         x = chainer.Variable(a)
         chainerx.testing.assert_array_equal(x.array, a)
         with pytest.raises(RuntimeError):
-            x.node()
+            x.node
 
     @attr.chainerx
     def test_unsafe_chainerx_init(self):
         a = chainerx.asarray(self.x)
-        x = chainer.variable.UnsafeVariable(a)
+        x = chainer.variable._unsafe_variable(a)
         chainerx.testing.assert_array_equal(x.array, a)
         with pytest.raises(RuntimeError):
-            x.node()
+            x.node
 
     @attr.chainerx
     def test_unsafe_chainerx_init_explicit(self):
         a = chainerx.asarray(self.x)
-        x = chainer.variable.UnsafeVariable(a, is_chainerx_array=True)
+        x = chainer.variable._unsafe_variable(a, is_chainerx_array=True)
         chainerx.testing.assert_array_equal(x.array, a)
         with pytest.raises(RuntimeError):
-            x.node()
+            x.node
 
     def check_attributes(self, xp):
         a = get_array(xp, self.x)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -209,15 +209,15 @@ class TestVariable(unittest.TestCase):
         self.size = int(np.prod(self.x_shape))
         self.c = np.arange(self.size).reshape(self.c_shape).astype(np.float32)
 
-    def test_unsafe_init(self):
+    def test_init_unchecked(self):
         a = np.asarray(self.x)
-        x = chainer.variable._unsafe_variable(a)
+        x = chainer.Variable._init_unchecked(a)
         np.testing.assert_array_equal(x.array, a)
         assert isinstance(x.node, chainer.variable.VariableNode)
 
-    def test_unsafe_init_explicit(self):
+    def test_init_unchecked_explicit(self):
         a = np.asarray(self.x)
-        x = chainer.variable._unsafe_variable(a, is_chainerx_array=False)
+        x = chainer.Variable._init_unchecked(a, is_chainerx_array=False)
         np.testing.assert_array_equal(x.array, a)
         assert isinstance(x.node, chainer.variable.VariableNode)
 
@@ -230,17 +230,17 @@ class TestVariable(unittest.TestCase):
             x.node
 
     @attr.chainerx
-    def test_unsafe_chainerx_init(self):
+    def test_chainerx_init_unchecked(self):
         a = chainerx.asarray(self.x)
-        x = chainer.variable._unsafe_variable(a)
+        x = chainer.Variable._init_unchecked(a)
         chainerx.testing.assert_array_equal(x.array, a)
         with pytest.raises(RuntimeError):
             x.node
 
     @attr.chainerx
-    def test_unsafe_chainerx_init_explicit(self):
+    def test_chainerx_init_unchecked_explicit(self):
         a = chainerx.asarray(self.x)
-        x = chainer.variable._unsafe_variable(a, is_chainerx_array=True)
+        x = chainer.Variable._init_unchecked(a, is_chainerx_array=True)
         chainerx.testing.assert_array_equal(x.array, a)
         with pytest.raises(RuntimeError):
             x.node

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -209,11 +209,41 @@ class TestVariable(unittest.TestCase):
         self.size = int(np.prod(self.x_shape))
         self.c = np.arange(self.size).reshape(self.c_shape).astype(np.float32)
 
+    def test_unsafe_init(self):
+        a = np.asarray(self.x)
+        x = chainer.variable.UnsafeVariable(a)
+        np.testing.assert_array_equal(x.array, a)
+        assert isinstance(x.node(), chainer.variable.VariableNode)
+
+    def test_unsafe_init_explicit(self):
+        a = np.asarray(self.x)
+        x = chainer.variable.UnsafeVariable(a, is_chainerx_array=False)
+        np.testing.assert_array_equal(x.array, a)
+        assert isinstance(x.node(), chainer.variable.VariableNode)
+
     @attr.chainerx
     def test_chainerx_init(self):
         a = chainerx.asarray(self.x)
         x = chainer.Variable(a)
         chainerx.testing.assert_array_equal(x.array, a)
+        with pytest.raises(RuntimeError):
+            x.node()
+
+    @attr.chainerx
+    def test_unsafe_chainerx_init(self):
+        a = chainerx.asarray(self.x)
+        x = chainer.variable.UnsafeVariable(a)
+        chainerx.testing.assert_array_equal(x.array, a)
+        with pytest.raises(RuntimeError):
+            x.node()
+
+    @attr.chainerx
+    def test_unsafe_chainerx_init_explicit(self):
+        a = chainerx.asarray(self.x)
+        x = chainer.variable.UnsafeVariable(a, is_chainerx_array=True)
+        chainerx.testing.assert_array_equal(x.array, a)
+        with pytest.raises(RuntimeError):
+            x.node()
 
     def check_attributes(self, xp):
         a = get_array(xp, self.x)


### PR DESCRIPTION
`parse_kwargs` is essential for our user's experience but generates non-trivial overhead especially in hotspots. One problem is that this validation mechanism is hard to optimize or remove as discussed in #6030.

This patch introduces `_unsafe_variable`, which is an optimized factory method of `Variable` only for internal use. It skips the validation to reduce the overhead generated in the framework like `FunctionNode.apply` ([here](https://github.com/chainer/chainer/blob/88d0d1ae50d7fc2592672c19d9f639406873c42f/chainer/function_node.py#L275-L278)) and `UpdateRule.update_core_chainerx` ([here](https://github.com/chainer/chainer/blob/88d0d1ae50d7fc2592672c19d9f639406873c42f/chainer/optimizer.py#L308)).

It also fixes `get_array_module` to reduce the number of function calls.

Note: It is renamed to `Variable._init_unchecked()`.

## Benchmarks of `Variable` constructors
- number of calls: `10000000`
- device: `native:0`
- batch size: `1`
- require_grad: `False`

The script is [here](https://gist.github.com/okapies/207001ce67994fc7bd02736ef232aaab).

## `data` is `chainerx.ndarray`
| | `Variable` | `_unsafe_variable` |
|:--|:--|:--|
| current | 49.95680534094572 | - |
| *this* | 43.18582313135266 | 31.15744174271822 |

## `data` is `numpy.ndarray`
| | `Variable` | `_unsafe_variable` |
|:--|:--|:--|
| current | 38.3368557356298 | - |
| *this* | 32.35968181490898 | 19.19199386611581 |
