### PR TITLE
Fix cupy import failure detection

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -12,7 +12,7 @@ from chainer.training.updaters import standard_updater
 try:
     from cupy.cuda import nccl
     _available = True
-except ImportError:
+except Exception:
     _available = False
 
 import numpy


### PR DESCRIPTION
In some environment, the second import failure of CuPy may raise `AttributeError` instead of `ImportError` if CUDA driver DLLs are unavailable.

```py
Python 3.7.1 (v3.7.1:260ec2c36a, Oct 20 2018, 14:57:15) [MSC v.1915 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import cupy
Traceback (most recent call last):
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\__init__.py", line 11, in <module>
    from cupy import core  # NOQA
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\core\__init__.py", line 1, in <module>
    from cupy.core import core  # NOQA
  File "cupy\core\core.pyx", line 1, in init cupy.core.core
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\cuda\__init__.py", line 4, in <module>
    from cupy.cuda import compiler  # NOQA
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\cuda\compiler.py", line 11, in <module>
    from cupy.cuda import device
  File "cupy\cuda\runtime.pxd", line 5, in init cupy.cuda.device
ImportError: DLL load failed: The specified module could not be found.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\__init__.py", line 32, in <module>
    six.reraise(ImportError, ImportError(msg), exc_info[2])
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\six.py", line 692, in reraise
    raise value.with_traceback(tb)
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\__init__.py", line 11, in <module>
    from cupy import core  # NOQA
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\core\__init__.py", line 1, in <module>
    from cupy.core import core  # NOQA
  File "cupy\core\core.pyx", line 1, in init cupy.core.core
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\cuda\__init__.py", line 4, in <module>
    from cupy.cuda import compiler  # NOQA
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\cuda\compiler.py", line 11, in <module>
    from cupy.cuda import device
  File "cupy\cuda\runtime.pxd", line 5, in init cupy.cuda.device
ImportError: CuPy is not correctly installed.

If you are using wheel distribution (cupy-cudaXX), make sure that the version of CuPy you installed matches with the ver
sion of CUDA on your host.
Also, confirm that only one CuPy package is installed:
  $ pip freeze

If you are building CuPy from source, please check your environment, uninstall CuPy and reinstall it with:
  $ pip install cupy --no-cache-dir -vvvv

Check the Installation Guide for details:
  https://docs-cupy.chainer.org/en/latest/install.html

original error: DLL load failed: The specified module could not be found.
>>> import cupy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\__init__.py", line 11, in <module>
    from cupy import core  # NOQA
  File "C:\Development\venv\kmaehashi-test\lib\site-packages\cupy\core\__init__.py", line 1, in <module>
    from cupy.core import core  # NOQA
  File "cupy\core\core.pyx", line 2603, in init cupy.core.core
AttributeError: type object 'cupy.core.core.broadcast' has no attribute '__reduce_cython__'
```

Originally reported in https://github.com/cupy/cupy/issues/1910.