### PR TITLE
Add `distributions.Independent`

### DIFF
--- a/chainer/distributions/__init__.py
+++ b/chainer/distributions/__init__.py
@@ -10,6 +10,7 @@ from chainer.distributions.exponential import Exponential  # NOQA
 from chainer.distributions.gamma import Gamma  # NOQA
 from chainer.distributions.geometric import Geometric  # NOQA
 from chainer.distributions.gumbel import Gumbel  # NOQA
+from chainer.distributions.independent import Independent  # NOQA
 from chainer.distributions.laplace import Laplace  # NOQA
 from chainer.distributions.log_normal import LogNormal  # NOQA
 from chainer.distributions.multivariate_normal import MultivariateNormal  # NOQA

--- a/chainer/distributions/bernoulli.py
+++ b/chainer/distributions/bernoulli.py
@@ -131,6 +131,10 @@ class Bernoulli(distribution.Distribution):
     def mean(self):
         return self.p
 
+    @property
+    def params(self):
+        return {'logit': self.logit}
+
     def prob(self, x):
         x = chainer.as_variable(x)
         prob = x * self.p + (1 - x) * (1 - self.p)

--- a/chainer/distributions/beta.py
+++ b/chainer/distributions/beta.py
@@ -79,6 +79,10 @@ class Beta(distribution.Distribution):
     def mean(self):
         return self.a / self._a_plus_b
 
+    @property
+    def params(self):
+        return {'a': self.a, 'b': self.b}
+
     def sample_n(self, n):
         xp = backend.get_array_module(self.a)
         eps = xp.random.beta(self.a.data, self.b.data, size=(n,)+self.a.shape)

--- a/chainer/distributions/categorical.py
+++ b/chainer/distributions/categorical.py
@@ -74,6 +74,10 @@ class Categorical(distribution.Distribution):
         else:
             return self.log_p[mg + [x.astype(numpy.int32)]]
 
+    @property
+    def params(self):
+        return {'p': self.p}
+
     def sample_n(self, n):
         xp = backend.get_array_module(self.p)
         onebyone_p = self.p.data.reshape(-1, self.p.shape[-1])

--- a/chainer/distributions/cauchy.py
+++ b/chainer/distributions/cauchy.py
@@ -82,6 +82,10 @@ class Cauchy(distribution.Distribution):
         xp = cuda.get_array_module(self.loc)
         return chainer.as_variable(xp.full_like(self.loc.data, xp.nan))
 
+    @property
+    def params(self):
+        return {'loc': self.loc, 'scale': self.scale}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.loc)
         if xp is cuda.cupy:

--- a/chainer/distributions/chisquare.py
+++ b/chainer/distributions/chisquare.py
@@ -56,6 +56,10 @@ class Chisquare(distribution.Distribution):
     def mean(self):
         return self.k
 
+    @property
+    def params(self):
+        return {'k': self.k}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.k)
         if xp is cuda.cupy:

--- a/chainer/distributions/dirichlet.py
+++ b/chainer/distributions/dirichlet.py
@@ -68,6 +68,10 @@ class Dirichlet(distribution.Distribution):
         alpha0 = expand_dims.expand_dims(self.alpha0, axis=-1)
         return self.alpha / alpha0
 
+    @property
+    def params(self):
+        return {'alpha': self.alpha}
+
     def sample_n(self, n):
         obo_alpha = self.alpha.data.reshape(-1, self.event_shape[0])
         xp = cuda.get_array_module(self.alpha)

--- a/chainer/distributions/exponential.py
+++ b/chainer/distributions/exponential.py
@@ -69,6 +69,10 @@ class Exponential(distribution.Distribution):
     def mean(self):
         return 1 / self.lam
 
+    @property
+    def params(self):
+        return {'lam': self.lam}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.lam)
         if xp is cuda.cupy:

--- a/chainer/distributions/gamma.py
+++ b/chainer/distributions/gamma.py
@@ -63,6 +63,10 @@ class Gamma(distribution.Distribution):
     def mean(self):
         return self.k * self.theta
 
+    @property
+    def params(self):
+        return {'k': self.k, 'theta': self.theta}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.k)
         if xp is cuda.cupy:

--- a/chainer/distributions/geometric.py
+++ b/chainer/distributions/geometric.py
@@ -47,6 +47,10 @@ class Geometric(distribution.Distribution):
     def mean(self):
         return 1 / self.p
 
