### PR TITLE
Fix `str.join` `TypeError` in `FunctionTestCase` helper

### DIFF
--- a/chainer/testing/function.py
+++ b/chainer/testing/function.py
@@ -397,7 +397,8 @@ def _check_variable_types(vars, device, func_name):
             '{}() must return a tuple of Variables of arrays supported by '
             'device {}.\n'
             'Actual: {}'.format(
-                func_name, device, ', '.join(type(a.array) for a in vars)))
+                func_name, device,
+                ', '.join(str(type(a.array)) for a in vars)))
 
 
 def _check_forward_output_arrays_equal(


### PR DESCRIPTION
Fixes a typical `TypeError` when joining non `str`s. 

E.g.
```
In [1]: ''.join(type(i) for i in [1,2,3])
...
TypeError: sequence item 0: expected str instance, type found
```