### PR TITLE
add decorrelated batchnormalization (take-over)

### DIFF
--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -196,6 +196,8 @@ from chainer.functions.normalization.batch_normalization import batch_normalizat
 from chainer.functions.normalization.batch_normalization import fixed_batch_normalization  # NOQA
 from chainer.functions.normalization.batch_renormalization import batch_renormalization  # NOQA
 from chainer.functions.normalization.batch_renormalization import fixed_batch_renormalization  # NOQA
+from chainer.functions.normalization.decorrelated_batch_normalization import decorrelated_batch_normalization  # NOQA
+from chainer.functions.normalization.decorrelated_batch_normalization import fixed_decorrelated_batch_normalization  # NOQA
 from chainer.functions.normalization.group_normalization import group_normalization  # NOQA
 from chainer.functions.normalization.l2_normalization import normalize  # NOQA
 from chainer.functions.normalization.layer_normalization import layer_normalization  # NOQA

--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -1,0 +1,190 @@
+from chainer.backends import cuda
+from chainer import function
+from chainer import function_node
+from chainer.utils import argument
+from chainer.utils import type_check
+
+
+class DecorrelatedBatchNormalizationFunction(function_node.FunctionNode):
+
+    mean = None
+    U = None
+
+    def __init__(self, groups, eps=2e-5, mean=None, projection=None,
+                 decay=0.9):
+        self.groups = groups  # TODO(tommi): Implement group whitening
+
+        self.expected_mean = mean
+        self.expected_projection = projection
+
+        self.eps = eps
+        self.decay = decay
+        self.axis = None
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 1)
+        x_type = in_types[0]
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+        )
+        type_check.expect(
+            x_type.ndim >= 2,
+        )
+
+    def forward(self, inputs):
+        self.retain_inputs(())
+        x = inputs[0]
+        xp = cuda.get_array_module(x)
+        spatial_ndim = len(x.shape[2:])
+        spatial_axis = tuple(range(2, 2 + spatial_ndim))
+        b, c = x.shape[:2]
+        m = b
+        for i in spatial_axis:
+            m *= x.shape[i]
+
+        if self.expected_mean is None:
+            self.expected_mean = xp.zeros(c, dtype=x.dtype)
+            self.expected_projection = xp.eye(c, dtype=x.dtype)
+
+        x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+
+        mean = x_hat.mean(axis=1)
+        x_hat = x_hat - mean[:, None]
+        self.eps = x.dtype.type(self.eps)
+
+        I = self.eps * xp.eye(c, dtype=x.dtype)
+        cov = x_hat.dot(x_hat.T) / x.dtype.type(m) + I
+        self.eigvals, self.eigvectors = xp.linalg.eigh(cov)
+        U = xp.diag(self.eigvals ** -0.5).dot(self.eigvectors.T)
+        self.y_hat_pca = U.dot(x_hat)  # PCA whitening
+        y_hat = self.eigvectors.dot(self.y_hat_pca)  # ZCA whitening
+
+        y = y_hat.reshape((c, b,) + x.shape[2:]).transpose(
+            (1, 0) + spatial_axis)
+
+        # Update running statistics
+        q = x.size // c
+        adjust = q / max(q - 1., 1.)  # unbiased estimation
+        self.expected_mean *= self.decay
+        self.expected_mean += (1 - self.decay) * mean
+        self.expected_projection *= self.decay
+        projection = self.eigvectors.dot(U)
+        self.expected_projection += (1 - self.decay) * adjust * projection
+
+        return y,
+
+    def backward(self, indexes, grad_outputs):
+        gy, = grad_outputs
+
+        f = DecorrelatedBatchNormalizationGrad(
+            self.eigvals, self.eigvectors, self.y_hat_pca)
+        return f(gy),
+
+
+class DecorrelatedBatchNormalizationGrad(function.Function):
+
+    def __init__(self, eigvals, eigvectors, y_hat_pca):
+        self.eigvals = eigvals
+        self.eigvectors = eigvectors
+        self.y_hat_pca = y_hat_pca
+
+    def forward(self, inputs):
+        self.retain_inputs(())
+        gy = inputs[0]
+        xp = cuda.get_array_module(gy)
+        spatial_ndim = len(gy.shape[2:])
+        spatial_axis = tuple(range(2, 2 + spatial_ndim))
+        b, c = gy.shape[:2]
+        m = b
+        for i in spatial_axis:
+            m *= gy.shape[i]
+
+        gy_hat = gy.transpose((1, 0) + spatial_axis).reshape((c, -1))  # (c, m)
+
+        gy_hat_pca = self.eigvectors.T.dot(gy_hat)  # (c, m)
+        f = gy_hat_pca.mean(axis=1)
+
+        K = self.eigvals[:, None] - self.eigvals[None, :]
+        xp.fill_diagonal(K, 1)
+        K = 1 / K  # (c, c)
+        xp.fill_diagonal(K, 0)
+
+        V = xp.diag(self.eigvals)
+        V_sqrt = xp.diag(self.eigvals ** 0.5)
+        V_invsqrt = xp.diag(self.eigvals ** -0.5)
+
+        F_c = gy_hat_pca.dot(self.y_hat_pca.T) / gy.dtype.type(m)
+        M = xp.diag(xp.diag(F_c))
+
+        S = 2 * _sym(K.T * (V.dot(F_c.T) + V_sqrt.dot(F_c).dot(V_sqrt)))
+        R = gy_hat_pca - f[:, None] + (S - M).T.dot(self.y_hat_pca)  # (c, m)
+        gx_hat = R.T.dot(V_invsqrt).dot(self.eigvectors.T).T
+
+        gx = gx_hat.reshape((c, b,) + gy.shape[2:]).transpose(
+            (1, 0) + spatial_axis)
+
+        self.retain_outputs(())
+        return gx,
+
+    def backward(self, inputs, grad_outputs):
+        raise NotImplementedError
+
+
+class FixedDecorrelatedBatchNormalizationFunction(function_node.FunctionNode):
+
+    def __init__(self, groups):
+        self.groups = groups
+
+    def check_type_forward(self, in_types):
+        type_check.expect(in_types.size() == 3)
+        x_type, mean_type, var_type = in_types
+        type_check.expect(
+            x_type.dtype.kind == 'f',
+            mean_type.dtype == x_type.dtype,
+            var_type.dtype == x_type.dtype,
+        )
+        type_check.expect(
+            x_type.ndim >= 2,
+        )
+
+    def forward(self, inputs):
+        x, mean, projection = inputs
+        spatial_ndim = len(x.shape[2:])
+        spatial_axis = tuple(range(2, 2 + spatial_ndim))
+        b, c = x.shape[:2]
+
+        x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))  # (c, m)
+
+        y_hat = projection.dot(x_hat - mean[:, None])
+
+        y = y_hat.reshape((c, b,) + x.shape[2:]).transpose(
+            (1, 0) + spatial_axis)
+
+        return y,
+
+    def backward(self, indexes, grad_outputs):
+        raise NotImplementedError
+
+
+def _sym(x):
+    return (x + x.T) / 2
+
+
+def decorrelated_batch_normalization(x, **kwargs):
+    groups, eps, expected_mean, expected_projection, decay = \
+        argument.parse_kwargs(
+            kwargs, ('groups', 16), ('eps', 2e-5), ('expected_mean', None),
+            ('expected_projection', None), ('decay', 0.9))
+
+    f = DecorrelatedBatchNormalizationFunction(groups, eps, expected_mean,
+                                               expected_projection,
+                                               decay)
+    return f.apply((x,))[0]
+
+
+def fixed_decorrelated_batch_normalization(x, mean, projection, **kwargs):
+    groups, = argument.parse_kwargs(
+        kwargs, ('groups', 16))
+
+    f = FixedDecorrelatedBatchNormalizationFunction(groups)
+    return f.apply((x, mean, projection))[0]

--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -229,7 +229,7 @@ class FixedDecorrelatedBatchNormalizationGrad(function_node.FunctionNode):
 
 
 def decorrelated_batch_normalization(x, **kwargs):
-    """decorrelated_batch_normalization(x, groups=16, eps2e-5,
+    """decorrelated_batch_normalization(x, *, groups=16, eps2e-5,
 running_mean=None, running_projection=None, decay=0.9)
 
     Decorrelated batch normalization function.

