### PR TITLE
Improve accuracy of test of `F.rrelu`

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -38,7 +38,7 @@ class TestRReLU(testing.FunctionTestCase):
             self.l, self.u = self.u, self.l
 
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_forward_options = {'atol': 2e-4, 'rtol': 2e-3}
             self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_double_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -38,7 +38,7 @@ class TestRReLU(testing.FunctionTestCase):
             self.l, self.u = self.u, self.l
 
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 2e-4, 'rtol': 2e-3}
+            self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
             self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_double_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
 
@@ -51,9 +51,8 @@ class TestRReLU(testing.FunctionTestCase):
 
     def forward(self, inputs, device):
         x, = inputs
-        r = self.r
+        r = self.r.astype(x.dtype)
         r = device.send(r)
-        r = r.astype(x.dtype)
         with chainer.using_config('train', self.train):
             y = functions.rrelu(x, l=self.l, u=self.u, r=r)
         return y,
@@ -64,7 +63,7 @@ class TestRReLU(testing.FunctionTestCase):
         if self.train:
             expected = numpy.where(x >= 0, x, x * r)
         else:
-            r_test = numpy.mean([self.l, self.u], dtype=self.dtype)
+            r_test = numpy.mean([self.l, self.u]).astype(self.dtype)
             expected = numpy.where(x >= 0, x, x * r_test)
         return expected,
 


### PR DESCRIPTION
Close #6314.

The source of the error: `dtype.type(lower + upper)` in `F.rrelu` is more accurate than `numpy.mean([lower, upper], dtype=dtype)` in the test.
```
>>> np.mean([0.0005, 2.0005], dtype=np.float16)
1.0
>>> np.float16((0.0005 + 2.0005) / 2)
1.001
```