+    @property
+    def params(self):
+        return {'p': self.p}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.p)
         if xp is cuda.cupy:

--- a/chainer/distributions/gumbel.py
+++ b/chainer/distributions/gumbel.py
@@ -71,6 +71,10 @@ class Gumbel(distribution.Distribution):
     def mean(self):
         return self.loc + EULER * self.scale
 
+    @property
+    def params(self):
+        return {'loc': self.loc, 'scale': self.scale}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.loc)
         if xp is cuda.cupy:

--- a/chainer/distributions/independent.py
+++ b/chainer/distributions/independent.py
@@ -56,18 +56,20 @@ class Independent(distribution.Distribution):
     def covariance(self):
         '''Returns the covariance of the distribution based on the original
         i.i.d. distribution. By definition, the covariance of the new
-        distribution becomes block diagonal matrix. Let :math:`\\Sigma_x` be
-        the covariance matrix of the original random variable :math:`x
-        \\in R^d`, and :math:`x^{(1)}, x^{(2)}, \\cdots x^{(m)}` be the
-        :math:`m` i.i.d. random variables, new covariance matrix
-        :math:`\\Sigma_y` of :math:`y = [x^{(1)}, x^{(2)}, \\cdots, x^{(m)}]
-        \\in R^{md}` can be written as
+        distribution becomes block diagonal matrix. Let
+        :math:`\\Sigma_{\\mathbf{x}}` be the covariance matrix of the original
+        random variable :math:`\\mathbf{x} \\in \\mathbb{R}^d`, and
+        :math:`\\mathbf{x}^{(1)}, \\mathbf{x}^{(2)}, \\cdots \\mathbf{x}^{(m)}`
+        be the :math:`m` i.i.d. random variables, new covariance matrix
+        :math:`\\Sigma_{\\mathbf{y}}` of :math:`\\mathbf{y} =
+        [\\mathbf{x}^{(1)}, \\mathbf{x}^{(2)}, \\cdots, \\mathbf{x}^{(m)}] \\in
+        \\mathbb{R}^{md}` can be written as
 
         .. math::
             \\left[\\begin{array}{ccc}
-                    \\Sigma_{x^{1}} &         & 0               \\\\
-                                    & \\ddots &                 \\\\
-                    0               &         & \\Sigma_{x^{m}}
+                    \\Sigma_{\\mathbf{x}^{1}} & & 0 \\\\
+                    & \\ddots & \\\\
+                    0 & & \\Sigma_{\\mathbf{x}^{m}}
             \\end{array} \\right].
 
         Note that this relationship holds only if the covariance matrix of the

--- a/chainer/distributions/independent.py
+++ b/chainer/distributions/independent.py
@@ -1,0 +1,226 @@
+from functools import reduce
+import operator
+
+import numpy
+
+from chainer.backend import cuda
+from chainer import distribution
+from chainer.functions.array import reshape, repeat, transpose
+from chainer.functions.math import sum as sum_mod
+from chainer.functions.math import prod
+from chainer.utils import cache
+
+
+class Independent(distribution.Distribution):
+    def __init__(self, distribution, reinterpreted_batch_ndims=None):
+        '''Construct a `Independent` distribution.
+        Args:
+            distribution (:class:`~chainer.Distribution`): The base
+                distribution instance to transform.
+            reinterpreted_batch_ndims (:class:`int`): Integer number of
+                rightmost batch dims which will be regarded as event dims.
+                When ``None`` all but the first batch axis (batch axis 0) will
+                be transferred to event dimensions.
+        '''
+
+        super(Independent, self).__init__()
+        self.__distribution = distribution
+        if reinterpreted_batch_ndims is None:
+            reinterpreted_batch_ndims = \
+                self._get_default_reinterpreted_batch_ndims(distribution)
+        self.__reinterpreted_batch_ndims = reinterpreted_batch_ndims
+
+        self.__batch_shape = \
+            distribution.batch_shape[:-self.reinterpreted_batch_ndims]
+        self.__event_shape = \
+            distribution.batch_shape[-self.reinterpreted_batch_ndims:] + \
+            distribution.event_shape
+
+    @property
+    def distribution(self):
+        return self.__distribution
+
+    @property
+    def reinterpreted_batch_ndims(self):
+        return self.__reinterpreted_batch_ndims
+
+    @property
+    def batch_shape(self):
+        return self.__batch_shape
+
+    @property
+    def event_shape(self):
+        return self.__event_shape
+
+    @property
+    def covariance(self):
+        '''Returns the covariance of the distribution based on the original
+        i.i.d. distribution. By definition, the covariance of the new
+        distribution becomes block diagonal matrix. Let :math:`\\Sigma_x` be
+        the covariance matrix of the original random variable :math:`x
+        \\in R^d`, and :math:`x^{(1)}, x^{(2)}, \\cdots x^{(m)}` be the
+        :math:`m` i.i.d. random variables, new covariance matrix
+        :math:`\\Sigma_y` of :math:`y = [x^{(1)}, x^{(2)}, \\cdots, x^{(m)}]
+        \\in R^{md}` can be written as
+
+        .. math::
+            \\left[\\begin{array}{ccc}
+                    \\Sigma_{x^{1}} &         & 0               \\\\
+                                    & \\ddots &                 \\\\
+                    0               &         & \\Sigma_{x^{m}}
+            \\end{array} \\right].
+
+        Note that this relationship holds only if the covariance matrix of the
+        original distribution is given analytically.
+        '''
+        num_repeat = reduce(
+            operator.mul,
+            self.distribution.batch_shape[-self.reinterpreted_batch_ndims:], 1)
+        dim = reduce(operator.mul, self.distribution.event_shape, 1)
+        cov = repeat.repeat(
+            reshape.reshape(
+                self.distribution.covariance,
+                ((self.batch_shape) + (1, num_repeat, dim, dim))),
+            num_repeat, axis=-4)
+        cov = reshape.reshape(
+            transpose.transpose(
+                cov, axes=(
+                    tuple(range(len(self.batch_shape))) + (-4, -2, -3, -1))),
+            self.batch_shape + (num_repeat * dim, num_repeat * dim))
+        block_indicator = self.xp.reshape(
+            self._block_indicator,
+            tuple([1] * len(self.batch_shape)) + self._block_indicator.shape)
+        return cov * block_indicator
+
+    @property
+    def entropy(self):
+        return self._reduce(sum_mod.sum, self.distribution.entropy)
+
+    def cdf(self, x):
+        return self._reduce(prod.prod, self.distribution.cdf(x))
+
+    def icdf(self, x):
+        raise RuntimeError(
+            'Cumulative distribution function for multivariate variable '
+            'is not invertible.')
+
+    def log_cdf(self, x):
+        return self._reduce(sum_mod.sum, self.distribution.log_cdf(x))
+
+    def log_prob(self, x):
+        return self._reduce(sum_mod.sum, self.distribution.log_prob(x))
+
+    def log_survival_function(self, x):
+        return self._reduce(
+            sum_mod.sum, self.distribution.log_survival_function(x))
+
+    @property
+    def mean(self):
+        return self.distribution.mean
+
+    @property
+    def mode(self):
+        return self.distribution.mode
+
+    @property
+    def params(self):
+        return self.distribution.params
+
+    def perplexity(self, x):
+        return self._reduce(prod.prod, self.distribution.perplexity(x))
+
+    def prob(self, x):
+        return self._reduce(prod.prod, self.distribution.prob(x))
+
+    def sample_n(self, n):
+        return self.distribution.sample_n(n)
+
+    @property
+    def stddev(self):
+        return self.distribution.stddev
+
+    @property
+    def support(self):
+        return self.distribution.support
+
+    def survival_function(self, x):
+        return self._reduce(prod.prod, self.distribution.survival_function(x))
+
+    @property
+    def variance(self):
+        return self.distribution.variance
+
+    @property
+    def xp(self):
+        return self.distribution.xp
+
+    def _reduce(self, op, stat):
+        range_ = tuple(
+            (-1 - numpy.arange(self.reinterpreted_batch_ndims)).tolist())
+        return op(stat, axis=range_)
+
+    def _get_default_reinterpreted_batch_ndims(self, distribution):
+        ndims = len(distribution.batch_shape)
+        return max(0, ndims - 1)
+
+    @cache.cached_property
+    def _block_indicator(self):
+        num_repeat = reduce(
+            operator.mul,
+            self.distribution.batch_shape[-self.reinterpreted_batch_ndims:], 1)
+        dim = reduce(operator.mul, self.distribution.event_shape, 1)
+        block_indicator = numpy.fromfunction(
+            lambda i, j: i // dim == j // dim,
+            (num_repeat * dim, num_repeat * dim)).astype(int)
+        if self.xp is cuda.cupy:
+            block_indicator = cuda.to_gpu(block_indicator)
+        return block_indicator
+
+
+@distribution.register_kl(Independent, Independent)
+def _kl_independent_independent(dist1, dist2):
+    '''Batched KL divergence :math:`\\mathrm{KL}(\\mathrm{dist1} ||
+    \\mathrm{dist2})` for Independent distributions.
+
+    We can leverage the fact that
+    .. math::
+        \\mathrm{KL}(
+                \\mathrm{Independent}(\\mathrm{dist1}) ||
+                \\mathrm{Independent}(\\mathrm{dist2}))
+        = \\mathrm{sum}(\\mathrm{KL}(\\mathrm{dist1} || \\mathrm{dist2}))
+    where the sum is over the ``reinterpreted_batch_ndims``.
+
+    Args:
+        dist1 (:class:`~chainer.distribution.Independent`): Instance of
+            `Independent`.
+        dist2 (:class:`~chainer.distribution.Independent`): Instance of
+            `Independent`.
+
+    Returns:
+        Batchwise ``KL(dist1 || dist2)``.
+
+    Raises:
+        :class:`ValueError`: If the event space for ``dist1`` and ``dist2``,
+            or their underlying distributions don't match.
+    '''
+
+    p = dist1.distribution
+    q = dist2.distribution
+
+    # The KL between any two (non)-batched distributions is a scalar.
+    # Given that the KL between two factored distributions is the sum, i.e.
+    # KL(p1(x)p2(y) || q1(x)q2(y)) = KL(p1 || q1) + KL(q1 || q2), we compute
+    # KL(p || q) and do a `reduce_sum` on the reinterpreted batch dimensions.
+    if dist1.event_shape == dist2.event_shape:
+        if p.event_shape == q.event_shape:
+            num_reduce_dims = len(dist1.event_shape) - len(p.event_shape)
+            reduce_dims = tuple([-i - 1 for i in range(0, num_reduce_dims)])
+
+            return sum_mod.sum(
+                distribution.kl_divergence(p, q), axis=reduce_dims)
+        else:
+            raise NotImplementedError(
+                'KL between Independents with different '
+                'event shapes not supported.')
+    else:
+        raise ValueError('Event shapes do not match.')

--- a/chainer/distributions/independent.py
+++ b/chainer/distributions/independent.py
@@ -28,6 +28,10 @@ class Independent(distribution.Distribution):
         if reinterpreted_batch_ndims is None:
             reinterpreted_batch_ndims = \
                 self._get_default_reinterpreted_batch_ndims(distribution)
+        elif reinterpreted_batch_ndims > len(distribution.batch_shape):
+            raise ValueError(
+                'reinterpreted_batch_ndims must be less than or equal to the '
+                'number of dimensions of `distribution.batch_shape`.')
         self.__reinterpreted_batch_ndims = reinterpreted_batch_ndims
 
         batch_ndim = \

--- a/chainer/distributions/independent.py
+++ b/chainer/distributions/independent.py
@@ -12,17 +12,19 @@ from chainer.utils import cache
 
 
 class Independent(distribution.Distribution):
-    def __init__(self, distribution, reinterpreted_batch_ndims=None):
-        '''Construct a `Independent` distribution.
-        Args:
-            distribution (:class:`~chainer.Distribution`): The base
-                distribution instance to transform.
-            reinterpreted_batch_ndims (:class:`int`): Integer number of
-                rightmost batch dims which will be regarded as event dims.
-                When ``None`` all but the first batch axis (batch axis 0) will
-                be transferred to event dimensions.
-        '''
 
+    """Independent distribution.
+
+    Args:
+        distribution (:class:`~chainer.Distribution`): The base distribution
+            instance to transform.
+        reinterpreted_batch_ndims (:class:`int`): Integer number of rightmost
+            batch dims which will be regarded as event dims. When ``None`` all
+            but the first batch axis (batch axis 0) will be transferred to
+            event dimensions.
+    """
+
+    def __init__(self, distribution, reinterpreted_batch_ndims=None):
         super(Independent, self).__init__()
         self.__distribution = distribution
         if reinterpreted_batch_ndims is None:
@@ -106,6 +108,17 @@ class Independent(distribution.Distribution):
         return self._reduce(prod.prod, self.distribution.cdf(x))
 
     def icdf(self, x):
+        '''Cumulative distribution function for multivariate variable is not
+        invertible. This function always raises :class:`RuntimeError`.
+
+        Args:
+            x (:class:`~chainer.Variable` or :ref:`ndarray`): Data points in
+                the codomain of the distribution
+
+        Raises:
+            :class:`RuntimeError`
+        '''
+
         raise RuntimeError(
             'Cumulative distribution function for multivariate variable '
             'is not invertible.')

--- a/chainer/distributions/independent.py
+++ b/chainer/distributions/independent.py
@@ -1,11 +1,13 @@
-from functools import reduce
+import functools
 import operator
 
 import numpy
 
 from chainer.backend import cuda
 from chainer import distribution
-from chainer.functions.array import reshape, repeat, transpose
+from chainer.functions.array import repeat
+from chainer.functions.array import reshape
+from chainer.functions.array import transpose
 from chainer.functions.math import sum as sum_mod
 from chainer.functions.math import prod
 from chainer.utils import cache
@@ -81,10 +83,10 @@ class Independent(distribution.Distribution):
         Note that this relationship holds only if the covariance matrix of the
         original distribution is given analytically.
         '''