--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -273,9 +273,7 @@ running_mean=None, running_projection=None, decay=0.9)
 
 
 def fixed_decorrelated_batch_normalization(x, mean, projection, groups=16):
-    """fixed_decorrelated_batch_normalization(x, mean, projection, groups=16)
-
-    Decorrelated batch normalization function with fixed statistics.
+    """Decorrelated batch normalization function with fixed statistics.
 
     This is a variant of decorrelated batch normalization, where the mean and
     projection statistics are given by the caller as fixed variables. This is

--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -188,6 +188,33 @@ def _sym(x):
 
 
 def decorrelated_batch_normalization(x, **kwargs):
+    """Decorrelated batch normalization function.
+
+    It takes the input variable ``x`` and normalizes it using
+    batch statistics to make the output zero-mean and decorrelated.
+
+    Args:
+        x (Variable): Input variable.
+        groups (int): Number of groups to use for group whitening.
+        eps (float): Epsilon value for numerical stability.
+        expected_mean (numpy.ndarray or cupy.ndarray):
+            Expected value of the mean. This is a
+            running average of the mean over several mini-batches using
+            the decay parameter. If ``None``, the expected mean is initialized
+            to zero.
+        expected_projection (numpy.ndarray or cupy.ndarray):
+            Expected value of the project matrix. This is a
+            running average of the projection over several mini-batches using
+            the decay parameter. If ``None``, the expected projected is
+            initialized to the identity matrix.
+        decay (float): Decay rate of moving average. It is used during
+            training.
+
+    See: `Decorrelated Batch Normalization <https://arxiv.org/abs/1804.08450>`_
+
+    .. seealso:: :class:`links.DecorrelatedBatchNormalization`
+
+    """  # NOQA
     groups, eps, expected_mean, expected_projection, decay = \
         argument.parse_kwargs(
             kwargs, ('groups', 16), ('eps', 2e-5), ('expected_mean', None),
@@ -200,6 +227,25 @@ def decorrelated_batch_normalization(x, **kwargs):
 
 
 def fixed_decorrelated_batch_normalization(x, mean, projection, **kwargs):
+    """Decorrelated batch normalization function with fixed statistics.
+
+    This is a variant of decorrelated batch normalization, where the mean and
+    projection statistics are given by the caller as fixed variables. This is
+    used in testing mode of the decorrelated batch normalization layer, where
+    batch statistics cannot be used for prediction consistency.
+
+    Args:
+        x (Variable): Input variable.
+        mean (Variable): Shifting parameter of input.
+        projection (Variable): Projection matrix for decorrelation of input.
+        groups (int): Number of groups to use for group whitening.
+
+
+    .. seealso::
+       :func:`functions.decorrelated_batch_normalization`,
+       :class:`links.DecorrelatedBatchNormalization`
+
+    """
     groups, = argument.parse_kwargs(
         kwargs, ('groups', 16))
 

--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -142,7 +142,8 @@ class DecorrelatedBatchNormalizationGrad(function_node.FunctionNode):
 
     def backward(self, inputs, grad_outputs):
         # TODO(crcrpar): Implement this.
-        raise NotImplementedError
+        raise NotImplementedError("Double backward is not implemented for"
+                                  " decorrelated batch normalizatin.")
 
 
 class FixedDecorrelatedBatchNormalizationFunction(function_node.FunctionNode):
@@ -227,7 +228,8 @@ class FixedDecorrelatedBatchNormalizationGrad(function_node.FunctionNode):
 
     def backward(self, inputs, grad_outputs):
         # TODO(crcrpar): Implement this.
-        raise NotImplementedError
+        raise NotImplementedError("Double backward is not implemented for"
+                                  " fixed decorrelated batch normalizatin.")
 
 
 def decorrelated_batch_normalization(x, **kwargs):

--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -58,6 +58,7 @@ from chainer.links.model.vision.vgg import VGG16Layers  # NOQA
 from chainer.links.model.vision.vgg import VGG19Layers  # NOQA
 from chainer.links.normalization.batch_normalization import BatchNormalization  # NOQA
 from chainer.links.normalization.batch_renormalization import BatchRenormalization  # NOQA
+from chainer.links.normalization.decorrelated_batch_normalization import DecorrelatedBatchNormalization  # NOQA
 from chainer.links.normalization.group_normalization import GroupNormalization  # NOQA
 from chainer.links.normalization.layer_normalization import LayerNormalization  # NOQA
 from chainer.links.theano.theano_function import TheanoFunction  # NOQA

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -73,7 +73,7 @@ class DecorrelatedBatchNormalization(link.Link):
         self.groups = groups
 
     def forward(self, x, **kwargs):
-        """forward(self, x, finetune=False)
+        """forward(self, x, *, finetune=False)
 
         Invokes the forward propagation of DecorrelatedBatchNormalization.
 

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -48,7 +48,7 @@ class DecorrelatedBatchNormalization(link.Link):
 
     Attributes:
         avg_mean (:ref:`ndarray`): Population mean.
-        avg_projection (:ref:`ndarray): Population
+        avg_projection (:ref:`ndarray`): Population
             projection.
         groups (int): Number of groups to use for group whitening.
         N (int): Count of batches given for fine-tuning.

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -47,8 +47,8 @@ class DecorrelatedBatchNormalization(link.Link):
        :func:`~chainer.functions.fixed_decorrelated_batch_normalization`
 
     Attributes:
-        avg_mean (numpy.ndarray or cupy.ndarray): Population mean.
-        avg_projection (numpy.ndarray or cupy.ndarray): Population
+        avg_mean (:ref:`ndarray`): Population mean.
+        avg_projection (:ref:`ndarray): Population
             projection.
         groups (int): Number of groups to use for group whitening.
         N (int): Count of batches given for fine-tuning.
@@ -73,7 +73,9 @@ class DecorrelatedBatchNormalization(link.Link):
         self.groups = groups
 
     def forward(self, x, **kwargs):
-        """Invokes the forward propagation of DecorrelatedBatchNormalization.
+        """forward(self, x, finetune=False)
+
+        Invokes the forward propagation of DecorrelatedBatchNormalization.
 
         In training mode, the DecorrelatedBatchNormalization computes moving
         averages of the mean and projection for evaluation during training,
@@ -114,8 +116,6 @@ class DecorrelatedBatchNormalization(link.Link):
                 decay=decay)
         else:
             # Use running average statistics or fine-tuned statistics.
