### PR TITLE
Simplify `F.rollaxis` test

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_rollaxis.py
@@ -2,10 +2,8 @@ import unittest
 
 import numpy
 
-import chainer
 from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import attr
 from chainer.utils import type_check
@@ -22,60 +20,45 @@ from chainer.utils import type_check
     {'axis': 2, 'start': -3, 'out_shape': (4, 2, 3)},
     {'axis': 0, 'start': 0, 'out_shape': (2, 3, 4)},
 )
-class TestRollaxis(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestRollaxis(testing.FunctionTestCase):
 
     dtype = numpy.float32
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
-        self.g = numpy.random.uniform(-1, 1, self.out_shape).astype(self.dtype)
-        self.gg = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
         self.check_backward_options = {}
-        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+        self.check_double_backward_options.update({'atol': 1e-3, 'rtol': 1e-2})
 
-    def check_forward(self, x_data):
-        x = chainer.Variable(x_data)
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, (2, 3, 4)).astype(self.dtype)
+        return x,
+
+    def forward(self, inputs, device):
+        x, = inputs
         y = functions.rollaxis(x, self.axis, self.start)
+        return y,
 
-        expect = numpy.rollaxis(self.x, self.axis, self.start)
-        testing.assert_allclose(y.data, expect)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    def check_backward(self, x_data, g_data):
-        def f(x):
-            return functions.rollaxis(x, self.axis, self.start)
-
-        gradient_check.check_backward(
-            f, x_data, g_data, dtype='d', **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.g)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g))
-
-    def check_double_backward(self, x_data, g_data, gg_data):
-        def f(x):
-            return functions.rollaxis(x, self.axis, self.start)
-
-        gradient_check.check_double_backward(
-            f, x_data, g_data, gg_data, dtype='d',
-            **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.g, self.gg)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.g),
-                                   cuda.to_gpu(self.gg))
+    def forward_expected(self, inputs):
+        x, = inputs
+        y_expect = numpy.rollaxis(x, self.axis, self.start)
+        return y_expect,
 
 
 @testing.parameterize(


### PR DESCRIPTION
Simplifies `test_rollaxis` using `testing.FunctionTestCase`

solves part of issue #6071