### PR TITLE
Simplify `F.log_softmax` test

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_log_softmax.py
@@ -5,10 +5,8 @@ import numpy
 import chainer
 from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
-import chainerx
 
 
 @testing.parameterize(*testing.product_dict(
@@ -25,18 +23,27 @@ import chainerx
     ],
 ))
 @testing.fix_random()
-class TestLogSoftmax(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestLogSoftmax(testing.FunctionTestCase):
 
     def setUp(self):
-        if self.shape is None:
-            # For checking numerical stability
-            value = -5 if self.dtype == numpy.float16 else -1000
-            self.x = numpy.array([[value, 1]], dtype=self.dtype)
-        else:
-            self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(-1, 1, self.x.shape).astype(self.dtype)
-        self.ggx = numpy.random.uniform(-1, 1, self.x.shape).astype(self.dtype)
-
         self.check_forward_options = {}
         self.check_backward_options = {}
         self.check_double_backward_options = {}
@@ -45,99 +52,25 @@ class TestLogSoftmax(unittest.TestCase):
             self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
             self.check_double_backward_options = {'atol': 1e-2, 'rtol': 1e-1}
 
-    def check_forward(self, x_data, use_cudnn='always'):
-        x = chainer.Variable(x_data)
-        with chainer.using_config('use_cudnn', use_cudnn):
-            y = functions.log_softmax(x, axis=self.axis)
-        self.assertEqual(y.data.dtype, self.dtype)
+    def generate_inputs(self):
+        if self.shape is None:
+            # For checking numerical stability
+            value = -5 if self.dtype == numpy.float16 else -1000
+            x = numpy.array([[value, 1]], dtype=self.dtype)
+        else:
+            x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        return x,
 
+    def forward(self, inputs, device):
+        x, = inputs
+        return functions.log_softmax(x, axis=self.axis),
+
+    def forward_expected(self, inputs):
+        x, = inputs
         log_z = numpy.ufunc.reduce(
-            numpy.logaddexp, self.x, axis=self.axis, keepdims=True)
-        y_expect = self.x - log_z
-
-        testing.assert_allclose(
-            y_expect, y.data, **self.check_forward_options)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    @attr.gpu
-    def test_forward_gpu_non_contiguous(self):
-        self.check_forward(
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)))
-
-    @attr.gpu
-    def test_forward_gpu_no_cudnn(self):
-        self.check_forward(cuda.to_gpu(self.x), 'never')
-
-    @attr.chainerx
-    def test_forward_chainerx(self):
-        self.check_forward(chainerx.array(self.x))
-
-    def check_backward(self, x_data, gy_data, use_cudnn='always'):
-        def f(x):
-            return functions.log_softmax(x, self.axis)
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            gradient_check.check_backward(
-                f, x_data, gy_data, dtype=numpy.float64,
-                **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    @attr.gpu
-    def test_backward_gpu_non_contiguous(self):
-        self.check_backward(
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
-            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)))
-
-    @attr.gpu
-    def test_backward_gpu_no_cudnn(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy), 'never')
-
-    @attr.chainerx
-    def test_backward_chainerx(self):
-        self.check_backward(chainerx.array(self.x), chainerx.array(self.gy))
-
-    def check_double_backward(self, x_data, gy_data, ggx_data,
-                              use_cudnn='always'):
-        def f(x):
-            return functions.log_softmax(x, self.axis)
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            gradient_check.check_double_backward(
-                f, x_data, gy_data, ggx_data,
-                dtype=numpy.float64, **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.gy, self.ggx)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
-
-    @attr.gpu
-    def test_double_backward_gpu_no_cudnn(self):
-        self.check_double_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
-            'never')
-
-    @attr.chainerx
-    def test_double_backward_chainerx(self):
-        self.check_double_backward(
-            chainerx.array(self.x),
-            chainerx.array(self.gy),
-            chainerx.array(self.ggx))
+            numpy.logaddexp, x, axis=self.axis, keepdims=True)
+        y_expect = x - log_z
+        return y_expect,
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Simplifies `test_log_softmax` using `testing.FunctionTestCase`.
Fixes part of issue #6071
