### PR TITLE
Fix unit test collection timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requirements = {
         'pycodestyle>=2.4,<2.5',
     ],
     'test': [
-        'pytest',
+        'pytest==4.1.1',  # 4.2.0 is slow collecting tests and times out on CI.
         'mock',
     ],
     'doctest': [


### PR DESCRIPTION
Since `pytest==4.2.0`, collection of tests has become slow (it gets slower and slower over time) and times out certain CI builds. Pinning `pytest` to the previous versions gets around the problem but I'm not sure it's the right thing to do.