-            # mean = variable.Variable(self.avg_mean)
-            # projection = variable.Variable(self.avg_projection)
             mean = self.avg_mean
             projection = self.avg_projection
             ret = functions.fixed_decorrelated_batch_normalization(

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -1,0 +1,55 @@
+import numpy
+
+from chainer import configuration
+from chainer import functions
+from chainer import link
+from chainer.utils import argument
+from chainer import variable
+
+
+class DecorrelatedBatchNormalization(link.Link):
+
+    def __init__(self, size, groups=16, decay=0.9, eps=2e-5,
+                 dtype=numpy.float32):
+        super(DecorrelatedBatchNormalization, self).__init__()
+        self.expected_mean = numpy.zeros(size, dtype=dtype)
+        self.register_persistent('expected_mean')
+        self.expected_projection = numpy.eye(size, dtype=dtype)
+        self.register_persistent('expected_projection')
+        self.N = 0
+        self.register_persistent('N')
+        self.decay = decay
+        self.eps = eps
+        self.groups = groups
+
+    def __call__(self, x, **kwargs):
+        finetune, = argument.parse_kwargs(kwargs, ('finetune', False))
+
+        if configuration.config.train:
+            if finetune:
+                self.N += 1
+                decay = 1. - 1. / self.N
+            else:
+                decay = self.decay
+
+            ret = functions.decorrelated_batch_normalization(
+                x, groups=self.groups, eps=self.eps,
+                expected_mean=self.expected_mean,
+                expected_projection=self.expected_projection, decay=decay)
+        else:
+            # Use running average statistics or fine-tuned statistics.
+            mean = variable.Variable(self.expected_mean)
+            projection = variable.Variable(self.expected_projection)
+            ret = functions.fixed_decorrelated_batch_normalization(
+                x, mean, projection, groups=self.groups)
+        return ret
+
+    def start_finetuning(self):
+        """Resets the population count for collecting population statistics.
+
+        This method can be skipped if it is the first time to use the
+        fine-tuning mode. Otherwise, this method should be called before
+        starting the fine-tuning mode again.
+
+        """
+        self.N = 0

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -9,13 +9,12 @@ from chainer import variable
 
 class DecorrelatedBatchNormalization(link.Link):
 
-    """Decorrelated batch normalization layer on outputs of linear or
-    convolution functions.
+    """Decorrelated batch normalization layer.
 
     This link wraps the
     :func:`~chainer.functions.decorrelated_batch_normalization` and
     :func:`~chainer.functions.fixed_decorrelated_batch_normalization`
-    functions.
+    functions. It works on outputs of linear or convolution functions.
 
     It runs in three modes: training mode, fine-tuning mode, and testing mode.
 

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -12,9 +12,9 @@ class DecorrelatedBatchNormalization(link.Link):
     def __init__(self, size, groups=16, decay=0.9, eps=2e-5,
                  dtype=numpy.float32):
         super(DecorrelatedBatchNormalization, self).__init__()
-        self.expected_mean = numpy.zeros(size, dtype=dtype)
+        self.expected_mean = numpy.zeros(size // groups, dtype=dtype)
         self.register_persistent('expected_mean')
-        self.expected_projection = numpy.eye(size, dtype=dtype)
+        self.expected_projection = numpy.eye(size // groups, dtype=dtype)
         self.register_persistent('expected_projection')
         self.N = 0
         self.register_persistent('N')

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -4,7 +4,6 @@ from chainer import configuration
 from chainer import functions
 from chainer import link
 from chainer.utils import argument
-from chainer import variable
 
 
 class DecorrelatedBatchNormalization(link.Link):

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -97,10 +97,21 @@ class DecorrelatedBatchNormalization(link.Link):
             else:
                 decay = self.decay
 
+            avg_mean = self.avg_mean
+            avg_projection = self.avg_projection
+
+            if configuration.config.in_recomputing:
+                # Do not update statistics when extra forward computation is
+                # called.
+                if finetune:
+                    self.N -= 1
+                avg_mean = None
+                avg_projection = None
+
             ret = functions.decorrelated_batch_normalization(
                 x, groups=self.groups, eps=self.eps,
-                running_mean=self.avg_mean,
-                running_projection=self.avg_projection, decay=decay)
+                running_mean=avg_mean, running_projection=avg_projection,
+                decay=decay)
         else:
             # Use running average statistics or fine-tuned statistics.
             # mean = variable.Variable(self.avg_mean)

--- a/docs/source/reference/functions.rst
+++ b/docs/source/reference/functions.rst
@@ -295,8 +295,10 @@ Normalization functions
 
    chainer.functions.batch_normalization
    chainer.functions.batch_renormalization
+   chainer.functions.decorrelated_batch_normalization
    chainer.functions.fixed_batch_normalization
    chainer.functions.fixed_batch_renormalization
+   chainer.functions.fixed_decorrelated_batch_normalization
    chainer.functions.group_normalization
    chainer.functions.layer_normalization
    chainer.functions.local_response_normalization

--- a/docs/source/reference/links.rst
+++ b/docs/source/reference/links.rst
@@ -71,6 +71,7 @@ Activation/loss/normalization functions with parameters
 
    chainer.links.BatchNormalization
    chainer.links.BatchRenormalization
+   chainer.links.DecorrelatedBatchNormalization
    chainer.links.GroupNormalization
    chainer.links.LayerNormalization
    chainer.links.BinaryHierarchicalSoftmax

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -45,7 +45,7 @@ def _calc_projection(x, mean, eps, groups):
     'groups': [1, 2],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float32],
-    'c_contiguous': [True, False],
+    'contiguous': ['C', None],
 }) + testing.product({
     'n_channels': [8],
     'ndim': [1],
@@ -53,7 +53,7 @@ def _calc_projection(x, mean, eps, groups):
     'eps': [2e-5, 5e-1],
     # NOTE(crcrpar): np.linalg.eigh does not support float16
     'dtype': [numpy.float32, numpy.float64],
-    'c_contiguous': [True, False],
+    'contiguous': ['C', None],
 })))
 @testing.backend.inject_backend_tests(
     None,
@@ -113,14 +113,14 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
     'groups': [1, 2],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float32],
-    'c_contiguous': [True, False],
+    'contiguous': ['C', None],
 }) + testing.product({
     'n_channels': [8],
     'ndim': [1],
     'groups': [1, 2],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'c_contiguous': [True, False],
+    'contiguous': ['C', None],
 })))
 @testing.backend.inject_backend_tests(
     None,

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -65,8 +65,7 @@ def _calc_projection(x, mean, eps, groups):
 )
 class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
 
-    # TODO(crcrpar): Set this variable ``False`` or delete this line once
-    # double backward of
+    # TODO(crcrpar): Delete this line once double backward of
     # :func:`chainer.functions.decorrelated_batch_normalization` is
     # implemented.
     skip_double_backward_test = True
@@ -76,13 +75,10 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
         check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
         check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
         if self.dtype == numpy.float16:
-            check_forward_options['atol'] = 1e-2
-            check_forward_options['rtol'] = 1e-2
-            check_backward_options['atol'] = 1e-2
-            check_backward_options['rtol'] = 1e-2
+            check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
         elif self.dtype == numpy.float32:
-            check_backward_options['atol'] = 1e-2
-            check_backward_options['rtol'] = 1e-2
+            check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
         self.check_forward_options = check_forward_options
         self.check_backward_options = check_backward_options
 
@@ -136,8 +132,7 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
 )
 class TestFixedDecorrelatedBatchNormalization(testing.FunctionTestCase):
 
-    # TODO(crcrpar): Set this option ``False`` or delete thie line
-    # once double backward of
+    # TODO(crcrpar): Delete thie line once double backward of
     # :func:`chainer.functions.fixed_decorrelated_batch_normalization` is
     # implemented.
     # skip_backward_test = True

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -4,8 +4,7 @@ from chainer import functions
 from chainer import testing
 
 
-def _decorrelated_batch_normalization(args):
-    x, mean, projection, groups = args
+def _decorrelated_batch_normalization(x, mean, projection, groups):
     spatial_ndim = len(x.shape[2:])
     spatial_axis = tuple(range(2, 2 + spatial_ndim))
     b, c = x.shape[:2]
@@ -104,8 +103,8 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
         mean = x_hat.mean(axis=1)
         projection = _calc_projection(x, mean, self.eps, self.groups)
 
-        args = [x, mean, projection, self.groups]
-        return _decorrelated_batch_normalization(args),
+        return _decorrelated_batch_normalization(
+            x, mean, projection, self.groups),
 
 
 @testing.parameterize(*(testing.product({
@@ -173,8 +172,8 @@ class TestFixedDecorrelatedBatchNormalization(testing.FunctionTestCase):
         x, = inputs
         mean = self.mean.copy()
         projection = self.projection.copy()
-        args = [x, mean, projection, self.groups]
-        return _decorrelated_batch_normalization(args),
+        return _decorrelated_batch_normalization(
+            x, mean, projection, self.groups),
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -1,17 +1,7 @@
-import unittest
-
 import numpy
 
-from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
-from chainer.testing import backend
-
-
-def _to_fcontiguous(arrays):
-    xp = cuda.get_array_module(*arrays)
-    return [xp.asfortranarray(a) for a in arrays]
 
 
 def _decorrelated_batch_normalization(args):
@@ -21,12 +11,9 @@ def _decorrelated_batch_normalization(args):
     b, c = x.shape[:2]
     g = groups
     C = c // g
-
     x = x.reshape((b * g, C) + x.shape[2:])
     x_hat = x.transpose((1, 0) + spatial_axis).reshape(C, -1)
-
     y_hat = projection.dot(x_hat - mean[:, None])
-
     y = y_hat.reshape((C, b * g) + x.shape[2:]).transpose(
         (1, 0) + spatial_axis)
     y = y.reshape((-1, c) + x.shape[2:])
@@ -45,10 +32,8 @@ def _calc_projection(x, mean, eps, groups):
 
     x = x.reshape((b * g, C) + x.shape[2:])
     x_hat = x.transpose((1, 0) + spatial_axis).reshape(C, -1)
-
     mean = x_hat.mean(axis=1)
     x_hat = x_hat - mean[:, None]
-
     cov = x_hat.dot(x_hat.T) / m + eps * numpy.eye(C, dtype=x.dtype)
     eigvals, eigvectors = numpy.linalg.eigh(cov)
     projection = eigvectors.dot(numpy.diag(eigvals ** -0.5)).dot(eigvectors.T)
@@ -67,99 +52,64 @@ def _calc_projection(x, mean, eps, groups):
     'ndim': [1],
     'groups': [1, 2],
     'eps': [2e-5, 5e-1],
-    # NOTE(tommi): xp.linalg.eigh does not support float16
+    # NOTE(crcrpar): np.linalg.eigh does not support float16
     'dtype': [numpy.float32, numpy.float64],
     'c_contiguous': [True, False],
 })))
