### PR TITLE
Rewrite the tests of `F.triplet`

### DIFF
--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -136,6 +136,14 @@ def _populate_module_functions():
 
     chainerx.vstack = _vstack
 
+    def _repeat(arr, repeats, axis=None):
+        xp, dev, arr = _from_chainerx(arr)
+        with dev:
+            ret = xp.repeat(arr, repeats, axis)
+        return _to_chainerx(ret)
+
+    chainerx.repeat = _repeat
+
 
 def _populate_ndarray():
     ndarray = chainerx.ndarray

--- a/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
@@ -6,8 +6,8 @@ import six
 from chainer.backends import cuda
 from chainer import functions
 from chainer import testing
-from chainer import utils
 from chainer.testing import attr
+from chainer import utils
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
@@ -3,11 +3,10 @@ import unittest
 import numpy
 import six
 
-import chainer
 from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
+from chainer import utils
 from chainer.testing import attr
 
 
@@ -18,42 +17,34 @@ from chainer.testing import attr
     'margin': [0.1, 0.5],
     'reduce': ['mean', 'no']
 }))
-class TestTriplet(unittest.TestCase):
+@testing.fix_random()
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {}
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestTriplet(testing.FunctionTestCase):
+
+    dodge_nondifferentiable = True
 
     def setUp(self):
-        eps = 1e-3
-        x_shape = (self.batchsize, self.input_dim)
-
-        # Sample differentiable inputs
-        while True:
-            self.a = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-            self.p = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-            self.n = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-            if (abs(self.a - self.p) < 2 * eps).any():
-                continue
-            if (abs(self.a - self.n) < 2 * eps).any():
-                continue
-            dist = numpy.sum(
-                (self.a - self.p) ** 2 - (self.a - self.n) ** 2,
-                axis=1) + self.margin
-            if (abs(dist) < 2 * eps).any():
-                continue
-            break
-
-        if self.reduce == 'mean':
-            gy_shape = ()
-        else:
-            gy_shape = self.batchsize,
-        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
-        self.gga = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-        self.ggp = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-        self.ggn = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
 
         if self.dtype == numpy.float16:
             self.check_forward_options = {'rtol': 5e-3, 'atol': 5e-3}
             self.check_backward_options = {'rtol': 5e-2, 'atol': 5e-2}
-            self.check_double_backward_options = {
-                'dtype': numpy.float64, 'rtol': 1e-3, 'atol': 1e-3}
+            self.check_double_backward_options = {'rtol': 1e-3, 'atol': 1e-3}
         elif self.dtype == numpy.float32:
             self.check_forward_options = {'rtol': 1e-4, 'atol': 1e-4}
             self.check_backward_options = {'rtol': 5e-4, 'atol': 5e-4}
@@ -65,85 +56,56 @@ class TestTriplet(unittest.TestCase):
         else:
             raise ValueError('invalid dtype')
 
-    def check_forward(self, a_data, p_data, n_data):
-        a_val = chainer.Variable(a_data)
-        p_val = chainer.Variable(p_data)
-        n_val = chainer.Variable(n_data)
-        loss = functions.triplet(a_val, p_val, n_val, self.margin, self.reduce)
-        if self.reduce == 'mean':
-            self.assertEqual(loss.data.shape, ())
-        else:
-            self.assertEqual(loss.data.shape, (self.batchsize,))
-        self.assertEqual(loss.data.dtype, self.dtype)
-        loss_value = cuda.to_cpu(loss.data)
+    def generate_inputs(self):
+        eps = 1e-3
+        x_shape = (self.batchsize, self.input_dim)
 
