### PR TITLE
Add imports of initializers and math, required in "Define your own function" examples

### DIFF
--- a/docs/source/imports.rst
+++ b/docs/source/imports.rst
@@ -3,13 +3,14 @@
 
 .. testcode::
 
+     import math
      import numpy as np
      import chainer
      from chainer import backend
      from chainer import backends
      from chainer.backends import cuda
      from chainer import Function, gradient_check, report, training, utils, Variable
-     from chainer import datasets, iterators, optimizers, serializers
+     from chainer import datasets, initializers, iterators, optimizers, serializers
      from chainer import Link, Chain, ChainList
      import chainer.functions as F
      import chainer.links as L


### PR DESCRIPTION
Add imports of initializers and math, required in "Define your own function" examples.

In examples, provided in https://docs.chainer.org/en/stable/guides/functions.html#links-that-wrap-functions, there are two missing imports: `from chainer import initializers` and `import math`.
```

class EltwiseParamProduct(Link):
    def __init__(self, shape):
        super(EltwiseParamProduct, self).__init__()
        with self.init_scope():
            self.W = chainer.Parameter(**initializers**.Normal(scale=1.), shape)

    def forward(self, x):
        return self.W * x
```
```

class Linear(Link):
    def __init__(self, in_size, out_size):
        super(Linear, self).__init__()
        with self.init_scope():
            self.W = chainer.Parameter(
                initializers.Normal(1. / math.sqrt(in_size)),
                (out_size, in_size))
            self.b = chainer.Parameter(0, (out_size,))

    def forward(self, x):
        return linear(x, self.W, self.b)
```