### PR TITLE
Document NumPy 1.16 support

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,7 +25,7 @@ You need to have the following components to use Chainer.
 * `Python <https://python.org/>`_
     * Supported Versions: 2.7.6+, 3.4.3+, 3.5.1+, 3.6.0+ and 3.7.0+.
 * `NumPy <http://www.numpy.org/>`_
-    * Supported Versions: 1.9, 1.10, 1.11, 1.12, 1.13, 1.14 and 1.15.
+    * Supported Versions: 1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15 and 1.16.
     * NumPy will be installed automatically during the installation of Chainer.
 
 Before installing Chainer, we recommend you to upgrade ``setuptools`` and ``pip``::


### PR DESCRIPTION
Closes #6080.

(c.f. CuPy: https://github.com/cupy/cupy/pull/1986)