-@backend.inject_backend_tests(
-    ['test_forward', 'test_backward'],
+@testing.backend.inject_backend_tests(
+    None,
     # CPU tests
-    [{'use_cuda': False}]
+    [{}]
     # GPU tests
     + [{'use_cuda': True}]
 )
-class TestDecorrelatedBatchNormalization(unittest.TestCase):
+class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
+
+    # TODO(crcrpar): Set this variable ``False`` or delete this line once
+    # double backward of
+    # :func:`chainer.functions.decorrelated_batch_normalization` is
+    # implemented.
+    skip_double_backward_test = True
 
     def setUp(self):
-        C = self.n_channels // self.groups
+        self.decay = 0.9
+        check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            check_forward_options['atol'] = 1e-2
+            check_forward_options['rtol'] = 1e-2
+            check_backward_options['atol'] = 1e-2
+            check_backward_options['rtol'] = 1e-2
+        elif self.dtype == numpy.float32:
+            check_backward_options['atol'] = 1e-2
+            check_backward_options['rtol'] = 1e-2
+        self.check_forward_options = check_forward_options
+        self.check_backward_options = check_backward_options
+
+    def generate_inputs(self):
         dtype = self.dtype
         ndim = self.ndim
-
-        head_ndim = 2
         shape = (5, self.n_channels) + (2,) * ndim
         x = numpy.random.uniform(-1, 1, shape).astype(dtype)
-        gy = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        return x,
 
+    def forward(self, inputs, device):
+        x, = inputs
+        return functions.decorrelated_batch_normalization(
+            x, groups=self.groups, eps=self.eps),
+
+    def forward_expected(self, inputs):
+        x, = inputs
+        C = self.n_channels // self.groups
+        head_ndim = 2
         spatial_axis = tuple(range(head_ndim, x.ndim))
         x_hat = x.reshape((5 * self.groups, C) + x.shape[2:])
         x_hat = x_hat.transpose((1, 0) + spatial_axis).reshape(C, -1)
         mean = x_hat.mean(axis=1)
         projection = _calc_projection(x, mean, self.eps, self.groups)
 
-        self.decay = 0.9
-        self.mean = mean
-        self.projection = projection
-
-        self.inputs = [x]
-        self.grad_outputs = [gy]
-
-        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {
-            'atol': 1e-4, 'rtol': 1e-3, 'dtype': numpy.float64}
-        if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
-        elif self.dtype == numpy.float32:
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
-
-    def forward_cpu(self, inputs):
-        y_expect = _decorrelated_batch_normalization(
-            inputs + [self.mean, self.projection, self.groups])
-        return y_expect,
-
-    def check_forward(self, inputs, backend_config):
-        y_expected, = self.forward_cpu(inputs)
-
-        if backend_config.use_cuda:
-            inputs = cuda.to_gpu(inputs)
-        if not self.c_contiguous:
-            inputs = _to_fcontiguous(inputs)
-
-        with backend_config:
-            y = functions.decorrelated_batch_normalization(
-                *inputs, groups=self.groups, decay=self.decay,
-                eps=self.eps)
-        assert y.dtype == self.dtype
-
-        testing.assert_allclose(
-            y_expected, y.array, **self.check_forward_options)
-
-    def test_forward(self, backend_config):
-        self.check_forward(self.inputs, backend_config)
-
-    def check_backward(self, inputs, grad_outputs, backend_config):
-        if backend_config.use_cuda:
-            inputs = cuda.to_gpu(inputs)
-            grad_outputs = cuda.to_gpu(grad_outputs)
-        if not self.c_contiguous:
-            inputs = _to_fcontiguous(inputs)
-            grad_outputs = _to_fcontiguous(grad_outputs)
-
-        def f(*inputs):
-            y = functions.decorrelated_batch_normalization(
-                *inputs, groups=self.groups, decay=self.decay,
-                eps=self.eps)
-            return y,
-
-        with backend_config:
-            gradient_check.check_backward(
-                f, inputs, grad_outputs,
-                **self.check_backward_options)
-
-    def test_backward(self, backend_config):
-        self.check_backward(self.inputs, self.grad_outputs, backend_config)
+        args = [x, mean, projection, self.groups]
+        return _decorrelated_batch_normalization(args),
 
 
 @testing.parameterize(*(testing.product({
@@ -177,53 +127,59 @@ class TestDecorrelatedBatchNormalization(unittest.TestCase):
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'c_contiguous': [True, False],
 })))
-@backend.inject_backend_tests(
-    ['test_forward'],
+@testing.backend.inject_backend_tests(
+    None,
     # CPU tests
-    [{'use_cuda': False}]
+    [{}]
     # GPU tests
     + [{'use_cuda': True}]
 )
-class TestFixedDecorrelatedBatchNormalization(unittest.TestCase):
+class TestFixedDecorrelatedBatchNormalization(testing.FunctionTestCase):
+
+    # TODO(crcrpar): Set this option ``False`` or delete thie line
+    # once double backward of
+    # :func:`chainer.functions.fixed_decorrelated_batch_normalization` is
+    # implemented.
+    # skip_backward_test = True
+    skip_double_backward_test = True
 
     def setUp(self):
         C = self.n_channels // self.groups
         dtype = self.dtype
-        ndim = self.ndim
+        self.mean = numpy.random.uniform(-1, 1, C).astype(dtype)
+        self.projection = numpy.random.uniform(0.5, 1, (C, C)).astype(dtype)
 
+        check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+        if self.dtype == numpy.float32:
+            check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+        self.check_forward_options = check_forward_options
+        self.check_backward_options = check_backward_options
+
+    def generate_inputs(self):
+        dtype = self.dtype
+        ndim = self.ndim
         shape = (5, self.n_channels) + (2,) * ndim
         x = numpy.random.uniform(-1, 1, shape).astype(dtype)
-        mean = numpy.random.uniform(-1, 1, C).astype(dtype)
-        projection = numpy.random.uniform(0.5, 1, (C, C)).astype(dtype)
+        return x,
 
-        self.inputs = [x, mean, projection]
+    def forward(self, inputs, device):
+        x, = inputs
+        mean = device.send_array(self.mean.copy())
+        projection = device.send_array(self.projection.copy())
+        return functions.fixed_decorrelated_batch_normalization(
+            x, mean, projection, groups=self.groups
+        ),
 
-        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
-
-    def forward_cpu(self, inputs):
-        y_expect = _decorrelated_batch_normalization(inputs + [self.groups])
-        return y_expect,
-
-    def check_forward(self, inputs, backend_config):
-        y_expected, = self.forward_cpu(inputs)
-
-        if backend_config.use_cuda:
-            inputs = cuda.to_gpu(inputs)
-        if not self.c_contiguous:
-            inputs = _to_fcontiguous(inputs)
-
-        with backend_config:
-            y = functions.fixed_decorrelated_batch_normalization(
-                *inputs, groups=self.groups)
-        assert y.dtype == self.dtype
-
-        testing.assert_allclose(
-            y_expected, y.array, **self.check_forward_options)
-
-    def test_forward(self, backend_config):
-        self.check_forward(self.inputs, backend_config)
+    def forward_expected(self, inputs):
+        x, = inputs
+        mean = self.mean.copy()
+        projection = self.projection.copy()
+        args = [x, mean, projection, self.groups]
+        return _decorrelated_batch_normalization(args),
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -104,7 +104,8 @@ class TestDecorrelatedBatchNormalization(unittest.TestCase):
         self.grad_outputs = [gy]
 
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'dtype': numpy.float64}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3, 'dtype':
+                                       numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
             self.check_backward_options = {

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -139,10 +139,9 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
 )
 class TestFixedDecorrelatedBatchNormalization(testing.FunctionTestCase):
 
-    # TODO(crcrpar): Delete thie line once double backward of
+    # TODO(crcrpar): Delete this line once double backward of
     # :func:`~chainer.functions.fixed_decorrelated_batch_normalization` is
     # implemented.
-    # skip_backward_test = True
     skip_double_backward_test = True
 
     def setUp(self):

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import six
 
 from chainer.backends import cuda
 from chainer import functions
@@ -16,45 +15,57 @@ def _to_fcontiguous(arrays):
 
 
 def _decorrelated_batch_normalization(args):
-    x, mean, projection = args
+    x, mean, projection, groups = args
     spatial_ndim = len(x.shape[2:])
     spatial_axis = tuple(range(2, 2 + spatial_ndim))
     b, c = x.shape[:2]
+    g = groups
+    C = c // g
 
-    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+    x = x.reshape((b * g, C, ) + x.shape[2:])
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((C, -1))
 
     y_hat = projection.dot(x_hat - mean[:, None])
 
-    y = y_hat.reshape((c, b,) + x.shape[2:]).transpose((1, 0) + spatial_axis)
+    y = y_hat.reshape((C, b * g,) + x.shape[2:]).transpose(
+        (1, 0) + spatial_axis)
+    y = y.reshape((-1, c, ) + x.shape[2:])
     return y
 
 
-def _calc_projection(x, mean, eps):
+def _calc_projection(x, mean, eps, groups):
     spatial_ndim = len(x.shape[2:])
     spatial_axis = tuple(range(2, 2 + spatial_ndim))
     b, c = x.shape[:2]
-    m = b * numpy.prod(numpy.array([x.shape[i] for i in spatial_axis]))
+    g = groups
+    C = c // g
+    m = b * g
+    for i in spatial_axis:
+        m *= x.shape[i]
 
-    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+    x = x.reshape((b * g, C, ) + x.shape[2:])
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((C, -1))
 
     mean = x_hat.mean(axis=1)
     x_hat = x_hat - mean[:, None]
 
-    cov = x_hat.dot(x_hat.T) / m + eps * numpy.eye(c, dtype=x.dtype)
+    cov = x_hat.dot(x_hat.T) / m + eps * numpy.eye(C, dtype=x.dtype)
     eigvals, eigvectors = numpy.linalg.eigh(cov)
     projection = eigvectors.dot(numpy.diag(eigvals ** -0.5)).dot(eigvectors.T)
     return projection
 
 
 @testing.parameterize(*(testing.product({
-    'n_channels': [1, 3],
+    'n_channels': [8],
     'ndim': [0, 2],
+    'groups': [1, 2],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float32],
     'c_contiguous': [True, False],
 }) + testing.product({
-    'n_channels': [3],
+    'n_channels': [8],
     'ndim': [1],
+    'groups': [1, 2],
     'eps': [2e-5, 5e-1],
     # NOTE(tommi): xp.linalg.eigh does not support float16
     'dtype': [numpy.float32, numpy.float64],
@@ -70,18 +81,20 @@ def _calc_projection(x, mean, eps):
 class TestDecorrelatedBatchNormalization(unittest.TestCase):
 
     def setUp(self):
-        n_channels = self.n_channels
+        C = self.n_channels // self.groups
         dtype = self.dtype
         ndim = self.ndim
 
         head_ndim = 2
-        shape = (5, n_channels) + (2,) * ndim
+        shape = (5, self.n_channels) + (2,) * ndim
         x = numpy.random.uniform(-1, 1, shape).astype(dtype)
         gy = numpy.random.uniform(-1, 1, shape).astype(dtype)
 
-        aggr_axes = (0,) + tuple(six.moves.range(head_ndim, x.ndim))
-        mean = x.mean(axis=aggr_axes)
-        projection = _calc_projection(x, mean, self.eps)
+        spatial_axis = tuple(range(head_ndim, x.ndim))
+        x_hat = x.reshape((5 * self.groups, C, ) + x.shape[2:])
+        x_hat = x_hat.transpose((1, 0) + spatial_axis).reshape((C, -1))
+        mean = x_hat.mean(axis=1)
+        projection = _calc_projection(x, mean, self.eps, self.groups)
 
         self.decay = 0.9
         self.mean = mean
@@ -96,10 +109,13 @@ class TestDecorrelatedBatchNormalization(unittest.TestCase):
             self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+        elif self.dtype == numpy.float32:
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
 
     def forward_cpu(self, inputs):
         y_expect = _decorrelated_batch_normalization(
-            inputs + [self.mean, self.projection])
+            inputs + [self.mean, self.projection, self.groups])
         return y_expect,
 
     def check_forward(self, inputs, backend_config):
@@ -112,7 +128,8 @@ class TestDecorrelatedBatchNormalization(unittest.TestCase):
 
         with backend_config:
             y = functions.decorrelated_batch_normalization(
-                *inputs, decay=self.decay, eps=self.eps)
+                *inputs, groups=self.groups, decay=self.decay,
+                eps=self.eps)
         assert y.data.dtype == self.dtype
 
         testing.assert_allclose(
@@ -131,7 +148,8 @@ class TestDecorrelatedBatchNormalization(unittest.TestCase):
 
         def f(*inputs):
             y = functions.decorrelated_batch_normalization(
-                *inputs, decay=self.decay, eps=self.eps)
+                *inputs, groups=self.groups, decay=self.decay,
+                eps=self.eps)
             return y,
 
         with backend_config:
@@ -144,14 +162,16 @@ class TestDecorrelatedBatchNormalization(unittest.TestCase):
 
 
 @testing.parameterize(*(testing.product({
-    'n_channels': [1, 3],
+    'n_channels': [8],
     'ndim': [0, 1, 2],
+    'groups': [1, 2],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float32],
     'c_contiguous': [True, False],
 }) + testing.product({
-    'n_channels': [3],
+    'n_channels': [8],
     'ndim': [1],
+    'groups': [1, 2],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'c_contiguous': [True, False],
@@ -166,14 +186,14 @@ class TestDecorrelatedBatchNormalization(unittest.TestCase):
 class TestFixedDecorrelatedBatchNormalization(unittest.TestCase):
 
     def setUp(self):
-        c = self.n_channels
+        C = self.n_channels // self.groups
         dtype = self.dtype
         ndim = self.ndim
 
-        shape = (5, c) + (2,) * ndim
+        shape = (5, self.n_channels) + (2,) * ndim
         x = numpy.random.uniform(-1, 1, shape).astype(dtype)
-        mean = numpy.random.uniform(-1, 1, c).astype(dtype)
-        projection = numpy.random.uniform(0.5, 1, (c, c)).astype(dtype)
+        mean = numpy.random.uniform(-1, 1, C).astype(dtype)
+        projection = numpy.random.uniform(0.5, 1, (C, C)).astype(dtype)
 
         self.inputs = [x, mean, projection]
 
@@ -182,7 +202,7 @@ class TestFixedDecorrelatedBatchNormalization(unittest.TestCase):
             self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
 
     def forward_cpu(self, inputs):
-        y_expect = _decorrelated_batch_normalization(inputs)
+        y_expect = _decorrelated_batch_normalization(inputs + [self.groups, ])
         return y_expect,
 
     def check_forward(self, inputs, backend_config):
@@ -194,7 +214,8 @@ class TestFixedDecorrelatedBatchNormalization(unittest.TestCase):
             inputs = _to_fcontiguous(inputs)
 
         with backend_config:
-            y = functions.fixed_decorrelated_batch_normalization(*inputs)
+            y = functions.fixed_decorrelated_batch_normalization(
+                *inputs, groups=self.groups)
         assert y.data.dtype == self.dtype
 
         testing.assert_allclose(

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -66,7 +66,7 @@ def _calc_projection(x, mean, eps, groups):
 class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
 
     # TODO(crcrpar): Delete this line once double backward of
-    # :func:`chainer.functions.decorrelated_batch_normalization` is
+    # :func:`~chainer.functions.decorrelated_batch_normalization` is
     # implemented.
     skip_double_backward_test = True
 
@@ -133,7 +133,7 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
 class TestFixedDecorrelatedBatchNormalization(testing.FunctionTestCase):
 
     # TODO(crcrpar): Delete thie line once double backward of
-    # :func:`chainer.functions.fixed_decorrelated_batch_normalization` is
+    # :func:`~chainer.functions.fixed_decorrelated_batch_normalization` is
     # implemented.
     # skip_backward_test = True
     skip_double_backward_test = True

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -61,6 +61,10 @@ def _calc_projection(x, mean, eps, groups):
     [{}]
     # GPU tests
     + [{'use_cuda': True}]
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0']
+    })
 )
 class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
 
@@ -128,6 +132,10 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
     [{}]
     # GPU tests
     + [{'use_cuda': True}]
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0'],
+    })
 )
 class TestFixedDecorrelatedBatchNormalization(testing.FunctionTestCase):
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -1,0 +1,207 @@
+import unittest
+
+import numpy
+import six
+
+from chainer.backends import cuda
+from chainer import functions
+from chainer import gradient_check
+from chainer import testing
+from chainer.testing import backend
+
+
+def _to_fcontiguous(arrays):
+    xp = cuda.get_array_module(*arrays)
+    return [xp.asfortranarray(a) for a in arrays]
+
+
+def _decorrelated_batch_normalization(args):
+    x, mean, projection = args
+    spatial_ndim = len(x.shape[2:])
+    spatial_axis = tuple(range(2, 2 + spatial_ndim))
+    b, c = x.shape[:2]
+
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+
+    y_hat = projection.dot(x_hat - mean[:, None])
+
+    y = y_hat.reshape((c, b,) + x.shape[2:]).transpose((1, 0) + spatial_axis)
+    return y
+
+
+def _calc_projection(x, mean, eps):
+    spatial_ndim = len(x.shape[2:])
+    spatial_axis = tuple(range(2, 2 + spatial_ndim))
+    b, c = x.shape[:2]
+    m = b * numpy.prod(numpy.array([x.shape[i] for i in spatial_axis]))
+
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+
+    mean = x_hat.mean(axis=1)
+    x_hat = x_hat - mean[:, None]
+
+    cov = x_hat.dot(x_hat.T) / m + eps * numpy.eye(c, dtype=x.dtype)
+    eigvals, eigvectors = numpy.linalg.eigh(cov)
+    projection = eigvectors.dot(numpy.diag(eigvals ** -0.5)).dot(eigvectors.T)
+    return projection
+
+
+@testing.parameterize(*(testing.product({
+    'n_channels': [1, 3],
+    'ndim': [0, 2],
+    'eps': [2e-5, 5e-1],
+    'dtype': [numpy.float32],
+    'c_contiguous': [True, False],
+}) + testing.product({
+    'n_channels': [3],
+    'ndim': [1],
+    'eps': [2e-5, 5e-1],
+    # NOTE(tommi): xp.linalg.eigh does not support float16
+    'dtype': [numpy.float32, numpy.float64],
+    'c_contiguous': [True, False],
+})))
+@backend.inject_backend_tests(
+    ['test_forward', 'test_backward'],
+    # CPU tests
+    [{'use_cuda': False}]
+    # GPU tests
+    + [{'use_cuda': True}]
+)
+class TestDecorrelatedBatchNormalization(unittest.TestCase):
+
+    def setUp(self):
+        n_channels = self.n_channels
+        dtype = self.dtype
+        ndim = self.ndim
+
+        head_ndim = 2
+        shape = (5, n_channels) + (2,) * ndim
+        x = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        gy = numpy.random.uniform(-1, 1, shape).astype(dtype)
+
+        aggr_axes = (0,) + tuple(six.moves.range(head_ndim, x.ndim))
+        mean = x.mean(axis=aggr_axes)
+        projection = _calc_projection(x, mean, self.eps)
+
+        self.decay = 0.9
+        self.mean = mean
+        self.projection = projection
+
+        self.inputs = [x]
+        self.grad_outputs = [gy]
+
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'dtype': numpy.float64}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+
+    def forward_cpu(self, inputs):
+        y_expect = _decorrelated_batch_normalization(
+            inputs + [self.mean, self.projection])
+        return y_expect,
+
+    def check_forward(self, inputs, backend_config):
+        y_expected, = self.forward_cpu(inputs)
+
+        if backend_config.use_cuda:
+            inputs = cuda.to_gpu(inputs)
+        if not self.c_contiguous:
+            inputs = _to_fcontiguous(inputs)
+
+        with backend_config:
+            y = functions.decorrelated_batch_normalization(
+                *inputs, decay=self.decay, eps=self.eps)
+        assert y.data.dtype == self.dtype
+
+        testing.assert_allclose(
+            y_expected, y.data, **self.check_forward_options)
+
+    def test_forward(self, backend_config):
+        self.check_forward(self.inputs, backend_config)
+
+    def check_backward(self, inputs, grad_outputs, backend_config):
+        if backend_config.use_cuda:
+            inputs = cuda.to_gpu(inputs)
+            grad_outputs = cuda.to_gpu(grad_outputs)
+        if not self.c_contiguous:
+            inputs = _to_fcontiguous(inputs)
+            grad_outputs = _to_fcontiguous(grad_outputs)
+
+        def f(*inputs):
+            y = functions.decorrelated_batch_normalization(
+                *inputs, decay=self.decay, eps=self.eps)
+            return y,
+
+        with backend_config:
+            gradient_check.check_backward(
+                f, inputs, grad_outputs,
+                **self.check_backward_options)
+
+    def test_backward(self, backend_config):
+        self.check_backward(self.inputs, self.grad_outputs, backend_config)
+
+
+@testing.parameterize(*(testing.product({
+    'n_channels': [1, 3],
+    'ndim': [0, 1, 2],
+    'eps': [2e-5, 5e-1],
+    'dtype': [numpy.float32],
+    'c_contiguous': [True, False],
+}) + testing.product({
+    'n_channels': [3],
+    'ndim': [1],
+    'eps': [2e-5, 5e-1],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'c_contiguous': [True, False],
+})))
+@backend.inject_backend_tests(
+    ['test_forward'],
+    # CPU tests
+    [{'use_cuda': False}]
+    # GPU tests
+    + [{'use_cuda': True}]
+)
+class TestFixedDecorrelatedBatchNormalization(unittest.TestCase):
+
+    def setUp(self):
+        c = self.n_channels
+        dtype = self.dtype
+        ndim = self.ndim
+
+        shape = (5, c) + (2,) * ndim
+        x = numpy.random.uniform(-1, 1, shape).astype(dtype)
+        mean = numpy.random.uniform(-1, 1, c).astype(dtype)
+        projection = numpy.random.uniform(0.5, 1, (c, c)).astype(dtype)
+
+        self.inputs = [x, mean, projection]
+
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
+
+    def forward_cpu(self, inputs):
+        y_expect = _decorrelated_batch_normalization(inputs)
+        return y_expect,
+
+    def check_forward(self, inputs, backend_config):
+        y_expected, = self.forward_cpu(inputs)
+
+        if backend_config.use_cuda:
+            inputs = cuda.to_gpu(inputs)
+        if not self.c_contiguous:
+            inputs = _to_fcontiguous(inputs)
+
+        with backend_config:
+            y = functions.fixed_decorrelated_batch_normalization(*inputs)
+        assert y.data.dtype == self.dtype
+
+        testing.assert_allclose(
+            y_expected, y.data, **self.check_forward_options)
+
+    def test_forward(self, backend_config):
+        self.check_forward(self.inputs, backend_config)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/util_tests/test_forget.py
+++ b/tests/chainer_tests/functions_tests/util_tests/test_forget.py
@@ -162,7 +162,7 @@ class TestForgetGrad(unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'link_name': ['bn', 'brn'],
+    'link_name': ['bn', 'brn', 'dbn'],
     'finetune': [False, True],
 }))
 class TestBatchNormalization(unittest.TestCase):
