### PR TITLE
Check input size consistency in RNN and LSTM when using cuDNN

### DIFF
--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -411,6 +411,13 @@ def n_step_lstm_base(
         lengths = [len(x) for x in xs]
         xs = chainer.functions.concat(xs, axis=0)
 
+        # Check input size consistency with xs and ws here.
+        x_in = xs[0].shape[0]
+        w_in = ws[0][0].shape[1]
+        if x_in != w_in:
+            raise ValueError('Inconsistent input size in input values and '
+                             'weight parameters')
+
         w = n_step_rnn.cudnn_rnn_weight_concat(
             n_layers, states, use_bi_direction, 'lstm', ws, bs)
 

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -403,6 +403,13 @@ def n_step_lstm_base(
             'Use chainer.using_config')
         argument.assert_kwargs_empty(kwargs)
 
+    # Check input size consistency with xs and ws here.
+    x_in = xs[0].shape[1]
+    w_in = ws[0][0].shape[1]
+    if x_in != w_in:
+        raise ValueError('Inconsistent input size in input values and weight '
+                         'parameters')
+
     xp = backend.get_array_module(hx, hx.data)
 
     if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
@@ -410,13 +417,6 @@ def n_step_lstm_base(
         states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]
         xs = chainer.functions.concat(xs, axis=0)
-
-        # Check input size consistency with xs and ws here.
-        x_in = xs[0].shape[0]
-        w_in = ws[0][0].shape[1]
-        if x_in != w_in:
-            raise ValueError('Inconsistent input size in input values and '
-                             'weight parameters')
 
         w = n_step_rnn.cudnn_rnn_weight_concat(
             n_layers, states, use_bi_direction, 'lstm', ws, bs)

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -408,7 +408,7 @@ def n_step_lstm_base(
     w_in = ws[0][0].shape[1]
     if x_in != w_in:
         raise ValueError('Inconsistent input size in input values and weight '
-                         'parameters')
+                         'parameters: {} != {}'.format(x_in, w_in))
 
     xp = backend.get_array_module(hx, hx.data)
 

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -633,6 +633,13 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
         raise ValueError('Invalid activation: "%s". Please select from [%s]'
                          % (activation, candidate))
 
+    # Check input size consistency with xs and ws.
+    x_in = xs[0].shape[1]
+    w_in = ws[0][0].shape[1]
+    if x_in != w_in:
+        raise ValueError('Inconsistent input size in input values and weight '
+                         'parameters')
+
     xp = backend.get_array_module(hx)
 
     if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
@@ -640,13 +647,6 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
         states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]
         xs = chainer.functions.concat(xs, axis=0)
-
-        # Check input size consistency with xs and ws here.
-        x_in = xs[0].shape[0]
-        w_in = ws[0][0].shape[1]
-        if x_in != w_in:
-            raise ValueError('Inconsistent input size in input values and '
-                             'weight parameters')
 
         rnn_mode = 'rnn_%s' % activation
         w = cudnn_rnn_weight_concat(

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -641,6 +641,13 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
         lengths = [len(x) for x in xs]
         xs = chainer.functions.concat(xs, axis=0)
 
+        # Check input size consistency with xs and ws here.
+        x_in = xs[0].shape[0]
+        w_in = ws[0][0].shape[1]
+        if x_in != w_in:
+            raise ValueError('Inconsistent input size in input values and '
+                             'weight parameters')
+
         rnn_mode = 'rnn_%s' % activation
         w = cudnn_rnn_weight_concat(
             n_layers, states, use_bi_direction, rnn_mode, ws, bs)

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -638,7 +638,7 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
     w_in = ws[0][0].shape[1]
     if x_in != w_in:
         raise ValueError('Inconsistent input size in input values and weight '
-                         'parameters')
+                         'parameters: {} != {}'.format(x_in, w_in))
 
     xp = backend.get_array_module(hx)
 

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -230,6 +230,51 @@ class TestNStepLSTM(unittest.TestCase):
         self.check_call_cudnn_backward('auto')
 
 
+class TestNStepLSTMInconsistentInputSize(unittest.TestCase):
+
+    def testInconsistentInputSize(self):
+        batches = [3, 2, 1]
+        in_size = 3
+        out_size = 2
+        n_layers = 2
+        dropout = 0.0
+
+        h_shape = (n_layers, batches[0], out_size)
+        cx = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        cx = _wrap_variable(_to_gpu(cx))
+        hx = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        hx = _wrap_variable(_to_gpu(hx))
+
+        ws = []
+        bs = []
+        for i in range(n_layers):
+            weights = []
+            biases = []
+            for j in range(8):
+                if i == 0 and j < 4:
+                    w_in = in_size
+                else:
+                    w_in = out_size
+
+                weights.append(numpy.random.uniform(
+                    -1, 1, (out_size, w_in)).astype('f'))
+                biases.append(numpy.random.uniform(
+                    -1, 1, (out_size,)).astype('f'))
+            ws.append(weights)
+            bs.append(biases)
+        ws = _wrap_variable(_to_gpu(ws))
+        bs = _wrap_variable(_to_gpu(bs))
+
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
+              for b in batches]
+        xs = _wrap_variable(_to_gpu(xs))
+
+        with self.assertRaises(ValueError):
+            functions.n_step_lstm(
+                n_layers, dropout, hx, cx, ws, bs, xs)
+
+
 class TestNStepBiLSTM(unittest.TestCase):
 
     batches = [3, 2, 1]
