### PR TITLE
Add option `unit` to `CupyMemoryProfileHook.print_report()`

### DIFF
--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -31,9 +31,9 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
 
                    FunctionName  UsedBytes  AcquiredBytes  Occurrence
                  LinearFunction     5.16GB       179.98MB        3900
-                           ReLU   991.82MB       458.97MB        2600
-            SoftmaxCrossEntropy     7.71MB         5.08MB        1300
-                       Accuracy   617.97KB       351.00KB         700
+                           ReLU     0.99GB       458.97MB        2600
+            SoftmaxCrossEntropy     0.01GB         5.08MB        1300
+                       Accuracy     0.00GB         0.35MB         700
 
         where *FunctionName* is the name of function that calls the hook, and
         *UsedBytes* is the memory bytes the function used from cupy memory
@@ -140,10 +140,11 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
 
         Args:
             unit (str): Supplementary units used for used memories.
-                `B`, `KB`, `MB`, `GB`, `TB`, `PB, `EB`, `ZB`, `auto`(default)
+                `B`, `KB`, `MB`, `GB`, `TB`, `PB`, `EB`, `ZB`, `auto`(default)
                 and `auto_foreach` are supported. If `auto`, units of memories
-                are aligned to the largest, and if `auto_foreach`, units of
-                memories are adjusted for each element.
+                are aligned to the each largest of 'used_bytes' and
+                'acquired_bytes'. If `auto_foreach`, units of memories are
+                adjusted for each element.
         """
         entries = [[
             'FunctionName', 'UsedBytes', 'AcquiredBytes', 'Occurrence']]

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -48,6 +48,8 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
     """
 
     name = 'CupyMemoryProfileHook'
+    _units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
+    _table = {u: 1024.0 ** i for i, u in enumerate(_units)}
 
     def __init__(self):
         cuda.check_cuda_available()
@@ -124,45 +126,46 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
             record['occurrence'] += 1
         return summary
 
-    def _humanized_size(self, size):
-        """Returns a human redable bytes string."""
-        for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E']:
-            if size < 1024.0:
-                return '%3.2f%sB' % (size, unit)
-            size /= 1024.0
-        return '%.2f%sB' % (size, 'Z')
-
-
-    def _align(self, size):
-        """Returns align info: (denominator, unit)."""
+    def _choose_unit(self, size):
+        """Choose optimal unit."""
         denomi = 1
-        for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E']:
+        for unit in self._units[:-1]:
             if size / denomi >= 1:
                 return denomi, unit
             denomi *= 1024.0
-        return denomi, 'Z'
+        return denomi, self._units[-1]
 
-    def print_report(self, align_units=False, file=sys.stdout):
+    def print_report(self, unit='auto', file=sys.stdout):
         """Prints a summary report of memory profiling in functions.
 
         Args:
-            align_units (bool): If `True`, units of times are aligned to the largest.
+            unit (str): Supplementary units used for used memories.
+                `B`, `KB`, `MB`, `GB`, `TB`, `PB, `EB`, `ZB`, `auto`(default)
+                and `auto_foreach` are supported. If `auto`, units of memories
+                are aligned to the largest, and if `auto_foreach`, units of
+                memories are adjusted for each element.
         """
         entries = [[
             'FunctionName', 'UsedBytes', 'AcquiredBytes', 'Occurrence']]
-        if align_units:
-            max_used = max(record['used_bytes'] for record in self.summary().values())
-            max_acquired = max(record['acquired_bytes'] for record in self.summary().values())
-            denomi_used, unit_used = self._align(max_used)
-            denomi_acquired, unit_acquired = self._align(max_acquired)
+        if unit == 'auto':
+            max_used = max(
+                record['used_bytes'] for record in self.summary().values())
+            max_acquired = max(
+                record['acquired_bytes'] for record in self.summary().values())
+            denomi_used, unit_used = self._choose_unit(max_used)
+            denomi_acquired, unit_acquired = self._choose_unit(max_acquired)
+        elif unit != 'auto_foreach':
+            denomi_used = denomi_acquired = self._table[unit]
+            unit_used = unit_acquired = unit
         for function_name, record in self.summary().items():
-            used_bytes, acquired_bytes = record['used_bytes'], record['acquired_bytes']
-            if align_units:
-                used_bytes = '%3.2f%sB' % (used_bytes / denomi_used, unit_used)
-                acquired_bytes = '%3.2f%sB' % (acquired_bytes / denomi_acquired, unit_acquired)
-            else:
-                used_bytes = self._humanized_size(used_bytes)
-                acquired_bytes = self._humanized_size(acquired_bytes)
+            used_bytes = record['used_bytes']
+            acquired_bytes = record['acquired_bytes']
+            if unit == 'auto_foreach':
+                denomi_used, unit_used = self._choose_unit(used_bytes)
+                denomi_acquired, unit_acquired = self._choose_unit(acquired_bytes)
+            used_bytes = '%3.2f%s' % (used_bytes / denomi_used, unit_used)
+            acquired_bytes = '%3.2f%s' % (
+                acquired_bytes / denomi_acquired, unit_acquired)
             occurrence = str(record['occurrence'])
             entries.append(
                 [function_name, used_bytes, acquired_bytes, occurrence])

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -142,22 +142,22 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
             denomi *= 1024.0
         return denomi, 'Z'
 
-    def print_report(self, align=False, file=sys.stdout):
+    def print_report(self, align_units=False, file=sys.stdout):
         """Prints a summary report of memory profiling in functions.
 
         Args:
