### PR TITLE
Suppress warning in caffe test

### DIFF
--- a/tests/chainer_tests/exporters_tests/test_caffe.py
+++ b/tests/chainer_tests/exporters_tests/test_caffe.py
@@ -1,13 +1,20 @@
 import os
 import unittest
+import warnings
 
 import numpy
 
 import chainer
-from chainer.exporters import caffe
 import chainer.functions as F
 import chainer.links as L
 from chainer import testing
+
+
+# The caffe submodule relies on protobuf which under protobuf==3.7.0 and
+# Python 3.7 raises a DeprecationWarning from the collections module.
+with warnings.catch_warnings():
+    warnings.filterwarnings(action='ignore', category=DeprecationWarning)
+    from chainer.exporters import caffe
 
 
 # @testing.parameterize([

--- a/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
+++ b/tests/chainer_tests/links_tests/caffe_tests/test_caffe_function.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+import warnings
 
 import mock
 import numpy
@@ -8,9 +9,15 @@ import six
 
 import chainer
 from chainer import links
-from chainer.links import caffe
-from chainer.links.caffe.caffe_function import caffe_pb
 from chainer import testing
+
+
+# The caffe submodule relies on protobuf which under protobuf==3.7.0 and
+# Python 3.7 raises a DeprecationWarning from the collections module.
+with warnings.catch_warnings():
+    warnings.filterwarnings(action='ignore', category=DeprecationWarning)
+    from chainer.links import caffe
+    from chainer.links.caffe.caffe_function import caffe_pb
 
 
 def _iter_init(param, data):


### PR DESCRIPTION
This PR suppresses a `DeprecationWarning` raised by the Caffe function tests in Python 3.7 with `protobuf==3.7.0`.