### PR TITLE
Allow bool evaluation in `type_check`

### DIFF
--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -482,6 +482,12 @@ class BoolBinaryOperator(BinaryOperator, Testable):
                 '{0} {1} {2}'.format(self.lhs, self.exp, self.rhs),
                 '{0} {1} {2}'.format(left, self.inv, right))
 
+    def __bool__(self):
+        return self.eval()
+
+    def __nonzero__(self):
+        return self.__bool__()
+
 
 class InvalidType(Exception):
     """Raised when types of data for forward/backward are invalid.

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -289,18 +289,20 @@ class TestBoolBinaryOperator(unittest.TestCase):
 
     def test_eval(self):
         self.assertTrue(self.op1.eval())
+        self.assertFalse(self.op2.eval())
 
     def test_expect(self):
+        self.op1.expect()
         with self.assertRaises(T.InvalidType):
             self.op2.expect()
 
     def test_bool(self):
-        with self.assertRaises(RuntimeError):
-            bool(self.op1)
+        self.assertTrue(bool(self.op1))
+        self.assertFalse(bool(self.op2))
 
     def test_bool_operator(self):
-        with self.assertRaises(RuntimeError):
-            not self.op1
+        self.assertFalse(not self.op1)
+        self.assertTrue(not self.op2)
 
 
 class TestLazyGetItem(unittest.TestCase):


### PR DESCRIPTION
I think it's useful when debugging.

Without this, it's difficult to debug in `check_type_forward` because you cannot write something like
```py
if x_type.dtype == numpy.float32:
    print("OK")
```
which would result in:
```
RuntimeError: Don't convert Expr to bool. Please call Expr.eval method to evaluate expression.
```

You cannot write something like this either (which is suggested by the error message above):
```py
if (x_type.dtype == numpy.float32).eval():
    print("OK")
```
which would result in:
```
AttributeError: 'bool' object has no attribute 'eval'
```

That's because `check_type_forward` is called twice in different modes, with different way of evaluation.
This is not intuitive.