### PR TITLE
[backport] Check input size consistency in RNN and LSTM when using cuDNN

### DIFF
--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -420,6 +420,13 @@ def n_step_lstm_base(
             'Use chainer.using_config')
         argument.assert_kwargs_empty(kwargs)
 
+    # Check input size consistency with xs and ws here.
+    x_in = xs[0].shape[1]
+    w_in = ws[0][0].shape[1]
+    if x_in != w_in:
+        raise ValueError('Inconsistent input size in input values and weight '
+                         'parameters: {} != {}'.format(x_in, w_in))
+
     xp = backend.get_array_module(hx, hx.data)
 
     if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -657,6 +657,13 @@ def n_step_rnn_base(n_layers, dropout_ratio, hx, ws, bs, xs,
         raise ValueError('Invalid activation: "%s". Please select from [%s]'
                          % (activation, candidate))
 
+    # Check input size consistency with xs and ws.
+    x_in = xs[0].shape[1]
+    w_in = ws[0][0].shape[1]
+    if x_in != w_in:
+        raise ValueError('Inconsistent input size in input values and weight '
+                         'parameters: {} != {}'.format(x_in, w_in))
+
     xp = backend.get_array_module(hx)
 
     if xp is not numpy and chainer.should_use_cudnn('>=auto', 5000):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -229,6 +229,45 @@ class TestNStepLSTM(unittest.TestCase):
         self.check_call_cudnn_backward('never')
         self.check_call_cudnn_backward('auto')
 
+    def check_inconsistent_input_size(
+            self, h_data, c_data, xs_data, ws_data, bs_data):
+        h = _wrap_variable(h_data)
+        c = _wrap_variable(c_data)
+        xs = _wrap_variable(xs_data)
+        ws = _wrap_variable(ws_data)
+        bs = _wrap_variable(bs_data)
+        with self.assertRaises(ValueError):
+            functions.n_step_lstm(
+                self.n_layers, self.dropout, h, c, ws, bs, xs)
+
+    def test_inconsistent_input_size_cpu(self):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
+              for b in self.batches]
+        self.check_inconsistent_input_size(
+            self.hx, self.cx, xs, self.ws, self.bs)
+
+    def check_inconsistent_input_size_gpu(self, use_cudnn):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
+              for b in self.batches]
+
+        hx = _to_gpu(self.hx)
+        cx = _to_gpu(self.cx)
+        xs = _to_gpu(xs)
+        ws = _to_gpu(self.ws)
+        bs = _to_gpu(self.bs)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            self.check_inconsistent_input_size(hx, cx, xs, ws, bs)
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_always(self):
+        self.check_inconsistent_input_size_gpu('always')
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_never(self):
+        self.check_inconsistent_input_size_gpu('never')
+
 
 class TestNStepBiLSTM(unittest.TestCase):
 
@@ -458,6 +497,45 @@ class TestNStepBiLSTM(unittest.TestCase):
         self.check_call_cudnn_backward('always')
         self.check_call_cudnn_backward('never')
         self.check_call_cudnn_backward('auto')
+
+    def check_inconsistent_input_size(
+            self, h_data, c_data, xs_data, ws_data, bs_data):
+        h = _wrap_variable(h_data)
+        c = _wrap_variable(c_data)
+        xs = _wrap_variable(xs_data)
+        ws = _wrap_variable(ws_data)
+        bs = _wrap_variable(bs_data)
+        with self.assertRaises(ValueError):
+            functions.n_step_bilstm(
+                self.n_layers, self.dropout, h, c, ws, bs, xs)
+
+    def test_inconsistent_input_size_cpu(self):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
+              for b in self.batches]
+        self.check_inconsistent_input_size(
+            self.hx, self.cx, xs, self.ws, self.bs)
+
+    def check_inconsistent_input_size_gpu(self, use_cudnn):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        xs = [numpy.random.uniform(-1, 1, (b, x_in_size)).astype('f')
+              for b in self.batches]
+
+        hx = _to_gpu(self.hx)
+        cx = _to_gpu(self.cx)
+        xs = _to_gpu(xs)
+        ws = _to_gpu(self.ws)
+        bs = _to_gpu(self.bs)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            self.check_inconsistent_input_size(hx, cx, xs, ws, bs)
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_always(self):
+        self.check_inconsistent_input_size_gpu('always')
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_never(self):
+        self.check_inconsistent_input_size_gpu('never')
 
 
 def _stack_weight(ws):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -268,6 +268,42 @@ class TestNStepRNN(unittest.TestCase):
         self.check_call_cudnn_backward_inference('never')
         self.check_call_cudnn_backward_inference('auto')
 
