### PR TITLE
Fix chainermn tests

### DIFF
--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -300,6 +300,9 @@ class TestPureNcclCommunicator(unittest.TestCase):
 class TestDifferentDtype(unittest.TestCase):
 
     def setup(self, gpu):
+        if self.communicator.size != 2:
+            pytest.skip('This test is for two processes')
+
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
             self.device = self.communicator.rank
@@ -307,9 +310,6 @@ class TestDifferentDtype(unittest.TestCase):
         else:
             self.communicator = chainermn.create_communicator('naive')
             self.device = -1
-
-        if self.communicator.size != 2:
-            pytest.skip('This test is for two processes')
 
         # dtypes to be tested
         # DO NOT USE chainer.testing.parameterize
@@ -562,6 +562,9 @@ class TestDifferentDtype(unittest.TestCase):
 class TestNonContiguousArray(unittest.TestCase):
 
     def setup(self, gpu):
+        if self.communicator.size != 2:
+            pytest.skip('This test is for two processes')
+            
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
             self.device = self.communicator.rank
@@ -569,9 +572,6 @@ class TestNonContiguousArray(unittest.TestCase):
         else:
             self.communicator = chainermn.create_communicator('naive')
             self.device = -1
-
-        if self.communicator.size != 2:
-            pytest.skip('This test is for two processes')
 
     def check_send(self):
         if self.communicator.rank == 0:

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -302,17 +302,14 @@ class TestDifferentDtype(unittest.TestCase):
     def setup(self, gpu):
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
+            self.device = self.communicator.intra_rank
+            chainer.cuda.get_device_from_id(self.device).use()
         else:
             self.communicator = chainermn.create_communicator('naive')
+            self.device = -1
 
         if self.communicator.size != 2:
             pytest.skip('This test is for two processes')
-
-        if gpu:
-            self.device = self.communicator.rank
-            chainer.cuda.get_device_from_id(self.device).use()
-        else:
-            self.device = -1
 
         # dtypes to be tested
         # DO NOT USE chainer.testing.parameterize
@@ -567,17 +564,14 @@ class TestNonContiguousArray(unittest.TestCase):
     def setup(self, gpu):
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
+            self.device = self.communicator.intra_rank
+            chainer.cuda.get_device_from_id(self.device).use()
         else:
             self.communicator = chainermn.create_communicator('naive')
+            self.device = -1
 
         if self.communicator.size != 2:
             pytest.skip('This test is for two processes')
-
-        if gpu:
-            self.device = self.communicator.rank
-            chainer.cuda.get_device_from_id(self.device).use()
-        else:
-            self.device = -1
 
     def check_send(self):
         if self.communicator.rank == 0:

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -300,15 +300,18 @@ class TestPureNcclCommunicator(unittest.TestCase):
 class TestDifferentDtype(unittest.TestCase):
 
     def setup(self, gpu):
+        if gpu:
+            self.communicator = chainermn.create_communicator('hierarchical')
+        else:
+            self.communicator = chainermn.create_communicator('naive')
+
         if self.communicator.size != 2:
             pytest.skip('This test is for two processes')
 
         if gpu:
-            self.communicator = chainermn.create_communicator('hierarchical')
             self.device = self.communicator.rank
             chainer.cuda.get_device_from_id(self.device).use()
         else:
-            self.communicator = chainermn.create_communicator('naive')
             self.device = -1
 
         # dtypes to be tested
@@ -562,15 +565,18 @@ class TestDifferentDtype(unittest.TestCase):
 class TestNonContiguousArray(unittest.TestCase):
 
     def setup(self, gpu):
-        if self.communicator.size != 2:
-            pytest.skip('This test is for two processes')
-            
         if gpu:
             self.communicator = chainermn.create_communicator('hierarchical')
+        else:
+            self.communicator = chainermn.create_communicator('naive')
+
+        if self.communicator.size != 2:
+            pytest.skip('This test is for two processes')
+
+        if gpu:
             self.device = self.communicator.rank
             chainer.cuda.get_device_from_id(self.device).use()
         else:
-            self.communicator = chainermn.create_communicator('naive')
             self.device = -1
 
     def check_send(self):

--- a/tests/chainermn_tests/conftest.py
+++ b/tests/chainermn_tests/conftest.py
@@ -1,0 +1,17 @@
+import multiprocessing
+import platform
+import pytest
+
+
+def dummy_func():
+    pass
+
+
+@pytest.fixture(scope='session', autouse=True)
+def scope_session():
+    if int(platform.python_version_tuple()[0]) >= 3:
+        multiprocessing.set_start_method('forkserver')
+        p = multiprocessing.Process(target=dummy_func)
+        p.start()
+        p.join()
+    yield


### PR DESCRIPTION
This PR fixes chainermn tests.
The causes of the chainermn test clash are here
1.  use `MultiprocessIterator` without forkserver
2. Test skip mistake
