### PR TITLE
Adding binomial distribution to Chainer

### DIFF
--- a/chainer/distributions/__init__.py
+++ b/chainer/distributions/__init__.py
@@ -2,6 +2,7 @@
 
 from chainer.distributions.bernoulli import Bernoulli  # NOQA
 from chainer.distributions.beta import Beta  # NOQA
+from chainer.distributions.binomial import Binomial # NOQA
 from chainer.distributions.categorical import Categorical  # NOQA
 from chainer.distributions.cauchy import Cauchy  # NOQA
 from chainer.distributions.chisquare import Chisquare  # NOQA

--- a/chainer/distributions/binomial.py
+++ b/chainer/distributions/binomial.py
@@ -1,0 +1,78 @@
+import numpy
+import chainer
+from chainer.backends import cuda
+from chainer import distribution
+from chainer.functions.math import exponential
+from chainer.utils import cache
+
+
+class Binomial(distribution.Distribution):
+
+    """Binomial Distribution.
+
+    The probability mass function of the distribution is expressed as:
+
+    .. math::
+        Pr(x = k) = (n k) p^{k} (1-p)^{n-k}
+        for k = 1, 2, 3, ...,
+
+    Args:
+        p(:class:`~chainer.Variable` or :ref:`ndarray`):
+            Success probability for each trial.
+        n(:class:`~chainer.Variable` or :ref:`ndarray`):
+            Number of total trials in distribution.
+    """
+
+    def __init__(self, n, p):
+        super(Binomial, self).__init__()
+        self.__n = n
+        self.__p = p
+
+    @cache.cached_property
+    def n(self):
+        return chainer.as_variable(self.__n)
+
+    @cache.cached_property
+    def p(self):
+        return chainer.as_variable(self.__p)
+
+    @property
+    def batch_shape(self):
+        return self.p.shape
+
+    @property
+    def event_shape(self):
+        return ()
+
+    @cache.cached_property
+    def mean(self):
+        return self.n * self.p
+
+    @cache.cached_property
+    def variance(self):
+        return self.n * self.p * (1 - self.p)
+
+    def sample_n(self, k):
+        xp = cuda.get_array_module(self.p)
+        if xp is cuda.cupy:
+            eps = xp.random.binomial(
+                self.n.data.astype('int64'),
+                self.p.data,
+                size=(k,)+self.batch_shape, dtype=self.p.dtype)
+        else:
+            eps = xp.random.binomial( 
+                self.n.data.astype('int64'),
+                self.p.data,
+                size=(k,)+self.batch_shape).astype(self.p.dtype)
+        return chainer.Variable(eps)
+
+    @property
+    def support(self):
+        return 'positive integer'
+
+@distribution.register_kl(Binomial, Binomial)
+def _kl_binomial_binomial(dist1, dist2):
+    return ((exponential.log(dist1.p) - exponential.log(dist2.p))
+            * dist1.n * dist1.p + (exponential.log(1 - dist1.p)
+            - exponential(1 - dist2.p)) * dist1.n * (1 - dist1.p)
+            )

--- a/chainer/distributions/binomial.py
+++ b/chainer/distributions/binomial.py
@@ -1,4 +1,3 @@
-import numpy
 import chainer
 from chainer.backends import cuda
 from chainer import distribution
@@ -60,7 +59,7 @@ class Binomial(distribution.Distribution):
                 self.p.data,
                 size=(k,)+self.batch_shape, dtype=self.p.dtype)
         else:
