### PR TITLE
Unwrap ChainerX connected array from `Variable`

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -868,6 +868,25 @@ class Variable(object):
             self._has_chainerx_array = False
 
     @property
+    def chainerx_array(self):
+        """A view of the raw ChainerX array.
+
+        In contrary to :data:`Variable.array` which is always disconnected,
+        the array represented by this attribute may be connected to the
+        computational graph.
+
+        It is a view, so it has a distinct gradient from the original array.
+
+        If this attribute is queried on a :class:`Variable` with a non-ChainerX
+        array, :class:`ValueError` will be raised.
+        """
+        if not self._has_chainerx_array:
+            raise ValueError(
+                'chainerx_array is not available for Variable with '
+                'non-ChainerX array.')
+        return self._data[0].view()
+
+    @property
     def data(self):
         # type: () -> tp.Optional[types.NdArray]
         """The underlying data array (equivalent to :attr:`array`).

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -3020,6 +3020,7 @@ class TestVariableChainerxArrayViewBackprop(unittest.TestCase):
             chainerx.array([2, 4], np.float32), x.grad)
 
 
+@attr.chainerx
 class TestVariableChainerxArrayView(unittest.TestCase):
 
     def test_unwrap_disconnected(self):


### PR DESCRIPTION
Fixes #6279 
Introduces `Variable.chx_view()` which returns a view (`chx.ndarray`) of the original array.