@@ -177,6 +177,9 @@ class TestBatchNormalization(unittest.TestCase):
                         self.link = links.BatchNormalization(3)
                     elif link_name == 'brn':
                         self.link = links.BatchRenormalization(3)
+                    elif link_name == 'dbn':
+                        self.link = links.DecorrelatedBatchNormalization(
+                            3, groups=3)
                 self.forget = forget
                 self.finetune = finetune
 

--- a/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -79,8 +79,8 @@ class BatchNormalizationTest(unittest.TestCase):
             self.mean = numpy.random.uniform(-1, 1, (C,)).astype(self.dtype)
             self.projection = numpy.random.uniform(0.5, 1, (C, C)).astype(
                 self.dtype)
-            self.link.expected_mean[...] = self.mean
-            self.link.expected_projection[...] = self.projection
+            self.link.avg_mean[...] = self.mean
+            self.link.avg_projection[...] = self.projection
         else:
             spatial_axis = tuple(range(head_ndim, self.x.ndim))
             x_hat = self.x.reshape((5 * self.groups, C, ) + self.x.shape[2:])

--- a/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -1,0 +1,118 @@
+import unittest
+
+import numpy
+import six
+
+import chainer
+from chainer.backends import cuda
+from chainer import gradient_check
+from chainer import links
+from chainer import testing
+from chainer.testing import attr
+from chainer.testing import condition
+
+
+def _decorrelated_batch_normalization(args):
+    x, mean, projection = args
+    spatial_ndim = len(x.shape[2:])
+    spatial_axis = tuple(range(2, 2 + spatial_ndim))
+    b, c = x.shape[:2]
+
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+
+    y_hat = projection.dot(x_hat - mean[:, None])
+
+    y = y_hat.reshape((c, b,) + x.shape[2:]).transpose((1, 0) + spatial_axis)
+    return y
+
+
+def _calc_projection(x, mean, eps):
+    spatial_ndim = len(x.shape[2:])
+    spatial_axis = tuple(range(2, 2 + spatial_ndim))
+    b, c = x.shape[:2]
+    m = b * numpy.prod(numpy.array([x.shape[i] for i in spatial_axis]))
+
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+
+    mean = x_hat.mean(axis=1)
+    x_hat = x_hat - mean[:, None]
+
+    cov = x_hat.dot(x_hat.T) / m + eps * numpy.eye(c, dtype=x.dtype)
+    eigvals, eigvectors = numpy.linalg.eigh(cov)
+    projection = eigvectors.dot(numpy.diag(eigvals ** -0.5)).dot(eigvectors.T)
+    return projection
+
+
+@testing.parameterize(*(testing.product({
+    'test': [True, False],
+    'ndim': [0, 2],
+    # NOTE(tommi): xp.linalg.eigh does not support float16
+    'dtype': [numpy.float32, numpy.float64],
+})))
+class BatchNormalizationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
+
+        self.link = links.DecorrelatedBatchNormalization(3, dtype=self.dtype)
+        self.link.cleargrads()
+
+        shape = (5, 3) + (2,) * self.ndim
+        self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+        self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
+
+        if self.test:
+            self.mean = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
+            self.projection = numpy.random.uniform(0.5, 1, (3, 3)).astype(
+                self.dtype)
+            self.link.expected_mean[...] = self.mean
+            self.link.expected_projection[...] = self.projection
+        else:
+            self.mean = self.x.mean(axis=self.aggr_axes)
+            self.projection = _calc_projection(self.x, self.mean,
+                                               self.link.eps)
+        self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_optionss = {'atol': 5e-1, 'rtol': 1e-1}
+
+    def check_forward(self, x_data):
+        with chainer.using_config('train', not self.test):
+            x = chainer.Variable(x_data)
+            y = self.link(x)
+            self.assertEqual(y.data.dtype, self.dtype)
+
+        y_expect = _decorrelated_batch_normalization((
+            self.x, self.mean, self.projection))
+
+        testing.assert_allclose(
+            y_expect, y.data, **self.check_forward_optionss)
+
+    @condition.retry(3)
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_forward_gpu(self):
+        self.link.to_gpu()
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x_data, y_grad):
+        gradient_check.check_backward(
+            self.link, x_data, y_grad, (),
+            eps=1e-2, **self.check_backward_optionss)
+
+    @condition.retry(3)
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    @condition.retry(3)
+    def test_backward_gpu(self):
+        self.link.to_gpu()
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -10,8 +10,7 @@ from chainer import testing
 from chainer.testing import attr
 
 
