### PR TITLE
Fix to clarify the description about initializer argument

### DIFF
--- a/chainer/link.py
+++ b/chainer/link.py
@@ -321,11 +321,13 @@ class Link(object):
             shape (int or tuple of ints): Shape of the parameter array. If it
                 is omitted, the parameter variable is left uninitialized.
             dtype: Data type of the parameter array.
-            initializer: If it is not ``None``, the data is initialized with
-                the given initializer. If it is an array, the data is directly
-                initialized by it. If it is callable, it is used as a weight
-                initializer. Note that in these cases, ``dtype`` argument is
-                ignored.
+            initializer (:ref:`initializer <initializer>`): If it is not
+                ``None``, the data is initialized with the given initializer.
+                If it is an array, the data is directly initialized by it. If
+                it is callable, it is used as a weight initializer. Note that
+                in these cases, ``dtype`` argument is ignored. It can also be
+                a scalar, in which case the data array will be filled by this
+                scalar. Note that float32 is used in this case.
 
         """
         if name in self.__dict__:


### PR DESCRIPTION
The `initializer` argument of the functions accept a scalar value, but it is not explicitly documented in some places. This patch fixes these docstrings.