### PR TITLE
skip MultiprocessIterator finalization at exit

### DIFF
--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -1,4 +1,5 @@
 from __future__ import division
+import atexit
 import datetime
 import multiprocessing
 from multiprocessing import sharedctypes  # type: ignore
@@ -615,3 +616,13 @@ def _unpack(data, mem):
     elif t is _PackedNdarray:
         data = data.unpack(mem)
     return data
+
+
+# When the CPython interpreter exits, daemon threads abruptly exits without
+# any Python-level finalization. This makes `thread.is_alive` unreliable.
+# Pooled processes are also terminated by `multiprocessing` module.
+# As there is no way to ensure correct finalization, we simply skip
+# `MultiprocessIterator`'s finalization routine.
+@atexit.register
+def _force_skip_finalization():
+    MultiprocessIterator._finalized = True

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -97,8 +97,13 @@ class MultiprocessIterator(iterator.Iterator):
     class TimeoutWarning(RuntimeWarning):
         pass
 
-    _interruption_testing = False  # for testing
+    # For testing.
+    _interruption_testing = False
+    # This attribute shall not assigned to `False` in `__init__` because
+    # it have to be overridden by `atexit` hook.
     _finalized = False
+    # These are initialized here so that `__del__` can always access them.
+    # Note that `__del__` may run before `__init__` completed.
     _prefetch_loop = None
     _comm = None
 


### PR DESCRIPTION
Finalization routine of `MultiprocessIterator` hangs when uncaught exception is triggered. Tested with Python 3.6.6 on Linux x86_64. Even though `with` statement is generally recommended, the hang is undesirable. This PR workaround the issue by skipping `MultiprocessIterator` finalization after `atexit` hook execution.

Such type of a hang occurs if `iterator.__del__` is called when the interpreter finalizing itself. In the following program, probably the traceback held by the exception object defers `__del__` call until the interpreter finalization.

```python
import chainer

class Dataset(chainer.dataset.DatasetMixin):
    def __len__(self):
        return 100

    def get_example(self, i):
        return i

def main():
    dataset = Dataset()
    iterator = chainer.iterators.MultiprocessIterator(dataset, 16, repeat=False, shuffle=False, n_processes=8)
    for batch in iterator:
        raise RuntimeError("Err")

main()
```