### PR TITLE
Do not compare `xp` with `numpy` for cupy code path

### DIFF
--- a/chainer/functions/activation/log_softmax.py
+++ b/chainer/functions/activation/log_softmax.py
@@ -1,5 +1,3 @@
-import numpy
-
 import chainer
 from chainer import backend
 from chainer.backends import cuda
@@ -27,7 +25,7 @@ def logsumexp(x, axis):
 def _log_softmax(x, axis=1):
     if chainer.should_use_cudnn('>=auto'):
         xp = backend.get_array_module(x)
-        if xp is not numpy:
+        if xp is cuda.cupy:
             return cudnn.softmax_forward(x, axis, _algorithm)
     log_z = logsumexp(x, axis)
     y = x - log_z
@@ -80,7 +78,7 @@ class LogSoftmaxGrad(function_node.FunctionNode):
         self.retain_inputs((0, 1))
         y, gy = inputs
         xp = self._x_xp
-        if xp is not numpy and chainer.should_use_cudnn('>=auto'):
+        if xp is cuda.cupy and chainer.should_use_cudnn('>=auto'):
             gx = cudnn.softmax_backward(y, gy, self.axis, _algorithm)
         else:
             gx = gy - xp.exp(y) * gy.sum(axis=self.axis, keepdims=True)

--- a/chainer/functions/activation/softmax.py
+++ b/chainer/functions/activation/softmax.py
@@ -1,5 +1,3 @@
-import numpy
-
 import chainer
 from chainer import backend
 from chainer.backends import cuda
@@ -30,7 +28,7 @@ class Softmax(function_node.FunctionNode):
 
     def forward(self, x):
         xp = backend.get_array_module(*x)
-        if xp is not numpy and chainer.should_use_cudnn('>=auto'):
+        if xp is cuda.cupy and chainer.should_use_cudnn('>=auto'):
             y = cudnn.softmax_forward(x[0], self.axis, _algorithm)
         else:
             y = x[0] - x[0].max(axis=self.axis, keepdims=True)
@@ -55,7 +53,7 @@ class _SoftmaxGrad(function_node.FunctionNode):
         self.retain_inputs((0, 1))
         y, gy = inputs
         xp = backend.get_array_module(*y)
-        if xp is not numpy and chainer.should_use_cudnn('>=auto'):
+        if xp is cuda.cupy and chainer.should_use_cudnn('>=auto'):
             gx = cudnn.softmax_backward(y, gy, self.axis, _algorithm)
         else:
             gx = y * gy

