### PR TITLE
Use Chainer-style parameterization in ChainerX op test 

### DIFF
--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -9,6 +9,7 @@ from chainer.testing.helper import patch  # NOQA
 from chainer.testing.helper import with_requires  # NOQA
 from chainer.testing.helper import without_requires  # NOQA
 from chainer.testing.parameterized import parameterize  # NOQA
+from chainer.testing.parameterized import parameterize_pytest  # NOQA
 from chainer.testing.parameterized import product  # NOQA
 from chainer.testing.parameterized import product_dict  # NOQA
 from chainer.testing.random import fix_random  # NOQA

--- a/chainer/testing/_bundle.py
+++ b/chainer/testing/_bundle.py
@@ -1,7 +1,6 @@
 import collections
 import inspect
 import sys
-import unittest
 
 
 # A tuple that represents a test case.
@@ -23,8 +22,9 @@ class _ParameterizedTestCaseBundle(object):
 
 
 def make_decorator(test_case_generator):
-    # `test_case_generator` is a callable that receives the source TestCase
-    # class and returns an iterable of generated test cases.
+    # `test_case_generator` is a callable that receives the source test class
+    # (typically a subclass of unittest.TestCase) and returns an iterable of
+    # generated test cases.
     # Each element of the iterable is a 3-element tuple:
     # [0] Generated class name
     # [1] Dict of members
@@ -39,12 +39,10 @@ def make_decorator(test_case_generator):
         else:
             # Input is a bare test case, i.e. not one generated from another
             # parameterize.
-            assert issubclass(cases, unittest.TestCase)
             cases = [_TestCaseTuple(cases, None, None)]
 
         generated_cases = []
         for klass, mod_name, cls_name in cases:
-            assert issubclass(klass, unittest.TestCase)
             if mod_name is not None:
                 # The input is a parameterized test case.
                 # Remove it from its module.

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -87,11 +87,30 @@ def _parameterize_test_case_generator(base, params):
 
 
 def parameterize(*params):
+    # TODO(niboshi): Add documentation
     return _bundle.make_decorator(
         lambda base: _parameterize_test_case_generator(base, params))
 
 
+def parameterize_pytest(names, values):
+    # Pytest-style parameterization.
+    # TODO(niboshi): Add documentation
+    assert isinstance(names, str)
+    assert isinstance(values, (tuple, list))
+
+    def safe_zip(ns, vs):
+        if not isinstance(vs, (tuple, list)):
+            vs = (vs,)
+        assert len(ns) == len(vs)
+        return zip(ns, vs)
+
+    names = names.split(',')
+    params = [dict(safe_zip(names, value_list)) for value_list in values]
+    return parameterize(*params)
+
+
 def product(parameter):
+    # TODO(niboshi): Add documentation
     if isinstance(parameter, dict):
         keys = sorted(parameter)
         values = [parameter[key] for key in keys]
@@ -120,6 +139,7 @@ def product(parameter):
 
 
 def product_dict(*parameters):
+    # TODO(niboshi): Add documentation
     return [
         {k: v for dic in dicts for k, v in six.iteritems(dic)}
         for dicts in itertools.product(*parameters)]

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_connection.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_connection.py
@@ -28,7 +28,7 @@ def _create_conv_args(
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
-@pytest.mark.parametrize('x_shape,w_shape,b_shape,stride,pad', [
+@chainer.testing.parameterize_pytest('x_shape,w_shape,b_shape,stride,pad', [
     ((1, 3), (5, 3), (5,), 1, 0),
     ((1, 3), (5, 3), None, 1, 0),
     ((2, 3, 4), (5, 3, 1), (5,), 1, 0),
@@ -42,29 +42,21 @@ def _create_conv_args(
     ((1, 3, 2, 6, 3), (2, 3, 1, 3, 2), (2,), (1, 2, 3), (2, 0, 1)),
     ((2, 3, 2, 6, 3), (2, 3, 1, 3, 2), None, (1, 2, 3), (2, 0, 1)),
 ])
-@pytest.mark.parametrize('cover_all', [True, False])
+@chainer.testing.parameterize_pytest('cover_all', [True, False])
 class test_conv(op_utils.ChainerOpTest):
 
-    def setup(
-            self, x_shape, w_shape, b_shape, stride, pad, cover_all,
-            float_dtype):
+    def setup(self, float_dtype):
 
         device = chainerx.get_default_device()
-        if device.backend.name == 'cuda' and len(x_shape) <= 3:
+        if device.backend.name == 'cuda' and len(self.x_shape) <= 3:
             # TODO(hvy): Support 1 dimensional convolution with CUDA.
             pytest.skip('cudnn does not support 1-dim convolution')
-        if device.backend.name == 'cuda' and cover_all:
+        if device.backend.name == 'cuda' and self.cover_all:
             pytest.skip('cudnn does not support cover_all')
         if device.backend.name == 'native' and float_dtype == 'float16':
             # TODO(niboshi): Fix accuracy
             pytest.skip('Native float16 operation has insufficient accuracy')
 
-        self.x_shape = x_shape
-        self.w_shape = w_shape
-        self.b_shape = b_shape
-        self.stride = stride
-        self.pad = pad
-        self.cover_all = cover_all
         self.dtype = float_dtype
 
         if float_dtype == 'float16':


### PR DESCRIPTION
`@pytest.mark.parametrize` only allows simple list / product of parameters.
With this fix, `op_test` can utilize `@chainer.testing.parameterize`.

Also added `@chainer.testing.parameterize_pytest` which allows pytest-style parameterization.

Depends on #6248.