### PR TITLE
let backticks embrace outputs of chainer.print_runtime_info

### DIFF
--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -31,6 +31,7 @@ class _RuntimeInfo(object):
 
     def __str__(self):
         s = six.StringIO()
+        s.write('''```\n''')
         s.write('''Platform: {}\n'''.format(self.platform_version))
         s.write('''Chainer: {}\n'''.format(self.chainer_version))
         s.write('''NumPy: {}\n'''.format(self.numpy_version))
@@ -44,6 +45,7 @@ class _RuntimeInfo(object):
             s.write('''iDeep: Not Available\n''')
         else:
             s.write('''iDeep: {}\n'''.format(self.ideep_version))
+        s.write('''```\n''')
         return s.getvalue()
 
 


### PR DESCRIPTION
This PR places three backticks at the beginning and end of outputs of `chainer.print_runtime_info` because some people (at least I) always do this.