-            align (bool): If `True`, units of times are aligned to the largest.
+            align_units (bool): If `True`, units of times are aligned to the largest.
         """
         entries = [[
             'FunctionName', 'UsedBytes', 'AcquiredBytes', 'Occurrence']]
-        if align:
+        if align_units:
             max_used = max(record['used_bytes'] for record in self.summary().values())
             max_acquired = max(record['acquired_bytes'] for record in self.summary().values())
             denomi_used, unit_used = self._align(max_used)
             denomi_acquired, unit_acquired = self._align(max_acquired)
         for function_name, record in self.summary().items():
             used_bytes, acquired_bytes = record['used_bytes'], record['acquired_bytes']
-            if align:
+            if align_units:
                 used_bytes = '%3.2f%sB' % (used_bytes / denomi_used, unit_used)
                 acquired_bytes = '%3.2f%sB' % (acquired_bytes / denomi_acquired, unit_acquired)
             else:

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -162,7 +162,8 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
             acquired_bytes = record['acquired_bytes']
             if unit == 'auto_foreach':
                 denomi_used, unit_used = self._choose_unit(used_bytes)
-                denomi_acquired, unit_acquired = self._choose_unit(acquired_bytes)
+                denomi_acquired, unit_acquired = self._choose_unit(
+                    acquired_bytes)
             used_bytes = '%3.2f%s' % (used_bytes / denomi_used, unit_used)
             acquired_bytes = '%3.2f%s' % (
                 acquired_bytes / denomi_acquired, unit_acquired)

--- a/chainer/function_hooks/cupy_memory_profile.py
+++ b/chainer/function_hooks/cupy_memory_profile.py
@@ -142,7 +142,7 @@ class CupyMemoryProfileHook(function_hook.FunctionHook):
             unit (str): Supplementary units used for used memories.
                 `B`, `KB`, `MB`, `GB`, `TB`, `PB`, `EB`, `ZB`, `auto`(default)
                 and `auto_foreach` are supported. If `auto`, units of memories
-                are aligned to the each largest of 'used_bytes' and
+                are aligned to the largest values of 'used_bytes' and
                 'acquired_bytes'. If `auto_foreach`, units of memories are
                 adjusted for each element.
         """

