### PR TITLE
Use float accumulation in ChainerX float16 `Dot`

### DIFF
--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -162,6 +162,7 @@ void NativeDevice::Dot(const Array& a, const Array& b, const Array& out) {
     }
 #endif  // CHAINERX_ENABLE_BLAS
 
+    out.Fill(0);
     VisitDtype(out.dtype(), [&](auto pt) {
         using T = typename decltype(pt)::type;
 
@@ -180,7 +181,6 @@ void NativeDevice::Dot(const Array& a, const Array& b, const Array& out) {
         constexpr auto acc_dtype = PrimitiveType<AccT>::kDtype;
 
         Array acc = out.AsType(acc_dtype, false);
-        acc.Fill(0);
         IndexableArray<AccT, 2> acc_iarray{acc};
         for (int64_t i = 0; i < m; ++i) {
             for (int64_t l = 0; l < k; ++l) {

--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -155,6 +155,7 @@ void NativeDevice::Dot(const Array& a, const Array& b, const Array& out) {
         Array acc = out.AsType(Dtype::kFloat32);
         Gemm(a32, b32, acc);
 
+        // TODO(gwtnb): Replace Fill(0) and += with CopyTo when CopyTo is added
         out.Fill(0);
         out += acc.AsType(Dtype::kFloat16);
         return;

--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -177,7 +177,7 @@ void NativeDevice::Dot(const Array& a, const Array& b, const Array& out) {
         CHAINERX_ASSERT(out.shape()[0] == m);
         CHAINERX_ASSERT(out.shape()[1] == n);
 
-        using AccT = typename std::conditional<std::is_same<T, Float16>{}, float, T>::type;
+        using AccT = std::conditional_t<std::is_same<T, Float16>{}, float, T>;
         constexpr auto acc_dtype = PrimitiveType<AccT>::kDtype;
 
         Array acc = out.AsType(acc_dtype, false);


### PR DESCRIPTION
Improvement of #6227. Use single precision arithmetic in half precision `Dot` of the native backend. This PR may improve accuracy and speed. Note that some workspace memory is used.
