### PR TITLE
Fix manifest typos

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,8 @@ include LICENSE
 
 graft chainerx
 include chainerx_build_helper.py
-include chainerx_cc/README.txt
-include chainerx_cc/LINCENSE.txt
+include chainerx_cc/README.md
+include chainerx_cc/LICENSE.txt
 include chainerx_cc/CMakeLists.txt
 graft chainerx_cc/chainerx
 graft chainerx_cc/third_party


### PR DESCRIPTION
Fixing:

```
➜  Chainer git:(master) python setup.py build install > /dev/null
warning: no files found matching 'chainerx_cc/README.txt'
warning: no files found matching 'chainerx_cc/LINCENSE.txt'
```