### PR TITLE
Fix seq2seq example

### DIFF
--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -136,7 +136,7 @@ class CalculateBleu(chainer.training.Extension):
         self.device = device
         self.max_length = max_length
 
-    def forward(self, trainer):
+    def __init__(self, trainer):
         with chainer.no_backprop_mode():
             references = []
             hypotheses = []

--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -136,7 +136,7 @@ class CalculateBleu(chainer.training.Extension):
         self.device = device
         self.max_length = max_length
 
-    def __init__(self, trainer):
+    def __call__(self, trainer):
         with chainer.no_backprop_mode():
             references = []
             hypotheses = []


### PR DESCRIPTION
This PR is quick fix for a bug in the seq2seq example. The `__call__` method of a trainer extension defined in the seq2seq example is mistakenly renamed to `forward` by this commit for LinkHook: https://github.com/chainer/chainer/pull/4912/files#diff-b41c7c0a2fadcae4e15f628ccfe20936L139
I appreciate that @niboshi and @asi1024 found this bug. Thanks both, sincerely.

I think the example tests have some room for improvement to be able to check this kind of bugs.