### PR TITLE
Add `FunctionTestCase` to documentation

### DIFF
--- a/docs/source/reference/check.rst
+++ b/docs/source/reference/check.rst
@@ -59,6 +59,7 @@ Utilities for testing functions.
    :toctree: generated/
    :nosignatures:
 
+   chainer.testing.FunctionTestCase
    chainer.testing.unary_math_function_unittest
 
 Serialization testing utilities


### PR DESCRIPTION
Document `chainer.testing.FunctionTestCase` (#3499) because it is public (from the naming convention).