-        #
-        # Compute expected value
-        #
-        loss_expect = numpy.empty((self.a.shape[0],), dtype=self.dtype)
-        for i in six.moves.range(self.a.shape[0]):
-            ad, pd, nd = self.a[i], self.p[i], self.n[i]
+        # Sample differentiable inputs
+        while True:
+            a = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+            p = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+            n = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+            if (abs(a - p) < 2 * eps).any():
+                continue
+            if (abs(a - n) < 2 * eps).any():
+                continue
+            dist = numpy.sum((a - p) ** 2 - (a - n) ** 2, axis=1) + self.margin
+            if (abs(dist) < 2 * eps).any():
+                continue
+            break
+        return a, p, n
+
+    def generate_grad_outputs(self, outputs_template):
+        if self.reduce == 'mean':
+            gy_shape = ()
+        else:
+            gy_shape = self.batchsize,
+        return numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype),
+
+    def generate_grad_grad_inputs(self, inputs_template):
+        x_shape = (self.batchsize, self.input_dim)
+        gga = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+        ggp = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+        ggn = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
+        return gga, ggp, ggn
+
+    def forward(self, inputs, device):
+        anchor, positive, negative = inputs
+        return functions.triplet(
+            anchor, positive, negative, self.margin, self.reduce),
+
+    def forward_expected(self, inputs):
+        anchor, positive, negative = inputs
+        loss_expect = numpy.empty((anchor.shape[0],), dtype=self.dtype)
+        for i in six.moves.range(anchor.shape[0]):
+            ad, pd, nd = anchor[i], positive[i], negative[i]
             dp = numpy.sum((ad - pd) ** 2)
             dn = numpy.sum((ad - nd) ** 2)
             loss_expect[i] = max((dp - dn + self.margin), 0)
         if self.reduce == 'mean':
             loss_expect = loss_expect.mean()
-        numpy.testing.assert_allclose(
-            loss_expect, loss_value, **self.check_forward_options)
 
-    def test_negative_margin(self):
-        self.margin = -1
-        self.assertRaises(ValueError, self.check_forward,
-                          self.a, self.p, self.n)
-        self.assertRaises(ValueError, self.check_backward,
-                          self.a, self.p, self.n, self.gy)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.a, self.p, self.n)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.a), cuda.to_gpu(self.p),
-                           cuda.to_gpu(self.n))
-
-    def check_backward(self, a_data, p_data, n_data, gy_data):
-        def f(a, p, n):
-            return functions.triplet(
-                a, p, n, margin=self.margin, reduce=self.reduce)
-
-        gradient_check.check_backward(
-            f, (a_data, p_data, n_data), gy_data, dtype=numpy.float64,
-            **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.a, self.p, self.n, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.a), cuda.to_gpu(self.p),
-                            cuda.to_gpu(self.n), cuda.to_gpu(self.gy))
-
-    def check_double_backward(self, a_data, p_data, n_data, gy_data, gga_data,
-                              ggp_data, ggn_data):
-        def f(a, p, n):
-            return functions.triplet(
-                a, p, n, margin=self.margin, reduce=self.reduce)
-
-        gradient_check.check_double_backward(
-            f, (a_data, p_data, n_data), gy_data,
-            (gga_data, ggp_data, ggn_data),
-            **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(
-            self.a, self.p, self.n, self.gy, self.gga, self.ggp, self.ggn)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(
-            cuda.to_gpu(self.a), cuda.to_gpu(self.p), cuda.to_gpu(self.n),
-            cuda.to_gpu(self.gy), cuda.to_gpu(self.gga), cuda.to_gpu(self.ggp),
-            cuda.to_gpu(self.ggn))
+        return utils.force_array(loss_expect, self.dtype),
 
 
 class TestContrastiveInvalidReductionOption(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_triplet.py
@@ -75,20 +75,6 @@ class TestTriplet(testing.FunctionTestCase):
             break
         return a, p, n
 
-    def generate_grad_outputs(self, outputs_template):
-        if self.reduce == 'mean':
-            gy_shape = ()
-        else:
-            gy_shape = self.batchsize,
-        return numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype),
-
-    def generate_grad_grad_inputs(self, inputs_template):
-        x_shape = (self.batchsize, self.input_dim)
-        gga = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-        ggp = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-        ggn = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-        return gga, ggp, ggn
-
     def forward(self, inputs, device):
         anchor, positive, negative = inputs
         return functions.triplet(


### PR DESCRIPTION
rel: #6071 
Resolves #6190 

This PR aims at simplifying and stabilizing the tests of `F.triplet` using `chainer.testing.FunctionTestCase`.