### PR TITLE
Raise `NotImplementedError` if `Extension.__call__` is not overridden

### DIFF
--- a/chainer/training/extension.py
+++ b/chainer/training/extension.py
@@ -61,7 +61,8 @@ class Extension(object):
             trainer (Trainer): Trainer object that calls this operator.
 
         """
-        pass
+        raise NotImplementedError(
+            'Extension implementation must override __call__.')
 
     def __getattr__(self, name):
         if name == 'invoke_before_training':

--- a/tests/chainer_tests/training_tests/test_extension.py
+++ b/tests/chainer_tests/training_tests/test_extension.py
@@ -1,10 +1,21 @@
 import unittest
 
+import pytest
+
 from chainer import testing
 from chainer import training
 
 
 class TestExtension(unittest.TestCase):
+
+    def test_raise_error_if_call_not_implemented(self):
+        class MyExtension(training.Extension):
+            pass
+
+        ext = MyExtension()
+        trainer = testing.get_trainer_with_mock_updater()
+        with pytest.raises(NotImplementedError):
+            ext(trainer)
 
     def test_default_name(self):
         class MyExtension(training.Extension):


### PR DESCRIPTION
Detects bugs like the one fixed in #6091.