-def _decorrelated_batch_normalization(args):
-    x, mean, projection, groups = args
+def _decorrelated_batch_normalization(x, mean, projection, groups):
     spatial_ndim = len(x.shape[2:])
     spatial_axis = tuple(range(2, 2 + spatial_ndim))
     b, c = x.shape[:2]
@@ -98,8 +97,8 @@ class DecorrelatedBatchNormalizationTest(unittest.TestCase):
             y = self.link(x)
             self.assertEqual(y.dtype, self.dtype)
 
-        y_expect = _decorrelated_batch_normalization((
-            self.x, self.mean, self.projection, self.groups))
+        y_expect = _decorrelated_batch_normalization(
+            self.x, self.mean, self.projection, self.groups)
 
         testing.assert_allclose(
             y_expect, y.array, **self.check_forward_options)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -88,12 +88,12 @@ class BatchNormalizationTest(unittest.TestCase):
             self.mean = x_hat.mean(axis=1)
             self.projection = _calc_projection(self.x, self.mean,
                                                self.link.eps, self.groups)
-        self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_optionss = {'atol': 1e-4, 'rtol': 1e-3, 'dtype':
-                                        numpy.float64}
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3, 'dtype':
+                                       numpy.float64}
         if self.dtype == numpy.float16:
-            self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_optionss = {'atol': 5e-1, 'rtol': 1e-1}
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
+            self.check_backward_options = {'atol': 5e-1, 'rtol': 1e-1}
         elif self.dtype == numpy.float32:
             self.check_backward_options = {
                 'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
@@ -108,7 +108,7 @@ class BatchNormalizationTest(unittest.TestCase):
             self.x, self.mean, self.projection, self.groups))
 
         testing.assert_allclose(
-            y_expect, y.data, **self.check_forward_optionss)
+            y_expect, y.data, **self.check_forward_options)
 
     @condition.retry(3)
     def test_forward_cpu(self):
