### PR TITLE
add option `align` to `chainer.TimerHook.print_report()`

### DIFF
--- a/tests/chainer_tests/function_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/function_hooks_tests/test_timer.py
@@ -193,5 +193,17 @@ class TestTimerPrintReport(unittest.TestCase):
         actual = io.getvalue()
         six.assertRegex(self, actual, expect)
 
+    def test_print_report_align(self):
+        x = self.x
+        self.f.apply((chainer.Variable(x),))
+        self.f.apply((chainer.Variable(x),))
+        io = six.StringIO()
+        self.h.print_report(align=True, file=io)
+        expect = r'''\AFunctionName  ElapsedTime  Occurrence
+ +Exp +[0-9.\-e]+.s +[0-9]+$
+'''
+        actual = io.getvalue()
+        six.assertRegex(self, actual, expect)
+
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
The units of elapsed times are not aligned in current version.
It is hard to find a processing time bottleneck.
This PR adds option `align` to the member function `print_report()`.
For example,

xxx.print_report()

                   FunctionName  ElapsedTime  Occurrence
                 LinearFunction      1.24sec        3900
                           ReLU     593.05ms        2600
            SoftmaxCrossEntropy     824.11ms        1300
                       Accuracy     176.54ms         700

to

xxx.print_report(align=True)

                   FunctionName  ElapsedTime  Occurrence
                 LinearFunction      1.24sec        3900
                           ReLU       0.59sec       2600
            SoftmaxCrossEntropy       0.82sec       1300
                       Accuracy       0.18sec        700