### PR TITLE
Fix examples/.gitignore

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,1 +1,1 @@
-result/
+**/result/

--- a/examples/mnist/.gitignore
+++ b/examples/mnist/.gitignore
@@ -1,16 +1,2 @@
-graph.dot
-graph.wo_split.dot
-mlp.model
-mlp.state
-mnist.pkl
-accuracy.png
-cg.dot
-log
-loss.png
-snapshot_iter_12000
-t10k-images-idx3-ubyte.gz
-t10k-labels-idx1-ubyte.gz
-train-images-idx3-ubyte.gz
-train-labels-idx1-ubyte.gz
 result_data_parallel/
 result_model_parallel/


### PR DESCRIPTION
Current `examples/.gitignore` added by https://github.com/chainer/chainer/pull/2205 only ignores examples/result.
But I don't think this is expected behavior because every single example folder like `'mnist'` and `'dcgan'` has `README.md` and some users would run an experiment in one specific example folder.

IMO, it is natural to assume users to run a MNIST example by `python train_mnist.py ...` instead of `python mnist/train_mnist.py ...`.