### PR TITLE
[WIP] Fix Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,11 @@ install:
   - travis_wait bash scripts/ci/travis/run-tests.sh install
 
 script:
-  - bash scripts/ci/travis/run-tests.sh script
+  - bash scripts/ci/travis/run-tests.sh script 1
+  - bash scripts/ci/travis/run-tests.sh script 2
+  - bash scripts/ci/travis/run-tests.sh script 3
+  - bash scripts/ci/travis/run-tests.sh script 4
+  - bash scripts/ci/travis/run-tests.sh script 5
 
 addons:
   apt:

--- a/scripts/ci/travis/run-tests.sh
+++ b/scripts/ci/travis/run-tests.sh
@@ -9,7 +9,10 @@ phase="$1"
 
 # Check phase argument
 case "$phase" in
-    before_install|install|script)
+    before_install|install)
+        ;;
+    script)
+        step_num="$2"
         ;;
     *)
         echo "Unknown phase: ${phase}" >&2
@@ -243,8 +246,10 @@ case "${CHAINER_TRAVIS_TEST}" in
                 run_step python_mypy_check_deps
             ;;
             script)
-                run_step python_style_check
-                run_step python_mypy_check
+                case "$step_num" in
+                    1) run_step python_style_check ;;
+                    2) run_step python_mypy_check ;;
+                esac
             ;;
         esac
         ;;
@@ -258,12 +263,13 @@ case "${CHAINER_TRAVIS_TEST}" in
                 run_step install_chainerx_style_check_deps
             ;;
             script)
-                run_step chainerx_cpplint
-                run_step chainerx_clang_format
-
-                run_step chainerx_cmake  # cmake is required for clang-tidy
-                run_step chainerx_clang_tidy normal
-                run_step chainerx_clang_tidy test
+                case "$step_num" in
+                    1) run_step chainerx_cpplint ;;
+                    2) run_step chainerx_clang_format ;;
+                    3) run_step chainerx_cmake ;;  # cmake is required for clang-tidy
+                    4) run_step chainerx_clang_tidy normal ;;
+                    5) run_step chainerx_clang_tidy test ;;
+                esac
             ;;
         esac
         ;;
@@ -285,16 +291,19 @@ case "${CHAINER_TRAVIS_TEST}" in
                 ;;
 
             script)
-                run_step chainer_install_from_sdist
-                run_step chainer_tests
-                run_step chainermn_tests
-
-                if [[ $SKIP_CHAINERX != 1 ]]; then
-                    CHAINER_DOCS_SKIP_LINKCODE=1 \
-                        run_step docs
-                else
-                    echo "Documentation build is skipped as ChainerX is not available.";
-                fi
+                case "$step_num" in
+                    1) run_step chainer_install_from_sdist ;;
+                    2) run_step chainer_tests ;;
+                    3) run_step chainermn_tests ;;
+                    4)
+                        if [[ $SKIP_CHAINERX != 1 ]]; then
+                            CHAINER_DOCS_SKIP_LINKCODE=1 \
+                                run_step docs
+                        else
+                            echo "Documentation build is skipped as ChainerX is not available.";
+                        fi
+                        ;;
+                esac
                 ;;
         esac
         ;;

--- a/scripts/ci/travis/run-tests.sh
+++ b/scripts/ci/travis/run-tests.sh
@@ -21,16 +21,11 @@ esac
 # Assign default values
 : "${MATRIX_EVAL:=}"
 : "${SKIP_CHAINERX:=0}"
-: "${CHAINER_TEST_STATUS:=0}"
 
 DEFAULT_JOBS=2
 REPO_DIR="$TRAVIS_BUILD_DIR"
 WORK_DIR="$TRAVIS_BUILD_DIR"/_workspace
 mkdir -p "$WORK_DIR"
-
-# Env script which is sourced before each step
-CHAINER_BASH_ENV="$WORK_DIR"/_chainer_bash_env
-touch "$CHAINER_BASH_ENV"
 
 
 # Test step definitions
@@ -217,8 +212,6 @@ step_chainerx_cmake() {
         -DCMAKE_INSTALL_PREFIX="$WORK_DIR"/install_target \
         "$REPO_DIR"/chainerx_cc
     popd
-
-    echo "CHAINERX_BUILD_DIR=\"$CHAINERX_BUILD_DIR\"" >> "$CHAINER_BASH_ENV"
 }
 
 
@@ -231,29 +224,12 @@ step_chainerx_clang_tidy() {
 }
 
 
