### PR TITLE
Rename `chainerx` -> `chx` in public API

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -10,8 +10,8 @@ import chainerx
 # Aliases
 from chainer._backend import Device
 from chainer.backends._chainerx import ChainerxDevice
-from chainer.backends._chainerx import from_chainerx  # NOQA
-from chainer.backends._chainerx import to_chainerx  # NOQA
+from chainer.backends._chainerx import from_chx  # NOQA
+from chainer.backends._chainerx import to_chx  # NOQA
 from chainer.backends._cpu import CpuDevice
 from chainer.backends.cuda import GpuDevice
 from chainer.backends.intel64 import Intel64Device

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -81,7 +81,7 @@ class ChainerxDevice(_backend.Device):
         chainerx.set_default_device(self.device)
 
 
-def to_chainerx(array):
+def to_chx(array):
     """Converts an array or arrays to ChainerX.
 
     Destination ChainerX devices are chosen according to the types of input
@@ -90,7 +90,7 @@ def to_chainerx(array):
     return _backend._convert_arrays(array, _array_to_chainerx)
 
 
-def from_chainerx(array):
+def from_chx(array):
     """Converts an array or arrays from ChainerX to NumPy or CuPy ones.
 
     Destination array types are chosen such that no copies occur.

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -159,8 +159,8 @@ class FunctionAdapter(function_node.FunctionNode):
         is_chainerx_fallback_mode = self._is_chainerx_fallback_mode
         if is_chainerx_fallback_mode:
             # Convert input and output gradients to numpy/cupy
-            in_data = backend.from_chainerx(in_data)
-            grad_out_data = backend.from_chainerx(grad_out_data)
+            in_data = backend.from_chx(in_data)
+            grad_out_data = backend.from_chx(grad_out_data)
 
         # Call Function.backward
         with cuda.get_device_from_array(*(in_data + grad_out_data)):
@@ -177,7 +177,7 @@ class FunctionAdapter(function_node.FunctionNode):
 
         # Convert input gradients back to ChainerX
         if is_chainerx_fallback_mode:
-            gxs = backend.to_chainerx(gxs)
+            gxs = backend.to_chx(gxs)
 
         ret = []
         for i in target_input_indexes:
@@ -328,7 +328,7 @@ class Function(object):
 
         """
         if self.node._is_chainerx_fallback_mode:
-            return backend.from_chainerx(self.node.output_data)
+            return backend.from_chx(self.node.output_data)
         return self.node.output_data
 
     @property

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -428,7 +428,7 @@ Use apply() method instead.\
                     if device is None:
                         device = x.device
                 else:
-                    fallback_data = backend.from_chainerx(data)
+                    fallback_data = backend.from_chx(data)
                     if device is None:
                         device = backend.ChainerxDevice(data.device)
 
@@ -446,7 +446,7 @@ Use apply() method instead.\
 
         # TODO(hvy): Take configuration.config.enable_backprop into
         # account?
-        chainerx_out_data = backend.to_chainerx(outputs)
+        chainerx_out_data = backend.to_chx(outputs)
 
         # Insert a ChainerX op-node that calls FunctionNode.backward in
         # backprop. Note that chainerx_out_data may not require gradients.
@@ -1194,7 +1194,7 @@ def _extract_apply_in_data(inputs):
                         has_chainerx_array = True
 
         if has_chainerx_array:
-            return True, tuple(backend.to_chainerx(arrays))
+            return True, tuple(backend.to_chx(arrays))
         else:
             return False, tuple(arrays)
 
@@ -1254,7 +1254,7 @@ def _make_chainerx_attribute_fallback_class(obj, device):
         if isinstance(value, chainerx.ndarray):
             fallback_arr = fallback_array_cache.get(name)
             if fallback_arr is None:
-                fallback_arr = backend.from_chainerx(value)
+                fallback_arr = backend.from_chx(value)
                 fallback_array_cache[name] = fallback_arr
             return fallback_arr
         return value
@@ -1263,7 +1263,7 @@ def _make_chainerx_attribute_fallback_class(obj, device):
     def setattr(self, name, value):
         if isinstance(value, fallback_device.xp.ndarray):
             fallback_array_cache[name] = value
-            sup.__setattr__(name, backend.to_chainerx(value))
+            sup.__setattr__(name, backend.to_chx(value))
             return
         sup.__setattr__(name, value)
 

--- a/chainer/functions/array/get_item.py
+++ b/chainer/functions/array/get_item.py
@@ -40,7 +40,7 @@ class GetItem(function_node.FunctionNode):
 
     def forward(self, xs):
         slices = tuple([
-            backend.from_chainerx(s) if isinstance(s, chainerx.ndarray) else s
+            backend.from_chx(s) if isinstance(s, chainerx.ndarray) else s
             for s in self.slices])
         return utils.force_array(xs[0][slices]),
 

--- a/chainer/functions/array/scatter_add.py
+++ b/chainer/functions/array/scatter_add.py
@@ -40,7 +40,7 @@ class ScatterAdd(function_node.FunctionNode):
         y = a.copy()
         xp = backend.get_array_module(a)
         slices = tuple([
-            backend.from_chainerx(s) if isinstance(s, chainerx.ndarray) else s
+            backend.from_chx(s) if isinstance(s, chainerx.ndarray) else s
             for s in self.slices])
         if y[slices].shape != b.shape:
             raise ValueError(

--- a/chainer/functions/array/select_item.py
+++ b/chainer/functions/array/select_item.py
@@ -67,14 +67,14 @@ class Assign(function_node.FunctionNode):
         self.t = t.data
 
     def forward_cpu(self, inputs):
-        t = backend.from_chainerx(self.t)  # Workaround for ChainerX.
+        t = backend.from_chx(self.t)  # Workaround for ChainerX.
 
         gx = numpy.zeros(self.shape, self.dtype)
         gx[six.moves.range(self.t.size), t] = inputs[0]
         return gx,
 
     def forward_gpu(self, inputs):
-        t = backend.from_chainerx(self.t)  # Workaround for ChainerX.
+        t = backend.from_chx(self.t)  # Workaround for ChainerX.
 
         gx = cuda.cupy.zeros(self.shape, self.dtype)
         gx = cuda.elementwise(

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -34,7 +34,7 @@ class NegativeSamplingFunction(function_node.FunctionNode):
         size = int(t.shape[0])
         # first one is the positive, and others are sampled negatives
         samples = self.sampler((size, self.sample_size + 1))
-        samples = backend.from_chainerx(samples)
+        samples = backend.from_chx(samples)
         samples[:, 0] = t
         return samples
 

--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -112,7 +112,7 @@ class SoftmaxCrossEntropy(function_node.FunctionNode):
         return y,
 
     def forward_cpu(self, inputs):
-        class_weight = backend.from_chainerx(self.class_weight)
+        class_weight = backend.from_chx(self.class_weight)
 
         self.retain_inputs((0, 1))
         x, t = inputs
@@ -147,7 +147,7 @@ class SoftmaxCrossEntropy(function_node.FunctionNode):
             return -log_p.reshape(t.shape),
 
     def forward_gpu(self, inputs):
-        class_weight = backend.from_chainerx(self.class_weight)
+        class_weight = backend.from_chx(self.class_weight)
 
         self.retain_inputs((0, 1))
         cupy = cuda.cupy

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -44,7 +44,7 @@ def _chainerx_preprocess_const(x, value, label):
     # conversion without copy is possible.
     if isinstance(value, (numpy.ndarray, cuda.ndarray)):
         # TODO(niboshi): force zero-copy
-        return backend.to_chainerx(value)
+        return backend.to_chx(value)
 
     if isinstance(value, (six.integer_types, float)):
         return value

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -230,7 +230,7 @@ class BatchNormalization(function_node.FunctionNode):
 
             xp = backend.get_array_module(self.running_mean, self.running_var)
             if xp is chainerx:
-                self.running_mean, self.running_var = backend.from_chainerx(
+                self.running_mean, self.running_var = backend.from_chx(
                     (self.running_mean, self.running_var))
 
             self.running_mean *= self.decay
@@ -239,8 +239,8 @@ class BatchNormalization(function_node.FunctionNode):
             self.running_var += (1 - self.decay) * adjust * var
 
             if xp is chainerx:
-                self.running_mean = backend.to_chainerx(self.running_mean)
-                self.running_var = backend.to_chainerx(self.running_var)
+                self.running_mean = backend.to_chx(self.running_mean)
+                self.running_var = backend.to_chx(self.running_var)
 
         return y,
 

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -472,7 +472,7 @@ class Link(object):
         intel64.check_ideep_available()
         return self.to_device(intel64)
 
-    def to_chainerx(self):
+    def to_chx(self):
         """Converts parameter variables and persistent values to ChainerX \
 without any copy.
 
