### PR TITLE
Fix double-backprop of `F.rrelu`

### DIFF
--- a/chainer/functions/activation/rrelu.py
+++ b/chainer/functions/activation/rrelu.py
@@ -86,7 +86,7 @@ class _RReLUGrad(function_node.FunctionNode):
         return gy,
 
     def backward(self, indexes, grad_outputs):
-        return _RReLUGrad(self.x, self.y, self.r).apply(grad_outputs)
+        return _RReLUGrad(self.y, self.r).apply(grad_outputs)
 
 
 def rrelu(x, l=1. / 8, u=1. / 3, **kwargs):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -30,7 +30,7 @@ class TestRReLU(testing.FunctionTestCase):
 
     dodge_nondifferentiable = True
 
-    def before_test(self, test_name):
+    def setUp(self):
         # Assumption l < u
         self.l = numpy.random.uniform(0, 1)
         self.u = numpy.random.uniform(0, 1)

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -13,7 +13,7 @@ from chainer.testing import attr
 
 @testing.parameterize(*testing.product({
     'train': [True, False],
-    'shape': [(3, 2), (5, 6)],
+    'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestRReLU(unittest.TestCase):
@@ -78,7 +78,7 @@ class TestRReLU(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'specify_r': [True, False],
     'train': [True, False],
-    'shape': [(3, 2), (5, 6)],
+    'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 class TestRReLUR(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -9,11 +9,6 @@ from chainer import testing
 from chainer.testing import attr
 
 
-@testing.parameterize(*testing.product({
-    'train': [True, False],
-    'shape': [(3, 2), ()],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
 @testing.inject_backend_tests(
     None,
     # CPU tests
@@ -26,6 +21,11 @@ from chainer.testing import attr
         'cuda_device': [0, 1],
     })
 )
+@testing.parameterize(*testing.product({
+    'train': [True, False],
+    'shape': [(3, 2), ()],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
 class TestRReLU(testing.FunctionTestCase):
 
     dodge_nondifferentiable = True

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -64,7 +64,7 @@ class TestRReLU(testing.FunctionTestCase):
         if self.train:
             expected = numpy.where(x >= 0, x, x * r)
         else:
-            r_test = ((self.l + self.u) * 0.5).astype(self.dtype)
+            r_test = numpy.mean([self.l, self.u], dtype=self.dtype)
             expected = numpy.where(x >= 0, x, x * r_test)
         return expected,
 


### PR DESCRIPTION
#5619 broke `_RReLUGrad.backward`.

```
>>> x = chainer.Variable(np.random.randn(2, 3).astype('f'))
>>> y = F.rrelu(x)
>>> y.grad = np.random.randn(2, 3).astype('f')
>>> y.backward(enable_double_backprop=True)
>>> x.grad_var.grad = np.random.randn(2, 3).astype('f')
>>> x.grad_var.backward()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tos/GitHub/chainer/chainer/variable.py", line 1386, in backward
    _backprop_to_all([self], retain_grad, loss_scale)
  File "/Users/tos/GitHub/chainer/chainer/variable.py", line 1577, in _backprop_to_all
    func, target_input_indexes, out_grad, in_grad)
  File "/Users/tos/GitHub/chainer/chainer/_backprop_utils.py", line 116, in backprop_step
    target_input_indexes, grad_outputs)
  File "/Users/tos/GitHub/chainer/chainer/functions/activation/rrelu.py", line 89, in backward
    return _RReLUGrad(self.x, self.y, self.r).apply(grad_outputs)
AttributeError: '_RReLUGrad' object has no attribute 'x'
```