-run_prestep() {
-    # Failure immediately stops the script.
-
+run_step() {
     step="$1"
     shift
     echo "=== Step: $step $@"
-
-    source "$CHAINER_BASH_ENV"
 
     step_"$step" "$@"
-}
-
-
-run_step() {
-    # In case of failure, CHAINER_TEST_STATUS is incremented by 1.
-
-    step="$1"
-    shift
-    echo "=== Step: $step $@"
-
-    source "$CHAINER_BASH_ENV"
-
-    step_"$step" "$@" || CHAINER_TEST_STATUS=$((CHAINER_TEST_STATUS + 1))
 }
 
 
@@ -276,17 +252,16 @@ case "${CHAINER_TRAVIS_TEST}" in
     "c-static-check")
         case "$phase" in
             before_install)
-                run_prestep before_install_chainerx_style_check_deps
+                run_step before_install_chainerx_style_check_deps
             ;;
             install)
-                run_prestep install_chainerx_style_check_deps
-
-                run_prestep chainerx_cmake  # cmake is required for clang-tidy
+                run_step install_chainerx_style_check_deps
             ;;
             script)
                 run_step chainerx_cpplint
                 run_step chainerx_clang_format
 
+                run_step chainerx_cmake  # cmake is required for clang-tidy
                 run_step chainerx_clang_tidy normal
                 run_step chainerx_clang_tidy test
             ;;
@@ -297,21 +272,20 @@ case "${CHAINER_TRAVIS_TEST}" in
         case "$phase" in
             before_install)
                 eval "${MATRIX_EVAL}"
-                run_prestep before_install_chainer_test
-                run_prestep before_install_chainermn_test_deps
+                run_step before_install_chainer_test
+                run_step before_install_chainermn_test_deps
                 ;;
 
             install)
                 pip install -U pip wheel
 
-                run_prestep install_chainer_test_deps
-                run_prestep install_chainer_docs_deps
-                run_prestep install_chainermn_test_deps
-
-                run_prestep chainer_install_from_sdist
+                run_step install_chainer_test_deps
+                run_step install_chainer_docs_deps
+                run_step install_chainermn_test_deps
                 ;;
 
             script)
+                run_step chainer_install_from_sdist
                 run_step chainer_tests
                 run_step chainermn_tests
 
@@ -329,6 +303,3 @@ case "${CHAINER_TRAVIS_TEST}" in
         exit 1
         ;;
 esac
-
-# In "script" phases, the number of failed steps is assigned to this variable.
-exit $CHAINER_TEST_STATUS

--- a/scripts/ci/travis/run-tests.sh
+++ b/scripts/ci/travis/run-tests.sh
@@ -2,7 +2,7 @@
 # This script defines CI steps to be run in Travis CI.
 # TODO(niboshi): Definitions of the steps could be merged with scripts/ci/steps.sh.
 
-set -eux
+set -eu
 
 
 phase="$1"
@@ -202,7 +202,7 @@ step_chainerx_clang_format() {
 
 
 step_chainerx_cmake() {
-    CHAINERX_BUILD_DIR="$WORK_DIR"/chainerx_build
+    export CHAINERX_BUILD_DIR="$WORK_DIR"/chainerx_build
     mkdir -p "$CHAINERX_BUILD_DIR"
     pushd "$CHAINERX_BUILD_DIR"
 
@@ -231,7 +231,7 @@ run_step() {
     step="$1"
     shift
     echo "=== Step: $step $@"
-
+    set -x
     step_"$step" "$@"
 }
 

--- a/scripts/ci/travis/run-tests.sh
+++ b/scripts/ci/travis/run-tests.sh
@@ -28,6 +28,7 @@ esac
 DEFAULT_JOBS=2
 REPO_DIR="$TRAVIS_BUILD_DIR"
 WORK_DIR="$TRAVIS_BUILD_DIR"/_workspace
+CHAINERX_BUILD_DIR="$WORK_DIR"/chainerx_build
 mkdir -p "$WORK_DIR"
 
 
@@ -202,7 +203,6 @@ step_chainerx_clang_format() {
 
 
 step_chainerx_cmake() {
-    export CHAINERX_BUILD_DIR="$WORK_DIR"/chainerx_build
     mkdir -p "$CHAINERX_BUILD_DIR"
     pushd "$CHAINERX_BUILD_DIR"
 


### PR DESCRIPTION
The current script only checks last lines of steps, because `set -e` is ignored.

> The -e setting shall be ignored when executing the compound list following the while, until, if, or elif reserved word, a pipeline beginning with the ! reserved word, or any command of an AND-OR list other than the last. 