### PR TITLE
Fix dali_util in imagenet example for fp16

### DIFF
--- a/examples/imagenet/dali_util.py
+++ b/examples/imagenet/dali_util.py
@@ -146,7 +146,7 @@ class DaliConverter(object):
                 # copy data from DALI array to CuPy array
                 x.copy_to_external(ctypes.c_void_p(x_cupy.data.ptr))
                 cuda.cupy.cuda.runtime.deviceSynchronize()
-                x = x_cupy
+                x = x_cupy.astype(chainer.get_dtype())
                 if self.perturbation is not None:
                     x = x - self.perturbation
                 if device is not None and device < 0:
@@ -177,7 +177,7 @@ def dali_converter(inputs, device=None):
             # copy data from DALI array to CuPy array
             x.copy_to_external(ctypes.c_void_p(x_cupy.data.ptr))
             cuda.cupy.cuda.runtime.deviceSynchronize()
-            x = x_cupy
+            x = x_cupy.astype(chainer.get_dtype())
             if device is not None and device < 0:
                 x = cuda.to_cpu(x)
         else:


### PR DESCRIPTION
This PR aims to fix dtype mismatch issue in imagenet example when DALI and fp16 (chainer.config.dtype = float16) are used together.