@@ -491,25 +491,25 @@ without any copy.
 
         d = self.__dict__
         for name in self._params:
-            d[name].to_chainerx()
+            d[name].to_chx()
         for name in self._persistent:
             if not numpy.isscalar(d[name]):
-                d[name] = backend.to_chainerx(d[name])
+                d[name] = backend.to_chx(d[name])
 
         self._device = (
             backend.ChainerxDevice.from_fallback_device(self._device))
 
         return self
 
-    def from_chainerx(self):
+    def from_chx(self):
         """Converts parameter variables and persistent values from ChainerX \
 to NumPy/CuPy devices without any copy."""
         d = self.__dict__
         for name in self._params:
-            d[name].from_chainerx()
+            d[name].from_chx()
         for name in self._persistent:
             if not numpy.isscalar(d[name]):
-                d[name] = backend.from_chainerx(d[name])
+                d[name] = backend.from_chx(d[name])
 
         if isinstance(self._device, backend.ChainerxDevice):
             self._device = self._device.fallback_device
@@ -1041,22 +1041,22 @@ class Chain(Link):
             d[name] = copied
         return ret  # type: ignore
 
-    def to_chainerx(self):
+    def to_chx(self):
         # type: () -> 'Chain'
 
-        super(Chain, self).to_chainerx()
+        super(Chain, self).to_chx()
         d = self.__dict__
         for name in self._children:
-            d[name].to_chainerx()
+            d[name].to_chx()
         return self
 
-    def from_chainerx(self):
+    def from_chx(self):
         # type: () -> 'Chain'
 
-        super(Chain, self).from_chainerx()
+        super(Chain, self).from_chx()
         d = self.__dict__
         for name in self._children:
-            d[name].from_chainerx()
+            d[name].from_chx()
         return self
 
     def _to_device(self, device, skip_between_cupy_devices=False):
@@ -1276,12 +1276,12 @@ class ChainList(Link, collections_abc.MutableSequence):
             children[i] = child
         return ret  # type: ignore
 
-    def to_chainerx(self):
+    def to_chx(self):
         # type: () -> 'ChainList'
 
-        super(ChainList, self).to_chainerx()
+        super(ChainList, self).to_chx()
         for link in self._children:
-            link.to_chainerx()
+            link.to_chx()
         return self
 
     def _to_device(self, device, skip_between_cupy_devices=False):

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -294,7 +294,7 @@ class UpdateRule(object):
         for state_name, st in self.state.items():
             st = self.state[state_name]
             if isinstance(st, chainerx.ndarray):
-                fallback_arr = backend.from_chainerx(st)
+                fallback_arr = backend.from_chx(st)
                 self.state[state_name] = fallback_arr
                 chainerx_state_arrays[state_name] = (st, fallback_arr)
 
@@ -303,7 +303,7 @@ class UpdateRule(object):
         # cache and avoid redundant conversion. Else, create the cache here
         # and use it.
         if param._chainerx_fallback_array is None:
-            param._chainerx_fallback_array = backend.from_chainerx(
+            param._chainerx_fallback_array = backend.from_chx(
                 param.array)
 
         temp_param = variable.Variable._init_unchecked(
@@ -311,7 +311,7 @@ class UpdateRule(object):
 
         if grad_array is not None:
             temp_param._set_grad_without_check(
-                backend.from_chainerx(grad_array))
+                backend.from_chx(grad_array))
 
         # Update
         update_core(temp_param)
@@ -323,7 +323,7 @@ class UpdateRule(object):
                 # The optimizer altered the reference of the state, instead of
                 # updating it in-place. We need to convert the new state back
                 # to ChainerX.
-                arr = backend.to_chainerx(cur_arr)
+                arr = backend.to_chx(cur_arr)
             self.state[state_name] = arr
 
     def init_state(self, param):

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -870,7 +870,7 @@ class Variable(object):
             self._has_chainerx_array = False
 
     @property
-    def chainerx_array(self):
+    def chx_array(self):
         """A view of the raw ChainerX array.
 
         In contrary to :data:`Variable.array` which is always disconnected,
@@ -884,7 +884,7 @@ class Variable(object):
         """
         if not self._has_chainerx_array:
             raise ValueError(
-                'chainerx_array is not available for Variable with '
+                'chx_array is not available for Variable with '
                 'non-ChainerX array.')
         return self._data[0].view()
 
@@ -1063,7 +1063,7 @@ class Variable(object):
         intel64.check_ideep_available()
         self.to_device(intel64)
 
-    def to_chainerx(self):
+    def to_chx(self):
         """Converts the array and gradient to ChainerX arrays without copy.
 
         This method converts the underlying array and gradient to
@@ -1072,9 +1072,9 @@ class Variable(object):
         The new array is a view of the original one.
 
         """
-        self._to_chainerx(allow_unchaining=False)
+        self._to_chx(allow_unchaining=False)
 
-    def _to_chainerx(self, allow_unchaining):
+    def _to_chx(self, allow_unchaining):
         if not chainerx.is_available():
             raise RuntimeError('ChainerX is not available.')
 
@@ -1098,7 +1098,7 @@ class Variable(object):
             backend.ChainerxDevice.from_fallback_device(self.device),
             allow_unchaining)
 
-    def from_chainerx(self):
+    def from_chx(self):
         """Converts the array and gradient to non-ChainerX arrays without copy.
 
         This method converts the underlying ChainerX array and gradient
@@ -1110,9 +1110,9 @@ class Variable(object):
         Raises an error if such a conversion is not supported for the device.
 
         """
-        self._from_chainerx(allow_unchaining=False)
+        self._from_chx(allow_unchaining=False)
 
-    def _from_chainerx(self, allow_unchaining):
+    def _from_chx(self, allow_unchaining):
         if not self._has_chainerx_array:
             return
 
@@ -1742,7 +1742,7 @@ class Parameter(Variable):
     def to_intel64(self):
         self.to_device(intel64)
 
-    def to_chainerx(self):
+    def to_chx(self):
         if not chainerx.is_available():
             raise RuntimeError('ChainerX is not available.')
 
@@ -1760,9 +1760,9 @@ class Parameter(Variable):
             self._initial_device = backend.ChainerxDevice(
                 chainerx.get_device('cuda:{}'.format(device.device.id)))
 
-        super(Parameter, self)._to_chainerx(allow_unchaining=True)
+        super(Parameter, self)._to_chx(allow_unchaining=True)
 
-    def from_chainerx(self):
+    def from_chx(self):
         if self.array is not None:
             device = backend.get_device_from_array(self.array)
         else:
@@ -1776,7 +1776,7 @@ class Parameter(Variable):
                 self._initial_device = chainer.get_device(
                     (cuda.cupy, device.device.index))
 
-        super(Parameter, self)._from_chainerx(allow_unchaining=True)
+        super(Parameter, self)._from_chx(allow_unchaining=True)
 
     def to_device(self, device):
         device = chainer.get_device(device)

--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -67,7 +67,7 @@ def _from_cupy(array):
         array)
 
 
