### PR TITLE
Improve chainer examples

### DIFF
--- a/examples/dcgan/train_dcgan.py
+++ b/examples/dcgan/train_dcgan.py
@@ -24,7 +24,7 @@ def main():
                         help='Directory of image files.  Default is cifar-10.')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', type=str,
                         help='Resume the training from snapshot')
     parser.add_argument('--n_hidden', '-n', type=int, default=100,
                         help='Number of hidden units (z)')
@@ -108,7 +108,7 @@ def main():
             10, 10, args.seed, args.out),
         trigger=snapshot_interval)
 
-    if args.resume:
+    if args.resume is not None:
         # Resume from a snapshot
         chainer.serializers.load_npz(args.resume, trainer)
 

--- a/examples/image_captioning/train.py
+++ b/examples/image_captioning/train.py
@@ -16,6 +16,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--out', type=str, default='result',
                         help='Output directory')
+    parser.add_argument('--resume', '-r', type=str,
+                        help='Resume the training from snapshot')
     parser.add_argument('--mscoco-root', type=str, default='data',
                         help='MSOCO dataset root directory')
     parser.add_argument('--max-iters', type=int, default=50000,
@@ -133,10 +135,17 @@ def main():
     # Save model snapshots so that later on, we can load them and generate new
     # captions for any image. This can be done in the `predict.py` script
     trainer.extend(
+        extensions.snapshot(filename='snapshot_{.updater.iteration}'),
+        trigger=(args.snapshot_iter, 'iteration')
+    )
+    trainer.extend(
         extensions.snapshot_object(model, 'model_{.updater.iteration}'),
         trigger=(args.snapshot_iter, 'iteration')
     )
     trainer.extend(extensions.ProgressBar())
+
+    if args.resume is not None:
+        chainer.serializers.load_npz(args.resume, trainer)
     trainer.run()
 
 

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -61,7 +61,7 @@ def main():
                         'negative integer, NumPy arrays are used')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', type=str,
                         help='Resume the training from snapshot')
     parser.add_argument('--unit', '-u', type=int, default=1000,
                         help='Number of units')
@@ -141,7 +141,7 @@ def main():
     # Print a progress bar to stdout
     trainer.extend(extensions.ProgressBar())
 
-    if args.resume:
+    if args.resume is not None:
         # Resume from a snapshot
         chainer.serializers.load_npz(args.resume, trainer)
 

--- a/examples/mnist/train_mnist_custom_loop.py
+++ b/examples/mnist/train_mnist_custom_loop.py
@@ -52,7 +52,7 @@ def main():
                         'negative integer, NumPy arrays are used')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', type=str,
                         help='Resume the training from snapshot using model '
                              'and state files in the specified directory')
     parser.add_argument('--unit', '-u', type=int, default=1000,
@@ -79,10 +79,17 @@ def main():
     optimizer = chainer.optimizers.Adam()
     optimizer.setup(model)
 
-    if args.resume:
+    if args.resume is not None:
         # Resume from a snapshot
-        serializers.load_npz('{}/mlp.model'.format(args.resume), model)
-        serializers.load_npz('{}/mlp.state'.format(args.resume), optimizer)
+        resume = args.resume
+        if os.path.exists(resume):
+            serializers.load_npz(os.path.join(resume, 'mlp.model'), model)
+            serializers.load_npz(os.path.join(resume, 'mlp.state'), optimizer)
+        else:
+            raise ValueError(
+                '`args.resume` ("{}") is specified,'
+                ' but it does not exist'.format(resume)
+            )
 
     # Load the MNIST dataset
     train, test = chainer.datasets.get_mnist()
@@ -129,12 +136,13 @@ def main():
             sum_loss = 0
 
     # Save the model and the optimizer
-    if not os.path.exists(args.out):
-        os.makedirs(args.out)
+    out = args.out
+    if not os.path.isdir(out):
+        os.makedirs(out)
     print('save the model')
-    serializers.save_npz('{}/mlp.model'.format(args.out), model)
+    serializers.save_npz(os.path.join(out, 'mlp.model'), model)
     print('save the optimizer')
-    serializers.save_npz('{}/mlp.state'.format(args.out), optimizer)
+    serializers.save_npz(os.path.join(out, 'mlp.state'), optimizer)
 
 
 if __name__ == '__main__':

--- a/examples/pix2pix/train_facade.py
+++ b/examples/pix2pix/train_facade.py
@@ -31,7 +31,7 @@ def main():
                         help='Directory of image files.')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', type=str,
                         help='Resume the training from snapshot')
     parser.add_argument('--seed', type=int, default=0,
                         help='Random seed')
