### PR TITLE
change backward of `F.log_ndtr` to avoid nan

### DIFF
--- a/chainer/functions/math/log_ndtr.py
+++ b/chainer/functions/math/log_ndtr.py
@@ -2,8 +2,7 @@ import numpy
 
 from chainer.backends import cuda
 from chainer import function_node
-from chainer.functions.math import exponential
-from chainer.functions.math import ndtr
+from chainer.functions.math import erfcx
 from chainer import utils
 from chainer.utils import type_check
 
@@ -50,8 +49,7 @@ class LogNdtr(function_node.FunctionNode):
 
     def backward(self, indexes, gy):
         x = self.get_retained_inputs()[0]
-        return (2 * numpy.pi) ** -0.5 * exponential.exp(-0.5 * x ** 2) \
-            / ndtr.ndtr(x) * gy[0],
+        return (2 / numpy.pi) ** 0.5 / erfcx.erfcx(- x / 2 ** 0.5) * gy[0],
 
 
 def log_ndtr(x):


### PR DESCRIPTION
If we use `chainer.functions.log_ndtr` of now implementation, we may get nan variable,
```
>>> x = cupy.linspace(-20, -10, 11).astype(np.float32)
>>> x = chainer.Variable(x)
>>> y = chainer.functions.log_ndtr(x)
>>> chainer.grad([y], [x])
[variable([      nan,       nan,       nan,       nan,       nan,       nan,
                 nan,       inf, 12.082214, 11.089464, 10.098132])]
```

so, I fixed this.
```
>>> x = cupy.linspace(-20, -10, 11).astype(np.float32)
>>> x = chainer.Variable(x)
>>> y = chainer.functions.log_ndtr(x)
>>> chainer.grad([y], [x])
[variable([20.049751, 19.052343, 18.055216, 17.058424, 16.062021, 15.066087,
          14.070718, 13.076037, 12.082214, 11.089464, 10.098093])]
```