### PR TITLE
Simplify `F.moveaxis` test

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_moveaxis.py
@@ -3,10 +3,8 @@ import unittest
 import numpy
 import six
 
-import chainer
 from chainer import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.utils import type_check
@@ -42,60 +40,45 @@ def _moveaxis(a, source, destination):
     {'source': (0, 2), 'destination': (1, 0), 'out_shape': (4, 2, 3)},
     {'source': (0, -1), 'destination': (-1, 1), 'out_shape': (3, 4, 2)},
 )
-class TestMoveaxis(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestMoveaxis(testing.FunctionTestCase):
 
     dtype = numpy.float32
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
-        self.g = numpy.random.uniform(-1, 1, self.out_shape).astype(self.dtype)
-        self.gg = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
         self.check_backward_options = {}
         self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
 
-    def check_forward(self, x_data):
-        x = chainer.Variable(x_data)
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
+        return x,
+
+    def forward(self, inputs, device):
+        x, = inputs
         y = functions.moveaxis(x, self.source, self.destination)
+        return y,
 
-        expect = _moveaxis(self.x, self.source, self.destination)
-        testing.assert_allclose(y.data, expect)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    def check_backward(self, x_data, g_data):
-        def f(x):
-            return functions.moveaxis(x, self.source, self.destination)
-
-        gradient_check.check_backward(
-            f, x_data, g_data, dtype='d', **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.g)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g))
-
-    def check_double_backward(self, x_data, g_data, gg_data):
-        def f(x):
-            return functions.moveaxis(x, self.source, self.destination)
-
-        gradient_check.check_double_backward(
-            f, x_data, g_data, gg_data, dtype='d',
-            **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.g, self.gg)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g),
-                                   cuda.to_gpu(self.gg))
+    def forward_expected(self, inputs):
+        x, = inputs
+        y_expect = _moveaxis(x, self.source, self.destination)
+        return y_expect,
 
 
 @testing.parameterize(


### PR DESCRIPTION
Simplifies `test_moveaxis` using `testing.FunctionTestCase`

Solves part of issue #6071
