### PR TITLE
Add AdaBound (and AMSBound)

### DIFF
--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -235,9 +235,9 @@ class AdamRule(optimizer.UpdateRule):
                        m += one_minus_beta1 * (grad_ - m);
                        v += one_minus_beta2 * (grad_ * grad - v);
                        vhat = max(vhat, v);
-                       param -= eta * (m * max(lower, min(upper, alpha_t /
-                                       (sqrt(vhat) + eps))) +
-                                       weight_decay_rate * param);''',
+                       param -= eta *
+                           (max(min(alpha_t / (sqrt(vhat) + eps), upper),
+                                lower) * m + weight_decay_rate * param);''',
                     'amsbound')
             AdamRule._amsbound_kernel(
                 grad, self.alpha_t, 1 - hp.beta1,
@@ -255,9 +255,9 @@ class AdamRule(optimizer.UpdateRule):
                     '''T grad_ = static_cast<T>(grad);
                        m += one_minus_beta1 * (grad_ - m);
                        v += one_minus_beta2 * (grad_ * grad_ - v);
-                       param -= eta * (m * max(lower, min(upper, alpha_t /
-                                       (sqrt(v) + eps))) +
-                                       weight_decay_rate * param);''',
+                       param -= eta *
+                           (max(min(alpha_t / (sqrt(v) + eps), upper),
+                                lower) * m + weight_decay_rate * param);''',
                     'adabound')
             AdamRule._adabound_kernel(
                 grad, self.alpha_t, 1 - hp.beta1,

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -111,7 +111,7 @@ class AdamRule(optimizer.UpdateRule):
         amsgrad (bool): Whether to use the AMSGrad variant of Adam.
         adabound (bool): Whether to use the AdaBound variant of Adam.
         final_lr (float): Final (SGD) learning rate in AdaBound.
-        gamma (float): convergence speed of the bound functions in adabound.
+        gamma (float): Convergence speed of the bound functions in AdaBound.
 
     """
     _kernel = None

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -364,7 +364,7 @@ class Adam(optimizer.GradientMethod):
         amsgrad (bool): Whether to use AMSGrad variant of Adam.
         adabound (bool): Whether to use the AdaBound variant of Adam.
         final_lr (float): Final (SGD) learning rate in AdaBound.
-        gamma (float): convergence speed of the bound functions in adabound.
+        gamma (float): Convergence speed of the bound functions in AdaBound.
 
     """
 

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -363,7 +363,7 @@ class Adam(optimizer.GradientMethod):
         weight_decay_rate (float): Weight decay rate.
         amsgrad (bool): Whether to use AMSGrad variant of Adam.
         adabound (bool): Whether to use the AdaBound variant of Adam.
-        final_lr (float): final (SGD) learning rate in adabound.
+        final_lr (float): Final (SGD) learning rate in AdaBound.
         gamma (float): convergence speed of the bound functions in adabound.
 
     """

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -321,6 +321,8 @@ class AdamRule(optimizer.UpdateRule):
                 'Can\'t determine the bounds of AdaBound optimizer '
                 'because the update steps have not been started.')
         hp = self.hyperparam
+        # Workaround to reflect changing `alpha` in `final_lr`.
+        # (by some of `chainer.training.extensions`)
         final_lr = hp.final_lr * hp.alpha / self.state['initial_alpha']
         lower = final_lr * (1.0 - 1.0 / (hp.gamma * self.t + 1))
         upper = final_lr * (1.0 + 1.0 / (hp.gamma * self.t))

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -153,7 +153,8 @@ class AdamRule(optimizer.UpdateRule):
             self.hyperparam.gamma = gamma
 
     def init_state(self, param):
-        self.state['initial_alpha'] = self.hyperparam.alpha
+        if self.hyperparam.adabound:
+            self.state['initial_alpha'] = self.hyperparam.alpha
         xp = backend.get_array_module(param.data)
         with cuda.get_device_from_array(param.data):
             self.state['m'] = xp.zeros_like(param.data)

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -110,7 +110,7 @@ class AdamRule(optimizer.UpdateRule):
         weight_decay_rate (float): Weight decay rate.
         amsgrad (bool): Whether to use the AMSGrad variant of Adam.
         adabound (bool): Whether to use the AdaBound variant of Adam.
-        final_lr (float): final (SGD) learning rate in adabound.
+        final_lr (float): Final (SGD) learning rate in AdaBound.
         gamma (float): convergence speed of the bound functions in adabound.
 
     """

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -151,10 +151,10 @@ class AdamRule(optimizer.UpdateRule):
             self.hyperparam.final_lr = final_lr
         if gamma is not None:
             self.hyperparam.gamma = gamma
+        if self.hyperparam.adabound:
+            self.initial_alpha = self.hyperparam.alpha
 
     def init_state(self, param):
-        if self.hyperparam.adabound:
-            self.state['initial_alpha'] = self.hyperparam.alpha
         xp = backend.get_array_module(param.data)
         with cuda.get_device_from_array(param.data):
             self.state['m'] = xp.zeros_like(param.data)
@@ -323,7 +323,7 @@ class AdamRule(optimizer.UpdateRule):
         hp = self.hyperparam
         # Workaround to reflect changing `alpha` in `final_lr`.
         # (by some of `chainer.training.extensions`)
-        final_lr = hp.final_lr * hp.alpha / self.state['initial_alpha']
+        final_lr = hp.final_lr * hp.alpha / self.initial_alpha
         lower = final_lr * (1.0 - 1.0 / (hp.gamma * self.t + 1))
         upper = final_lr * (1.0 + 1.0 / (hp.gamma * self.t))
         return lower, upper

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -202,7 +202,11 @@ class AdamRule(optimizer.UpdateRule):
 
         if hp.amsgrad:
             vhat = self.state['vhat']
-            numpy.maximum(vhat, v, out=vhat)
+            # For iDeep
+            if isinstance(vhat, intel64.mdarray):
+                vhat = numpy.maximum(vhat, v)
+            else:
+                numpy.maximum(vhat, v, out=vhat)
         else:
             vhat = v
         vhat = vhat.astype(dtype, copy=False)

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -168,6 +168,9 @@ class AdamRule(optimizer.UpdateRule):
                 self.state['m'], itype=intel64.ideep.wgt_array)
             self.state['v'] = intel64.ideep.array(
                 self.state['v'], itype=intel64.ideep.wgt_array)
+            if self.hyperparam.amsgrad:
+                self.state['vhat'] = intel64.ideep.array(
+                    self.state['vhat'], itype=intel64.ideep.wgt_array)
 
     def _check_eps(self, interm_dtype):
         # Checks that the eps does not underflow.

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -239,7 +239,7 @@ class TestAdam(OptimizerTestBase, unittest.TestCase):
             'amsgrad': self.amsgrad,
             'adabound': self.adabound,
         }
-        return optimizers.Adam(0.05, kwargs)
+        return optimizers.Adam(0.05, **kwargs)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -239,7 +239,7 @@ class TestAdam(OptimizerTestBase, unittest.TestCase):
             'amsgrad': self.amsgrad,
             'adabound': self.adabound,
         }
-        return optimizers.Adam(0.05)
+        return optimizers.Adam(0.05, kwargs)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -237,7 +237,7 @@ class TestAdam(OptimizerTestBase, unittest.TestCase):
     def create(self):
         kwargs = {
             'amsgrad': self.amsgrad,
-            'adabound': self.adabound
+            'adabound': self.adabound,
         }
         return optimizers.Adam(0.05)
 

--- a/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers_by_linear_model.py
@@ -228,11 +228,17 @@ class TestAdaGrad(OptimizerTestBase, unittest.TestCase):
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'use_placeholder': [False, True],
     'loss_scaling': [False, 'static', 'dynamic'],
+    'amsgrad': [False, True],
+    'adabound': [False, True],
 }))
 @_inject_backend_tests
 class TestAdam(OptimizerTestBase, unittest.TestCase):
 
     def create(self):
+        kwargs = {
+            'amsgrad': self.amsgrad,
+            'adabound': self.adabound
+        }
         return optimizers.Adam(0.05)
 
 


### PR DESCRIPTION
This PR adds [AdaBound (ICLR2019)](https://openreview.net/forum?id=Bkg3g2R9FX).
This PR is the same as #6367, but the learning progress is confirmed in the local environment.
Note: The parameter `final_lr_rate` is different formation from original paper for exclusion of redundant calculation,
`final_lr_rate = alpha_star / alpha`.