-            eps = xp.random.binomial( 
+            eps = xp.random.binomial(
                 self.n.data.astype('int64'),
                 self.p.data,
                 size=(k,)+self.batch_shape).astype(self.p.dtype)
@@ -69,6 +68,7 @@ class Binomial(distribution.Distribution):
     @property
     def support(self):
         return 'positive integer'
+
 
 @distribution.register_kl(Binomial, Binomial)
 def _kl_binomial_binomial(dist1, dist2):

--- a/tests/chainer_tests/distributions_tests/test_binomial.py
+++ b/tests/chainer_tests/distributions_tests/test_binomial.py
@@ -1,40 +1,40 @@
-import numpy 
-
+import numpy
 from chainer import distributions
 from chainer import testing
 
 
 @testing.parameterize(*testing.product({
-	'shape': [(2, 3), ()],
-	'is_variable': [True, False],
-	'sample_shape': [(3, 2), ()],
+    'shape': [(2, 3), ()],
+    'is_variable': [True, False],
+    'sample_shape': [(3, 2), ()],
 }))
 @testing.fix_random()
 @testing.with_requires('scipy')
 class TestBinomial(testing.distribution_unittest):
 
-	scipy_onebyone = True
+    scipy_onebyone = True
 
-	def setUp_configure(self):
-		from scipy import stats
-		self.dist = distributions.Binomial
-		self.scipy_dist = stats.binom
+    def setUp_configure(self):
+        from scipy import stats
+        self.dist = distributions.Binomial
+        self.scipy_dist = stats.binom
 
-		self.test_targets = set([
-			"batch_shape", "mean", "variance",
-			"support"])
+        self.test_targets = set([
+            "batch_shape", "mean", "variance",
+            "support"])
 
-		p = numpy.random.uniform(0, 1, self.shape).astype(numpy.float32)
-		n = numpy.random.randint(1, 10, self.shape).astype(numpy.float32)
-		self.params = {"n": n, "p": p}
-		self.scipy_params = {"n": n, "p": p}
+        p = numpy.random.uniform(0, 1, self.shape).astype(numpy.float32)
+        n = numpy.random.randint(1, 10, self.shape).astype(numpy.float32)
+        self.params = {"n": n, "p": p}
+        self.scipy_params = {"n": n, "p": p}
 
-		self.support = 'positive integer'
-		self.continuous = False
+        self.support = 'positive integer'
+        self.continuous = False
 
-	def sample_for_test(self):
-		smp = numpy.random.binomial(
-			0.5, 10, self.sample_shape + self.shape).astype(numpy.int32)
-		return smp
+    def sample_for_test(self):
+        smp = numpy.random.binomial(
+            0.5, 10, self.sample_shape + self.shape).astype(numpy.int32)
+        return smp
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/distributions_tests/test_binomial.py
+++ b/tests/chainer_tests/distributions_tests/test_binomial.py
@@ -1,0 +1,40 @@
+import numpy 
+
+from chainer import distributions
+from chainer import testing
+
+
+@testing.parameterize(*testing.product({
+	'shape': [(2, 3), ()],
+	'is_variable': [True, False],
+	'sample_shape': [(3, 2), ()],
+}))
+@testing.fix_random()
+@testing.with_requires('scipy')
+class TestBinomial(testing.distribution_unittest):
+
+	scipy_onebyone = True
+
+	def setUp_configure(self):
+		from scipy import stats
+		self.dist = distributions.Binomial
+		self.scipy_dist = stats.binom
+
+		self.test_targets = set([
+			"batch_shape", "mean", "variance",
+			"support"])
+
+		p = numpy.random.uniform(0, 1, self.shape).astype(numpy.float32)
+		n = numpy.random.randint(1, 10, self.shape).astype(numpy.float32)
+		self.params = {"n": n, "p": p}
+		self.scipy_params = {"n": n, "p": p}
+
+		self.support = 'positive integer'
+		self.continuous = False
+
+	def sample_for_test(self):
+		smp = numpy.random.binomial(
+			0.5, 10, self.sample_shape + self.shape).astype(numpy.int32)
+		return smp
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
Adding binomial distribution to chainer.distributions.

I also created a test for this in chainer/tests/chainer_tests/distributions_tests/test_binomial.py

For some reason, the sample test within my test file gives a type casting issue. However, I verified this distribution is working by calling the distribution from another file and observing the result. 

Ex. 
dist = chainer.distributions.Binomial(n, p)
dist.sample_n(20) #this works as intended

If you can help me fix the test issue, it would be great, but it seems the distributions is working.
