### PR TITLE
Improve performance of `using_config`

### DIFF
--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -1,4 +1,3 @@
-import contextlib
 import sys
 import threading
 import typing as tp  # NOQA
@@ -123,7 +122,34 @@ See :ref:`configuration` for details.
 '''
 
 
-@contextlib.contextmanager
+class _ConfigContext(object):
+
+    is_local = False
+    old_value = None
+
+    def __init__(self, config, name, value):
+        self.config = config
+        self.name = name
+        self.value = value
+
+    def __enter__(self):
+        name = self.name
+        value = self.value
+        config = self.config
+        is_local = hasattr(config._local, name)
+        if is_local:
+            self.old_value = getattr(config, name)
+            self.is_local = is_local
+
+        setattr(config, name, value)
+
+    def __exit__(self, typ, value, traceback):
+        if self.is_local:
+            setattr(self.config, self.name, self.old_value)
+        else:
+            delattr(self.config, self.name)
+
+
 def using_config(name, value, config=config):
     """using_config(name, value, config=chainer.config)
 
@@ -139,16 +165,4 @@ def using_config(name, value, config=config):
         :ref:`configuration`
 
     """
-    if hasattr(config._local, name):
-        old_value = getattr(config, name)
-        setattr(config, name, value)
-        try:
-            yield
-        finally:
-            setattr(config, name, old_value)
-    else:
-        setattr(config, name, value)
-        try:
-            yield
-        finally:
-            delattr(config, name)
+    return _ConfigContext(config, name, value)


### PR DESCRIPTION
2.84 us -> 2.05 us

```py
with chainer.using_config('debug', False):
    pass
```