### PR TITLE
Enable Python chainerx tests in Travis Windows matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ matrix:
       python: "3.7"
       env:
       - CHAINER_TRAVIS_TEST="chainer"
-      - SKIP_CHAINERX=1
       - SKIP_CHAINERMN=1
 
     - name: "macOS Py27"

--- a/scripts/ci/travis/run-tests.sh
+++ b/scripts/ci/travis/run-tests.sh
@@ -130,11 +130,9 @@ case "${CHAINER_TRAVIS_TEST}" in
                         run_step chainerx_python_tests
                 fi
 
-                if [[ $SKIP_CHAINERX != 1 ]]; then
+                if [[ $SKIP_CHAINERX != 1 && $TRAVIS_OS_NAME != "windows" ]]; then
                     CHAINER_DOCS_SKIP_LINKCODE=1 \
                         run_step docs
-                else
-                    echo "Documentation build is skipped as ChainerX is not available.";
                 fi
                 ;;
         esac


### PR DESCRIPTION
Fixes #6104.
Depends on #5888.