--- a/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
+++ b/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
@@ -154,6 +154,16 @@ class TestCupyMemoryProfileHookToFunction(unittest.TestCase):
 
 
 @attr.gpu
+@testing.parameterize(
+    {'unit': 'B'},
+    {'unit': 'KB'},
+    {'unit': 'MB'},
+    {'unit': 'GB'},
+    {'unit': 'TB'},
+    {'unit': 'PB'},
+    {'unit': 'EB'},
+    {'unit': 'ZB'},
+)
 class TestCupyMemoryProfileReport(unittest.TestCase):
 
     def setUp(self):
@@ -183,17 +193,7 @@ class TestCupyMemoryProfileReport(unittest.TestCase):
 
     def test_print_report(self):
         io = six.StringIO()
-        self.h.print_report(file=io)
-        expect = r'''\AFunctionName  UsedBytes  AcquiredBytes  Occurrence
- +Exp +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+
- +ReLU +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+$
-'''
-        actual = io.getvalue()
-        six.assertRegex(self, actual, expect)
-
-    def test_print_report_align_units(self):
-        io = six.StringIO()
-        self.h.print_report(align_units=True, file=io)
+        self.h.print_report(unit=self.unit, file=io)
         expect = r'''\AFunctionName  UsedBytes  AcquiredBytes  Occurrence
  +Exp +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+
  +ReLU +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+$

--- a/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
+++ b/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
@@ -162,6 +162,8 @@ class TestCupyMemoryProfileHookToFunction(unittest.TestCase):
     {'unit': 'PB'},
     {'unit': 'EB'},
     {'unit': 'ZB'},
+    {'unit': 'auto'},
+    {'unit': 'auto_foreach'},
 )
 @attr.gpu
 class TestCupyMemoryProfileReport(unittest.TestCase):

--- a/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
+++ b/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
@@ -191,5 +191,15 @@ class TestCupyMemoryProfileReport(unittest.TestCase):
         actual = io.getvalue()
         six.assertRegex(self, actual, expect)
 
+    def test_print_report_align(self):
+        io = six.StringIO()
+        self.h.print_report(align=True, file=io)
+        expect = r'''\AFunctionName  UsedBytes  AcquiredBytes  Occurrence
+ +Exp +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+
+ +ReLU +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+$
+'''
+        actual = io.getvalue()
+        six.assertRegex(self, actual, expect)
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
+++ b/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
@@ -153,7 +153,6 @@ class TestCupyMemoryProfileHookToFunction(unittest.TestCase):
         self.assertEqual(self.h.total_acquired_bytes(), 1024)
 
 
-@attr.gpu
 @testing.parameterize(
     {'unit': 'B'},
     {'unit': 'KB'},
@@ -164,6 +163,7 @@ class TestCupyMemoryProfileHookToFunction(unittest.TestCase):
     {'unit': 'EB'},
     {'unit': 'ZB'},
 )
+@attr.gpu
 class TestCupyMemoryProfileReport(unittest.TestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
+++ b/tests/chainer_tests/function_hooks_tests/test_cupy_memory_profile.py
@@ -191,9 +191,9 @@ class TestCupyMemoryProfileReport(unittest.TestCase):
         actual = io.getvalue()
         six.assertRegex(self, actual, expect)
 
-    def test_print_report_align(self):
+    def test_print_report_align_units(self):
         io = six.StringIO()
-        self.h.print_report(align=True, file=io)
+        self.h.print_report(align_units=True, file=io)
         expect = r'''\AFunctionName  UsedBytes  AcquiredBytes  Occurrence
  +Exp +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+
  +ReLU +[0-9.\-e]+.?B +[0-9.\-e]+.?B +[0-9]+$


### PR DESCRIPTION
Same as #6254.

The units of memory profile are not aligned in current version.
It is hard to find a bottleneck.
This PR adds option `align` to the member function `print_report()`.