### PR TITLE
Improve performance of `using_device` for NumPy and Intel64 devices

### DIFF
--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -1,6 +1,3 @@
-import contextlib
-
-
 def _convert_arrays(array, func):
     # Converts array or arrays
     if isinstance(array, (list, tuple)):
@@ -22,9 +19,15 @@ def _convert_arrays(array, func):
         return func(array)
 
 
-@contextlib.contextmanager
-def _dummy_context():
-    yield
+class _DummyContext(object):
+    def __enter__(self):
+        pass
+
+    def __exit__(self, typ, value, traceback):
+        pass
+
+
+_dummy_context = _DummyContext()
 
 
 # TODO(niboshi): Write more detailed description about interface/usage.
@@ -65,7 +68,7 @@ class Device(object):
 
     def create_context(self):
         # Returns an object that implements __enter__ and __exit__.
-        return _dummy_context()
+        return _dummy_context
 
     def send(self, arrays):
         """Transfers given arrays to the device.


### PR DESCRIPTION
1.86 us -> 0.54 us (only if `device` is either `CpuDevice` or `Intel64Device`).
```py
with chainer.using_device(device):
    pass
```