-def _from_chainerx(array, check_backprop=True):
+def _from_chx(array, check_backprop=True):
     # Converts chainerx.ndarray to numpy/cupy.ndarray.
     # Objects with other types are kept intact.
     # Returns a pair: (xp, cupy device or dummy context, numpy/cupy.ndarray).
@@ -92,7 +92,7 @@ def _from_chainerx(array, check_backprop=True):
         'backends.')
 
 
-def _to_chainerx(array):
+def _to_chx(array):
     # Converts numpy/cupy.ndarray to chainerx.ndarray.
     # Objects with other types are kept intact.
     if isinstance(array, numpy.ndarray):
@@ -105,10 +105,10 @@ def _to_chainerx(array):
 def _populate_module_functions():
 
     def _isfinite(arr):
-        xp, dev, arr = _from_chainerx(arr)
+        xp, dev, arr = _from_chx(arr)
         with dev:
             ret = xp.isfinite(arr)
-        return _to_chainerx(ret)
+        return _to_chx(ret)
 
     chainerx.isfinite = _isfinite
 
@@ -116,11 +116,11 @@ def _populate_module_functions():
         assert len(arrs) > 0
         arrs2 = []
         for a in arrs:
-            xp, dev, a2 = _from_chainerx(a)
+            xp, dev, a2 = _from_chx(a)
             arrs2.append(a2)
         with dev:
             ret = xp.hstack(arrs2)
-        return _to_chainerx(ret)
+        return _to_chx(ret)
 
     chainerx.hstack = _hstack
 
@@ -128,11 +128,11 @@ def _populate_module_functions():
         assert len(arrs) > 0
         arrs2 = []
         for a in arrs:
-            xp, dev, a2 = _from_chainerx(a)
+            xp, dev, a2 = _from_chx(a)
             arrs2.append(a2)
         with dev:
             ret = xp.vstack(arrs2)
-        return _to_chainerx(ret)
+        return _to_chx(ret)
 
     chainerx.vstack = _vstack
 
@@ -151,8 +151,8 @@ def _populate_ndarray():
 
         is_backprop_required = arr.is_backprop_required()
 
-        xp, dev, arr = _from_chainerx(arr, check_backprop=False)
-        _, _, key = _from_chainerx(key, check_backprop=False)
+        xp, dev, arr = _from_chx(arr, check_backprop=False)
+        _, _, key = _from_chx(key, check_backprop=False)
 
         with dev:
             ret = arr[key]
@@ -166,7 +166,7 @@ def _populate_ndarray():
                 'ChainerX getitem fallback for advanced indexing is not '
                 'supported for arrays that are connected to a graph.')
 
-        return _to_chainerx(ret)
+        return _to_chx(ret)
 
     # __setitem__ with advanced indexing
     def __setitem__(self, key, value):
@@ -175,9 +175,9 @@ def _populate_ndarray():
                 'ChainerX setitem fallback for advanced indexing is not '
                 'supported for arrays that are connected to a graph.')
 
-        xp, dev, self = _from_chainerx(self)
-        _, _, key = _from_chainerx(key)
-        _, _, value = _from_chainerx(value)
+        xp, dev, self = _from_chx(self)
+        _, _, key = _from_chx(key)
+        _, _, value = _from_chx(value)
 
         with dev:
             self[key] = value
@@ -186,26 +186,26 @@ def _populate_ndarray():
     ndarray.__getitem__ = __getitem__
 
     def _min(arr, *args, **kwargs):
-        _, dev, arr = _from_chainerx(arr)
+        _, dev, arr = _from_chx(arr)
         with dev:
             ret = arr.min(*args, **kwargs)
-        return _to_chainerx(ret)
+        return _to_chx(ret)
 
     ndarray.min = _min
 
     def _all(arr, *args, **kwargs):
-        _, dev, arr = _from_chainerx(arr)
+        _, dev, arr = _from_chx(arr)
         with dev:
             ret = arr.all(*args, **kwargs)
-        return _to_chainerx(ret)
+        return _to_chx(ret)
 
     ndarray.all = _all
 
     def _any(arr, *args, **kwargs):
-        _, dev, arr = _from_chainerx(arr)
+        _, dev, arr = _from_chx(arr)
         with dev:
             ret = arr.any(*args, **kwargs)
-        return _to_chainerx(ret)
+        return _to_chx(ret)
 
     ndarray.any = _any
 

--- a/tests/chainer_tests/backends_tests/test_chainerx.py
+++ b/tests/chainer_tests/backends_tests/test_chainerx.py
@@ -101,9 +101,9 @@ class TestFromToChainerx(unittest.TestCase):
         with chainer.using_device(backend.get_device_from_array(arr1)):
             arr1 -= 2
 
-    def test_from_chainerx(self, backend_config):
+    def test_from_chx(self, backend_config):
         arr = backend_config.get_array(numpy.ones((2, 3), numpy.float32))
-        arr_converted = backend.from_chainerx(arr)
+        arr_converted = backend.from_chx(arr)
 
         src_device = backend_config.device
         if src_device.xp is chainerx:
@@ -117,9 +117,9 @@ class TestFromToChainerx(unittest.TestCase):
         with backend_config:
             self.check_equal_memory_shared(arr, arr_converted)
 
-    def test_to_chainerx(self, backend_config):
+    def test_to_chx(self, backend_config):
         arr = backend_config.get_array(numpy.ones((2, 3), numpy.float32))
-        arr_converted = backend.to_chainerx(arr)
+        arr_converted = backend.to_chx(arr)
 
         src_device = backend_config.device
         assert isinstance(arr_converted, chainerx.ndarray)

--- a/tests/chainer_tests/functions_tests/array_tests/test_stack.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_stack.py
@@ -107,9 +107,9 @@ class TestStack(unittest.TestCase):
     @attr.chainerx
     def test_double_backward_chainerx(self):
         self.check_double_backward(
-            backend.to_chainerx(self.xs),
-            backend.to_chainerx(self.g),
-            backend.to_chainerx(self.ggs))
+            backend.to_chx(self.xs),
+            backend.to_chx(self.g),
+            backend.to_chx(self.ggs))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -99,23 +99,23 @@ class TestConvolutionND(unittest.TestCase):
 
     @attr.chainerx
     def test_forward_chainerx_native(self):
-        self.check_forward_consistency(backend.to_chainerx, nobias=False)
+        self.check_forward_consistency(backend.to_chx, nobias=False)
 
     @attr.chainerx
     def test_forward_chainerx_native_nobias(self):
-        self.check_forward_consistency(backend.to_chainerx, nobias=True)
+        self.check_forward_consistency(backend.to_chx, nobias=True)
 
     @attr.chainerx
     @attr.gpu
     def test_forward_chainerx_cuda(self):
         self.check_forward_consistency(
-            lambda xs: backend.to_chainerx(cuda.to_gpu(xs)), nobias=False)
+            lambda xs: backend.to_chx(cuda.to_gpu(xs)), nobias=False)
 
     @attr.chainerx
     @attr.gpu
     def test_forward_chainerx_cuda_nobias(self):
         self.check_forward_consistency(
-            lambda xs: backend.to_chainerx(cuda.to_gpu(xs)), nobias=True)
+            lambda xs: backend.to_chx(cuda.to_gpu(xs)), nobias=True)
 
     @attr.cudnn
     def test_forward_consistency(self):
@@ -190,32 +190,32 @@ class TestConvolutionND(unittest.TestCase):
     @attr.chainerx
     def test_backward_chainerx_native(self):
         self.check_backward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.W),
-            backend.to_chainerx(self.b), backend.to_chainerx(self.gy))
+            backend.to_chx(self.x), backend.to_chx(self.W),
+            backend.to_chx(self.b), backend.to_chx(self.gy))
 
     @attr.chainerx
     def test_backward_chainerx_native_nobias(self):
         self.check_backward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.W), None,
