### PR TITLE
Improve `F.relu` performance with CuPy

### DIFF
--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -57,7 +57,7 @@ class ReLU(function_node.FunctionNode):
             self._use_cudnn = True
             y = cudnn.activation_forward(x, _mode)
         else:
-            y = cuda.cupy.maximum(x, 0)
+            y = cuda.cupy.maximum(x, 0, dtype=x.dtype)
         self.retain_outputs((0,))
         return y,
 


### PR DESCRIPTION
Chainer can pass dtype hint to CuPy.