@@ -123,7 +123,7 @@ class BatchNormalizationTest(unittest.TestCase):
     def check_backward(self, x_data, y_grad):
         gradient_check.check_backward(
             self.link, x_data, y_grad, (),
-            eps=1e-2, **self.check_backward_optionss)
+            eps=1e-2, **self.check_backward_options)
 
     @condition.retry(3)
     def test_backward_cpu(self):

--- a/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import six
 
 import chainer
 from chainer.backends import cuda
@@ -13,37 +12,49 @@ from chainer.testing import condition
 
 
 def _decorrelated_batch_normalization(args):
-    x, mean, projection = args
+    x, mean, projection, groups = args
     spatial_ndim = len(x.shape[2:])
     spatial_axis = tuple(range(2, 2 + spatial_ndim))
     b, c = x.shape[:2]
+    g = groups
+    C = c // g
 
-    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+    x = x.reshape((b * g, C, ) + x.shape[2:])
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((C, -1))
 
     y_hat = projection.dot(x_hat - mean[:, None])
 
-    y = y_hat.reshape((c, b,) + x.shape[2:]).transpose((1, 0) + spatial_axis)
+    y = y_hat.reshape((C, b * g,) + x.shape[2:]).transpose(
+        (1, 0) + spatial_axis)
+    y = y.reshape((-1, c, ) + x.shape[2:])
     return y
 
 
-def _calc_projection(x, mean, eps):
+def _calc_projection(x, mean, eps, groups):
     spatial_ndim = len(x.shape[2:])
     spatial_axis = tuple(range(2, 2 + spatial_ndim))
     b, c = x.shape[:2]