-            backend.to_chainerx(self.gy))
+            backend.to_chx(self.x), backend.to_chx(self.W), None,
+            backend.to_chx(self.gy))
 
     @attr.chainerx
     @attr.gpu
     def test_backward_chainerx_cuda(self):
         self.check_backward(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.W)),
-            backend.to_chainerx(cuda.to_gpu(self.b)),
-            backend.to_chainerx(cuda.to_gpu(self.gy)))
+            backend.to_chx(cuda.to_gpu(self.x)),
+            backend.to_chx(cuda.to_gpu(self.W)),
+            backend.to_chx(cuda.to_gpu(self.b)),
+            backend.to_chx(cuda.to_gpu(self.gy)))
 
     @attr.chainerx
     @attr.gpu
     def test_backward_chainerx_cuda_nobias(self):
         self.check_backward(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.W)),
+            backend.to_chx(cuda.to_gpu(self.x)),
+            backend.to_chx(cuda.to_gpu(self.W)),
             None,
-            backend.to_chainerx(cuda.to_gpu(self.gy)))
+            backend.to_chx(cuda.to_gpu(self.gy)))
 
     @condition.retry(3)
     def test_backward_cpu(self):
@@ -283,40 +283,40 @@ class TestConvolutionND(unittest.TestCase):
     @attr.chainerx
     def test_double_backward_chainerx_native(self):
         self.check_double_backward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.W),
-            backend.to_chainerx(self.b), backend.to_chainerx(self.gy),
-            backend.to_chainerx(self.ggx), backend.to_chainerx(self.ggW),
-            backend.to_chainerx(self.ggb))
+            backend.to_chx(self.x), backend.to_chx(self.W),
+            backend.to_chx(self.b), backend.to_chx(self.gy),
+            backend.to_chx(self.ggx), backend.to_chx(self.ggW),
+            backend.to_chx(self.ggb))
 
     @attr.chainerx
     def test_double_backward_chainerx_native_nobias(self):
         self.check_double_backward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.W), None,
-            backend.to_chainerx(self.gy), backend.to_chainerx(self.ggx),
-            backend.to_chainerx(self.ggW), None)
+            backend.to_chx(self.x), backend.to_chx(self.W), None,
+            backend.to_chx(self.gy), backend.to_chx(self.ggx),
+            backend.to_chx(self.ggW), None)
 
     @attr.chainerx
     @attr.gpu
     def test_double_backward_chainerx_cuda(self):
         self.check_double_backward(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.W)),
-            backend.to_chainerx(cuda.to_gpu(self.b)),
-            backend.to_chainerx(cuda.to_gpu(self.gy)),
-            backend.to_chainerx(cuda.to_gpu(self.ggx)),
-            backend.to_chainerx(cuda.to_gpu(self.ggW)),
-            backend.to_chainerx(cuda.to_gpu(self.ggb)))
+            backend.to_chx(cuda.to_gpu(self.x)),
+            backend.to_chx(cuda.to_gpu(self.W)),
+            backend.to_chx(cuda.to_gpu(self.b)),
+            backend.to_chx(cuda.to_gpu(self.gy)),
+            backend.to_chx(cuda.to_gpu(self.ggx)),
+            backend.to_chx(cuda.to_gpu(self.ggW)),
+            backend.to_chx(cuda.to_gpu(self.ggb)))
 
     @attr.chainerx
     @attr.gpu
     def test_double_backward_chainerx_cuda_nobias(self):
         self.check_double_backward(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.W)),
+            backend.to_chx(cuda.to_gpu(self.x)),
+            backend.to_chx(cuda.to_gpu(self.W)),
             None,
-            backend.to_chainerx(cuda.to_gpu(self.gy)),
-            backend.to_chainerx(cuda.to_gpu(self.ggx)),
-            backend.to_chainerx(cuda.to_gpu(self.ggW)),
+            backend.to_chx(cuda.to_gpu(self.gy)),
+            backend.to_chx(cuda.to_gpu(self.ggx)),
+            backend.to_chx(cuda.to_gpu(self.ggW)),
             None)
 
     @condition.retry(3)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -209,18 +209,18 @@ class TestDeconvolutionND(unittest.TestCase):
     @condition.retry(3)
     def test_backward_chainerx_cpu(self):
         self.check_backward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.W),
-            backend.to_chainerx(self.b), backend.to_chainerx(self.gy))
+            backend.to_chx(self.x), backend.to_chx(self.W),
+            backend.to_chx(self.b), backend.to_chx(self.gy))
 
     @attr.chainerx
     @attr.gpu
     @condition.retry(3)
     def test_backward_chainerx_gpu(self):
         self.check_backward(
-            backend.to_chainerx(self.x).to_device('cuda'),
-            backend.to_chainerx(self.W).to_device('cuda'),
-            backend.to_chainerx(self.b).to_device('cuda'),
-            backend.to_chainerx(self.gy).to_device('cuda'))
+            backend.to_chx(self.x).to_device('cuda'),
+            backend.to_chx(self.W).to_device('cuda'),
+            backend.to_chx(self.b).to_device('cuda'),
+            backend.to_chx(self.gy).to_device('cuda'))
 
     def check_double_backward(
             self, inputs, grad_outputs, grad_grad_inputs, use_cudnn='always'):
@@ -281,9 +281,9 @@ class TestDeconvolutionND(unittest.TestCase):
     @attr.chainerx
     @condition.retry(3)
     def test_double_backward_chainerx_cpu(self):
-        inputs = [backend.to_chainerx(_) for _ in [self.x, self.W, self.b]]
-        grad_outputs = [backend.to_chainerx(_) for _ in [self.gy]]
-        grad_grad_inputs = [backend.to_chainerx(_) for _
+        inputs = [backend.to_chx(_) for _ in [self.x, self.W, self.b]]
+        grad_outputs = [backend.to_chx(_) for _ in [self.gy]]
+        grad_grad_inputs = [backend.to_chx(_) for _
                             in [self.ggx, self.ggW, self.ggb]]
 
         self.check_double_backward(
@@ -293,11 +293,11 @@ class TestDeconvolutionND(unittest.TestCase):
     @attr.gpu
     @condition.retry(3)
     def test_double_backward_chainerx_gpu(self):
-        inputs = [backend.to_chainerx(_).to_device('cuda')
+        inputs = [backend.to_chx(_).to_device('cuda')
                   for _ in [self.x, self.W, self.b]]
-        grad_outputs = [backend.to_chainerx(_).to_device('cuda')
+        grad_outputs = [backend.to_chx(_).to_device('cuda')
                         for _ in [self.gy]]
-        grad_grad_inputs = [backend.to_chainerx(_).to_device('cuda')
+        grad_grad_inputs = [backend.to_chx(_).to_device('cuda')
                             for _ in [self.ggx, self.ggW, self.ggb]]
 
         self.check_double_backward(

--- a/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_hinge.py
@@ -91,14 +91,14 @@ class TestHinge(unittest.TestCase):
     @attr.chainerx
     def test_forward_chainerx_native(self):
         self.check_forward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.t))
+            backend.to_chx(self.x), backend.to_chx(self.t))
 
     @attr.gpu
     @attr.chainerx
     def test_forward_chainerx_cuda(self):
         self.check_forward(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.t)))
+            backend.to_chx(cuda.to_gpu(self.x)),
+            backend.to_chx(cuda.to_gpu(self.t)))
 
     def check_backward(self, x_data, t_data):
         def f(x, t):
@@ -128,15 +128,15 @@ class TestHinge(unittest.TestCase):
     @attr.chainerx
     def test_backward_chainerx_native(self):
         self.check_backward_chainerx(
-            backend.to_chainerx(self.x),
-            backend.to_chainerx(self.t))
+            backend.to_chx(self.x),
+            backend.to_chx(self.t))
 
     @attr.gpu
     @attr.chainerx
     def test_backward_chainerx_cuda(self):
         self.check_backward_chainerx(
-            backend.to_chainerx(cuda.to_gpu(self.x)),
-            backend.to_chainerx(cuda.to_gpu(self.t)))
+            backend.to_chx(cuda.to_gpu(self.x)),
+            backend.to_chx(cuda.to_gpu(self.t)))
 
 
 class TestHingeInvalidOption(unittest.TestCase):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -156,7 +156,7 @@ class SoftmaxCrossEntropyTestBase(object):
     @attr.chainerx
     def test_forward_chainerx_native(self):
         def conv(x):
