### PR TITLE
Use `CMAKE_CURRENT_BINARY_DIR` in `CMakeLists.txt`

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -153,8 +153,8 @@ endif()
 # pybind11
 if(${CHAINERX_BUILD_PYTHON})
     get_third_party(pybind11)
-    include_directories(${CMAKE_BINARY_DIR}/pybind11/include)
-    add_subdirectory(${CMAKE_BINARY_DIR}/pybind11 ${CMAKE_BINARY_DIR}/pybind11-build)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR}/pybind11/include)
+    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/pybind11 ${CMAKE_CURRENT_BINARY_DIR}/pybind11-build)
 endif()
 
 # gsl-lite
@@ -177,7 +177,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/optional-lite/include)
 # TODO(niboshi): Remove gtest dependency from testing
 get_third_party(gtest)
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-    ${CMAKE_BINARY_DIR}/googletest-build
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
     EXCLUDE_FROM_ALL)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include)
 


### PR DESCRIPTION
This should have been done in

https://github.com/chainer/chainer/commit/59cc3df5daf1fe9a6563221dc92baab20d31956d
