### PR TITLE
Improve errors for disabled `Variable` operators

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1478,37 +1478,46 @@ class Variable(object):
                 'method.')
         self._node.data = self._data[0]
 
+    def _error_nobp_op(self, op):
+        raise TypeError(
+            'Variables do not support {} operator. '
+            'You could use `array` attribute instead.'.format(op))
+
     def __lt__(self, other):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        self._error_nobp_op('<')
 
     def __le__(self, other):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        self._error_nobp_op('<=')
 
     def __eq__(self, other):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        self._error_nobp_op('==')
 
     def __ne__(self, other):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        self._error_nobp_op('!=')
 
     def __gt__(self, other):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        self._error_nobp_op('>')
 
     def __ge__(self, other):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        self._error_nobp_op('>=')
 
     def __nonzero__(self):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        # Python 2.x
+        raise TypeError(
+            'Variables cannot be evaluated as Python bool.')
 
     def __bool__(self):
-        """This operator is not defined for Variable."""
-        raise NotImplementedError()
+        """This operator is not supported in Variables."""
+        # Python 3.x
+        raise TypeError(
+            'Variables cannot be evaluated as Python bool.')
 
     __array_priority__ = 200  # type: int
     __hash__ = None  # type: tp.Callable[[object], int]

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1782,42 +1782,6 @@ class TestMatMulInvalidShape(unittest.TestCase):
             operator.matmul(x, y)
 
 
-class TestNotSupportOperation(unittest.TestCase):
-
-    def setUp(self):
-        self.x = chainer.Variable(numpy.zeros(10))
-        self.y = chainer.Variable(numpy.zeros(10))
-
-    def test_lt(self):
-        with pytest.raises(NotImplementedError):
-            self.x < self.y
-
-    def test_le(self):
-        with pytest.raises(NotImplementedError):
-            self.x <= self.y
-
-    def test_eq(self):
-        with pytest.raises(NotImplementedError):
-            self.x == self.y
-
-    def test_ne(self):
-        with pytest.raises(NotImplementedError):
-            self.x != self.y
-
-    def test_gt(self):
-        with pytest.raises(NotImplementedError):
-            self.x > self.y
-
-    def test_ge(self):
-        with pytest.raises(NotImplementedError):
-            self.x >= self.y
-
-    def test_nonzero(self):
-        with pytest.raises(NotImplementedError):
-            if self.x:
-                pass
-
-
 class ConvertValueToStringTest(unittest.TestCase):
 
     def _check_scalar(self, value, string):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1353,33 +1353,33 @@ class TestVariableBasic(unittest.TestCase):
     def test_unequatable(self):
         a = chainer.Variable(np.ones((2,)))
         b = chainer.Variable(np.ones((2,)))
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a == b
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a == a
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a != b
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a != a
 
     def test_uncomparable(self):
         a = chainer.Variable(np.ones((2,)))
         b = chainer.Variable(np.ones((2,)))
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a < b
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a <= b
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a > b
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             a >= b
 
     def test_bool_inconvertible(self):
         a = chainer.Variable(np.ones((2,)))
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             if a:
                 pass
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             if not a:
                 pass
 


### PR DESCRIPTION
* Without messages, it's difficult to understand the cause.
* Python [officially suggests](https://docs.python.org/3/library/exceptions.html#NotImplementedError) that these methods should not be defined if not supported, but I think the built-in message is not informative enough: ```TypeError: '<' not supported between instances of 'Variable' and 'int'```
* Changed `NotImplementedError` to `TypeError` to match Python's built-in behavior.

#### Previously
```
NotImplementedError
```
#### This PR
```
TypeError: Variables do not support < operator. You could use `array` attribute instead.
```