### PR TITLE
[WIP] Call forward_postprocess with output values if the hook impl supports

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -335,7 +335,15 @@ Use apply() method instead.\
                     ', '.join(str(type(x)) for x in outputs)))
 
         for hook in hooks:
-            hook.forward_postprocess(self, in_data)
+            sig = inspect.signature(hook.forward_postprocess)
+            if len(sig.parameters) == 2:
+                hook.forward_postprocess(in_data, outputs)
+            elif len(sig.parameters) == 1:
+                hook.forward_postprocess(in_data)
+            else:
+                msg = ('{}.forward_postprocess has unsupported '
+                       'number of arguments.'.format(type(hook).__name__))
+                raise RuntimeError(msg)
 
         # NaN check of output values
         if is_debug:

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -335,15 +335,7 @@ Use apply() method instead.\
                     ', '.join(str(type(x)) for x in outputs)))
 
         for hook in hooks:
-            sig = inspect.signature(hook.forward_postprocess)
-            if len(sig.parameters) == 2:
-                hook.forward_postprocess(in_data, outputs)
-            elif len(sig.parameters) == 1:
-                hook.forward_postprocess(in_data)
-            else:
-                msg = ('{}.forward_postprocess has unsupported '
-                       'number of arguments.'.format(type(hook).__name__))
-                raise RuntimeError(msg)
+            hook.forward_postprocess(self, in_data, outputs)
 
         # NaN check of output values
         if is_debug:
@@ -895,6 +887,7 @@ Use apply() method instead.\
         """
         if not isinstance(hook, function_hook.FunctionHook):
             raise TypeError('Hook must be of type FunctionHook')
+        hook._wrap_legacy_hook()
         if name is None:
             name = hook.name
         hooks = self.local_function_hooks


### PR DESCRIPTION
This is an initial attempt to fix https://github.com/chainer/chainer/issues/6250

In order to keep backward compatibility, it checks signature of the specified hook.
In case the hook has only one argument, it calls without output values.
If it has 2, it calls with output value, and if it has more, an error is raised.

Although it's still work-in-progress, I want to hear opinions about the feature design.

TODO
* Code quality
* Tests and documentation

----
- Read [our contribution guide](https://docs.chainer.org/en/stable/contribution.html).
  - Does your code conform to our coding guidelines?
  - Did you write sufficient test code?
  - Did you write sufficient documentation?
- Also, take a look at [our compatibility policy](https://docs.chainer.org/en/stable/compatibility.html).