### PR TITLE
Fix `get_retained_{in/out}puts` to return `None` for `None` inputs/outputs

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -150,7 +150,7 @@ class FunctionAdapter(function_node.FunctionNode):
         for retained, i_in in six.moves.zip(
                 retained_inputs, self._input_indexes_to_retain):
             inputs[i_in] = retained
-            in_data[i_in] = retained.array
+            in_data[i_in] = None if retained is None else retained.array
         in_data = tuple(in_data)
 
         grad_out_data = tuple([None if grad is None else grad.data

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -195,7 +195,9 @@ class FunctionNode(object):
         """
         if self._is_chainerx_fallback_mode:
             retained_output_data = [
-                var.array for var in self._chainerx_retained_outputs]
+                None if var is None
+                else var.array
+                for var in self._chainerx_retained_outputs]
         else:
             if self._retained_output_data is None:
                 raise RuntimeError('retained output data is gone')
@@ -719,7 +721,8 @@ Use apply() method instead.\
                 array, requires_grad=array.is_backprop_required())
             for array in retained_inputs])
         self._chainerx_retained_outputs = tuple([
-            variable.Variable(
+            None if array is None
+            else variable.Variable(
                 array, requires_grad=(
                     False if array is None else array.is_backprop_required()))
             for array in retained_outputs])
@@ -847,7 +850,11 @@ Use apply() method instead.\
                 outputs_modified = True
             else:
                 output_var = output.get_variable()
-            ret.append(output_var)
+
+            if output_var.array is None:
+                ret.append(None)
+            else:
+                ret.append(output_var)
 
         if outputs_modified:
             self.outputs = tuple(new_outputs)

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -792,13 +792,14 @@ Use apply() method instead.\
         if self._input_indexes_to_retain is None or self.inputs is None:
             return ()
 
-        # TODO(hvy): It should be safe to remove this check.
-        if self._input_indexes_to_retain is None:
-            raise ValueError(self._get_error_message(
-                'retain_inputs is not called in forward.'))
-
-        return tuple([self.inputs[index].get_variable()
-                      for index in self._input_indexes_to_retain])
+        retained_inputs = []
+        for index in self._input_indexes_to_retain:
+            input = self.inputs[index]
+            if input.data is None:
+                retained_inputs.append(None)
+            else:
+                retained_inputs.append(input.get_variable())
+        return tuple(retained_inputs)
 
     def get_retained_outputs(self):
         """Returns a tuple of retained output variables.

--- a/tests/chainer_tests/test_backprop.py
+++ b/tests/chainer_tests/test_backprop.py
@@ -458,7 +458,7 @@ class TestFunctionOutputNone(unittest.TestCase):
                 retained_outputs = self.get_retained_outputs()
                 assert isinstance(retained_outputs, tuple)
                 y2, y3 = retained_outputs
-                assert y3.array is None
+                assert y3 is None
                 assert isinstance(y2.array, backward_xp.ndarray)
 
                 gx1 = 3 * gy2

--- a/tests/chainer_tests/test_backprop.py
+++ b/tests/chainer_tests/test_backprop.py
@@ -240,6 +240,138 @@ class TestFunctionBackprop(unittest.TestCase):
         {'use_cuda': True, 'cuda_device': 0},
         {'use_cuda': True, 'cuda_device': 1},
         # ChainerX
+        # TODO(niboshi): Fix ChainerX for None inputs
+        # {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        # {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        # {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestFunctionInputNone(unittest.TestCase):
+
+    def call_func_function(self, backend_config, x2):
+        forward_xp, backward_xp = _get_expected_xp(backend_config, True)
+
+        class Func(chainer.Function):
+            def forward(self, inputs):
+
+                # Inputs
+                assert isinstance(inputs, tuple)
+                x1, x2, x3 = inputs
+                assert x1 is None
+                assert isinstance(x2, forward_xp.ndarray)
+                assert x3 is None
+
+                y1 = x2 * 3
+                self.retain_inputs((1, 2))
+                self.retain_outputs(())
+                return y1,
+
+            def backward(self, inputs, grad_outputs):
+
+                # Retained inputs
+                assert isinstance(inputs, tuple)
+                x1, x2, x3 = inputs
+                assert x1 is None
+                assert isinstance(x2, backward_xp.ndarray)
+                assert x3 is None
+
+                # Output gradients
+                assert isinstance(grad_outputs, tuple)
+                gy1, = grad_outputs
+                assert isinstance(gy1, backward_xp.ndarray)
+
+                # Retained outputs
+                output_data = self.output_data
+                assert isinstance(output_data, tuple)
+                y1, = output_data
+                assert y1 is None
+
+                gx2 = 3 * gy1
+                return None, gx2, None
+
+        return Func()(None, x2, None),
+
+    def call_func_function_node(self, backend_config, x2):
+        forward_xp, backward_xp = _get_expected_xp(backend_config, False)
+
+        class Func(chainer.FunctionNode):
+            def forward(self, inputs):
+
+                # Inputs
+                x1, x2, x3 = inputs
+                assert x1 is None
+                assert isinstance(x2, forward_xp.ndarray)
+                assert x3 is None
+
+                y1 = x2 * 3
+                self.retain_inputs((1, 2))
+                self.retain_outputs(())
+                return y1,
+
+            def backward(self, input_indexes, grad_outputs):
+
+                # Input indexes
+                assert isinstance(input_indexes, tuple)
+                assert input_indexes == (1,)
+
+                # Retained inputs
+                retained_inputs = self.get_retained_inputs()
+                assert isinstance(retained_inputs, tuple)
+                x2, x3 = retained_inputs
+                assert isinstance(x2.array, backward_xp.ndarray)
+                assert x3 is None
+
+                # Output grads
+                assert isinstance(grad_outputs, tuple)
+                gy1, = grad_outputs
+                assert isinstance(gy1.array, backward_xp.ndarray)
+
+                # Retained outputs
+                retained_outputs = self.get_retained_outputs()
+                assert retained_outputs is ()
+
+                gx2 = 3 * gy1
+                return None, gx2, None
+
+        return Func().apply((None, x2, None))
+
+    def call_func(self, backend_config, x1):
+        if self.function_node:
+            return self.call_func_function_node(backend_config, x1)
+        else:
+            return self.call_func_function(backend_config, x1)
+
+    def test_backprop(self, backend_config):
+
+        x2_arr = numpy.array([2, 3], numpy.float32)
+        gy1_arr = numpy.array([2, 4], numpy.float32)
+        x2_arr, gy1_arr = backend_config.get_array((x2_arr, gy1_arr))
+
+        x2 = chainer.Variable(x2_arr, requires_grad=True)
+
+        # Forward
+        y1, = self.call_func(backend_config, x2)
+
+        assert isinstance(y1.array, backend_config.xp.ndarray)
+
+        # Backward
+        y1.grad = gy1_arr
+        y1.backward()
+
+        assert isinstance(x2.grad, backend_config.xp.ndarray)
+
+
+@testing.parameterize(*testing.product({
+    'function_node': [True, False],
+}))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        # CPU
+        {},
+        # CUDA
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+        # ChainerX
         {'use_chainerx': True, 'chainerx_device': 'native:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:1'},


### PR DESCRIPTION
This PR originally intended to support `None` as `FunctionNode` inputs in ChainerX (issue: #6120) , but during that I found that existing semantics should also change.

Previously, `get_retained_{in,out}puts` returns `Variable(None)` if the input/output is `None`.
In this PR it has changed to return `None`.

(Depends on #6118)