+    def check_inconsistent_input_size(self, h_data, xs_data, ws_data, bs_data):
+        h = _wrap_variable(h_data)
+        xs = _wrap_variable(xs_data)
+        ws = _wrap_variable(ws_data)
+        bs = _wrap_variable(bs_data)
+        with self.assertRaises(ValueError):
+            functions.n_step_rnn(
+                self.n_layers, self.dropout, h, ws, bs, xs,
+                activation=self.activation)
+
+    def test_inconsistent_input_size_cpu(self):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        x_shape = [(b, x_in_size) for b in self.batches]
+        xs = _shaped_random(x_shape)
+        self.check_inconsistent_input_size(self.hx, xs, self.ws, self.bs)
+
+    def check_inconsistent_input_size_gpu(self, use_cudnn):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        x_shape = [(b, x_in_size) for b in self.batches]
+        xs = _shaped_random(x_shape)
+
+        hx = _to_gpu(self.hx)
+        xs = _to_gpu(xs)
+        ws = _to_gpu(self.ws)
+        bs = _to_gpu(self.bs)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            self.check_inconsistent_input_size(hx, xs, ws, bs)
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_always(self):
+        self.check_inconsistent_input_size_gpu('always')
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_never(self):
+        self.check_inconsistent_input_size_gpu('never')
+
 
 @testing.parameterize(*testing.product({
     'activation': ['tanh', 'relu']
@@ -495,6 +531,42 @@ class TestNStepBiRNN(unittest.TestCase):
         self.check_call_cudnn_backward('always')
         self.check_call_cudnn_backward('never')
         self.check_call_cudnn_backward('auto')
+
+    def check_inconsistent_input_size(self, h_data, xs_data, ws_data, bs_data):
+        h = _wrap_variable(h_data)
+        xs = _wrap_variable(xs_data)
+        ws = _wrap_variable(ws_data)
+        bs = _wrap_variable(bs_data)
+        with self.assertRaises(ValueError):
+            functions.n_step_birnn(
+                self.n_layers, self.dropout, h, ws, bs, xs,
+                activation=self.activation)
+
+    def test_inconsistent_input_size_cpu(self):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        x_shape = [(b, x_in_size) for b in self.batches]
+        xs = _shaped_random(x_shape)
+        self.check_inconsistent_input_size(self.hx, xs, self.ws, self.bs)
+
+    def check_inconsistent_input_size_gpu(self, use_cudnn):
+        x_in_size = 4  # inconsistent in_size with that of ws.
+        x_shape = [(b, x_in_size) for b in self.batches]
+        xs = _shaped_random(x_shape)
+
+        hx = _to_gpu(self.hx)
+        xs = _to_gpu(xs)
+        ws = _to_gpu(self.ws)
+        bs = _to_gpu(self.bs)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            self.check_inconsistent_input_size(hx, xs, ws, bs)
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_always(self):
+        self.check_inconsistent_input_size_gpu('always')
+
+    @attr.gpu
+    def test_inconsistent_input_size_gpu_cudnn_never(self):
+        self.check_inconsistent_input_size_gpu('never')
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Backport of #6169