### PR TITLE
Add `__ne__` in Device for Python 2

### DIFF
--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -66,6 +66,9 @@ class Device(object):
         raise NotImplementedError(
             'Device implementation must override this method.')
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def create_context(self):
         # Returns an object that implements __enter__ and __exit__.
         return _dummy_context

--- a/tests/chainer_tests/test_backend.py
+++ b/tests/chainer_tests/test_backend.py
@@ -274,6 +274,7 @@ class TestDevice(unittest.TestCase):
     def test_eq_numpy(self):
         assert backend.get_device(numpy) == backend.get_device(numpy)
         assert backend.CpuDevice() == backend.get_device(numpy)
+        assert not backend.CpuDevice() != backend.get_device(numpy)  # __ne__()
 
     @attr.gpu
     def test_eq_cupy(self):


### PR DESCRIPTION
Add `__ne__` to `chainer.Device` to make `!=` operator work correctly in all environments because `!=` is not the inverse of `==` in Python 2.

```python
$ pyenv local 2.7.15
$ python
Python 2.7.15 (default, Jun 15 2018, 17:41:47) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import chainer
>>> d1 = chainer.backend._cpu.CpuDevice()
>>> d2 = chainer.backend._cpu.CpuDevice()
>>> d1 == d2
True
>>> d1 != d2
True
```