### PR TITLE
Simplify `F.flipud` test

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_flipud.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_flipud.py
@@ -1,62 +1,45 @@
-import unittest
-
 import numpy
 
-import chainer
-from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
-from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product({
     'shape': [(3,), (3, 4)],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestFlipUD(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestFlipUD(testing.FunctionTestCase):
 
-    def setUp(self):
-        self.x = numpy.random.uniform(0, 1, self.shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(0, 1, self.shape).astype(self.dtype)
-        self.ggx = numpy.random.uniform(0, 1, self.shape).astype(self.dtype)
+    def generate_inputs(self):
+        x = numpy.random.uniform(0, 1, self.shape).astype(self.dtype)
+        return x,
 
-    def check_forward(self, x_data):
-        x = chainer.Variable(x_data)
-        y = functions.flipud(x)
+    def forward_expected(self, inputs):
+        x, = inputs
+        y = numpy.flipud(x)
+        return y,
 
-        testing.assert_allclose(y.data, numpy.flipud(self.x))
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(
-            functions.flipud, x_data, y_grad, dtype=numpy.float64)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        gradient_check.check_double_backward(
-            functions.flipud, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
-            atol=5e-4, rtol=5e-3)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.gy, self.ggx)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy),
-                                   cuda.to_gpu(self.ggx))
+    def forward(self, inputs, device):
+        x, = inputs
+        return functions.flipud(x),
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Simplifies `test_flipud` using `testing.FunctionTestCase`

Solves part of issue #6071
