### PR TITLE
Omit `VariableNode` creation for `Variable`s with `requires_grad=False`

### DIFF
--- a/chainer/exporters/caffe.py
+++ b/chainer/exporters/caffe.py
@@ -165,7 +165,7 @@ class _RetrieveAsCaffeModel(object):
                     setattr(layer.inner_product_param, k, v)
                 _add_blob(layer, list(W.shape), W.data)
                 if b is not None:
-                    b.retain_data()
+                    b.retain_data(b.data)
                     _add_blob(layer, list(b.shape), b.data)
 
         elif func.label in ('Convolution2DFunction',
@@ -202,7 +202,7 @@ class _RetrieveAsCaffeModel(object):
                 _add_blob(layer, [n_out, n_in, kh, kw], W.data)
 
                 if b is not None:
-                    b.retain_data()
+                    b.retain_data(b.data)
                     _add_blob(layer, [n_out], b.data)
 
         elif func.label in ('MaxPooling2D', 'AveragePooling2D'):
@@ -272,7 +272,7 @@ class _RetrieveAsCaffeModel(object):
                 params['top'] = [layer_name]
                 if net is not None:
                     layer = net.layer.add()
-                beta.retain_data()
+                beta.retain_data(beta.data)
                 bias_term = beta.data is not None
                 scale_param = {
                     'axis': 1,

--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -62,8 +62,10 @@ class TestDropout(unittest.TestCase):
         if backend_config.use_cuda:
             inputs = cuda.to_gpu(inputs)
 
+        input_vars = [chainer.Variable(x, requires_grad=True) for x in inputs]
+
         with backend_config:
-            y = functions.dropout(*(inputs + [self.ratio]))
+            y = functions.dropout(*(input_vars + [self.ratio]))
 
         if backend_config.use_cudnn == 'always':
             if self.ratio == 0.0:

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -194,7 +194,7 @@ class TestVariableNode(unittest.TestCase):
 
     def test_grad(self):
         with pytest.raises(ValueError):
-            variable.VariableNode(chainer.Variable(), '', grad=None)
+            variable.VariableNode(chainer.Variable(), None, '', grad=None)
 
 
 @testing.parameterize(
@@ -961,7 +961,10 @@ class TestVariableToCpu(unittest.TestCase):
 
         assert x_var.xp is np
         assert x_var._has_chainerx_array is False
-        assert x_var.node is not None
+        if requires_grad:
+            assert x_var.node is not None
+        else:
+            assert x_var.node is None
         assert isinstance(x_var.data, np.ndarray)
         assert x.shape == x_var.shape
         assert x.dtype == x_var.dtype
@@ -1037,7 +1040,10 @@ class TestVariableToGpu(unittest.TestCase):
 
         assert x_var.xp is cuda.cupy
         assert x_var._has_chainerx_array is False
-        assert x_var.node is not None
+        if requires_grad:
+            assert x_var.node is not None
+        else:
+            assert x_var.node is None
         assert isinstance(x_var.data, cuda.cupy.ndarray)
         assert x.shape == x_var.shape
         assert x.dtype == x_var.dtype
@@ -1231,7 +1237,7 @@ class TestVariableFromChainerX(unittest.TestCase):
 
         assert x_var.xp is expected_xp
         assert x_var._has_chainerx_array is (expected_xp is chainerx)
-        assert x_var.node is not None
+        assert x_var.node is None
         assert isinstance(x_var.array, expected_xp.ndarray)
         assert expected_device is None or x_var.array.device == expected_device
         assert x.shape == x_var.shape


### PR DESCRIPTION
This PR cuts `VariableNode` creation for `Variable`s with `requires_grad=False`.

I cleaned up some less useful interfaces (`VariableNode.retain_data()` and `Variable.retain_data()`) and confined into a single method `VariableNode.retain_data()` with `data` argument.
Also added `data` argument to `VariableNode.__init__()`.

I assume they're interfaces for internal implementation. In that sense I think it's possible to go without the `no-compat` label, but strictly speaking this is `no-compat`.