### PR TITLE
Avoid `# NOQA` in docstrings (cont.)

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -672,7 +672,8 @@ def _zero_if_none(xp, x, shape, dtype):
 
 
 def batch_normalization(x, gamma, beta, **kwargs):
-    """batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None, running_var=None, decay=0.9, axis=None)
+    """batch_normalization(x, gamma, beta, eps=2e-5, running_mean=None, \
+running_var=None, decay=0.9, axis=None)
 
     Batch normalization function.
 
@@ -734,7 +735,7 @@ def batch_normalization(x, gamma, beta, **kwargs):
 
     .. seealso:: :class:`~chainer.links.BatchNormalization`
 
-    """  # NOQA
+    """
 
     eps, running_mean, running_var, decay, axis = argument.parse_kwargs(
         kwargs, ('eps', 2e-5), ('running_mean', None),

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -48,7 +48,7 @@ class NStepRNNBase(link.ChainList):
         :func:`chainer.links.NStepBiRNNReLU`
         :func:`chainer.links.NStepBiRNNTanh`
 
-    """  # NOQA
+    """
 
     def __init__(self, n_layers, in_size, out_size, dropout, **kwargs):
         if kwargs:


### PR DESCRIPTION
#6184 missed these docstrings.  I found these when I made its backport PR.

```
% grep '" *# *NOQA' **/*.py
chainer/link.py:        """  # NOQA
chainer/link.py:        """  # NOQA
chainerx/testing/helper.py:    """  # NOQA
```
I left these because they have long summary lines.