-        num_repeat = reduce(
+        num_repeat = functools.reduce(
             operator.mul,
             self.distribution.batch_shape[-self.reinterpreted_batch_ndims:], 1)
-        dim = reduce(operator.mul, self.distribution.event_shape, 1)
+        dim = functools.reduce(operator.mul, self.distribution.event_shape, 1)
         cov = repeat.repeat(
             reshape.reshape(
                 self.distribution.covariance,
@@ -184,10 +186,10 @@ class Independent(distribution.Distribution):
 
     @cache.cached_property
     def _block_indicator(self):
-        num_repeat = reduce(
+        num_repeat = functools.reduce(
             operator.mul,
             self.distribution.batch_shape[-self.reinterpreted_batch_ndims:], 1)
-        dim = reduce(operator.mul, self.distribution.event_shape, 1)
+        dim = functools.reduce(operator.mul, self.distribution.event_shape, 1)
         block_indicator = numpy.fromfunction(
             lambda i, j: i // dim == j // dim,
             (num_repeat * dim, num_repeat * dim)).astype(int)

--- a/chainer/distributions/independent.py
+++ b/chainer/distributions/independent.py
@@ -30,11 +30,11 @@ class Independent(distribution.Distribution):
                 self._get_default_reinterpreted_batch_ndims(distribution)
         self.__reinterpreted_batch_ndims = reinterpreted_batch_ndims
 
-        self.__batch_shape = \
-            distribution.batch_shape[:-self.reinterpreted_batch_ndims]
+        batch_ndim = \
+            len(self.distribution.batch_shape) - self.reinterpreted_batch_ndims
+        self.__batch_shape = distribution.batch_shape[:batch_ndim]
         self.__event_shape = \
-            distribution.batch_shape[-self.reinterpreted_batch_ndims:] + \
-            distribution.event_shape
+            distribution.batch_shape[batch_ndim:] + distribution.event_shape
 
     @property
     def distribution(self):

--- a/chainer/distributions/laplace.py
+++ b/chainer/distributions/laplace.py
@@ -115,6 +115,10 @@ class Laplace(distribution.Distribution):
     def mode(self):
         return self.loc
 
+    @property
+    def params(self):
+        return {'loc': self.loc, 'scale': self.scale}
+
     def prob(self, x):
         scale = self.scale
         return 0.5 / scale * exponential.exp(- abs(x - self.loc) / scale)

--- a/chainer/distributions/log_normal.py
+++ b/chainer/distributions/log_normal.py
@@ -65,6 +65,10 @@ class LogNormal(distribution.Distribution):
     def mean(self):
         return exponential.exp(self.mu + 0.5 * self.sigma ** 2)
 
+    @property
+    def params(self):
+        return {'mu': self.mu, 'sigma': self.sigma}
+
     def sample_n(self, n):
         xp = backend.get_array_module(self.mu)
         if xp is cuda.cupy:

--- a/chainer/distributions/multivariate_normal.py
+++ b/chainer/distributions/multivariate_normal.py
@@ -12,6 +12,7 @@ from chainer.functions.array import expand_dims
 from chainer.functions.array import squeeze
 from chainer.functions.array import stack
 from chainer.functions.array import swapaxes
+from chainer.functions.array import transpose
 from chainer.functions.array import where
 from chainer.functions.math import exponential
 from chainer.functions.math import matmul
@@ -201,6 +202,13 @@ class MultivariateNormal(distribution.Distribution):
     @property
     def support(self):
         return 'real'
+
+    @property
+    def covariance(self):
+        return matmul.matmul(
+            self.scale_tril, transpose.transpose(
+                self.scale_tril,
+                tuple(range(len(self.batch_shape))) + (-1, -2)))
 
 
 @distribution.register_kl(MultivariateNormal, MultivariateNormal)

--- a/chainer/distributions/multivariate_normal.py
+++ b/chainer/distributions/multivariate_normal.py
@@ -204,6 +204,10 @@ class MultivariateNormal(distribution.Distribution):
         return 'real'
 
     @property
+    def params(self):
+        return {'loc': self.loc, 'scale_tril': self.scale_tril}
+
+    @property
     def covariance(self):
         return matmul.matmul(
             self.scale_tril, transpose.transpose(

--- a/chainer/distributions/one_hot_categorical.py
+++ b/chainer/distributions/one_hot_categorical.py
@@ -71,6 +71,10 @@ class OneHotCategorical(distribution.Distribution):
     def mean(self):
         return self.p
 
+    @property
+    def params(self):
+        return {'p': self.p}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.p)
         obo_p = self.p.data.reshape((-1,) + self.event_shape)

--- a/chainer/distributions/pareto.py
+++ b/chainer/distributions/pareto.py
@@ -77,6 +77,10 @@ class Pareto(distribution.Distribution):
             self.alpha.data > 1,
             mean, xp.array(xp.inf, mean.dtype))
 
+    @property
+    def params(self):
+        return {'scale': self.scale, 'alpha': self.alpha}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.scale)
         if xp is cuda.cupy:

--- a/chainer/distributions/poisson.py
+++ b/chainer/distributions/poisson.py
@@ -57,6 +57,10 @@ class Poisson(distribution.Distribution):
     def mean(self):
         return self.lam
 
+    @property
+    def params(self):
+        return {'lam': self.lam}
+
     def sample_n(self, n):
         xp = cuda.get_array_module(self.lam)
         if xp is cuda.cupy:

--- a/chainer/distributions/uniform.py
+++ b/chainer/distributions/uniform.py
@@ -111,6 +111,13 @@ class Uniform(distribution.Distribution):
     def mean(self):
         return (self.high + self.low) / 2
 
+    @property
+    def params(self):
+        if self._use_low_high:
+            return {'low': self.low, 'high': self.high}
+        else:
+            return {'loc': self.loc, 'scale': self.scale}
+
     def sample_n(self, n):
         xp = backend.get_array_module(self.low)
         if xp is cuda.cupy:

--- a/docs/source/reference/distributions.rst
+++ b/docs/source/reference/distributions.rst
@@ -13,7 +13,7 @@ Distributions
 .. autosummary::
    :toctree: generated/
    :nosignatures:
-   
+
    chainer.distributions.Bernoulli
    chainer.distributions.Beta
    chainer.distributions.Categorical
@@ -24,6 +24,7 @@ Distributions
    chainer.distributions.Gamma
    chainer.distributions.Geometric
    chainer.distributions.Gumbel
+   chainer.distributions.Independent
    chainer.distributions.Laplace
    chainer.distributions.LogNormal
    chainer.distributions.MultivariateNormal
@@ -42,7 +43,7 @@ Functionals of distribution
 .. autosummary::
   :toctree: generated/
   :nosignatures:
-  
+
   chainer.cross_entropy
   chainer.kl_divergence
   chainer.register_kl

--- a/examples/vae/net.py
+++ b/examples/vae/net.py
@@ -42,9 +42,9 @@ class AvgELBOLoss(chainer.Chain):
         p_x = self.decoder(z)
         p_z = self.prior()
 
-        reconstr = F.mean(F.sum(p_x.log_prob(
-            F.broadcast_to(x[None, :], (self.k,) + x.shape)), axis=-1))
-        kl_penalty = F.mean(F.sum(chainer.kl_divergence(q_z, p_z), axis=-1))
+        reconstr = F.mean(p_x.log_prob(
+            F.broadcast_to(x[None, :], (self.k,) + x.shape)))
+        kl_penalty = F.mean(chainer.kl_divergence(q_z, p_z))
         loss = - (reconstr - self.beta * kl_penalty)
         reporter.report({'loss': loss}, self)
         reporter.report({'reconstr': reconstr}, self)
@@ -65,7 +65,7 @@ class Encoder(chainer.Chain):
         h = F.tanh(self.linear(x))
         mu = self.mu(h)
         ln_sigma = self.ln_sigma(h)  # log(sigma)
-        return D.Normal(loc=mu, log_scale=ln_sigma)
+        return D.Independent(D.Normal(loc=mu, log_scale=ln_sigma))
 
 
 class Decoder(chainer.Chain):
@@ -81,7 +81,9 @@ class Decoder(chainer.Chain):
         n_batch_axes = 1 if inference else 2
         h = F.tanh(self.linear(z, n_batch_axes=n_batch_axes))
         h = self.output(h, n_batch_axes=n_batch_axes)
-        return D.Bernoulli(logit=h, binary_check=self.binary_check)
+        return D.Independent(
+            D.Bernoulli(logit=h, binary_check=self.binary_check),
+            reinterpreted_batch_ndims=1)
 
 
 class Prior(chainer.Link):
@@ -95,7 +97,8 @@ class Prior(chainer.Link):
         self.register_persistent('scale')
 
     def forward(self):
-        return D.Normal(self.loc, scale=self.scale)
+        return D.Independent(
+            D.Normal(self.loc, scale=self.scale), reinterpreted_batch_ndims=1)
 
 
 def make_encoder(n_in, n_latent, n_h):

--- a/tests/chainer_tests/distributions_tests/test_independent.py
+++ b/tests/chainer_tests/distributions_tests/test_independent.py
@@ -1,0 +1,143 @@
+import functools
+import itertools
+import operator
+
+import numpy
+
+from chainer import distributions
+from chainer import testing
+from chainer.testing import array
+from chainer.testing import attr
+from chainer import utils
+
+
+def skip_not_in_params(property):
+    def decorator(f):
+        @functools.wraps(f)
+        def new_f(self, *args, **kwargs):
+            if property not in self.params.keys():
+                self.skipTest(
+                    "\'%s\' does not exist in params.keys()." % property)
+            else:
+                f(self, *args, **kwargs)
+        return new_f
+    return decorator
+
+
+def _generate_valid_shape_pattern(
+        inner_shape, inner_event_shape, reinterpreted_batch_ndims):
+    shape_pattern = []
+    for bs, es, m in itertools.product(
+            inner_shape, inner_event_shape, reinterpreted_batch_ndims):
+        if (m is not None) and (m > len(bs)):
+            continue
+        shape_pattern.append({
+            'full_shape': bs + es,
+            'inner_shape': bs,
+            'inner_event_shape': es,
+            'reinterpreted_batch_ndims': m
+        })
+    return shape_pattern
+
+
+def _generate_test_parameter(
+        parameter_list, inner_shape, inner_event_shape,
+        reinterpreted_batch_ndims):
+    shape_pattern = _generate_valid_shape_pattern(
+        inner_shape, inner_event_shape, reinterpreted_batch_ndims)
+    return list(map(
+        lambda dicts: dict(dicts[0], **dicts[1]),
+        itertools.product(parameter_list, shape_pattern)))
+
+
+@testing.parameterize(*_generate_test_parameter(
+    testing.product({
+        'sample_shape': [(3, 2), ()],
+        'is_variable': [True, False]
+    }),
+    inner_shape=[(4, 5), (5,), ()],
+    inner_event_shape=[()],
+    reinterpreted_batch_ndims=[1, 0, None]
+))
+@testing.fix_random()
+@testing.with_requires('scipy')
+class TestIndependentNormal(testing.distribution_unittest):
+
+    scipy_onebyone = True
+
+    def _build_inner_distribution(self):
+        pass
+
+    def setUp_configure(self):
+        from scipy import stats
+        self.dist = lambda **params: distributions.Independent(
+            distributions.Normal(**params), self.reinterpreted_batch_ndims)
+
+        self.test_targets = set([
+            "batch_shape", "entropy", "event_shape", "log_prob",
+            "support"])
+
+        loc = utils.force_array(numpy.random.uniform(
+            -1, 1, self.full_shape).astype(numpy.float32))
+        scale = utils.force_array(numpy.exp(numpy.random.uniform(
+            -1, 1, self.full_shape)).astype(numpy.float32))
+
+        if self.reinterpreted_batch_ndims is None:
+            reinterpreted_batch_ndims = max(0, len(self.inner_shape) - 1)
+        else:
+            reinterpreted_batch_ndims = self.reinterpreted_batch_ndims
+
+        batch_ndim = len(self.inner_shape) - reinterpreted_batch_ndims
+        self.shape = self.inner_shape[:batch_ndim]
+        self.event_shape = \
+            self.inner_shape[batch_ndim:] + self.inner_event_shape
+        d = functools.reduce(operator.mul, self.event_shape, 1)
+
+        if self.event_shape == ():
+            self.scipy_dist = stats.norm
+
+            self.params = {"loc": loc, "scale": scale}
+            self.scipy_params = {"loc": loc, "scale": scale}
+
+        else:
+            self.scipy_dist = stats.multivariate_normal
+
+            scale_tril = numpy.eye(d).astype(numpy.float32) * \
+                scale.reshape(self.shape + (d,))[..., None]
+            cov = numpy.einsum('...ij,...jk->...ik', scale_tril, scale_tril)
+
+            self.params = {"loc": loc, "scale": scale}
+            self.scipy_params = {"mean": numpy.reshape(
+                loc, self.shape + (d,)), "cov": cov}
+
+    def sample_for_test(self):
+        smp = numpy.random.normal(
+            size=self.sample_shape + self.full_shape
+        ).astype(numpy.float32)
+        return smp
+
+    def test_batch_ndim_error(self):
+        with self.assertRaises(ValueError):
+            distributions.Independent(
+                distributions.Normal(**self.params),
+                len(self.inner_shape) + 1)
+
+    def check_covariance(self, is_gpu):
+        if is_gpu:
+            cov1 = self.gpu_dist.covariance.array
+        else:
+            cov1 = self.cpu_dist.covariance.array
+        cov2 = self.params['cov']
+        array.assert_allclose(cov1, cov2)
+
+    @skip_not_in_params('cov')
+    def test_covariance_cpu(self):
+        self.check_covariance(False)
+
+    @skip_not_in_params('cov')
+    @attr.gpu
+    def test_covariance_gpu(self):
+        self.check_covariance(True)
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
Typical DL frameworks which handle probabilistic distributions such as Tensorflow Probability and PyTorch Distributions have `Independent` distribution class. I implemented the same interface in Chainer.

`Independent` distribution reinterprets some of the batch dims of distribution as event dims. This is mainly useful for changing the shape of the result of `distribution.log_prob(x)`, and it makes code clearer and simpler. For example, the current official example of the VAE's objective function is like

```python
...
q_z = D.Normal(loc=mu(x), log_scale=ln_sigma(x))
z = q_z.sample(k)
p_x = D.Bernoulli(logit=h(z))
p_z = D.Normal(zeros_array, ones_array)

reconstr = F.mean(F.sum(p_x.log_prob(
    F.broadcast_to(x[None, :], (k,) + x.shape)), axis=-1))
kl_penalty = F.mean(F.sum(chainer.kl_divergence(q_z, p_z), axis=-1))
...
```

However, this code assumes the last dimension of `p_x`, `q_z`, and `p_z` should be treated as event dim. This code will not work when we change `q_z` from `D.Normal` to `D.MultivariateNormal`. By using `D.Independent`, we can rewrite the above code as

```python
...
q_z = D.Independent(D.Normal(loc=mu(x), log_scale=ln_sigma(x)))
z = q_z.sample(k)
p_x = D.Independent(D.Bernoulli(logit=h(z)), reinterpreted_batch_ndims=1)
p_z = D.Independent(
    D.Normal(zeros_array, ones_array), reinterpreted_batch_ndims=1)

reconstr = F.mean(p_x.log_prob(
    F.broadcast_to(x[None, :], (self.k,) + x.shape)))
kl_penalty = F.mean(chainer.kl_divergence(q_z, p_z))
...
```

This code is assumption-free, and we can treat distribution.event_shape appropriately.