### PR TITLE
Dynamic loss scaling

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -667,14 +667,14 @@ class Optimizer(object):
         if scale is None:
             self._loss_scaling_is_dynamic = True
             if interval < 1:
-                raise ValueError('interval must be greater equal to 1. '
-                                 'Actual: {}'.format(interval))
+                raise ValueError('interval must be greater than or equal to 1.'
+                                 ' Actual: {}'.format(interval))
             self._loss_scale = 1.0
             self._loss_scaling_multiplier = math.pow(2.0, 1.0 / interval)
             self._loss_scaling_isnan_ever = False
         else:
             if scale <= 0:
-                raise ValueError('loss_scale must be positive number. '
+                raise ValueError('loss_scale must be a positive number. '
                                  'Actual: {}'.format(scale))
             self._loss_scale = scale
 
@@ -694,7 +694,7 @@ class Optimizer(object):
                 self._loss_scaling_isnan_ever = True
                 warnings.warn(
                     'Non finite number found in param.grad of {}'
-                    ' (iteration:{}, loss_scale:{})'
+                    ' (iteration: {}, loss_scale: {})'
                     ''.format(name, self.t, self._loss_scale))
 
     def is_safe_to_update(self):

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -138,4 +138,36 @@ class TestOptimizerHooks(unittest.TestCase):
         self.assertNotEqual(h_pre.value, h_post.value)
 
 
+@testing.parameterize(*testing.product({
+    'impl': [
+        optimizers.AdaDelta,
+        optimizers.AdaGrad,
+        optimizers.Adam,
+        optimizers.CorrectedMomentumSGD,
+        optimizers.MomentumSGD,
+        optimizers.MSVAG,
+        optimizers.NesterovAG,
+        optimizers.RMSprop,
+        optimizers.RMSpropGraves,
+        optimizers.SGD,
+        optimizers.SMORMS3,
+    ]
+}))
+class TestOptimizerLossScaling(unittest.TestCase):
+
+    def setUp(self):
+        self.target = SimpleChain()
+
+    def create(self, *args, **kwargs):
+        self.optimizer = self.impl(*args, **kwargs)
+        self.optimizer.setup(self.target)
+
+    def test_invalid_configs(self):
+        self.create()
+        with self.assertRaises(ValueError):
+            self.optimizer.loss_scaling(interval=0)
+        with self.assertRaises(ValueError):
+            self.optimizer.loss_scaling(scale=-1)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -73,10 +73,11 @@ class LinearModel(object):
         y_test = model(x_test)
         return F.accuracy(y_test, t_test)
 
-    def accuracy(self, backend_config):
+    def accuracy(self, backend_config, loss_scaling=False):
         model = self.model
         optimizer = self.optimizer
         optimizer.setup(model)
+        _optimizer_loss_scaling(optimizer, loss_scaling)
 
         if backend_config.use_ideep == 'always':
             if not intel64.is_ideep_available():
@@ -89,6 +90,16 @@ class LinearModel(object):
         with chainer.using_device(backend_config.device):
             return self._train_linear_classifier(
                 model, optimizer, backend_config)
+
+
+def _optimizer_loss_scaling(optimizer, loss_scaling):
+    if loss_scaling not in [False, 'dynamic', 'static']:
+        msg = 'loss_scaling must be False, \'dynamic\' or \'static\'.'
+        raise ValueError(msg)
+    if loss_scaling is 'dynamic':
+        optimizer.loss_scaling()
+    elif loss_scaling is 'static':
+        optimizer.loss_scaling(scale=10.0)
 
 
 _inject_backend_tests = (
@@ -110,6 +121,8 @@ _inject_backend_tests = (
 
 class OptimizerTestBase(object):
 
+    loss_scaling = False
+
     def create(self):
         raise NotImplementedError()
 
@@ -117,10 +130,24 @@ class OptimizerTestBase(object):
         self.model = LinearModel(self.create(), self.dtype,
                                  self.use_placeholder)
 
+    def skip_loss_scaling(self, backend_config=None):
+        if self.loss_scaling is not False:
+            if self.dtype != numpy.float16:
+                msg = 'loss_scaling is tested when dtype is float16.'
+                return True, msg
+            if backend_config is not None and not backend_config.use_cuda:
+                msg = 'loss_scaling is tested when use_cuda is True.'
+                return True, msg
+        return False, None
+
     @condition.retry(10)
     def test_linear_model(self, backend_config):
+        skip, msg = self.skip_loss_scaling(backend_config)
+        if skip:
+            return unittest.SkipTest(msg)
         try:
-            accuracy = self.model.accuracy(backend_config)
+            accuracy = self.model.accuracy(backend_config,
+                                           self.loss_scaling)
         except Skipped:
             # TODO(niboshi): This is temporary workaround.
             # See the comment on Skipped.
@@ -133,17 +160,24 @@ class OptimizerTestBase(object):
     def test_linear_model_multi_gpu(self):
         backend_config = backend.BackendConfig(
             {'use_cuda': True, 'cuda_device': 1})
+        skip, msg = self.skip_loss_scaling(backend_config)
+        if skip:
+            return unittest.SkipTest(msg)
         with cuda.Device(0):
             accuracy = self.model.accuracy(backend_config)
         self.assertGreater(cuda.to_cpu(accuracy.data), 0.9)
 
     @attr.multi_gpu(2)
     def test_model_setup_multi_gpu(self):
+        skip, msg = self.skip_loss_scaling()
+        if skip:
+            return unittest.SkipTest(msg)
         with cuda.Device(0):
             model = self.model.model
             optimizer = self.model.optimizer
             model.to_gpu(1)
             optimizer.setup(model)
+            _optimizer_loss_scaling(optimizer, self.loss_scaling)
         # Initialize the optimizer state by running an update
         for param in optimizer.target.params(False):
             param.cleargrad()
@@ -152,10 +186,14 @@ class OptimizerTestBase(object):
                 self.assertEqual(int(param.data.device), int(v.device))
 
     def test_initialize(self):
+        skip, msg = self.skip_loss_scaling()
+        if skip:
+            return unittest.SkipTest(msg)
         model = self.model.model
         assert isinstance(model, chainer.Link)
         optimizer = self.create()
         optimizer.setup(model)
+        _optimizer_loss_scaling(optimizer, self.loss_scaling)
 
         msg = 'optimization target must be a link'
         with six.assertRaisesRegex(self, TypeError, msg):
@@ -165,6 +203,7 @@ class OptimizerTestBase(object):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestAdaDelta(OptimizerTestBase, unittest.TestCase):
@@ -176,6 +215,7 @@ class TestAdaDelta(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestAdaGrad(OptimizerTestBase, unittest.TestCase):
@@ -187,6 +227,7 @@ class TestAdaGrad(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestAdam(OptimizerTestBase, unittest.TestCase):
@@ -202,6 +243,7 @@ class TestAdam(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestCorrectedMomentumSGD(OptimizerTestBase, unittest.TestCase):
@@ -213,6 +255,7 @@ class TestCorrectedMomentumSGD(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestMomentumSGD(OptimizerTestBase, unittest.TestCase):
@@ -224,6 +267,7 @@ class TestMomentumSGD(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestMSVAG(OptimizerTestBase, unittest.TestCase):
@@ -235,6 +279,7 @@ class TestMSVAG(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class NesterovAG(OptimizerTestBase, unittest.TestCase):
@@ -247,6 +292,7 @@ class NesterovAG(OptimizerTestBase, unittest.TestCase):
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
     'eps_inside_sqrt': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestRMSprop(OptimizerTestBase, unittest.TestCase):
@@ -261,6 +307,7 @@ class TestRMSprop(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestRMSpropGraves(OptimizerTestBase, unittest.TestCase):
@@ -272,6 +319,7 @@ class TestRMSpropGraves(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestSGD(OptimizerTestBase, unittest.TestCase):
@@ -283,6 +331,7 @@ class TestSGD(OptimizerTestBase, unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
+    'loss_scaling': [False, 'static', 'dynamic'],
 }))
 @_inject_backend_tests
 class TestSMORMS3(OptimizerTestBase, unittest.TestCase):


### PR DESCRIPTION
This PR aims to support "dynamic" loss scaling.

Loss scaling is already available with current Chainer, but it is "static" loss scaling. You have to select an appropriate loss scaling factor before training, hence becoming kind of hyper parameter.

With this PR, there is no need to select scaling factor in advance. The appropriate scaling factor is dynamically determined by just adding following line to your training script.

    optimizer.loss_scaling('dynamic', interval=1000)

When "dynamic" loss scaling is enabled, whole grads of parameters are checked every iteration, more specifically after backward() and before update() to see if there are NaNs in the grads. Initially the scaling factor is set to 1 and it will be doubled every iteration as long as there is no NaN in the grads. Once NaN is detected in the grads, the scaling factor will get halved. After that, the scaling factor is slowly increased every iteration so that it gets doubled in the specified "interval".

"Static" loss scaling is also supported and can be used as follows.

    optimizer.loss_scaling('static', loss_scale=100.0)

Considering compatibility, `optimizer.use_loss_scale(100.0)` is also available.  