### PR TITLE
Fix memory leak during backprop in Python 2

### DIFF
--- a/chainer/utils/_collections.py
+++ b/chainer/utils/_collections.py
@@ -5,11 +5,17 @@ import six
 
 
 if six.PY3:
-    RefCountFriendlyOrderedDict = collections.OrderedDict
+    OrderedDict = collections.OrderedDict
 else:
     # Reference counting cannot free keys in old `collections.OrderedDict`,
     # where a doubly linked list is used to maintain the order.
-    class RefCountFriendlyOrderedDict(object):
+    class OrderedDict(object):
+        """Dictionary that remembers insertion order
+
+        This class wraps `collections.OrderedDict` to free keys by reference
+        counting.
+        """
+
         def __init__(self):
             self.keys = set()
             self.dict = collections.OrderedDict()

--- a/chainer/utils/_collections.py
+++ b/chainer/utils/_collections.py
@@ -1,0 +1,31 @@
+import collections
+import weakref
+
+import six
+
+
+if six.PY3:
+    RefCountFriendlyOrderedDict = collections.OrderedDict
+else:
+    # Reference counting cannot free keys in old `collections.OrderedDict`,
+    # where a doubly linked list is used to maintain the order.
+    class RefCountFriendlyOrderedDict(object):
+        def __init__(self):
+            self.keys = set()
+            self.dict = collections.OrderedDict()
+
+        def __contains__(self, key):
+            return weakref.ref(key) in self.dict
+
+        def __setitem__(self, key, value):
+            self.keys.add(key)
+            self.dict[weakref.ref(key)] = value
+
+        def __getitem__(self, key):
+            return self.dict[weakref.ref(key)]
+
+        def items(self):
+            return [(k(), v) for k, v in self.dict.items()]
+
+        def values(self):
+            return self.dict.values()

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1501,7 +1501,7 @@ class Variable(object):
 
 
 def _backprop_to_all(outputs, retain_grad, loss_scale):
-    OrderedDict3 = chainer.utils._collections.RefCountFriendlyOrderedDict
+    OrderedDict3 = chainer.utils._collections.OrderedDict
 
     cand_funcs = []
     seen_set = set()

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1501,7 +1501,7 @@ class Variable(object):
 
 
 def _backprop_to_all(outputs, retain_grad, loss_scale):
-    OrderedDict3 = chainer.utils._collections.OrderedDict
+    OrderedDict = chainer.utils._collections.OrderedDict
 
     cand_funcs = []
     seen_set = set()
@@ -1566,7 +1566,7 @@ def _backprop_to_all(outputs, retain_grad, loss_scale):
             # Keep the order for the portability, rather than
             # in_grad = {x: grads.get_as_list(x)
             #            for x in set(target_inputs)}
-            in_grad = OrderedDict3()
+            in_grad = OrderedDict()
             for x in target_inputs:
                 if x not in in_grad:
                     in_grad[x] = grads.get_as_list(x)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -19,6 +19,7 @@ from chainer import initializers
 from chainer.initializers import constant
 from chainer import types  # NOQA
 from chainer.utils import argument
+import chainer.utils._collections
 import chainerx
 
 
@@ -1500,6 +1501,8 @@ class Variable(object):
 
 
 def _backprop_to_all(outputs, retain_grad, loss_scale):
+    OrderedDict3 = chainer.utils._collections.RefCountFriendlyOrderedDict
+
     cand_funcs = []
     seen_set = set()
 
@@ -1563,7 +1566,7 @@ def _backprop_to_all(outputs, retain_grad, loss_scale):
             # Keep the order for the portability, rather than
             # in_grad = {x: grads.get_as_list(x)
             #            for x in set(target_inputs)}
-            in_grad = collections.OrderedDict()
+            in_grad = OrderedDict3()
             for x in target_inputs:
                 if x not in in_grad:
                     in_grad[x] = grads.get_as_list(x)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1501,7 +1501,7 @@ class Variable(object):
 
 
 def _backprop_to_all(outputs, retain_grad, loss_scale):
-    OrderedDict = chainer.utils._collections.OrderedDict
+    OrderedDict = chainer.utils._collections.OrderedDict  # fix py2 memory leak
 
     cand_funcs = []
     seen_set = set()


### PR DESCRIPTION
This PR wraps a use of `collections.OrderedDict` in order to address a memory issue with Python 2.

Split from #5274.