### PR TITLE
add Kuzushiji-MNIST dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 *Chainer* is a Python-based deep learning framework aiming at flexibility.
 It provides automatic differentiation APIs based on the **define-by-run** approach (a.k.a. dynamic computational graphs) as well as object-oriented high-level APIs to build and train neural networks.
 It also supports CUDA/cuDNN using [CuPy](https://github.com/cupy/cupy) for high performance training and inference.
-For more details of Chainer, see the documents and resources listed above and join the community in Forum, Slack, and Twitter.
+For more details about Chainer, see the documents and resources listed above and join the community in Forum, Slack, and Twitter.
 
 ## Stable version
 

--- a/chainer/datasets/__init__.py
+++ b/chainer/datasets/__init__.py
@@ -10,6 +10,8 @@ from chainer.datasets.image_dataset import LabeledImageDataset  # NOQA
 from chainer.datasets.image_dataset import LabeledZippedImageDataset  # NOQA
 from chainer.datasets.image_dataset import MultiZippedImageDataset  # NOQA
 from chainer.datasets.image_dataset import ZippedImageDataset  # NOQA
+from chainer.datasets.kmnist import get_kmnist  # NOQA
+from chainer.datasets.kmnist import get_kmnist_labels  # NOQA
 from chainer.datasets.mnist import get_mnist  # NOQA
 from chainer.datasets.pickle_dataset import open_pickle_dataset  # NOQA
 from chainer.datasets.pickle_dataset import open_pickle_dataset_writer  # NOQA

--- a/chainer/datasets/__init__.py
+++ b/chainer/datasets/__init__.py
@@ -10,8 +10,8 @@ from chainer.datasets.image_dataset import LabeledImageDataset  # NOQA
 from chainer.datasets.image_dataset import LabeledZippedImageDataset  # NOQA
 from chainer.datasets.image_dataset import MultiZippedImageDataset  # NOQA
 from chainer.datasets.image_dataset import ZippedImageDataset  # NOQA
-from chainer.datasets.kmnist import get_kmnist  # NOQA
-from chainer.datasets.kmnist import get_kmnist_labels  # NOQA
+from chainer.datasets.kuzushiji_mnist import get_kuzushiji_mnist  # NOQA
+from chainer.datasets.kuzushiji_mnist import get_kuzushiji_mnist_labels  # NOQA
 from chainer.datasets.mnist import get_mnist  # NOQA
 from chainer.datasets.pickle_dataset import open_pickle_dataset  # NOQA
 from chainer.datasets.pickle_dataset import open_pickle_dataset_writer  # NOQA

--- a/chainer/datasets/kmnist.py
+++ b/chainer/datasets/kmnist.py
@@ -1,0 +1,98 @@
+import os
+
+import numpy
+
+import chainer
+from chainer.dataset import download
+from chainer.datasets._mnist_helper import make_npz
+from chainer.datasets._mnist_helper import preprocess_mnist
+
+
+_kmnist_labels = [('o', u'\u304A'), ('ki', u'\u304D'),
+                  ('su', u'\u3059'), ('tsu', u'\u3064'),
+                  ('na', u'\u306A'), ('ha', u'\u306F'),
+                  ('ma', u'\u307E'), ('ya', u'\u3084'),
+                  ('re', u'\u308C'), ('wo', u'\u3092')]
+
+
+def get_kmnist_labels():
+    """Provide a list of labels for the KMNIST dataset.
+
+    Returns:
+        List of labels in the form of tuples. Each tuple contains the 
+        character name in romaji as a string value and the unicode codepoint 
+        for the character.
+
+    """
+    return list(_kmnist_labels)
+
+
+def get_kmnist(withlabel=True, ndim=1, scale=1., dtype=None,
+               label_dtype=numpy.int32, rgb_format=False):
+    """Gets the KMNIST dataset.
+
+    `Kuzushiji-MNIST (KMNIST) <http://codh.rois.ac.jp/kmnist/>`_ is a set of
+    hand-written Japanese characters represented by grey-scale 28x28 images.
+    In the original images, each pixel is represented by one-byte unsigned
+    integer. This function scales the pixels to floating point values in the
+    interval ``[0, scale]``.
+
+    This function returns the training set and the test set of the official
+    KMNIST dataset. If ``withlabel`` is ``True``, each dataset consists of
+    tuples of images and labels, otherwise it only consists of images.
+
+    Args:
+        withlabel (bool): If ``True``, it returns datasets with labels. In this
+            case, each example is a tuple of an image and a label. Otherwise,
+            the datasets only contain images.
+        ndim (int): Number of dimensions of each image. The shape of each image
+            is determined depending on ``ndim`` as follows:
+
+            - ``ndim == 1``: the shape is ``(784,)``
+            - ``ndim == 2``: the shape is ``(28, 28)``
+            - ``ndim == 3``: the shape is ``(1, 28, 28)``
+
+        scale (float): Pixel value scale. If it is 1 (default), pixels are
+            scaled to the interval ``[0, 1]``.
+        dtype: Data type of resulting image arrays. ``chainer.config.dtype`` is
+            used by default (see :ref:`configuration`).
+        label_dtype: Data type of the labels.
+        rgb_format (bool): if ``ndim == 3`` and ``rgb_format`` is ``True``, the
+            image will be converted to rgb format by duplicating the channels
+            so the image shape is (3, 28, 28). Default is ``False``.
+
+    Returns:
+        A tuple of two datasets. If ``withlabel`` is ``True``, both datasets
+        are :class:`~chainer.datasets.TupleDataset` instances. Otherwise, both
+        datasets are arrays of images.
+
+    """
+    dtype = chainer.get_dtype(dtype)
+    train_raw = _retrieve_kmnist_training()
+    train = preprocess_mnist(train_raw, withlabel, ndim, scale, dtype,
+                             label_dtype, rgb_format)
+    test_raw = _retrieve_kmnist_test()
+    test = preprocess_mnist(test_raw, withlabel, ndim, scale, dtype,
+                            label_dtype, rgb_format)
+    return train, test
+
+
+def _retrieve_kmnist_training():
+    base_url = 'http://codh.rois.ac.jp/'
+    urls = [base_url + 'kmnist/dataset/kmnist/train-images-idx3-ubyte.gz',
+            base_url + 'kmnist/dataset/kmnist/train-labels-idx1-ubyte.gz']
+    return _retrieve_kmnist('train.npz', urls)
+
+
+def _retrieve_kmnist_test():
+    base_url = 'http://codh.rois.ac.jp/'
+    urls = [base_url + 'kmnist/dataset/kmnist/t10k-images-idx3-ubyte.gz',
+            base_url + 'kmnist/dataset/kmnist/t10k-labels-idx1-ubyte.gz']
+    return _retrieve_kmnist('test.npz', urls)
+
+
+def _retrieve_kmnist(name, urls):
+    root = download.get_dataset_directory('pfnet/chainer/kmnist')
+    path = os.path.join(root, name)
+    return download.cache_or_load_file(
+        path, lambda path: make_npz(path, urls), numpy.load)

--- a/chainer/datasets/kmnist.py
+++ b/chainer/datasets/kmnist.py
@@ -16,7 +16,7 @@ _kmnist_labels = [('o', u'\u304A'), ('ki', u'\u304D'),
 
 
 def get_kmnist_labels():
-    """Provide a list of labels for the KMNIST dataset.
+    """Provides a list of labels for the KMNIST dataset.
 
     Returns:
         List of labels in the form of tuples. Each tuple contains the

--- a/chainer/datasets/kmnist.py
+++ b/chainer/datasets/kmnist.py
@@ -24,7 +24,7 @@ def get_kmnist_labels():
         for the character.
 
     """
-    return list(_kmnist_labels)
+    return _kmnist_labels
 
 
 def get_kmnist(withlabel=True, ndim=1, scale=1., dtype=None,

--- a/chainer/datasets/kmnist.py
+++ b/chainer/datasets/kmnist.py
@@ -19,8 +19,8 @@ def get_kmnist_labels():
     """Provide a list of labels for the KMNIST dataset.
 
     Returns:
-        List of labels in the form of tuples. Each tuple contains the 
-        character name in romaji as a string value and the unicode codepoint 
+        List of labels in the form of tuples. Each tuple contains the
+        character name in romaji as a string value and the unicode codepoint
         for the character.
 
     """

--- a/chainer/datasets/kuzushiji_mnist.py
+++ b/chainer/datasets/kuzushiji_mnist.py
@@ -8,15 +8,15 @@ from chainer.datasets._mnist_helper import make_npz
 from chainer.datasets._mnist_helper import preprocess_mnist
 
 
-_kmnist_labels = [('o', u'\u304A'), ('ki', u'\u304D'),
-                  ('su', u'\u3059'), ('tsu', u'\u3064'),
-                  ('na', u'\u306A'), ('ha', u'\u306F'),
-                  ('ma', u'\u307E'), ('ya', u'\u3084'),
-                  ('re', u'\u308C'), ('wo', u'\u3092')]
+_kuzushiji_mnist_labels = [('o', u'\u304A'), ('ki', u'\u304D'),
+                           ('su', u'\u3059'), ('tsu', u'\u3064'),
+                           ('na', u'\u306A'), ('ha', u'\u306F'),
+                           ('ma', u'\u307E'), ('ya', u'\u3084'),
+                           ('re', u'\u308C'), ('wo', u'\u3092')]
 
 
-def get_kmnist_labels():
-    """Provides a list of labels for the KMNIST dataset.
+def get_kuzushiji_mnist_labels():
+    """Provides a list of labels for the Kuzushiji-MNIST dataset.
 
     Returns:
         List of labels in the form of tuples. Each tuple contains the
@@ -24,12 +24,12 @@ def get_kmnist_labels():
         for the character.
 
     """
-    return _kmnist_labels
+    return _kuzushiji_mnist_labels
 
 
-def get_kmnist(withlabel=True, ndim=1, scale=1., dtype=None,
-               label_dtype=numpy.int32, rgb_format=False):
-    """Gets the KMNIST dataset.
+def get_kuzushiji_mnist(withlabel=True, ndim=1, scale=1., dtype=None,
+                        label_dtype=numpy.int32, rgb_format=False):
+    """Gets the Kuzushiji-MNIST dataset.
 
     `Kuzushiji-MNIST (KMNIST) <http://codh.rois.ac.jp/kmnist/>`_ is a set of
     hand-written Japanese characters represented by grey-scale 28x28 images.
@@ -68,31 +68,31 @@ def get_kmnist(withlabel=True, ndim=1, scale=1., dtype=None,
 
     """
     dtype = chainer.get_dtype(dtype)
-    train_raw = _retrieve_kmnist_training()
+    train_raw = _retrieve_kuzushiji_mnist_training()
     train = preprocess_mnist(train_raw, withlabel, ndim, scale, dtype,
                              label_dtype, rgb_format)
-    test_raw = _retrieve_kmnist_test()
+    test_raw = _retrieve_kuzushiji_mnist_test()
     test = preprocess_mnist(test_raw, withlabel, ndim, scale, dtype,
                             label_dtype, rgb_format)
     return train, test
 
 
-def _retrieve_kmnist_training():
+def _retrieve_kuzushiji_mnist_training():
     base_url = 'http://codh.rois.ac.jp/'
     urls = [base_url + 'kmnist/dataset/kmnist/train-images-idx3-ubyte.gz',
             base_url + 'kmnist/dataset/kmnist/train-labels-idx1-ubyte.gz']
-    return _retrieve_kmnist('train.npz', urls)
+    return _retrieve_kuzushiji_mnist('train.npz', urls)
 
 
-def _retrieve_kmnist_test():
+def _retrieve_kuzushiji_mnist_test():
     base_url = 'http://codh.rois.ac.jp/'
     urls = [base_url + 'kmnist/dataset/kmnist/t10k-images-idx3-ubyte.gz',
             base_url + 'kmnist/dataset/kmnist/t10k-labels-idx1-ubyte.gz']
-    return _retrieve_kmnist('test.npz', urls)
+    return _retrieve_kuzushiji_mnist('test.npz', urls)
 
 
-def _retrieve_kmnist(name, urls):
-    root = download.get_dataset_directory('pfnet/chainer/kmnist')
+def _retrieve_kuzushiji_mnist(name, urls):
+    root = download.get_dataset_directory('pfnet/chainer/kuzushiji_mnist')
     path = os.path.join(root, name)
     return download.cache_or_load_file(
         path, lambda path: make_npz(path, urls), numpy.load)

--- a/docs/source/reference/datasets.rst
+++ b/docs/source/reference/datasets.rst
@@ -204,6 +204,8 @@ Concrete Datasets
    :nosignatures:
 
    chainer.datasets.get_mnist
+   chainer.datasets.get_kmnist
+   chainer.datasets.get_kmnist_labels
    chainer.datasets.get_fashion_mnist_labels
    chainer.datasets.get_fashion_mnist
    chainer.datasets.get_cifar10

--- a/docs/source/reference/datasets.rst
+++ b/docs/source/reference/datasets.rst
@@ -204,8 +204,8 @@ Concrete Datasets
    :nosignatures:
 
    chainer.datasets.get_mnist
-   chainer.datasets.get_kmnist
-   chainer.datasets.get_kmnist_labels
+   chainer.datasets.get_kuzushiji_mnist
+   chainer.datasets.get_kuzushiji_mnist_labels
    chainer.datasets.get_fashion_mnist_labels
    chainer.datasets.get_fashion_mnist
    chainer.datasets.get_cifar10

--- a/tests/chainer_tests/datasets_tests/test_mnist.py
+++ b/tests/chainer_tests/datasets_tests/test_mnist.py
@@ -8,8 +8,8 @@ import numpy
 from chainer.dataset import download
 from chainer.datasets import get_fashion_mnist
 from chainer.datasets import get_fashion_mnist_labels
-from chainer.datasets import get_kmnist
-from chainer.datasets import get_kmnist_labels
+from chainer.datasets import get_kuzushiji_mnist
+from chainer.datasets import get_kuzushiji_mnist_labels
 from chainer.datasets import get_mnist
 from chainer.datasets import tuple_dataset
 from chainer import testing
@@ -18,11 +18,11 @@ from chainer.testing import attr
 _fashion_mnist_labels = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',
                          'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']
 
-_kmnist_labels = [('o', u'\u304A'), ('ki', u'\u304D'),
-                  ('su', u'\u3059'), ('tsu', u'\u3064'),
-                  ('na', u'\u306A'), ('ha', u'\u306F'),
-                  ('ma', u'\u307E'), ('ya', u'\u3084'),
-                  ('re', u'\u308C'), ('wo', u'\u3092')]
+_kuzushiji_mnist_labels = [('o', u'\u304A'), ('ki', u'\u304D'),
+                           ('su', u'\u3059'), ('tsu', u'\u3064'),
+                           ('na', u'\u306A'), ('ha', u'\u306F'),
+                           ('ma', u'\u307E'), ('ya', u'\u3084'),
+                           ('re', u'\u308C'), ('wo', u'\u3092')]
 
 
 @testing.parameterize(*testing.product({
@@ -36,8 +36,8 @@ class TestMnist(unittest.TestCase):
     def setUp(self):
         self.mnist_root = download.get_dataset_directory(
             os.path.join('pfnet', 'chainer', 'mnist'))
-        self.kmnist_root = download.get_dataset_directory(
-            os.path.join('pfnet', 'chainer', 'kmnist'))
+        self.kuzushiji_mnist_root = download.get_dataset_directory(
+            os.path.join('pfnet', 'chainer', 'kuzushiji_mnist'))
         self.fashion_mnist_root = download.get_dataset_directory(
             os.path.join('pfnet', 'chainer', 'fashion-mnist'))
 
@@ -54,13 +54,14 @@ class TestMnist(unittest.TestCase):
         self.check_retrieval_once('train.npz', 'test.npz',
                                   self.mnist_root, get_mnist)
 
-    def test_get_kmnist_labels(self):
-        self.assertEqual(get_kmnist_labels(), _kmnist_labels)
+    def test_get_kuzushiji_mnist_labels(self):
+        self.assertEqual(get_kuzushiji_mnist_labels(), _kuzushiji_mnist_labels)
 
     @attr.slow
-    def test_get_kmnist(self):
+    def test_get_kuzushiji_mnist(self):
         self.check_retrieval_once('train.npz', 'test.npz',
-                                  self.kmnist_root, get_kmnist)
+                                  self.kuzushiji_mnist_root,
+                                  get_kuzushiji_mnist)
 
     def test_get_fashion_mnist_labels(self):
         self.assertEqual(get_fashion_mnist_labels(), _fashion_mnist_labels)
@@ -106,11 +107,11 @@ class TestMnist(unittest.TestCase):
                                    'chainer.datasets.mnist')
 
     @attr.slow
-    def test_get_kmnist_cached(self):
+    def test_get_kuzushiji_mnist_cached(self):
         self.check_retrieval_twice('train.npz', 'test.npz',
-                                   self.kmnist_root,
-                                   get_kmnist,
-                                   'chainer.datasets.kmnist')
+                                   self.kuzushiji_mnist_root,
+                                   get_kuzushiji_mnist,
+                                   'chainer.datasets.kuzushiji_mnist')
 
     @attr.slow
     def test_get_fashion_mnist_cached(self):

--- a/tests/chainer_tests/datasets_tests/test_mnist.py
+++ b/tests/chainer_tests/datasets_tests/test_mnist.py
@@ -9,12 +9,20 @@ from chainer.dataset import download
 from chainer.datasets import get_fashion_mnist
 from chainer.datasets import get_fashion_mnist_labels
 from chainer.datasets import get_mnist
+from chainer.datasets import get_kmnist
+from chainer.datasets import get_kmnist_labels
 from chainer.datasets import tuple_dataset
 from chainer import testing
 from chainer.testing import attr
 
 _fashion_mnist_labels = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',
                          'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']
+
+_kmnist_labels = [('o', u'\u304A'), ('ki', u'\u304D'),
+                  ('su', u'\u3059'), ('tsu', u'\u3064'),
+                  ('na', u'\u306A'), ('ha', u'\u306F'),
+                  ('ma', u'\u307E'), ('ya', u'\u3084'),
+                  ('re', u'\u308C'), ('wo', u'\u3092')]
 
 
 @testing.parameterize(*testing.product({
@@ -28,6 +36,8 @@ class TestMnist(unittest.TestCase):
     def setUp(self):
         self.mnist_root = download.get_dataset_directory(
             os.path.join('pfnet', 'chainer', 'mnist'))
+        self.kmnist_root = download.get_dataset_directory(
+            os.path.join('pfnet', 'chainer', 'kmnist'))
         self.fashion_mnist_root = download.get_dataset_directory(
             os.path.join('pfnet', 'chainer', 'fashion-mnist'))
 
@@ -43,6 +53,14 @@ class TestMnist(unittest.TestCase):
     def test_get_mnist(self):
         self.check_retrieval_once('train.npz', 'test.npz',
                                   self.mnist_root, get_mnist)
+
+    def test_get_kmnist_labels(self):
+        self.assertEqual(get_kmnist_labels(), _kmnist_labels)
+
+    @attr.slow
+    def test_get_kmnist(self):
+        self.check_retrieval_once('train.npz', 'test.npz',
+                                  self.kmnist_root, get_kmnist)
 
     def test_get_fashion_mnist_labels(self):
         self.assertEqual(get_fashion_mnist_labels(), _fashion_mnist_labels)
@@ -86,6 +104,13 @@ class TestMnist(unittest.TestCase):
                                    self.mnist_root,
                                    get_mnist,
                                    'chainer.datasets.mnist')
+
+    @attr.slow
+    def test_get_kmnist_cached(self):
+        self.check_retrieval_twice('train.npz', 'test.npz',
+                                   self.kmnist_root,
+                                   get_kmnist,
+                                   'chainer.datasets.kmnist')
 
     @attr.slow
     def test_get_fashion_mnist_cached(self):

--- a/tests/chainer_tests/datasets_tests/test_mnist.py
+++ b/tests/chainer_tests/datasets_tests/test_mnist.py
@@ -8,9 +8,9 @@ import numpy
 from chainer.dataset import download
 from chainer.datasets import get_fashion_mnist
 from chainer.datasets import get_fashion_mnist_labels
-from chainer.datasets import get_mnist
 from chainer.datasets import get_kmnist
 from chainer.datasets import get_kmnist_labels
+from chainer.datasets import get_mnist
 from chainer.datasets import tuple_dataset
 from chainer import testing
 from chainer.testing import attr


### PR DESCRIPTION
I'd like to suggest adding the Kuzushiji-MNIST dataset to Chainer.

The Kuzushiji-MNIST dataset is designed to be an
MNIST-like dataset focusing on handwritten Japanese
characters. All data features of KMNIST are identical to
MNIST, such as number of train and test images, image
size, etc with the intent of making it easy to run any
MNIST-based analysis or benchmarks against this new
dataset.

Details available here: https://github.com/rois-codh/kmnist