-    m = b * numpy.prod(numpy.array([x.shape[i] for i in spatial_axis]))
+    g = groups
+    C = c // g
+    m = b * g
+    for i in spatial_axis:
+        m *= x.shape[i]
 
-    x_hat = x.transpose((1, 0) + spatial_axis).reshape((c, -1))
+    x = x.reshape((b * g, C, ) + x.shape[2:])
+    x_hat = x.transpose((1, 0) + spatial_axis).reshape((C, -1))
 
     mean = x_hat.mean(axis=1)
     x_hat = x_hat - mean[:, None]
 
-    cov = x_hat.dot(x_hat.T) / m + eps * numpy.eye(c, dtype=x.dtype)
+    cov = x_hat.dot(x_hat.T) / m + eps * numpy.eye(C, dtype=x.dtype)
     eigvals, eigvectors = numpy.linalg.eigh(cov)
     projection = eigvectors.dot(numpy.diag(eigvals ** -0.5)).dot(eigvectors.T)
     return projection
 
 
 @testing.parameterize(*(testing.product({
+    'n_channels': [8],
+    'groups': [1, 2],
     'test': [True, False],
     'ndim': [0, 2],
     # NOTE(tommi): xp.linalg.eigh does not support float16
@@ -52,30 +63,40 @@ def _calc_projection(x, mean, eps):
 class BatchNormalizationTest(unittest.TestCase):
 
     def setUp(self):
-        self.aggr_axes = (0,) + tuple(six.moves.range(2, self.ndim + 2))
+        C = self.n_channels // self.groups
+        head_ndim = 2
 
-        self.link = links.DecorrelatedBatchNormalization(3, dtype=self.dtype)
+        self.link = links.DecorrelatedBatchNormalization(self.n_channels,
+                                                         groups=self.groups,
+                                                         dtype=self.dtype)
         self.link.cleargrads()
 
-        shape = (5, 3) + (2,) * self.ndim
+        shape = (5, self.n_channels) + (2,) * self.ndim
         self.x = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, shape).astype(self.dtype)
 
         if self.test:
-            self.mean = numpy.random.uniform(-1, 1, (3,)).astype(self.dtype)
-            self.projection = numpy.random.uniform(0.5, 1, (3, 3)).astype(
+            self.mean = numpy.random.uniform(-1, 1, (C,)).astype(self.dtype)
+            self.projection = numpy.random.uniform(0.5, 1, (C, C)).astype(
                 self.dtype)
             self.link.expected_mean[...] = self.mean
             self.link.expected_projection[...] = self.projection
         else:
-            self.mean = self.x.mean(axis=self.aggr_axes)
+            spatial_axis = tuple(range(head_ndim, self.x.ndim))
+            x_hat = self.x.reshape((5 * self.groups, C, ) + self.x.shape[2:])
+            x_hat = x_hat.transpose((1, 0) + spatial_axis).reshape((C, -1))
+            self.mean = x_hat.mean(axis=1)
             self.projection = _calc_projection(self.x, self.mean,
-                                               self.link.eps)
+                                               self.link.eps, self.groups)
         self.check_forward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_optionss = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_backward_optionss = {'atol': 1e-4, 'rtol': 1e-3, 'dtype':
+                                        numpy.float64}
         if self.dtype == numpy.float16:
             self.check_forward_optionss = {'atol': 1e-3, 'rtol': 1e-2}
             self.check_backward_optionss = {'atol': 5e-1, 'rtol': 1e-1}
+        elif self.dtype == numpy.float32:
+            self.check_backward_options = {
+                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, x_data):
         with chainer.using_config('train', not self.test):
@@ -84,7 +105,7 @@ class BatchNormalizationTest(unittest.TestCase):
             self.assertEqual(y.data.dtype, self.dtype)
 
         y_expect = _decorrelated_batch_normalization((
-            self.x, self.mean, self.projection))
+            self.x, self.mean, self.projection, self.groups))
 
         testing.assert_allclose(
             y_expect, y.data, **self.check_forward_optionss)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -8,7 +8,6 @@ from chainer import gradient_check
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 def _decorrelated_batch_normalization(args):
@@ -19,14 +18,14 @@ def _decorrelated_batch_normalization(args):
     g = groups
     C = c // g
 
-    x = x.reshape((b * g, C, ) + x.shape[2:])
+    x = x.reshape((b * g, C) + x.shape[2:])
     x_hat = x.transpose((1, 0) + spatial_axis).reshape((C, -1))
 
     y_hat = projection.dot(x_hat - mean[:, None])
 
-    y = y_hat.reshape((C, b * g,) + x.shape[2:]).transpose(
+    y = y_hat.reshape((C, b * g) + x.shape[2:]).transpose(
         (1, 0) + spatial_axis)
-    y = y.reshape((-1, c, ) + x.shape[2:])
+    y = y.reshape((-1, c) + x.shape[2:])
     return y
 
 
@@ -40,7 +39,7 @@ def _calc_projection(x, mean, eps, groups):
     for i in spatial_axis:
         m *= x.shape[i]
 
-    x = x.reshape((b * g, C, ) + x.shape[2:])
+    x = x.reshape((b * g, C) + x.shape[2:])
     x_hat = x.transpose((1, 0) + spatial_axis).reshape((C, -1))
 
     mean = x_hat.mean(axis=1)
@@ -57,18 +56,17 @@ def _calc_projection(x, mean, eps, groups):
     'groups': [1, 2],
     'test': [True, False],
     'ndim': [0, 2],
-    # NOTE(tommi): xp.linalg.eigh does not support float16
+    # NOTE(crcrpar): np.linalg.eigh does not support float16
     'dtype': [numpy.float32, numpy.float64],
 })))
-class BatchNormalizationTest(unittest.TestCase):
+class DecorrelatedBatchNormalizationTest(unittest.TestCase):
 
     def setUp(self):
         C = self.n_channels // self.groups
         head_ndim = 2
 
-        self.link = links.DecorrelatedBatchNormalization(self.n_channels,
-                                                         groups=self.groups,
-                                                         dtype=self.dtype)
+        self.link = links.DecorrelatedBatchNormalization(
+            self.n_channels, groups=self.groups, dtype=self.dtype)
         self.link.cleargrads()
 
         shape = (5, self.n_channels) + (2,) * self.ndim
@@ -83,39 +81,33 @@ class BatchNormalizationTest(unittest.TestCase):
             self.link.avg_projection[...] = self.projection
         else:
             spatial_axis = tuple(range(head_ndim, self.x.ndim))
-            x_hat = self.x.reshape((5 * self.groups, C, ) + self.x.shape[2:])
+            x_hat = self.x.reshape((5 * self.groups, C) + self.x.shape[2:])
             x_hat = x_hat.transpose((1, 0) + spatial_axis).reshape((C, -1))
             self.mean = x_hat.mean(axis=1)
             self.projection = _calc_projection(self.x, self.mean,
                                                self.link.eps, self.groups)
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3, 'dtype':
-                                       numpy.float64}
-        if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
-            self.check_backward_options = {'atol': 5e-1, 'rtol': 1e-1}
-        elif self.dtype == numpy.float32:
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 1e-2, 'rtol': 1e-2}
+        self.check_backward_options = {
+            'atol': 5e-3, 'rtol': 1e-3, 'dtype': numpy.float64}
+        if self.dtype == numpy.float32:
+            self.check_backward_options = {'atol': 5e-2, 'rtol': 5e-2}
 
     def check_forward(self, x_data):
         with chainer.using_config('train', not self.test):
             x = chainer.Variable(x_data)
             y = self.link(x)
-            self.assertEqual(y.data.dtype, self.dtype)
+            self.assertEqual(y.dtype, self.dtype)
 
         y_expect = _decorrelated_batch_normalization((
             self.x, self.mean, self.projection, self.groups))
 
         testing.assert_allclose(
-            y_expect, y.data, **self.check_forward_options)
+            y_expect, y.array, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.link.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -125,12 +117,10 @@ class BatchNormalizationTest(unittest.TestCase):
             self.link, x_data, y_grad, (),
             eps=1e-2, **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.link.to_gpu()
         self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))


### PR DESCRIPTION
take over #4686 

Both `F.decorrelated_batch_normalization` and `F.fixed_decorrelated_batch_normalization` do no support double backward. (rel: #4449)