### PR TITLE
Skip ChainerX float16 tests when FunctionTestCase is used

### DIFF
--- a/chainer/testing/function.py
+++ b/chainer/testing/function.py
@@ -218,11 +218,22 @@ class FunctionTestCase(unittest.TestCase):
         _check_variable_types(outputs, backend_config.device, 'forward')
         return outputs
 
+    def _skip_if_chainerx_float16(self, backend_config):
+        # This is a dirty workaround to avoid writing the skip logic in every
+        # test case.
+        # It assumes that there's an attribute 'dtype' in the test case.
+        # TODO(niboshi): Support float16 in ChainerX
+        if (backend_config.use_chainerx
+                and getattr(self, 'dtype', None) == numpy.float16):
+            raise unittest.SkipTest('ChainerX does not support float16')
+
     def test_forward(self, backend_config):
         """Tests forward computation."""
 
         if self.skip_forward_test:
-            raise unittest.SkipTest()
+            raise unittest.SkipTest('skip_forward_test is set')
+
+        self._skip_if_chainerx_float16(backend_config)
 
         self.backend_config = backend_config
         self.before_test('test_forward')
@@ -266,7 +277,9 @@ class FunctionTestCase(unittest.TestCase):
         """Tests backward computation."""
 
         if self.skip_backward_test:
-            raise unittest.SkipTest()
+            raise unittest.SkipTest('skip_backward_test is set')
+
+        self._skip_if_chainerx_float16(backend_config)
 
         # avoid cyclic import
         from chainer import gradient_check
@@ -309,7 +322,9 @@ class FunctionTestCase(unittest.TestCase):
         """Tests double-backward computation."""
 
         if self.skip_double_backward_test:
-            raise unittest.SkipTest()
+            raise unittest.SkipTest('skip_double_backward_test is set')
+
+        self._skip_if_chainerx_float16(backend_config)
 
         # avoid cyclic import
         from chainer import gradient_check

--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -34,11 +34,6 @@ class TestClippedReLU(testing.FunctionTestCase):
 
     z = 0.75
 
-    def before_test(self, test_name):
-        # TODO(niboshi): Support it
-        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
     def generate_inputs(self):
         x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         return x,

--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -38,11 +38,6 @@ class TestReLU(testing.FunctionTestCase):
 
     dodge_nondifferentiable = True
 
-    def before_test(self, test_name):
-        # TODO(niboshi): Support it
-        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
     def generate_inputs(self):
         x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
         return x,

--- a/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_hstack.py
@@ -46,11 +46,6 @@ from chainer.utils import type_check
     ])
 class TestHstack(testing.FunctionTestCase):
 
-    def before_test(self, test_name):
-        # TODO(niboshi): Support it
-        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
     def generate_inputs(self):
         return tuple([
             numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -145,11 +145,6 @@ class TestSplitAxis(testing.FunctionTestCase):
         x = numpy.arange(numpy.prod(shape), dtype=dtype).reshape(shape)
         return x,
 
-    def before_test(self, test_name):
-        # TODO(niboshi): Support it
-        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
     def forward(self, inputs, device):
         x, = inputs
         with warnings.catch_warnings():

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -54,11 +54,6 @@ class TestMaxPoolingND(testing.FunctionTestCase):
             self.check_double_backward_options.update({
                 'atol': 1e-3, 'rtol': 1e-2})
 
-    def before_test(self, test_name):
-        # TODO(niboshi): Support it
-        if self.backend_config.use_chainerx and self.dtype == numpy.float16:
-            raise unittest.SkipTest('ChainerX does not support float16')
-
     def generate_inputs(self):
         x_shape = (2, 3) + self.in_dims
         x = numpy.random.randn(*x_shape).astype(self.dtype, copy=False)


### PR DESCRIPTION
This is a temporary workaround to skip ChainerX float16 tests in function tests.
This workaround should be removed after ChainerX supports float16 (related: #5845).