### PR TITLE
Use FMA in `NativeDevice::Dot`

### DIFF
--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -127,18 +127,12 @@ T MultiplyAdd(T x, T y, T z) {
 }
 
 Float16 MultiplyAdd(Float16 x, Float16 y, Float16 z) {
-    return static_cast<Float16>(std::fmaf(static_cast<float>(x),
-                                          static_cast<float>(y),
-                                          static_cast<float>(z)));
+    return static_cast<Float16>(std::fmaf(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)));
 }
 
-float MultiplyAdd(float x, float y, float z) {
-    return std::fmaf(x, y, z);
-}
+float MultiplyAdd(float x, float y, float z) { return std::fmaf(x, y, z); }
 
-double MultiplyAdd(double x, double y, double z) {
-    return std::fma(x, y, z);
-}
+double MultiplyAdd(double x, double y, double z) { return std::fma(x, y, z); }
 
 }  // namespace
 

--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -121,22 +121,22 @@ void Gemm(const Array& a, const Array& b, const Array& out) {
 
 namespace {
 
-template <class T>
-T multiply_add(T x, T y, T z) {
+template <typename T>
+T MultiplyAdd(T x, T y, T z) {
     return x * y + z;
 }
 
-Float16 multiply_add(Float16 x, Float16 y, Float16 z) {
+Float16 MultiplyAdd(Float16 x, Float16 y, Float16 z) {
     return static_cast<Float16>(std::fmaf(static_cast<float>(x),
                                           static_cast<float>(y),
                                           static_cast<float>(z)));
 }
 
-float multiply_add(float x, float y, float z) {
+float MultiplyAdd(float x, float y, float z) {
     return std::fmaf(x, y, z);
 }
 
-double multiply_add(double x, double y, double z) {
+double MultiplyAdd(double x, double y, double z) {
     return std::fma(x, y, z);
 }
 
@@ -181,7 +181,7 @@ void NativeDevice::Dot(const Array& a, const Array& b, const Array& out) {
                     int64_t b_l_j[] = {l, j};
                     T b_value = native_internal::StorageToDataType<const T>(b_iarray[b_l_j]);
                     T& out_value = native_internal::StorageToDataType<T>(out_iarray[out_i_j]);
-                    out_value = multiply_add(a_value, b_value, out_value);
+                    out_value = MultiplyAdd(a_value, b_value, out_value);
                 }
             }
         }


### PR DESCRIPTION
This change may help for this failure https://github.com/chainer/chainer/pull/6218#issuecomment-463043900.

Although accumulation in `float` on float16 `Dot` offers better accuracy, it requires memory allocation. So I do not include `float` accumulation in this PR.