--- a/chainer/functions/connection/n_step_gru.py
+++ b/chainer/functions/connection/n_step_gru.py
@@ -266,7 +266,7 @@ def n_step_gru_base(n_layers, dropout_ratio, hx, ws, bs, xs,
 
     xp = backend.get_array_module(hx, hx.data)
 
-    if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
+    if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
         states = cuda.get_cudnn_dropout_states()
         states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -405,7 +405,7 @@ def n_step_lstm_base(
 
     xp = backend.get_array_module(hx, hx.data)
 
-    if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
+    if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
         states = cuda.get_cudnn_dropout_states()
         states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -635,7 +635,7 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
 
     xp = backend.get_array_module(hx)
 
-    if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):
+    if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
         states = cuda.get_cudnn_dropout_states()
         states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -613,7 +613,7 @@ class _BNMode(object):
     def can_use_cudnn(self, xp):
         # TODO(bkvogel): Check for float16 support again in next cuDNN version.
         # cuDNN v5 batch normalization does not seem to support float16.
-        return (xp is not numpy and
+        return (xp is cuda.cupy and
                 chainer.should_use_cudnn('>=auto', 5000) and
                 self.cudnn_dim_ok and
                 self.cudnn_dtype_ok)

--- a/chainer/functions/pooling/average_pooling_nd.py
+++ b/chainer/functions/pooling/average_pooling_nd.py
@@ -70,7 +70,7 @@ class AveragePoolingND(pooling_nd._PoolingND):
                 width = w
             else:
                 width = numpy.tensordot(width[..., None], w[None, ...], axes=1)
-        if xp is not numpy:
+        if xp is cuda.cupy:
             width = cuda.cupy.array(width)
         return width
 

--- a/chainer/functions/theano/theano_function.py
+++ b/chainer/functions/theano/theano_function.py
@@ -1,4 +1,3 @@
-import numpy
 import six
 
 from chainer import backend
@@ -26,7 +25,7 @@ class TheanoFunction(function.Function):
             )
 
     def forward(self, inputs):
-        gpu = backend.get_array_module(*inputs) is not numpy
+        gpu = backend.get_array_module(*inputs) is cuda.cupy
         inputs = [cuda.to_cpu(x) for x in inputs]
 
         outputs = self.forward_func(*inputs)
@@ -40,7 +39,7 @@ class TheanoFunction(function.Function):
         return tuple(outputs)
 
     def backward(self, inputs, grads):
-        gpu = backend.get_array_module(*inputs) is not numpy
+        gpu = backend.get_array_module(*inputs) is cuda.cupy
 
         # TODO(unno): We can remove redundant gpu-cpu copy using
         # theano.sandbox.cuda.basic_ops.gpu_from_host

--- a/chainer/initializers/normal.py
+++ b/chainer/initializers/normal.py
@@ -1,6 +1,7 @@
 import numpy
 
 from chainer import backend
+from chainer.backends import cuda
 from chainer import initializer
 
 
@@ -28,7 +29,7 @@ class Normal(initializer.Initializer):
     def __call__(self, array):
         xp = backend.get_array_module(array)
         args = {'loc': 0.0, 'scale': self.scale, 'size': array.shape}
-        if xp is not numpy:
+        if xp is cuda.cupy:
             # Only CuPy supports dtype option
             if self.dtype == numpy.float32 or self.dtype == numpy.float16:
                 # float16 is not supported in cuRAND

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -46,7 +46,7 @@ class _MpiBackend(_MultiNodeBatchNormalizationBackend):
         tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
         x.mean(axis=axis, out=tmp[:gamma.size])
         xp.square(x).mean(axis=axis, out=tmp[gamma.size:])
-        if xp is not numpy:
+        if xp is cuda.cupy:
             chainer.cuda.Stream.null.synchronize()
         mpi_comm.Allreduce(
             self.mpi4py_module.IN_PLACE,
@@ -62,7 +62,7 @@ class _MpiBackend(_MultiNodeBatchNormalizationBackend):
         tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
         gy.sum(axis=axis, out=tmp[:gamma.size])
         (gy * x_hat).sum(axis=axis, out=tmp[gamma.size:])
-        if xp is not numpy:
+        if xp is cuda.cupy:
             chainer.cuda.Stream.null.synchronize()
         mpi_comm.Allreduce(
             self.mpi4py_module.IN_PLACE,

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -297,7 +297,7 @@ class TestMaxPooling2DIndices(unittest.TestCase):
                     [xx[2:4, 0:2].ravel().argmax(),
                      xx[2:4, 2:4].ravel().argmax()],
                 ])
-        if out.xp is not numpy:
+        if out.xp is cuda.cupy:
             expect = cuda.to_gpu(expect)
         assert (expect == indices).all()
 

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_nd.py
@@ -200,7 +200,7 @@ class TestMaxPoolingNDIndices(unittest.TestCase):
                     [xx[2:4, 0:2].ravel().argmax(),
                      xx[2:4, 2:4].ravel().argmax()],
                 ])
-        if out.xp is not numpy:
+        if out.xp is cuda.cupy:
             expect = cuda.to_gpu(expect)
         assert (expect == indices).all()
 

--- a/tests/chainer_tests/link_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/link_hooks_tests/test_timer.py
@@ -31,7 +31,7 @@ class TestTimerHook(unittest.TestCase):
 
     def check_forward(self, xp):
         link = MyModel()
-        if xp is not numpy:
+        if xp is cuda.cupy:
             link = link.to_gpu()
         hook = link_hooks.TimerHook()
 


### PR DESCRIPTION
`xp` can be `chainerx`, too.
Testing `xp is numpy` for cupy should be wrong.