### PR TITLE
[backport] Fix typo in `classifier.py`

### DIFF
--- a/chainer/links/model/classifier.py
+++ b/chainer/links/model/classifier.py
@@ -102,7 +102,7 @@ class Classifier(link.Chain):
         When ``label_key`` is ``int``, the correpoding element in ``args``
         is treated as ground truth labels. And when it is ``str``, the
         element in ``kwargs`` is used.
-        The all elements of ``args`` and ``kwargs`` except the ground trush
+        The all elements of ``args`` and ``kwargs`` except the ground truth
         labels are features.
         It feeds features to the predictor and compare the result
         with ground truth labels.


### PR DESCRIPTION
Backport of #6090