### PR TITLE
Remove bad brew option from Travis CI

### DIFF
--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -51,7 +51,7 @@ step_before_install_chainer_test() {
     # Remove oclint as it conflicts with GCC (indirect dependency of hdf5)
     if [[ $TRAVIS_OS_NAME = "osx" ]]; then
         brew update >/dev/null
-        brew outdated pyenv || brew upgrade --quiet pyenv
+        brew outdated pyenv || brew upgrade pyenv
 
         PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION
         pyenv global $PYTHON_VERSION


### PR DESCRIPTION
Attempts to fix Travis failure due to unrecognized option `--quiet` to `brew upgrade` (it might be the case that's it's always been unrecognized but silently ignored, until the recent brew refactoring in 2.0.0).