@@ -106,7 +106,7 @@ def main():
             5, 5, args.seed, args.out),
         trigger=snapshot_interval)
 
-    if args.resume:
+    if args.resume is not None:
         # Resume from a snapshot
         chainer.serializers.load_npz(args.resume, trainer)
 

--- a/examples/ptb/train_ptb.py
+++ b/examples/ptb/train_ptb.py
@@ -184,7 +184,7 @@ def main():
                         help='Gradient norm threshold to clip')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', type=str,
                         help='Resume the training from snapshot')
     parser.add_argument('--test', action='store_true',
                         help='Use tiny datasets for quick tests')
@@ -245,7 +245,7 @@ def main():
     trainer.extend(extensions.snapshot())
     trainer.extend(extensions.snapshot_object(
         model, 'model_iter_{.updater.iteration}'))
-    if args.resume:
+    if args.resume is not None:
         chainer.serializers.load_npz(args.resume, trainer)
 
     trainer.run()

--- a/examples/seq2seq/seq2seq.py
+++ b/examples/seq2seq/seq2seq.py
@@ -247,9 +247,9 @@ def main():
                         help='number of sentence pairs in each mini-batch')
     parser.add_argument('--epoch', '-e', type=int, default=20,
                         help='number of sweeps over the dataset to train')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', type=str,
                         help='resume the training from snapshot')
-    parser.add_argument('--save', '-s', default='',
+    parser.add_argument('--save', '-s', type=str,
                         help='save a snapshot of the training')
     parser.add_argument('--unit', '-u', type=int, default=1024,
                         help='number of units')
@@ -375,6 +375,10 @@ def main():
          'validation/main/bleu', 'elapsed_time']),
         trigger=(args.log_interval, 'iteration'))
 
+    trainer.extend(
+        extensions.snapshot(filename='snapshot_epoch_{.updater.iteration}'),
+        trigger=(args.validation_interval, 'iteration'))
+
     if args.validation_source and args.validation_target:
         test_source = load_data(source_ids, args.validation_source)
         test_target = load_data(target_ids, args.validation_target)
@@ -411,14 +415,14 @@ def main():
                 model, test_data, 'validation/main/bleu', device),
             trigger=(args.validation_interval, 'iteration'))
 
-    print('start training')
-    if args.resume:
+    if args.resume is not None:
         # Resume from a snapshot
         chainer.serializers.load_npz(args.resume, trainer)
+    print('start training')
 
     trainer.run()
 
-    if args.save:
+    if args.save is not None:
         # Save a snapshot
         chainer.serializers.save_npz(args.save, trainer)
 

--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -15,9 +15,9 @@ import net
 
 def main():
     parser = argparse.ArgumentParser(description='Chainer example: VAE')
-    parser.add_argument('--initmodel', '-m', default='',
+    parser.add_argument('--initmodel', '-m', type=str,
                         help='Initialize the model from given file')
-    parser.add_argument('--resume', '-r', default='',
+    parser.add_argument('--resume', '-r', type=str,
                         help='Resume the optimization from snapshot')
     parser.add_argument('--gpu', '-g', default=-1, type=int,
                         help='GPU ID (negative value indicates CPU)')
@@ -64,7 +64,7 @@ def main():
     optimizer.setup(avg_elbo_loss)
 
     # Initialize
-    if args.initmodel:
+    if args.initmodel is not None:
         chainer.serializers.load_npz(args.initmodel, avg_elbo_loss)
 
     # Load the MNIST dataset
@@ -100,7 +100,7 @@ def main():
          'main/reconstr', 'main/kl_penalty', 'elapsed_time']))
     trainer.extend(extensions.ProgressBar())
 