@@ -581,6 +626,54 @@ class TestNStepLSTMDropout(unittest.TestCase):
                 h_counts[i], total * (1 - self.dropout) ** (self.length * i))
             self.assert_count(
                 c_counts[i], total * (1 - self.dropout) ** (self.length * i))
+
+
+class TestNStepBiLSTMInconsistentInputSize(unittest.TestCase):
+
+    def testInconsistentInputSize(self):
+        batches = [3, 2, 1]
+        in_size = 3
+        out_size = 2
+        n_layers = 2
+        dropout = 0.0
+
+        h_shape = (n_layers, batches[0], out_size)
+        cx = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        cx = _wrap_variable(_to_gpu(cx))
+        hx = numpy.random.uniform(-1, 1, h_shape).astype(numpy.float32)
+        hx = _wrap_variable(_to_gpu(hx))
+
+        ws = []
+        bs = []
+        for i in range(n_layers):
+            for di in [0, 1]:
+                weights = []
+                biases = []
+                for j in range(8):
+                    if i == 0 and j < 4:
+                        w_in = in_size
+                    elif i > 0 and j < 4:
+                        w_in = out_size * 2
+                    else:
+                        w_in = out_size
+
+                weights.append(numpy.random.uniform(
+                    -1, 1, (out_size, w_in)).astype('f'))
+                biases.append(numpy.random.uniform(
+                    -1, 1, (out_size,)).astype('f'))
+            ws.append(weights)
+            bs.append(biases)
+        ws = _wrap_variable(_to_gpu(ws))
+        bs = _wrap_variable(_to_gpu(bs))
+
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
+              for b in batches]
+        xs = _wrap_variable(_to_gpu(xs))
+
+        with self.assertRaises(ValueError):
+            functions.n_step_bilstm(
+                n_layers, dropout, hx, cx, ws, bs, xs)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -232,6 +232,7 @@ class TestNStepLSTM(unittest.TestCase):
 
 class TestNStepLSTMInconsistentInputSize(unittest.TestCase):
 
+    @attr.cudnn
     def testInconsistentInputSize(self):
         batches = [3, 2, 1]
         in_size = 3
@@ -630,6 +631,7 @@ class TestNStepLSTMDropout(unittest.TestCase):
 
 class TestNStepBiLSTMInconsistentInputSize(unittest.TestCase):
 
+    @attr.cudnn
     def testInconsistentInputSize(self):
         batches = [3, 2, 1]
         in_size = 3

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -229,7 +229,8 @@ class TestNStepLSTM(unittest.TestCase):
         self.check_call_cudnn_backward('never')
         self.check_call_cudnn_backward('auto')
 
-    def check_inconsistent_input_size(self, h_data, c_data, xs_data, ws_data, bs_data):
+    def check_inconsistent_input_size(
+            self, h_data, c_data, xs_data, ws_data, bs_data):
         h = _wrap_variable(h_data)
         c = _wrap_variable(c_data)
         xs = _wrap_variable(xs_data)
@@ -243,7 +244,8 @@ class TestNStepLSTM(unittest.TestCase):
         x_in_size = 4  # inconsistent in_size with that of ws.
         xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
               for b in self.batches]
-        self.check_inconsistent_input_size(self.hx, self.cx, xs, self.ws, self.bs)
+        self.check_inconsistent_input_size(
+            self.hx, self.cx, xs, self.ws, self.bs)
 
     def check_inconsistent_input_size_gpu(self, use_cudnn):
         x_in_size = 4  # inconsistent in_size with that of ws.
@@ -496,7 +498,8 @@ class TestNStepBiLSTM(unittest.TestCase):
         self.check_call_cudnn_backward('never')
         self.check_call_cudnn_backward('auto')
 
-    def check_inconsistent_input_size(self, h_data, c_data, xs_data, ws_data, bs_data):
+    def check_inconsistent_input_size(
+            self, h_data, c_data, xs_data, ws_data, bs_data):
         h = _wrap_variable(h_data)
         c = _wrap_variable(c_data)
         xs = _wrap_variable(xs_data)
@@ -510,7 +513,8 @@ class TestNStepBiLSTM(unittest.TestCase):
         x_in_size = 4  # inconsistent in_size with that of ws.
         xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
               for b in self.batches]
-        self.check_inconsistent_input_size(self.hx, self.cx, xs, self.ws, self.bs)
+        self.check_inconsistent_input_size(
+            self.hx, self.cx, xs, self.ws, self.bs)
 
     def check_inconsistent_input_size_gpu(self, use_cudnn):
         x_in_size = 4  # inconsistent in_size with that of ws.

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -271,6 +271,7 @@ class TestNStepRNN(unittest.TestCase):
 
 class TestNStepRNNInconsistentInputSize(unittest.TestCase):
 
+    @attr.cudnn
     def testInconsistentInputSize(self):
         batches = [3, 2, 1]
         in_size = 3
@@ -533,6 +534,7 @@ class TestNStepBiRNN(unittest.TestCase):
 
 class TestNStepBiRNNInconsistentInputSize(unittest.TestCase):
 
+    @attr.cudnn
     def testInconsistentInputSize(self):
         batches = [3, 2, 1]
         in_size = 3


### PR DESCRIPTION
Close #5436.

This PR makes RNN and LSTM functions check input size consistency with their input values and weights when using cuDNN.

- `F.n_step_rnn`
- `F.n_step_birnn`
- `F.n_step_lstm`
- `F.n_step_bilstm`
