### PR TITLE
Fix `Optimizer` to convert state arrays back to ChainerX

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -317,6 +317,9 @@ class UpdateRule(object):
 
         # Restore state arrays
         for state_name, arr in chainerx_state_arrays.items():
+            cur_arr = self.state[state_name]
+            if cur_arr is not arr:
+                arr = backend.to_chainerx(cur_arr)
             self.state[state_name] = arr
 
     def init_state(self, param):


### PR DESCRIPTION
Currently, `update_core_chainerx` in `Optimizer` class assumes that state arrays are updated in-place, but `optimizers.SMORM3` replaces the state arrays instead.