-    if args.resume:
+    if args.resume is not None:
         chainer.serializers.load_npz(args.resume, trainer)
 
     # Run the training

--- a/examples/word2vec/search.py
+++ b/examples/word2vec/search.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python
+import argparse
+import os
+
 import numpy
 import six
 
 n_result = 5  # number of search result to show
 
 
-with open('word2vec.model', 'r') as f:
+parser = argparse.ArgumentParser()
+parser.add_argument('--result', default='result',
+                    help='Directory of a training result')
+args = parser.parse_args()
+
+
+with open(os.path.join(args.result, 'word2vec.model'), 'r') as f:
     ss = f.readline().split()
     n_vocab, n_units = int(ss[0]), int(ss[1])
     word2index = {}

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -5,9 +5,10 @@ This code implements skip-gram model and continuous-bow model.
 """
 import argparse
 import collections
+import os
+import six
 
 import numpy as np
-import six
 
 import chainer
 from chainer.backends import cuda
@@ -172,13 +173,20 @@ def main():
                         'no approximation)')
     parser.add_argument('--out', default='result',
                         help='Directory to output the result')
+    parser.add_argument('--resume', '-r', type=str,
+                        help='Resume the training from snapshot')
+    parser.add_argument('--snapshot-interval', type=int,
+                        help='Interval of snapshots')
     parser.add_argument('--test', dest='test', action='store_true')
     parser.set_defaults(test=False)
     args = parser.parse_args()
 
     if args.gpu >= 0:
-        chainer.backends.cuda.get_device_from_id(args.gpu).use()
         cuda.check_cuda_available()
+
+    if args.snapshot_interval is None:
+        args.snapshot_interval = args.epoch
+    args.snapshot_interval = min(args.snapshot_interval, args.epoch)
 
     print('GPU: {}'.format(args.gpu))
     print('# unit: {}'.format(args.unit))
@@ -228,6 +236,7 @@ def main():
         raise Exception('Unknown model type: {}'.format(args.model))
 
     if args.gpu >= 0:
+        cuda.get_device_from_id(args.gpu).use()
         model.to_gpu()
 
     # Set up an optimizer
@@ -251,10 +260,17 @@ def main():
     trainer.extend(extensions.PrintReport(
         ['epoch', 'main/loss', 'validation/main/loss']))
     trainer.extend(extensions.ProgressBar())
+
+    trainer.extend(
+        extensions.snapshot(filename='snapshot_epoch_{.updater.epoch}'),
+        trigger=(args.snapshot_interval, 'epoch'))
+
+    if args.resume is not None:
+        chainer.serializers.load_npz(args.resume, trainer)
     trainer.run()
 
     # Save the word2vec model
-    with open('word2vec.model', 'w') as f:
+    with open(os.path.join(args.out, 'word2vec.model'), 'w') as f:
         f.write('%d %d\n' % (len(index2word), args.unit))
         w = cuda.to_cpu(model.embed.W.array)
         for i, wi in enumerate(w):

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -137,8 +137,8 @@ class WindowIterator(chainer.dataset.Iterator):
                                            self.current_position)
         self.epoch = serializer('epoch', self.epoch)
         self.is_new_epoch = serializer('is_new_epoch', self.is_new_epoch)
-        if self._order is not None:
-            serializer('_order', self._order)
+        if self.order is not None:
+            serializer('order', self.order)
 
 
 def convert(batch, device):


### PR DESCRIPTION
This PR partially accesses #6398 and related to #3500 and #6378.

- Avoid comparisons with empty string by setting `args.resume` as `None` by default.
- Extend `Trainer` instance with `extensions.snapshot`
- [custom loop] Fix ignorance of `args.resume` and add messages to be more user-friendly.
