### PR TITLE
Add NOLINT to reinterpret cast

### DIFF
--- a/chainerx_cc/chainerx/python/cuda/cuda_module.cc
+++ b/chainerx_cc/chainerx/python/cuda/cuda_module.cc
@@ -36,9 +36,9 @@ void Free(void* param, void* ptr, int device_id) {
 
 std::tuple<intptr_t, intptr_t, intptr_t> GetCAllocator() {
     return std::make_tuple(
-            reinterpret_cast<intptr_t>(&GetBackend("cuda")),  // NOLINT(cppcoreguidelines-cppcoreguidelines);
-            reinterpret_cast<intptr_t>(&Malloc),  // NOLINT(cppcoreguidelines-cppcoreguidelines);
-            reinterpret_cast<intptr_t>(&Free));  // NOLINT(cppcoreguidelines-cppcoreguidelines);
+            reinterpret_cast<intptr_t>(&GetBackend("cuda")),  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+            reinterpret_cast<intptr_t>(&Malloc),  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+            reinterpret_cast<intptr_t>(&Free));  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 }
 
 void InitChainerxCudaModule(py::module& m) {


### PR DESCRIPTION
Fixes `NOLINT` comment for a couple of `reinterpret_cast`s.