-            return chainer.backend.to_chainerx(x)
+            return chainer.backend.to_chx(x)
 
         self.check_forward(
             conv(self.x), conv(self.t),
@@ -166,7 +166,7 @@ class SoftmaxCrossEntropyTestBase(object):
     @attr.gpu
     def test_forward_chainerx_cuda(self):
         def conv(x):
-            return chainer.backend.to_chainerx(cuda.to_gpu(x))
+            return chainer.backend.to_chx(cuda.to_gpu(x))
 
         self.check_forward(
             conv(self.x), conv(self.t),
@@ -216,7 +216,7 @@ class SoftmaxCrossEntropyTestBase(object):
     @attr.chainerx
     def test_backward_chainerx_native(self):
         def conv(x):
-            return chainer.backend.to_chainerx(x)
+            return chainer.backend.to_chx(x)
 
         g_data = None
         if self.reduce == 'no':
@@ -231,7 +231,7 @@ class SoftmaxCrossEntropyTestBase(object):
     @attr.gpu
     def test_backward_chainerx_cuda(self):
         def conv(x):
-            return chainer.backend.to_chainerx(cuda.to_gpu(x))
+            return chainer.backend.to_chx(cuda.to_gpu(x))
 
         g_data = None
         if self.reduce == 'no':
@@ -329,7 +329,7 @@ class TestSoftmaxCrossEntropyEnableDoubleBackprop(
     @attr.chainerx
     def test_double_backward_chainerx_native(self):
         def conv(x):
-            return chainer.backend.to_chainerx(x)
+            return chainer.backend.to_chx(x)
 
         args = [conv(a) for a in [self.x, self.t, self.gy, self.ggx]]
         args.append(None if not self.weight_apply else conv(self.class_weight))
@@ -339,7 +339,7 @@ class TestSoftmaxCrossEntropyEnableDoubleBackprop(
     @attr.gpu
     def test_double_backward_chainerx_cuda(self):
         def conv(x):
-            return chainer.backend.to_chainerx(cuda.to_gpu(x))
+            return chainer.backend.to_chx(cuda.to_gpu(x))
 
         args = [conv(a) for a in [self.x, self.t, self.gy, self.ggx]]
         args.append(None if not self.weight_apply else conv(self.class_weight))

--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -22,7 +22,7 @@ def arrays_to_chainerx(orig_xp, np_arrays):
         orig_arrays = np_arrays
     elif orig_xp is cuda.cupy:
         orig_arrays = [cuda.to_gpu(a) for a in np_arrays]
-    return [chainer.backend.to_chainerx(a) for a in orig_arrays]
+    return [chainer.backend.to_chx(a) for a in orig_arrays]
 
 
 @testing.parameterize(*testing.product({
@@ -1238,12 +1238,12 @@ class TestVariableConstantArrayOp(unittest.TestCase):
 
     def forward_chainerx(self, op, orig_xp, positive=False):
         if orig_xp is numpy:
-            array_conv = chainer.backend.to_chainerx
+            array_conv = chainer.backend.to_chx
         else:
             assert orig_xp is cuda.cupy
 
             def array_conv(x):
-                return chainer.backend.to_chainerx(cuda.to_gpu(x))
+                return chainer.backend.to_chx(cuda.to_gpu(x))
         self.check_forward(op, array_conv, positive)
 
     @attr.chainerx

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_nd.py
@@ -97,12 +97,12 @@ class TestAveragePoolingND(unittest.TestCase):
 
     @attr.chainerx
     def test_forward_chainerx_native(self):
-        self.check_forward(backend.to_chainerx(self.x), 'never')
+        self.check_forward(backend.to_chx(self.x), 'never')
 
     @attr.chainerx
     @attr.gpu
     def test_forward_chainerx_cuda(self):
-        self.check_forward(backend.to_chainerx(cuda.to_gpu(self.x)), 'never')
+        self.check_forward(backend.to_chx(cuda.to_gpu(self.x)), 'never')
 
     def check_forward_consistency_regression(self, x_data, use_cudnn='always'):
         # Regression test to average_pooling_2d.
@@ -167,13 +167,13 @@ class TestAveragePoolingND(unittest.TestCase):
     @attr.chainerx
     def test_backward_chainerx_native(self):
         self.check_backward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.gy), 'never')
+            backend.to_chx(self.x), backend.to_chx(self.gy), 'never')
 
     @attr.chainerx
     @attr.gpu
     def test_backward_chainerx_cuda(self):
         def conv(a):
-            return backend.to_chainerx(cuda.to_gpu(a))
+            return backend.to_chx(cuda.to_gpu(a))
 
         self.check_backward(conv(self.x), conv(self.gy), 'never')
 
@@ -261,15 +261,15 @@ class TestAveragePoolingND(unittest.TestCase):
     @condition.retry(10)
     def test_double_backward_chainerx_native(self):
         self.check_double_backward(
-            backend.to_chainerx(self.x), backend.to_chainerx(self.gy),
-            backend.to_chainerx(self.ggx), 'never')
+            backend.to_chx(self.x), backend.to_chx(self.gy),
+            backend.to_chx(self.ggx), 'never')
 
     @attr.chainerx
     @attr.gpu
     @condition.retry(10)
     def test_double_backward_chainerx_cuda(self):
         def conv(a):
-            return backend.to_chainerx(cuda.to_gpu(a))
+            return backend.to_chx(cuda.to_gpu(a))
 
         self.check_double_backward(
             conv(self.x), conv(self.gy), conv(self.ggx), 'never')

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -103,7 +103,7 @@ class TestMaxPooling2D(unittest.TestCase):
         if not self.c_contiguous:
             inputs = _to_fcontiguous(inputs)
         if backend_config.use_chainerx:
-            inputs = chainer.backend.to_chainerx(inputs)
+            inputs = chainer.backend.to_chx(inputs)
 
         with backend_config:
             x, = inputs
@@ -131,7 +131,7 @@ class TestMaxPooling2D(unittest.TestCase):
                     and backend_config.chainerx_device.startswith('cuda:'))):
                 x = cuda.to_gpu(x)
             if backend_config.use_chainerx:
-                x = chainer.backend.to_chainerx(x)
+                x = chainer.backend.to_chx(x)
             x = chainer.Variable(x)
             with backend_config:
                 functions.max_pooling_2d(x, 3, stride=2)
@@ -145,7 +145,7 @@ class TestMaxPooling2D(unittest.TestCase):
                     and backend_config.chainerx_device.startswith('cuda:'))):
                 x = cuda.to_gpu(x)
             if backend_config.use_chainerx:
-                x = chainer.backend.to_chainerx(x)
+                x = chainer.backend.to_chx(x)
             x = chainer.Variable(x)
             with backend_config:
                 functions.max_pooling_2d(x, 3, stride=2)
@@ -162,8 +162,8 @@ class TestMaxPooling2D(unittest.TestCase):
             inputs = _to_fcontiguous(inputs)
             grad_outputs = _to_fcontiguous(grad_outputs)
         if backend_config.use_chainerx:
-            inputs = chainer.backend.to_chainerx(inputs)
-            grad_outputs = chainer.backend.to_chainerx(grad_outputs)
+            inputs = chainer.backend.to_chx(inputs)
+            grad_outputs = chainer.backend.to_chx(grad_outputs)
 
         def f(x):
             return functions.max_pooling_2d(
@@ -199,9 +199,9 @@ class TestMaxPooling2D(unittest.TestCase):
             grad_outputs = _to_fcontiguous(grad_outputs)
             grad_grad_inputs = _to_fcontiguous(grad_grad_inputs)
         if backend_config.use_chainerx:
-            inputs = chainer.backend.to_chainerx(inputs)
-            grad_outputs = chainer.backend.to_chainerx(grad_outputs)
-            grad_grad_inputs = chainer.backend.to_chainerx(grad_grad_inputs)
+            inputs = chainer.backend.to_chx(inputs)
+            grad_outputs = chainer.backend.to_chx(grad_outputs)
+            grad_grad_inputs = chainer.backend.to_chx(grad_grad_inputs)
 
         def f(x):
             return functions.max_pooling_2d(

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -361,7 +361,7 @@ class TestFunctionNodeMixChainerxAndXpArrays(unittest.TestCase):
     def check_mix_xp(self, xp):
         xp_x1 = xp.random.randn(2, 3).astype(numpy.float32)
         xp_x2 = xp.random.randn(2, 3).astype(numpy.float32)
-        x2 = backend.to_chainerx(xp_x2)
+        x2 = backend.to_chx(xp_x2)
         y, = self.SimpleFunctionNode(xp).apply((xp_x1, x2))
 
         assert isinstance(y.array, chainerx.ndarray)

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -604,9 +604,9 @@ class TestLink(LinkTestBase, unittest.TestCase):
 @attr.chainerx
 class TestLinkFromToChainerx(LinkTestBase, unittest.TestCase):
 
-    def test_from_chainerx(self, backend_config):
+    def test_from_chx(self, backend_config):
         self.link.to_device(backend_config.device)
-        self.link.from_chainerx()
+        self.link.from_chx()
 
         source_device = backend_config.device
 
@@ -626,9 +626,9 @@ class TestLinkFromToChainerx(LinkTestBase, unittest.TestCase):
 
         self.assertEqual(self.link._device, expected_device)
 
-    def test_to_chainerx(self, backend_config):
+    def test_to_chx(self, backend_config):
         self.link.to_device(backend_config.device)
-        self.link.to_chainerx()
+        self.link.to_chx()
 
         source_device = backend_config.device
 
@@ -1275,10 +1275,10 @@ class TestChainFromToChainerx(ChainTestBase, unittest.TestCase):
         self.check_array_device(self.l3.x.data, expected_device)
         self.check_array_device(self.l3.x.grad, expected_device)
 
-    def test_to_chainerx(self, backend_config):
+    def test_to_chx(self, backend_config):
         self.set_count_parameters()
         self.c2.to_device(backend_config.device)
-        self.c2.to_chainerx()
+        self.c2.to_chx()
 
         src_device = backend_config.device
         if src_device.xp is chainerx:
@@ -1288,10 +1288,10 @@ class TestChainFromToChainerx(ChainTestBase, unittest.TestCase):
                 backend.ChainerxDevice.from_fallback_device(src_device))
         self.check_expected_device(expected_device)
 
-    def test_from_chainerx(self, backend_config):
+    def test_from_chx(self, backend_config):
         self.set_count_parameters()
         self.c2.to_device(backend_config.device)
-        self.c2.from_chainerx()
+        self.c2.from_chx()
 
         src_device = backend_config.device
         if src_device.xp is chainerx:
@@ -1667,9 +1667,9 @@ class TestChainList(unittest.TestCase):
         self.assertIsInstance(self.l3.x.grad, cupy.ndarray)
 
     @attr.chainerx
-    def test_to_chainerx(self):
+    def test_to_chx(self):
         self.c2.to_device(backend.CpuDevice())
-        self.c2.to_chainerx()
+        self.c2.to_chx()
         self.assertIs(self.c2.xp, chainerx)
         self.assertIs(self.c1.xp, chainerx)
         self.assertIs(self.l1.xp, chainerx)
@@ -2138,14 +2138,14 @@ class TestToChainerX(unittest.TestCase):
         self.pa_array = pa_array
         self.ps_scalar = ps_scalar
 
-    def test_chainerx_to_chainerx(self):
+    def test_chainerx_to_chx(self):
         link = self.link
-        link.to_chainerx()
+        link.to_chx()
         prev_y = link.y
         prev_v = link.v
         prev_pa = link.pa
         prev_ps = link.ps
-        link.to_chainerx()
+        link.to_chx()
         assert link.device.device == chainerx.get_device('native:0')
 
         # Everything should be left untouched
@@ -2159,9 +2159,9 @@ class TestToChainerX(unittest.TestCase):
         # Persistent scalar
         assert link.ps is prev_ps
 
-    def test_cpu_to_chainerx(self):
+    def test_cpu_to_chx(self):
         link = self.link
-        link.to_chainerx()
+        link.to_chx()
 
         # Initialized parameter
         assert isinstance(link.y.data, chainerx.ndarray)
@@ -2177,11 +2177,11 @@ class TestToChainerX(unittest.TestCase):
         assert link.ps == self.ps_scalar
 
     @attr.gpu
-    def test_gpu_to_chainerx(self):
+    def test_gpu_to_chx(self):
         link = self.link
         link.to_gpu()
         assert link.device.device == cuda.Device(0)
-        link.to_chainerx()
+        link.to_chx()
         assert link.device.device == chainerx.get_device('cuda:0')
 
         # Arrays should be converted to chainerx.ndarray

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -113,7 +113,7 @@ class TestUpdateRule(unittest.TestCase):
 
     @attr.chainerx
     def test_update_chainerx(self):
-        self.var.to_chainerx()
+        self.var.to_chx()
         self.update_rule.update(self.var)
         self.assertEqual(self.update_rule.update_core_cpu.call_count, 1)
         self.assertEqual(self.update_rule.update_core_gpu.call_count, 0)
@@ -123,7 +123,7 @@ class TestUpdateRule(unittest.TestCase):
     @attr.gpu
     def test_update_chainerx_gpu(self):
         self.var.to_gpu()
-        self.var.to_chainerx()
+        self.var.to_chx()
         self.update_rule.update(self.var)
         self.assertEqual(self.update_rule.update_core_cpu.call_count, 0)
         self.assertEqual(self.update_rule.update_core_gpu.call_count, 1)
@@ -252,7 +252,7 @@ class TestUpdateRule(unittest.TestCase):
         self.update_rule.update(self.var)
 
     @attr.chainerx
-    def test_state_copy_to_chainerx(self):
+    def test_state_copy_to_chx(self):
         self.setup_state()
 
         def update_core(param):
@@ -262,7 +262,7 @@ class TestUpdateRule(unittest.TestCase):
 
         self.var.to_cpu()
         self.update_rule.update(self.var)
-        self.var.to_chainerx()
+        self.var.to_chx()
         self.update_rule.update_core = update_core
         self.update_rule.update(self.var)
 

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1118,11 +1118,11 @@ class TestVariableToChainerX(unittest.TestCase):
             return arrays[0].device
         assert False
 
-    def check_to_chainerx(self, x, gx, requires_grad=True):
+    def check_to_chx(self, x, gx, requires_grad=True):
         x_var = chainer.Variable(x, requires_grad=requires_grad)
         x_var.grad_var = chainer.Variable(gx, requires_grad=requires_grad)
 
-        x_var.to_chainerx()
+        x_var.to_chx()
 
         expected_device = self.infer_expected_device(x, gx)
 
@@ -1155,34 +1155,34 @@ class TestVariableToChainerX(unittest.TestCase):
         assert x_var.xp is chainerx
         assert x_var._has_chainerx_array is True
 
-    def test_to_chainerx_from_numpy(self):
-        self.check_to_chainerx(self.x, self.gx)
+    def test_to_chx_from_numpy(self):
+        self.check_to_chx(self.x, self.gx)
 
     @attr.gpu
-    def test_to_chainerx_from_cupy(self):
-        self.check_to_chainerx(cuda.to_gpu(self.x), cuda.to_gpu(self.gx))
+    def test_to_chx_from_cupy(self):
+        self.check_to_chx(cuda.to_gpu(self.x), cuda.to_gpu(self.gx))
 
     # TODO(hvy): Write test when implemented.
     @attr.ideep
-    def test_ideep_to_chainerx(self):
+    def test_ideep_to_chx(self):
         raise unittest.SkipTest('Not yet supported')
 
-    def test_to_chainerx_from_chainerx(self):
-        self.check_to_chainerx(
+    def test_to_chx_from_chx(self):
+        self.check_to_chx(
             chainerx.array(self.x), chainerx.array(self.gx))
 
-    def test_to_chainerx_from_another_device(self):
-        self.check_to_chainerx(
+    def test_to_chx_from_another_device(self):
+        self.check_to_chx(
             chainerx.array(self.x), chainerx.array(self.gx))
 
-    def test_to_chainerx_not_requiring_grad(self):
-        self.check_to_chainerx(self.x, self.gx, requires_grad=False)
+    def test_to_chx_not_requiring_grad(self):
+        self.check_to_chx(self.x, self.gx, requires_grad=False)
 
-    def test_to_chainerx_with_creator(self):
+    def test_to_chx_with_creator(self):
         x = chainer.Variable(self.x)
         y = x * x
         with self.assertRaises(RuntimeError):
-            y.to_chainerx()
+            y.to_chx()
 
 
 @testing.parameterize(
@@ -1190,7 +1190,7 @@ class TestVariableToChainerX(unittest.TestCase):
     {'x_shape': ()},
 )
 @chainer.testing.backend.inject_backend_tests(
-    ['test_from_chainerx'],
+    ['test_from_chx'],
     [
         # NumPy
         {},
@@ -1222,10 +1222,10 @@ class TestVariableFromChainerX(unittest.TestCase):
                 return cuda.cupy, cuda.cupy.cuda.Device(x.device.index)
         assert False
 
-    def test_from_chainerx(self, backend_config):
+    def test_from_chx(self, backend_config):
         x = backend_config.get_array(self.x)
         x_var = chainer.Variable(x, requires_grad=False)
-        x_var.from_chainerx()
+        x_var.from_chx()
 
         expected_xp, expected_device = self.infer_expected_xp_and_device(x)
 
@@ -1241,10 +1241,10 @@ class TestVariableFromChainerX(unittest.TestCase):
         np.testing.assert_array_equal(
             backend.CpuDevice().send(x_var.array), backend.CpuDevice().send(x))
 
-    def test_invalid_from_chainerx_requires_grad(self):
+    def test_invalid_from_chx_requires_grad(self):
         x = chainer.Variable(self.x, requires_grad=True)
         with self.assertRaises(RuntimeError):
-            x.from_chainerx()
+            x.from_chx()
 
 
 @testing.parameterize(
@@ -1540,27 +1540,27 @@ class TestParameterToDevice(unittest.TestCase):
 @attr.chainerx
 class TestParameterToChainerX(unittest.TestCase):
 
-    def check_to_chainerx(self, x):
+    def check_to_chx(self, x):
         assert isinstance(x, chainer.Parameter)
-        x.to_chainerx()
+        x.to_chx()
         assert x.xp is chainerx
         assert x._has_chainerx_array is True
 
     def check_initializer(self, shape):
         x = chainer.Parameter(shape=shape)
-        self.check_to_chainerx(x)
+        self.check_to_chx(x)
 
     def check_initialize_by_scalar(self, shape):
         x = chainer.Parameter(2., shape)
-        self.check_to_chainerx(x)
+        self.check_to_chx(x)
 
     def check_initialize_by_initializer(self, shape):
         x = chainer.Parameter(initializers.One(), shape)
-        self.check_to_chainerx(x)
+        self.check_to_chx(x)
 
     def check_initialize_by_none(self, shape):
         x = chainer.Parameter(None, shape)
-        self.check_to_chainerx(x)
+        self.check_to_chx(x)
 
     def check_initialize_by_array(self, shape, xp, device=None):
         if device is not None:
@@ -1569,34 +1569,34 @@ class TestParameterToChainerX(unittest.TestCase):
             data = xp.random.uniform(-1, 1, shape).astype('f')
 
         x = chainer.Parameter(data)
-        self.check_to_chainerx(x)
+        self.check_to_chx(x)
 
-    def test_initializer_to_chainerx(self):
+    def test_initializer_to_chx(self):
         self.check_initializer(self.x_shape)
 
-    def test_initialize_by_scalar_to_chainerx(self):
+    def test_initialize_by_scalar_to_chx(self):
         self.check_initialize_by_scalar(self.x_shape)
 
-    def test_initialize_by_initializer_to_chainerx(self):
+    def test_initialize_by_initializer_to_chx(self):
         self.check_initialize_by_initializer(self.x_shape)
 
-    def test_initialize_by_none_to_chainerx(self):
+    def test_initialize_by_none_to_chx(self):
         self.check_initialize_by_none(self.x_shape)
 
-    def test_initialize_by_array_to_chainerx_numpy(self):
+    def test_initialize_by_array_to_chx_numpy(self):
         self.check_initialize_by_array(self.x_shape, np)
 
     @attr.gpu
-    def test_initialize_by_array_to_chainerx_cupy(self):
+    def test_initialize_by_array_to_chx_cupy(self):
         self.check_initialize_by_array(self.x_shape, cuda.cupy)
 
     @attr.chainerx
-    def test_initialize_by_array_to_chainerx_chainerx_native(self):
+    def test_initialize_by_array_to_chx_chainerx_native(self):
         self.check_initialize_by_array(self.x_shape, chainerx, 'native:0')
 
     @attr.gpu
     @attr.chainerx
-    def test_initialize_by_array_to_chainerx_chainerx_cuda(self):
+    def test_initialize_by_array_to_chx_chainerx_cuda(self):
         self.check_initialize_by_array(self.x_shape, chainerx, 'cuda:0')
 
 
@@ -1607,27 +1607,27 @@ class TestParameterToChainerX(unittest.TestCase):
 @attr.chainerx
 class TestParameterFromChainerX(unittest.TestCase):
 
-    def check_from_chainerx(self, x, expected_xp):
+    def check_from_chx(self, x, expected_xp):
         assert isinstance(x, chainer.Parameter)
-        x.from_chainerx()
+        x.from_chx()
         assert x.xp is expected_xp
         assert x._has_chainerx_array is (expected_xp is chainerx)
 
     def check_initializer(self, shape, expected_xp):
         x = chainer.Parameter(shape=shape)
-        self.check_from_chainerx(x, expected_xp)
+        self.check_from_chx(x, expected_xp)
 
     def check_initialize_by_scalar(self, shape, expected_xp):
         x = chainer.Parameter(2., shape)
-        self.check_from_chainerx(x, expected_xp)
+        self.check_from_chx(x, expected_xp)
 
     def check_initialize_by_initializer(self, shape, expected_xp):
         x = chainer.Parameter(initializers.One(), shape)
-        self.check_from_chainerx(x, expected_xp)
+        self.check_from_chx(x, expected_xp)
 
     def check_initialize_by_none(self, shape, expected_xp):
         x = chainer.Parameter(None, shape)
-        self.check_from_chainerx(x, expected_xp)
+        self.check_from_chx(x, expected_xp)
 
     def check_initialize_by_array(self, shape, xp, expected_xp, device=None):
         if device is not None:
@@ -1636,34 +1636,34 @@ class TestParameterFromChainerX(unittest.TestCase):
             data = xp.random.uniform(-1, 1, shape).astype('f')
 
         x = chainer.Parameter(data)
-        self.check_from_chainerx(x, expected_xp)
+        self.check_from_chx(x, expected_xp)
 
-    def test_initializer_from_chainerx(self):
+    def test_initializer_from_chx(self):
         self.check_initializer(self.x_shape, np)
 
-    def test_initialize_by_scalar_from_chainerx(self):
+    def test_initialize_by_scalar_from_chx(self):
         self.check_initialize_by_scalar(self.x_shape, np)
 
-    def test_initialize_by_initializer_from_chainerx(self):
+    def test_initialize_by_initializer_from_chx(self):
         self.check_initialize_by_initializer(self.x_shape, np)
 
-    def test_initialize_by_none_from_chainerx(self):
+    def test_initialize_by_none_from_chx(self):
         self.check_initialize_by_none(self.x_shape, np)
 
-    def test_initialize_by_array_from_chainerx_numpy(self):
+    def test_initialize_by_array_from_chx_numpy(self):
         self.check_initialize_by_array(self.x_shape, np, np)
 
     @attr.gpu
-    def test_initialize_by_array_from_chainerx_cupy(self):
+    def test_initialize_by_array_from_chx_cupy(self):
         self.check_initialize_by_array(self.x_shape, cuda.cupy, cuda.cupy)
 
     @attr.chainerx
-    def test_initialize_by_array_from_chainerx_chainerx_native(self):
+    def test_initialize_by_array_from_chx_chainerx_native(self):
         self.check_initialize_by_array(self.x_shape, chainerx, np, 'native:0')
 
     @attr.gpu
     @attr.chainerx
-    def test_initialize_by_array_from_chainerx_chainerx_cuda(self):
+    def test_initialize_by_array_from_chx_chainerx_cuda(self):
         self.check_initialize_by_array(
             self.x_shape, chainerx, cuda.cupy, 'cuda:0')
 
@@ -1786,28 +1786,28 @@ class TestUninitializedParameter(unittest.TestCase):
         np.testing.assert_array_equal(x.grad, np.float32('nan'))
 
     @attr.chainerx
-    def test_initialize_to_chainerx_native(self):
+    def test_initialize_to_chx_native(self):
         x = chainer.Parameter(initializer=initializers.Constant(self.a))
         x.to_device(np)
-        x.to_chainerx()
+        x.to_chx()
         self.check_constant_initialization(
             x, self.a, chainerx, chainer.get_device('native:0'))
 
     @attr.chainerx
     @attr.gpu
-    def test_initialize_to_chainerx_cuda(self):
+    def test_initialize_to_chx_cuda(self):
         x = chainer.Parameter(initializer=initializers.Constant(self.a))
         x.to_device((cuda.cupy, 0))
-        x.to_chainerx()
+        x.to_chx()
         self.check_constant_initialization(
             x, self.a, chainerx, chainer.get_device('cuda:0'))
 
     @attr.chainerx
     @attr.multi_gpu(2)
-    def test_initialize_to_chainerx_cuda_noncurrent_gpu(self):
+    def test_initialize_to_chx_cuda_noncurrent_gpu(self):
         x = chainer.Parameter(initializer=initializers.Constant(self.a))
         x.to_device((cuda.cupy, 1))
-        x.to_chainerx()
+        x.to_chx()
         self.check_constant_initialization(
             x, self.a, chainerx, chainer.get_device('cuda:1'))
 
@@ -1856,20 +1856,20 @@ class TestUninitializedParameter(unittest.TestCase):
         self.check_zerograd(x, cuda.cupy)
 
     @attr.chainerx
-    def test_zerograd_to_chainerx(self):
+    def test_zerograd_to_chx(self):
         x = chainer.Parameter()
         with testing.assert_warns(DeprecationWarning):
             x.zerograd()
         x.to_device(np)
-        x.to_chainerx()
+        x.to_chx()
         x.initialize((3, 2))
         self.check_zerograd(x, chainerx)
 
     @attr.chainerx
-    def test_to_chainerx_zerograd(self):
+    def test_to_chx_zerograd(self):
         x = chainer.Parameter()
         x.to_device(np)
-        x.to_chainerx()
+        x.to_chx()
         with testing.assert_warns(DeprecationWarning):
             x.zerograd()
         x.initialize((3, 2))
@@ -2002,7 +2002,7 @@ class TestUninitializedParameter(unittest.TestCase):
         cp.testing.assert_array_equal(x.grad, self.b)
 
     @attr.chainerx
-    def test_addgrad_to_uninitialized_parameter_cpu_to_chainerx(self):
+    def test_addgrad_to_uninitialized_parameter_cpu_to_chx(self):
         # TODO(sonots): Support addgrad with ChainerX
         raise unittest.SkipTest('ChainerX does not support addgrad')
 
@@ -2415,13 +2415,13 @@ class UnnamedVariableToStringTestBase(object):
     @attr.chainerx
     def test_repr_chainerx_cpu(self):
         self._skip_chainerx_unsupported_dtype()
-        self.x.to_chainerx()
+        self.x.to_chx()
         assert repr(self.x) == self.repr
 
     @attr.chainerx
     def test_str_chainerx_cpu(self):
         self._skip_chainerx_unsupported_dtype()
-        self.x.to_chainerx()
+        self.x.to_chx()
         assert str(self.x) == self.str
 
     @attr.chainerx
@@ -2429,7 +2429,7 @@ class UnnamedVariableToStringTestBase(object):
     def test_repr_chainerx_gpu(self):
         self._skip_chainerx_unsupported_dtype()
         self.x.to_gpu()
-        self.x.to_chainerx()
+        self.x.to_chx()
         assert repr(self.x) == self.repr
 
     @attr.chainerx
@@ -2437,7 +2437,7 @@ class UnnamedVariableToStringTestBase(object):
     def test_str_chainerx_gpu(self):
         self._skip_chainerx_unsupported_dtype()
         self.x.to_gpu()
-        self.x.to_chainerx()
+        self.x.to_chx()
         assert str(self.x) == self.str
 
 
@@ -2977,7 +2977,7 @@ class TestLazyGradSum(unittest.TestCase):
 @attr.chainerx
 class TestVariableChainerxArrayViewBackprop(unittest.TestCase):
 
-    def test_chainerx_array_view(self):
+    def test_chx_array_view(self):
         from_connected = self.from_connected
         calculate_by_variable = self.calculate_by_variable
         backward_by_variable = self.backward_by_variable
@@ -2989,7 +2989,7 @@ class TestVariableChainerxArrayViewBackprop(unittest.TestCase):
 
         # Wrap with a variable
         x = chainer.Variable(a, requires_grad=True)
-        x_arr = x.chainerx_array  # Unwrap a view
+        x_arr = x.chx_array  # Unwrap a view
 
         assert x_arr.is_backprop_required()
         assert not x_arr.is_grad_required()
@@ -2999,7 +2999,7 @@ class TestVariableChainerxArrayViewBackprop(unittest.TestCase):
             # Calculate by variable
             y = F.square(x_arr)
             # Unwrap the output array
-            y_arr = y.chainerx_array
+            y_arr = y.chx_array
             y_arr.grad = chainerx.ones_like(y.array)
         else:
             # Calculate by array
@@ -3028,14 +3028,14 @@ class TestVariableChainerxArrayView(unittest.TestCase):
 
         # Wrap with a variable
         x = chainer.Variable(a, requires_grad=False)
-        x_arr = x.chainerx_array  # Unwrap a view
+        x_arr = x.chx_array  # Unwrap a view
 
         assert not x_arr.is_backprop_required()
 
         x_arr.require_grad()
         assert x_arr.is_backprop_required()
 
-        x_arr2 = x.chainerx_array  # Unwrap another view
+        x_arr2 = x.chx_array  # Unwrap another view
         # require_grad does not affect distinct views.
         assert not x_arr2.is_backprop_required()
 
@@ -3046,7 +3046,7 @@ class TestVariableChainerxArrayView(unittest.TestCase):
         a = np.array([1, 2], np.float32)
         x = chainer.Variable(a, requires_grad=True)
         with pytest.raises(ValueError):
-            x.chainerx_array
+            x.chx_array
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fixes #6310 
`to_chainerx` -> `to_chx`
`from_chainerx` -> `from_chainerx`
`Variable.chainerx_array` -> `Variable.chx_array`