### PR TITLE
add x_dtype and W_dtype to the if statement of FunctionTestCase._skip_if_chainerx_float16

### DIFF
--- a/chainer/testing/function.py
+++ b/chainer/testing/function.py
@@ -221,10 +221,13 @@ class FunctionTestCase(unittest.TestCase):
     def _skip_if_chainerx_float16(self, backend_config):
         # This is a dirty workaround to avoid writing the skip logic in every
         # test case.
-        # It assumes that there's an attribute 'dtype' in the test case.
+        # It assumes that there's attributes 'dtype', `x_dtype`, and `W_dtype`
+        # in the test case.
         # TODO(niboshi): Support float16 in ChainerX
-        if (backend_config.use_chainerx
-                and getattr(self, 'dtype', None) == numpy.float16):
+        if (backend_config.use_chainerx and (
+                getattr(self, 'dtype', None) == numpy.float16 or
+                getattr(self, 'x_dtype', None) == numpy.float16 or
+                getattr(self, 'W_dtype', None) == numpy.float16)):
             raise unittest.SkipTest('ChainerX does not support float16')
 
     def test_forward(self, backend_config):


### PR DESCRIPTION
rel: #6071 

This PR makes it easier to rewriting connection_tests.

As some connection_tests use `x_dtype` and `W_dtype` instead of `dtype`, it'll be more handy to
skip chainerx if x_dtype and/or W_dtype are `numpy.float16`.

ref:
https://github.com/chainer/chainer/blob/24705fb771bf3df8a954724c5ab567d2f2248456/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py#L24-L45

https://github.com/chainer/chainer/blob/12535b6279fb1ce55acc48e5c52ec68af9c23a05/tests/chainer_tests/functions_tests/connection_tests/test_linear.py#L21-L28