### PR TITLE
Remove Travis Ubuntu Py34 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,6 @@ matrix:
       - CHAINER_TRAVIS_TEST="chainer"
       - SKIP_CHAINERX=1
 
-    - name: "Ubuntu14.04 Py34"
-      dist: trusty
-      python: "3.4"
-      env:
-      - CHAINER_TRAVIS_TEST="chainer"
-      - SKIP_CHAINERX=1
-
     - name: "Ubuntu16.04 Py35 + ChainerX"
       dist: xenial
       python: "3.5"


### PR DESCRIPTION
Related to Python 3.4 support drop https://github.com/chainer/chainer/issues/6131.

This PR simply removes the Ubuntu Py34 job from the Travis matrix. It is maybe worth discussing if we should bump the Python version to 3.5 of this job instead of removing it, to test Chainer without ChainerX.