### PR TITLE
Limit the length of parameterized test class name

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -9,11 +9,37 @@ from chainer.testing import _bundle
 from chainer import utils
 
 
+def _shorten(s, maxlen):
+    # Shortens the string down to maxlen, by replacing the middle part with
+    # a 3-dots string '...'.
+    ellipsis = '...'
+    if len(s) <= maxlen:
+        return s
+    n1 = (maxlen - len(ellipsis)) // 2
+    n2 = maxlen - len(ellipsis) - n1
+    s = s[:n1] + ellipsis + s[-n2:]
+    assert len(s) == maxlen
+    return s
+
+
+def _make_class_name(base_class_name, i_param, param):
+    # Creates a class name for a single combination of parameters.
+    SINGLE_PARAM_MAXLEN = 100  # Length limit of a single parameter value
+    PARAMS_MAXLEN = 5000  # Length limit of the whole parameters part
+    param_strs = [
+        '{}={}'.format(k, _shorten(repr(v), SINGLE_PARAM_MAXLEN))
+        for k, v in param.items()]
+    param_strs = _shorten(', '.join(param_strs), PARAMS_MAXLEN)
+    cls_name = '{}_param_{}_{{{}}}'.format(
+        base_class_name, i_param, param_strs)
+    return cls_name
+
+
 def _parameterize_test_case_generator(base, params):
     # Defines the logic to generate parameterized test case classes.
 
     for i, param in enumerate(params):
-        cls_name = '{}_param_{}_{}'.format(base.__name__, i, param)
+        cls_name = _make_class_name(base.__name__, i, param)
 
         def __str__(self):
             name = base.__str__(self)


### PR DESCRIPTION
Fixes #6059.
The format and the hard limits are rather arbitrarily decided by intuition.
Perhaps there's room for discussion (or not).

`tests/chainer_tests/datasets_tests/test_concatenated_dataset.py`
```
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_0_{datasets=(array([[[[9.00619850e-01, 9.99080770e-01, 9.010....87048914,
          0.76144522, 0.80512511]]]]))}::test_concatenated_dataset PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_0_{datasets=(array([[[[9.00619850e-01, 9.99080770e-01, 9.010....87048914,
          0.76144522, 0.80512511]]]]))}::test_concatenated_dataset_slice PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_1_{datasets=(array([[[[0.38453422, 0.25592714, 0.21958553, ....5959013, 0.27877607, 0.37860692, 0.20639832]]]]))}::test_concatenated_dataset PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_1_{datasets=(array([[[[0.38453422, 0.25592714, 0.21958553, ....5959013, 0.27877607, 0.37860692, 0.20639832]]]]))}::test_concatenated_dataset_slice PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_2_{datasets=(array([[[[3.57292989e-01, 9.92439457e-02, 7.764...024883e-01, 4.75054798e-01, 4.68462232e-01]]]]),)}::test_concatenated_dataset PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_2_{datasets=(array([[[[3.57292989e-01, 9.92439457e-02, 7.764...024883e-01, 4.75054798e-01, 4.68462232e-01]]]]),)}::test_concatenated_dataset_slice PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_3_{datasets=()}::test_concatenated_dataset PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_3_{datasets=()}::test_concatenated_dataset_slice PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_4_{datasets=(array([[[[0.08670999, 0.27559199, 0.57571247, ....49 , 0.01821577, 0.06505648, 0.94988416]]]]), [])}::test_concatenated_dataset PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_4_{datasets=(array([[[[0.08670999, 0.27559199, 0.57571247, ....49 , 0.01821577, 0.06505648, 0.94988416]]]]), [])}::test_concatenated_dataset_slice PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_5_{datasets=([], [], [])}::test_concatenated_dataset PASSED
tests/chainer_tests/datasets_tests/test_concatenated_dataset.py::TestConcatenatedDataset_param_5_{datasets=([], [], [])}::test_concatenated_dataset_slice PASSED
```