### PR TITLE
Fix inappropriate usage of `is_arrays_compatible`

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -160,6 +160,9 @@ def get_cpu_array_types():
 
 # TODO(hvy): Move this function to backend?
 def is_arrays_compatible(arrays):
+    # Do not use this function to check if a single object is an array or
+    # not. Use isinstance(obj, chainer.get_array_types()) instead.
+
     arrays = [a for a in arrays if a is not None]
 
     if len(arrays) == 0:

--- a/chainer/links/activation/maxout.py
+++ b/chainer/links/activation/maxout.py
@@ -64,7 +64,7 @@ class Maxout(link.Chain):
            numpy.isscalar(initialW) or \
            isinstance(initialW, initializer.Initializer):
             pass
-        elif chainer.is_arrays_compatible([initialW]):
+        elif isinstance(initialW, chainer.get_array_types()):
             if initialW.ndim != 3:
                 raise ValueError('initialW.ndim should be 3')
             initialW = initialW.reshape(linear_out_size, in_size)
@@ -80,7 +80,7 @@ class Maxout(link.Chain):
            numpy.isscalar(initial_bias) or \
            isinstance(initial_bias, initializer.Initializer):
             pass
-        elif chainer.is_arrays_compatible([initial_bias]):
+        elif isinstance(initial_bias, chainer.get_array_types()):
             if initial_bias.ndim != 2:
                 raise ValueError('initial_bias.ndim should be 2')
             initial_bias = initial_bias.reshape(linear_out_size)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1677,7 +1677,7 @@ class Parameter(Variable):
         elif numpy.isscalar(initializer):
             initializer = constant.Constant(initializer)
         if shape is None:
-            if chainer.is_arrays_compatible([initializer]):
+            if isinstance(initializer, chainer.get_array_types()):
                 # parameter initialized by the initial array
                 super(Parameter, self).__init__(initializer, name=name)
             else:
@@ -1687,7 +1687,7 @@ class Parameter(Variable):
                 self._grad_initializer = constant.NaN(dtype)
         else:
             # parameter initialized with a given shape
-            if chainer.is_arrays_compatible([initializer]):
+            if isinstance(initializer, chainer.get_array_types()):
                 xp = backend.get_array_module(initializer)
                 initializer = constant.Constant(initializer)
             else:


### PR DESCRIPTION
Fixes unintentional usage of `is_arrays_compatible()` and replaces with `get_array_types()`.