### PR TITLE
Fix `chainer.links.NStepRNN` and its variants

### DIFF
--- a/chainer/functions/connection/n_step_gru.py
+++ b/chainer/functions/connection/n_step_gru.py
@@ -268,10 +268,11 @@ use_bi_direction)
     xp = backend.get_array_module(hx, hx.data)
 
     if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
-        states = cuda.get_cudnn_dropout_states()
-        states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]
         xs = chainer.functions.concat(xs, axis=0)
+        with chainer.using_device(xs.device):
+            states = cuda.get_cudnn_dropout_states()
+            states.set_dropout_ratio(dropout_ratio)
 
         w = n_step_rnn.cudnn_rnn_weight_concat(
             n_layers, states, use_bi_direction, 'gru', ws, bs)

--- a/chainer/functions/connection/n_step_lstm.py
+++ b/chainer/functions/connection/n_step_lstm.py
@@ -418,10 +418,11 @@ def n_step_lstm_base(
         xp is chainerx and hx.device.device.backend.name == 'cuda')
 
     if use_cuda and chainer.should_use_cudnn('>=auto', 5000):
-        states = cuda.get_cudnn_dropout_states()
-        states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]
         xs = chainer.functions.concat(xs, axis=0)
+        with chainer.using_device(xs.device):
+            states = cuda.get_cudnn_dropout_states()
+            states.set_dropout_ratio(dropout_ratio)
 
         w = n_step_rnn.cudnn_rnn_weight_concat(
             n_layers, states, use_bi_direction, 'lstm', ws, bs)

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -120,10 +120,10 @@ class CudnnRNNWeightConcat(function.Function):
                         b_type.shape[0] == out_size,
                     )
 
-    def forward(self, inputs):
+    def forward_gpu(self, inputs):
         handle = cudnn.get_handle()
         ws_size = self.n_layers * self.rnn_direction * self.n_W
-        ws = inputs[0:ws_size]
+        ws = inputs[:ws_size]
         bs = inputs[ws_size:]
         out_size = ws[0].shape[0]
         in_size = ws[0].shape[1]
@@ -266,7 +266,7 @@ class BaseNStepRNN(function.Function):
             x_type.shape[0] == self.sections[-1],
         )
 
-    def forward(self, inputs):
+    def forward_gpu(self, inputs):
         if self.use_cell:
             # LSTM
             hx, cx, w, xs = inputs
@@ -644,29 +644,30 @@ use_bi_direction)
     xp = backend.get_array_module(hx)
 
     if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
-        states = cuda.get_cudnn_dropout_states()
-        states.set_dropout_ratio(dropout_ratio)
-        lengths = [len(x) for x in xs]
-        xs = chainer.functions.concat(xs, axis=0)
+        with cuda.get_device_from_array(xs):
+            states = cuda.get_cudnn_dropout_states()
+            states.set_dropout_ratio(dropout_ratio)
+            lengths = [len(x) for x in xs]
+            xs = chainer.functions.concat(xs, axis=0)
 
-        rnn_mode = 'rnn_%s' % activation
-        w = cudnn_rnn_weight_concat(
-            n_layers, states, use_bi_direction, rnn_mode, ws, bs)
+            rnn_mode = 'rnn_%s' % activation
+            w = cudnn_rnn_weight_concat(
+                n_layers, states, use_bi_direction, rnn_mode, ws, bs)
 
-        if use_bi_direction:
-            # Bi-directional RNN
-            if activation == 'tanh':
-                rnn = NStepBiRNNTanh
-            elif activation == 'relu':
-                rnn = NStepBiRNNReLU
-        else:
-            # Uni-directional RNN
-            if activation == 'tanh':
-                rnn = NStepRNNTanh
-            elif activation == 'relu':
-                rnn = NStepRNNReLU
+            if use_bi_direction:
+                # Bi-directional RNN
+                if activation == 'tanh':
+                    rnn = NStepBiRNNTanh
+                elif activation == 'relu':
+                    rnn = NStepBiRNNReLU
+            else:
+                # Uni-directional RNN
+                if activation == 'tanh':
+                    rnn = NStepRNNTanh
+                elif activation == 'relu':
+                    rnn = NStepRNNReLU
 
-        hy, ys = rnn(n_layers, states, lengths)(hx, w, xs)
+            hy, ys = rnn(n_layers, states, lengths)(hx, w, xs)
         sections = numpy.cumsum(lengths[:-1])
         ys = chainer.functions.split_axis(ys, sections, 0)
         return hy, ys

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -644,10 +644,11 @@ use_bi_direction)
     xp = backend.get_array_module(hx)
 
     if xp is cuda.cupy and chainer.should_use_cudnn('>=auto', 5000):
-        states = cuda.get_cudnn_dropout_states()
-        states.set_dropout_ratio(dropout_ratio)
         lengths = [len(x) for x in xs]
         xs = chainer.functions.concat(xs, axis=0)
+        with chainer.using_device(xs.device):
+            states = cuda.get_cudnn_dropout_states()
+            states.set_dropout_ratio(dropout_ratio)
 
         rnn_mode = 'rnn_%s' % activation
         w = cudnn_rnn_weight_concat(

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -183,7 +183,6 @@ class NStepRNNBase(link.ChainList):
 
         assert isinstance(xs, (list, tuple))
 
-        # with chainer.using_device(self.device):
         indices = argsort_list_descent(xs)
 
         xs = permutate_list(xs, indices, inv=False)

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -183,29 +183,29 @@ class NStepRNNBase(link.ChainList):
 
         assert isinstance(xs, (list, tuple))
 
-        with chainer.using_device(self.device):
-            indices = argsort_list_descent(xs)
+        # with chainer.using_device(self.device):
+        indices = argsort_list_descent(xs)
 
-            xs = permutate_list(xs, indices, inv=False)
-            hxs = []
-            for hx in hs:
-                if hx is None:
-                    hx = self.init_hx(xs)
-                else:
-                    hx = permutate.permutate(hx, indices, axis=1, inv=False)
-                hxs.append(hx)
+        xs = permutate_list(xs, indices, inv=False)
+        hxs = []
+        for hx in hs:
+            if hx is None:
+                hx = self.init_hx(xs)
+            else:
+                hx = permutate.permutate(hx, indices, axis=1, inv=False)
+            hxs.append(hx)
 
-            trans_x = transpose_sequence.transpose_sequence(xs)
+        trans_x = transpose_sequence.transpose_sequence(xs)
 
-            args = [self.n_layers, self.dropout] + hxs + \
-                   [self.ws, self.bs, trans_x]
-            result = self.rnn(*args)
+        args = [self.n_layers, self.dropout] + hxs + \
+               [self.ws, self.bs, trans_x]
+        result = self.rnn(*args)
 
-            hys = [permutate.permutate(h, indices, axis=1, inv=True)
-                   for h in result[:-1]]
-            trans_y = result[-1]
-            ys = transpose_sequence.transpose_sequence(trans_y)
-            ys = permutate_list(ys, indices, inv=True)
+        hys = [permutate.permutate(h, indices, axis=1, inv=True)
+               for h in result[:-1]]
+        trans_y = result[-1]
+        ys = transpose_sequence.transpose_sequence(trans_y)
+        ys = permutate_list(ys, indices, inv=True)
 
         return hys, ys
 

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -182,7 +182,6 @@ class NStepRNNBase(link.ChainList):
             argument.assert_kwargs_empty(kwargs)
 
         assert isinstance(xs, (list, tuple))
-
         indices = argsort_list_descent(xs)
 
         xs = permutate_list(xs, indices, inv=False)

--- a/chainer/links/connection/n_step_rnn.py
+++ b/chainer/links/connection/n_step_rnn.py
@@ -99,6 +99,14 @@ class NStepRNNBase(link.ChainList):
         self.out_size = out_size
         self.direction = direction
 
+    def copy(self, mode='share'):
+        ret = super(NStepRNNBase, self).copy(mode)
+        ret.ws = [[getattr(layer, 'w%d' % i)
+                   for i in six.moves.range(ret.n_weights)] for layer in ret]
+        ret.bs = [[getattr(layer, 'b%d' % i)
+                   for i in six.moves.range(ret.n_weights)] for layer in ret]
+        return ret
+
     def init_hx(self, xs):
         shape = (self.n_layers * self.direction, len(xs), self.out_size)
         with chainer.using_device(self.device):

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_gru.py
@@ -114,6 +114,34 @@ class TestNStepGRU(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
+    def check_multi_gpu_forward(self, train=True):
+        msg = None
+        rnn = self.rnn.copy('copy')
+        rnn.dropout = .5
+        with cuda.get_device_from_id(1):
+            if self.hidden_none:
+                h = None
+            else:
+                h = cuda.to_gpu(self.h)
+            xs = [cuda.to_gpu(x) for x in self.xs]
+            rnn = rnn.to_gpu()
+        with cuda.get_device_from_id(0),\
+                chainer.using_config('train', train),\
+                chainer.using_config('use_cudnn', 'always'):
+            try:
+                rnn(h, xs)
+            except Exception as e:
+                msg = e
+        assert msg is None
+
+    def test_multi_gpu_forward_training(self):
+        self.check_multi_gpu_forward(True)
+
+    def test_multi_gpu_forward_test(self):
+        self.check_multi_gpu_forward(False)
+
     def check_backward(
             self, h_data, xs_data, gh_data, gys_data):
 
@@ -283,6 +311,34 @@ class TestNStepBiGRU(unittest.TestCase):
             self.check_forward(
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
+
+    @attr.cudnn
+    @attr.multi_gpu(2)
+    def check_multi_gpu_forward(self, train=True):
+        msg = None
+        rnn = self.rnn.copy('copy')
+        rnn.dropout = .5
+        with cuda.get_device_from_id(1):
+            if self.hidden_none:
+                h = None
+            else:
+                h = cuda.to_gpu(self.h)
+            xs = [cuda.to_gpu(x) for x in self.xs]
+            rnn = rnn.to_gpu()
+        with cuda.get_device_from_id(0),\
+                chainer.using_config('train', train),\
+                chainer.using_config('use_cudnn', 'always'):
+            try:
+                rnn(h, xs)
+            except Exception as e:
+                msg = e
+        assert msg is None
+
+    def test_multi_gpu_forward_training(self):
+        self.check_multi_gpu_forward(True)
+
+    def test_multi_gpu_forward_test(self):
+        self.check_multi_gpu_forward(False)
 
     def check_backward(
             self, h_data, xs_data, gh_data, gys_data):

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_gru.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_gru.py
@@ -117,8 +117,6 @@ class TestNStepGRU(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
-    @attr.cudnn
-    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         # See chainer/chainer#6262
         # NStepGRU w/ cudnn & dropout should work on not current device
@@ -141,9 +139,13 @@ class TestNStepGRU(unittest.TestCase):
                 msg = e
         assert msg is None
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 
@@ -321,8 +323,6 @@ class TestNStepBiGRU(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
-    @attr.cudnn
-    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         # See chainer/chainer#6262
         # NStepBiGRU w/ cudnn and dropout should work on not current device
@@ -345,9 +345,13 @@ class TestNStepBiGRU(unittest.TestCase):
                 msg = e
         assert msg is None
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
@@ -46,7 +46,7 @@ class TestNStepLSTM(unittest.TestCase):
 
         for layer in self.rnn:
             for p in layer.params():
-                p.data[...] = numpy.random.uniform(-1, 1, p.data.shape)
+                p.array[...] = numpy.random.uniform(-1, 1, p.shape)
         self.rnn.cleargrads()
 
     def check_forward(self, h_data, c_data, xs_data):
@@ -58,12 +58,12 @@ class TestNStepLSTM(unittest.TestCase):
         xs = [chainer.Variable(x) for x in xs_data]
         hy, cy, ys = self.rnn(h, c, xs)
 
-        self.assertEqual(hy.data.shape, h_data.shape)
-        self.assertEqual(cy.data.shape, c_data.shape)
-        self.assertEqual(len(xs), len(ys))
+        assert hy.shape == h_data.shape
+        assert cy.shape == c_data.shape
+        assert len(xs) == len(ys)
         for x, y in zip(xs, ys):
-            self.assertEqual(len(x.data), len(y.data))
-            self.assertEqual(y.data.shape[1], self.out_size)
+            assert len(x) == len(y)
+            assert y.shape[1] == self.out_size
 
         self.rnn.to_cpu()
 
@@ -74,15 +74,18 @@ class TestNStepLSTM(unittest.TestCase):
                 c_prev = self.c[layer, batch]
                 hs = []
                 for x in seq:
-                    i = sigmoid(x.dot(p.w0.data.T) + h_prev.dot(p.w4.data.T) +
-                                p.b0.data + p.b4.data)
-                    f = sigmoid(x.dot(p.w1.data.T) + h_prev.dot(p.w5.data.T) +
-                                p.b1.data + p.b5.data)
+                    i = sigmoid(
+                        x.dot(p.w0.array.T) + h_prev.dot(p.w4.array.T) +
+                        p.b0.array + p.b4.array)
+                    f = sigmoid(
+                        x.dot(p.w1.array.T) + h_prev.dot(p.w5.array.T) +
+                        p.b1.array + p.b5.array)
                     c_bar = numpy.tanh(
-                        x.dot(p.w2.data.T) + h_prev.dot(p.w6.data.T) +
-                        p.b2.data + p.b6.data)
-                    o = sigmoid(x.dot(p.w3.data.T) + h_prev.dot(p.w7.data.T) +
-                                p.b3.data + p.b7.data)
+                        x.dot(p.w2.array.T) + h_prev.dot(p.w6.array.T) +
+                        p.b2.array + p.b6.array)
+                    o = sigmoid(
+                        x.dot(p.w3.array.T) + h_prev.dot(p.w7.array.T) +
+                        p.b3.array + p.b7.array)
                     e_c = (f * c_prev + i * c_bar)
                     e_h = o * numpy.tanh(e_c)
 
@@ -91,10 +94,10 @@ class TestNStepLSTM(unittest.TestCase):
                     hs.append(e_h)
 
                 seq = hs
-                testing.assert_allclose(hy.data[layer, batch], h_prev)
-                testing.assert_allclose(cy.data[layer, batch], c_prev)
+                testing.assert_allclose(hy.array[layer, batch], h_prev)
+                testing.assert_allclose(cy.array[layer, batch], c_prev)
 
-            for y, ey in zip(ys[batch].data, seq):
+            for y, ey in zip(ys[batch].array, seq):
                 testing.assert_allclose(y, ey)
 
     def test_forward_cpu_train(self):
@@ -140,6 +143,8 @@ class TestNStepLSTM(unittest.TestCase):
     @attr.cudnn
     @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
+        # See chainer/chainer#6262
+        # NStepLSTM w/ cudnn & dropout should work on not current device
         msg = None
         rnn = self.rnn.copy('copy')
         rnn.dropout = .5
@@ -211,6 +216,7 @@ class TestNStepLSTM(unittest.TestCase):
 
     def test_n_cells(self):
         self.assertEqual(self.rnn.n_cells, 2)
+        assert self.rnn.n_cells == 2
 
 
 @testing.parameterize(*testing.product({
@@ -245,7 +251,7 @@ class TestNStepBiLSTM(unittest.TestCase):
 
         for layer in self.rnn:
             for p in layer.params():
-                p.data[...] = numpy.random.uniform(-1, 1, p.data.shape)
+                p.array[...] = numpy.random.uniform(-1, 1, p.shape)
         self.rnn.cleargrads()
 
     def check_forward(self, h_data, c_data, xs_data):
@@ -257,12 +263,12 @@ class TestNStepBiLSTM(unittest.TestCase):
         xs = [chainer.Variable(x) for x in xs_data]
         hy, cy, ys = self.rnn(h, c, xs)
 
-        self.assertEqual(hy.data.shape, h_data.shape)
-        self.assertEqual(cy.data.shape, c_data.shape)
-        self.assertEqual(len(xs), len(ys))
+        assert hy.shape == h_data.shape
+        assert cy.shape == c_data.shape
+        assert len(xs) == len(ys)
         for x, y in zip(xs, ys):
-            self.assertEqual(len(x.data), len(y.data))
-            self.assertEqual(y.data.shape[1], self.out_size * 2)
+            assert len(x) == len(y)
+            assert y.shape[1] == self.out_size * 2
 
         self.rnn.to_cpu()
 
@@ -276,17 +282,18 @@ class TestNStepBiLSTM(unittest.TestCase):
                 c_prev = self.c[layer_idx, batch]
                 hs_f = []
                 for x in seq:
-                    i = sigmoid(x.dot(p.w0.data.T) +
-                                h_prev.dot(p.w4.data.T) +
-                                p.b0.data + p.b4.data)
-                    f = sigmoid(x.dot(p.w1.data.T) +
-                                h_prev.dot(p.w5.data.T) +
-                                p.b1.data + p.b5.data)
-                    c_bar = numpy.tanh(x.dot(p.w2.data.T) +
-                                       h_prev.dot(p.w6.data.T) +
-                                       p.b2.data + p.b6.data)
-                    o = sigmoid(x.dot(p.w3.data.T) + h_prev.dot(p.w7.data.T) +
-                                p.b3.data + p.b7.data)
+                    i = sigmoid(x.dot(p.w0.array.T) +
+                                h_prev.dot(p.w4.array.T) +
+                                p.b0.array + p.b4.array)
+                    f = sigmoid(x.dot(p.w1.array.T) +
+                                h_prev.dot(p.w5.array.T) +
+                                p.b1.array + p.b5.array)
+                    c_bar = numpy.tanh(x.dot(p.w2.array.T) +
+                                       h_prev.dot(p.w6.array.T) +
+                                       p.b2.array + p.b6.array)
+                    o = sigmoid(
+                        x.dot(p.w3.array.T) + h_prev.dot(p.w7.array.T) +
+                        p.b3.array + p.b7.array)
                     e_c = (f * c_prev + i * c_bar)
                     e_h = o * numpy.tanh(e_c)
 
@@ -294,8 +301,8 @@ class TestNStepBiLSTM(unittest.TestCase):
                     c_prev = e_c
                     hs_f.append(e_h)
 
-                testing.assert_allclose(hy.data[layer_idx, batch], h_prev)
-                testing.assert_allclose(cy.data[layer_idx, batch], c_prev)
+                testing.assert_allclose(hy.array[layer_idx, batch], h_prev)
+                testing.assert_allclose(cy.array[layer_idx, batch], c_prev)
 
                 # backward
                 di = 1
@@ -305,17 +312,17 @@ class TestNStepBiLSTM(unittest.TestCase):
                 c_prev = self.c[layer_idx, batch]
                 hs_b = []
                 for x in reversed(seq):
-                    i = sigmoid(x.dot(p.w0.data.T) +
-                                h_prev.dot(p.w4.data.T) +
-                                p.b0.data + p.b4.data)
-                    f = sigmoid(x.dot(p.w1.data.T) +
-                                h_prev.dot(p.w5.data.T) +
-                                p.b1.data + p.b5.data)
-                    c_bar = numpy.tanh(x.dot(p.w2.data.T) +
-                                       h_prev.dot(p.w6.data.T) +
-                                       p.b2.data + p.b6.data)
-                    o = sigmoid(x.dot(p.w3.data.T) + h_prev.dot(p.w7.data.T) +
-                                p.b3.data + p.b7.data)
+                    i = sigmoid(x.dot(p.w0.array.T) +
+                                h_prev.dot(p.w4.array.T) +
+                                p.b0.array + p.b4.array)
+                    f = sigmoid(x.dot(p.w1.array.T) +
+                                h_prev.dot(p.w5.array.T) +
+                                p.b1.array + p.b5.array)
+                    c_bar = numpy.tanh(x.dot(p.w2.array.T) +
+                                       h_prev.dot(p.w6.array.T) +
+                                       p.b2.array + p.b6.array)
+                    o = sigmoid(x.dot(p.w3.array.T) + h_prev.dot(p.w7.array.T) +
+                                p.b3.array + p.b7.array)
                     e_c = (f * c_prev + i * c_bar)
                     e_h = o * numpy.tanh(e_c)
 
@@ -323,14 +330,14 @@ class TestNStepBiLSTM(unittest.TestCase):
                     c_prev = e_c
                     hs_b.append(e_h)
 
-                testing.assert_allclose(hy.data[layer_idx, batch], h_prev)
-                testing.assert_allclose(cy.data[layer_idx, batch], c_prev)
+                testing.assert_allclose(hy.array[layer_idx, batch], h_prev)
+                testing.assert_allclose(cy.array[layer_idx, batch], c_prev)
 
                 hs_b.reverse()
                 seq = [numpy.concatenate([hfi, hbi], axis=0) for (hfi, hbi)
                        in zip(hs_f, hs_b)]
 
-            for y, ey in zip(ys[batch].data, seq):
+            for y, ey in zip(ys[batch].array, seq):
                 testing.assert_allclose(y, ey)
 
     def test_forward_cpu_train(self):
@@ -364,6 +371,8 @@ class TestNStepBiLSTM(unittest.TestCase):
     @attr.gpu
     @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
+        # See chainer/chainer#6262
+        # NStepBiLSTM w/ cudnn & dropout should work on not current device
         msg = None
         rnn = self.rnn.copy('copy')
         rnn.dropout = .5
@@ -434,7 +443,7 @@ class TestNStepBiLSTM(unittest.TestCase):
                 [cuda.to_gpu(gy) for gy in self.gys])
 
     def test_n_cells(self):
-        self.assertEqual(self.rnn.n_cells, 2)
+        assert self.rnn.n_cells == 2
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
@@ -140,8 +140,6 @@ class TestNStepLSTM(unittest.TestCase):
                 cuda.to_gpu(self.c, 1),
                 [cuda.to_gpu(x, 1) for x in self.xs])
 
-    @attr.cudnn
-    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         # See chainer/chainer#6262
         # NStepLSTM w/ cudnn & dropout should work on not current device
@@ -165,9 +163,13 @@ class TestNStepLSTM(unittest.TestCase):
                 msg = e
         assert msg is None
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 
@@ -321,8 +323,9 @@ class TestNStepBiLSTM(unittest.TestCase):
                     c_bar = numpy.tanh(x.dot(p.w2.array.T) +
                                        h_prev.dot(p.w6.array.T) +
                                        p.b2.array + p.b6.array)
-                    o = sigmoid(x.dot(p.w3.array.T) + h_prev.dot(p.w7.array.T) +
-                                p.b3.array + p.b7.array)
+                    o = sigmoid(
+                        x.dot(p.w3.array.T) + h_prev.dot(p.w7.array.T) +
+                        p.b3.array + p.b7.array)
                     e_c = (f * c_prev + i * c_bar)
                     e_h = o * numpy.tanh(e_c)
 
@@ -368,8 +371,6 @@ class TestNStepBiLSTM(unittest.TestCase):
                 cuda.to_gpu(self.c),
                 [cuda.to_gpu(x) for x in self.xs])
 
-    @attr.gpu
-    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         # See chainer/chainer#6262
         # NStepBiLSTM w/ cudnn & dropout should work on not current device
@@ -393,9 +394,13 @@ class TestNStepBiLSTM(unittest.TestCase):
                 msg = e
         assert msg is None
 
+    @attr.gpu
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
+    @attr.gpu
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_lstm.py
@@ -137,6 +137,35 @@ class TestNStepLSTM(unittest.TestCase):
                 cuda.to_gpu(self.c, 1),
                 [cuda.to_gpu(x, 1) for x in self.xs])
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
+    def check_multi_gpu_forward(self, train=True):
+        msg = None
+        rnn = self.rnn.copy('copy')
+        rnn.dropout = .5
+        with cuda.get_device_from_id(1):
+            if self.hidden_none:
+                h = None
+            else:
+                h = cuda.to_gpu(self.h)
+            c = cuda.to_gpu(self.c)
+            xs = [cuda.to_gpu(x) for x in self.xs]
+            rnn = rnn.to_gpu()
+        with cuda.get_device_from_id(0),\
+                chainer.using_config('train', train),\
+                chainer.using_config('use_cudnn', 'always'):
+            try:
+                rnn(h, c, xs)
+            except Exception as e:
+                msg = e
+        assert msg is None
+
+    def test_multi_gpu_forward_training(self):
+        self.check_multi_gpu_forward(True)
+
+    def test_multi_gpu_forward_test(self):
+        self.check_multi_gpu_forward(False)
+
     def check_backward(
             self, h_data, c_data, xs_data, gh_data, gc_data, gys_data):
 
@@ -331,6 +360,35 @@ class TestNStepBiLSTM(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 cuda.to_gpu(self.c),
                 [cuda.to_gpu(x) for x in self.xs])
+
+    @attr.gpu
+    @attr.multi_gpu(2)
+    def check_multi_gpu_forward(self, train=True):
+        msg = None
+        rnn = self.rnn.copy('copy')
+        rnn.dropout = .5
+        with cuda.get_device_from_id(1):
+            if self.hidden_none:
+                h = None
+            else:
+                h = cuda.to_gpu(self.h)
+            c = cuda.to_gpu(self.c)
+            xs = [cuda.to_gpu(x) for x in self.xs]
+            rnn = rnn.to_gpu()
+        with cuda.get_device_from_id(0),\
+                chainer.using_config('train', train),\
+                chainer.using_config('use_cudnn', 'always'):
+            try:
+                rnn(h, c, xs)
+            except Exception as e:
+                msg = e
+        assert msg is None
+
+    def test_multi_gpu_forward_training(self):
+        self.check_multi_gpu_forward(True)
+
+    def test_multi_gpu_forward_test(self):
+        self.check_multi_gpu_forward(False)
 
     def check_backward(
             self, h_data, c_data, xs_data, gh_data, gc_data, gys_data):

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -329,7 +329,7 @@ class TestNStepBiRNN(unittest.TestCase):
             xs = [cuda.to_gpu(x) for x in self.xs]
             rnn = rnn.to_gpu()
         with cuda.get_device_from_id(0),\
-                chainer.using_config('train', True):
+                chainer.using_config('train', train):
             try:
                 rnn(h, xs)
             except Exception as e:

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -121,6 +121,9 @@ class TestNStepRNN(unittest.TestCase):
     @attr.cudnn
     @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
+        # See chainer/chainer#6262
+        # NStepRNNTanh and NStepRNNReLU w/ cudnn & dropout should work on
+        # not current device
         msg = None
         rnn = self.rnn.copy('copy')
         rnn.dropout = .5
@@ -321,6 +324,9 @@ class TestNStepBiRNN(unittest.TestCase):
     @attr.cudnn
     @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
+        # See chainer/chainer#6262
+        # NStepBiRNNTanh and NStepBiRNNReLU w/ cudnn & dropout should work on
+        # not current device
         msg = None
         rnn = self.rnn.copy('copy')
         rnn.dropout = .5

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -118,8 +118,6 @@ class TestNStepRNN(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
-    @attr.cudnn
-    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         # See chainer/chainer#6262
         # NStepRNNTanh and NStepRNNReLU w/ cudnn & dropout should work on
@@ -143,9 +141,13 @@ class TestNStepRNN(unittest.TestCase):
                 msg = e
         assert msg is None
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 
@@ -321,8 +323,6 @@ class TestNStepBiRNN(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
-    @attr.cudnn
-    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         # See chainer/chainer#6262
         # NStepBiRNNTanh and NStepBiRNNReLU w/ cudnn & dropout should work on
@@ -346,9 +346,13 @@ class TestNStepBiRNN(unittest.TestCase):
                 msg = e
         assert msg is None
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -50,7 +50,7 @@ class TestNStepRNN(unittest.TestCase):
 
         for layer in self.rnn:
             for p in layer.params():
-                p.data[...] = numpy.random.uniform(-1, 1, p.data.shape)
+                p.array[...] = numpy.random.uniform(-1, 1, p.shape)
         self.rnn.cleargrads()
 
     def check_forward(self, h_data, xs_data):
@@ -61,11 +61,11 @@ class TestNStepRNN(unittest.TestCase):
         xs = [chainer.Variable(x) for x in xs_data]
         hy, ys = self.rnn(h, xs)
 
-        self.assertEqual(hy.data.shape, h_data.shape)
-        self.assertEqual(len(xs), len(ys))
+        assert hy.shape == h_data.shape
+        assert len(xs) == len(ys)
         for x, y in zip(xs, ys):
-            self.assertEqual(len(x.data), len(y.data))
-            self.assertEqual(y.data.shape[1], self.out_size)
+            assert len(x) == len(y)
+            assert y.shape[1] == self.out_size
 
         self.rnn.to_cpu()
 
@@ -80,16 +80,16 @@ class TestNStepRNN(unittest.TestCase):
                     elif self.activation == 'relu':
                         activation_func = relu
 
-                    h_prev = activation_func(x.dot(p.w0.data.T) +
-                                             h_prev.dot(p.w1.data.T) +
-                                             p.b0.data + p.b1.data)
+                    h_prev = activation_func(x.dot(p.w0.array.T) +
+                                             h_prev.dot(p.w1.array.T) +
+                                             p.b0.array + p.b1.array)
 
                     hs.append(h_prev)
 
                 seq = hs
                 testing.assert_allclose(hy.data[layer, batch], h_prev)
 
-            for y, ey in zip(ys[batch].data, seq):
+            for y, ey in zip(ys[batch].array, seq):
                 testing.assert_allclose(y, ey)
 
     def test_forward_cpu_train(self):
@@ -189,7 +189,7 @@ class TestNStepRNN(unittest.TestCase):
                 [cuda.to_gpu(gy) for gy in self.gys])
 
     def test_n_cells(self):
-        self.assertEqual(self.rnn.n_cells, 1)
+        assert self.rnn.n_cells == 1
 
 
 @testing.parameterize(*testing.product({
@@ -227,7 +227,7 @@ class TestNStepBiRNN(unittest.TestCase):
 
         for layer in self.rnn:
             for p in layer.params():
-                p.data[...] = numpy.random.uniform(-1, 1, p.data.shape)
+                p.array[...] = numpy.random.uniform(-1, 1, p.array.shape)
         self.rnn.cleargrads()
 
     def check_forward(self, h_data, xs_data):
@@ -238,11 +238,11 @@ class TestNStepBiRNN(unittest.TestCase):
         xs = [chainer.Variable(x) for x in xs_data]
         hy, ys = self.rnn(h, xs)
 
-        self.assertEqual(hy.data.shape, h_data.shape)
-        self.assertEqual(len(xs), len(ys))
+        assert hy.shape == h_data.shape
+        assert len(xs) == len(ys)
         for x, y in zip(xs, ys):
-            self.assertEqual(len(x.data), len(y.data))
-            self.assertEqual(y.data.shape[1], self.out_size * 2)
+            assert len(x) == len(y)
+            assert y.shape[1] == self.out_size * 2
 
         self.rnn.to_cpu()
 
@@ -260,12 +260,12 @@ class TestNStepBiRNN(unittest.TestCase):
                     elif self.activation == 'relu':
                         activation_func = relu
 
-                    h_prev = activation_func(x.dot(p.w0.data.T) +
-                                             h_prev.dot(p.w1.data.T) +
-                                             p.b0.data + p.b1.data)
+                    h_prev = activation_func(x.dot(p.w0.array.T) +
+                                             h_prev.dot(p.w1.array.T) +
+                                             p.b0.array + p.b1.array)
                     hs_f.append(h_prev)
 
-                testing.assert_allclose(hy.data[layer_idx, batch], h_prev)
+                testing.assert_allclose(hy.array[layer_idx, batch], h_prev)
 
                 # backward
                 di = 1
@@ -278,9 +278,9 @@ class TestNStepBiRNN(unittest.TestCase):
                         activation_func = numpy.tanh
                     elif self.activation == 'relu':
                         activation_func = relu
-                    h_prev = activation_func(x.dot(p.w0.data.T) +
-                                             h_prev.dot(p.w1.data.T) +
-                                             p.b0.data + p.b1.data)
+                    h_prev = activation_func(x.dot(p.w0.array.T) +
+                                             h_prev.dot(p.w1.array.T) +
+                                             p.b0.array + p.b1.array)
                     hs_b.append(h_prev)
                 testing.assert_allclose(hy.data[layer_idx, batch], h_prev)
 
@@ -288,7 +288,7 @@ class TestNStepBiRNN(unittest.TestCase):
                 seq = [numpy.concatenate([hfi, hbi], axis=0) for (hfi, hbi)
                        in zip(hs_f, hs_b)]
 
-            for y, ey in zip(ys[batch].data, seq):
+            for y, ey in zip(ys[batch].array, seq):
                 testing.assert_allclose(y, ey)
 
     def test_forward_cpu_train(self):
@@ -334,7 +334,7 @@ class TestNStepBiRNN(unittest.TestCase):
                 rnn(h, xs)
             except Exception as e:
                 msg = e
-        assert msg is None, msg
+        assert msg is None
 
     @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
@@ -388,7 +388,7 @@ class TestNStepBiRNN(unittest.TestCase):
                 [cuda.to_gpu(gy) for gy in self.gys])
 
     def test_n_cells(self):
-        self.assertEqual(self.rnn.n_cells, 1)
+        assert self.rnn.n_cells == 1
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -118,6 +118,8 @@ class TestNStepRNN(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         msg = None
         rnn = self.rnn.copy('copy')
@@ -130,18 +132,17 @@ class TestNStepRNN(unittest.TestCase):
             xs = [cuda.to_gpu(x) for x in self.xs]
             rnn = rnn.to_gpu()
         with cuda.get_device_from_id(0),\
-                chainer.using_config('train', train):
+                chainer.using_config('train', train),\
+                chainer.using_config('use_cudnn', 'always'):
             try:
                 rnn(h, xs)
             except Exception as e:
                 msg = e
         assert msg is None
 
-    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
-    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 
@@ -317,6 +318,8 @@ class TestNStepBiRNN(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
+    @attr.cudnn
+    @attr.multi_gpu(2)
     def check_multi_gpu_forward(self, train=True):
         msg = None
         rnn = self.rnn.copy('copy')
@@ -329,18 +332,17 @@ class TestNStepBiRNN(unittest.TestCase):
             xs = [cuda.to_gpu(x) for x in self.xs]
             rnn = rnn.to_gpu()
         with cuda.get_device_from_id(0),\
-                chainer.using_config('train', train):
+                chainer.using_config('train', train),\
+                chainer.using_config('use_cudnn', 'always'):
             try:
                 rnn(h, xs)
             except Exception as e:
                 msg = e
         assert msg is None
 
-    @attr.multi_gpu(2)
     def test_multi_gpu_forward_training(self):
         self.check_multi_gpu_forward(True)
 
-    @attr.multi_gpu(2)
     def test_multi_gpu_forward_test(self):
         self.check_multi_gpu_forward(False)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -129,10 +129,6 @@ class TestNStepRNN(unittest.TestCase):
                 h = cuda.to_gpu(self.h)
             xs = [cuda.to_gpu(x) for x in self.xs]
             rnn = rnn.to_gpu()
-            rnn.ws = [[getattr(layer, 'w%d' % i)
-                       for i in range(rnn.n_weights)] for layer in rnn]
-            rnn.bs = [[getattr(layer, 'b%d' % i)
-                       for i in range(rnn.n_weights)] for layer in rnn]
         with cuda.get_device_from_id(0),\
                 chainer.using_config('train', train):
             try:
@@ -332,10 +328,6 @@ class TestNStepBiRNN(unittest.TestCase):
                 h = cuda.to_gpu(self.h)
             xs = [cuda.to_gpu(x) for x in self.xs]
             rnn = rnn.to_gpu()
-            rnn.ws = [[getattr(layer, 'w%d' % i)
-                       for i in range(rnn.n_weights)] for layer in rnn]
-            rnn.bs = [[getattr(layer, 'b%d' % i)
-                       for i in range(rnn.n_weights)] for layer in rnn]
         with cuda.get_device_from_id(0),\
                 chainer.using_config('train', True):
             try:

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -129,6 +129,10 @@ class TestNStepRNN(unittest.TestCase):
                 h = cuda.to_gpu(self.h)
             xs = [cuda.to_gpu(x) for x in self.xs]
             rnn = rnn.to_gpu()
+            rnn.ws = [[getattr(layer, 'w%d' % i)
+                       for i in range(rnn.n_weights)] for layer in rnn]
+            rnn.bs = [[getattr(layer, 'b%d' % i)
+                       for i in range(rnn.n_weights)] for layer in rnn]
         with cuda.get_device_from_id(0),\
                 chainer.using_config('train', train):
             try:
@@ -318,9 +322,9 @@ class TestNStepBiRNN(unittest.TestCase):
                 [cuda.to_gpu(x) for x in self.xs])
 
     def check_multi_gpu_forward(self, train=True):
+        msg = None
         rnn = self.rnn.copy('copy')
         rnn.dropout = .5
-        msg = None
         with cuda.get_device_from_id(1):
             if self.hidden_none:
                 h = None
@@ -328,6 +332,10 @@ class TestNStepBiRNN(unittest.TestCase):
                 h = cuda.to_gpu(self.h)
             xs = [cuda.to_gpu(x) for x in self.xs]
             rnn = rnn.to_gpu()
+            rnn.ws = [[getattr(layer, 'w%d' % i)
+                       for i in range(rnn.n_weights)] for layer in rnn]
+            rnn.bs = [[getattr(layer, 'b%d' % i)
+                       for i in range(rnn.n_weights)] for layer in rnn]
         with cuda.get_device_from_id(0),\
                 chainer.using_config('train', True):
             try:

--- a/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_n_step_rnn.py
@@ -118,6 +118,33 @@ class TestNStepRNN(unittest.TestCase):
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
 
+    def check_multi_gpu_forward(self, train=True):
+        msg = None
+        rnn = self.rnn.copy('copy')
+        rnn.dropout = .5
+        with cuda.get_device_from_id(1):
+            if self.hidden_none:
+                h = None
+            else:
+                h = cuda.to_gpu(self.h)
+            xs = [cuda.to_gpu(x) for x in self.xs]
+            rnn = rnn.to_gpu()
+        with cuda.get_device_from_id(0),\
+                chainer.using_config('train', train):
+            try:
+                rnn(h, xs)
+            except Exception as e:
+                msg = e
+        assert msg is None
+
+    @attr.multi_gpu(2)
+    def test_multi_gpu_forward_training(self):
+        self.check_multi_gpu_forward(True)
+
+    @attr.multi_gpu(2)
+    def test_multi_gpu_forward_test(self):
+        self.check_multi_gpu_forward(False)
+
     def check_backward(
             self, h_data, xs_data, gh_data, gys_data):
 
@@ -289,6 +316,33 @@ class TestNStepBiRNN(unittest.TestCase):
             self.check_forward(
                 cuda.to_gpu(self.h),
                 [cuda.to_gpu(x) for x in self.xs])
+
+    def check_multi_gpu_forward(self, train=True):
+        rnn = self.rnn.copy('copy')
+        rnn.dropout = .5
+        msg = None
+        with cuda.get_device_from_id(1):
+            if self.hidden_none:
+                h = None
+            else:
+                h = cuda.to_gpu(self.h)
+            xs = [cuda.to_gpu(x) for x in self.xs]
+            rnn = rnn.to_gpu()
+        with cuda.get_device_from_id(0),\
+                chainer.using_config('train', True):
+            try:
+                rnn(h, xs)
+            except Exception as e:
+                msg = e
+        assert msg is None, msg
+
+    @attr.multi_gpu(2)
+    def test_multi_gpu_forward_training(self):
+        self.check_multi_gpu_forward(True)
+
+    @attr.multi_gpu(2)
+    def test_multi_gpu_forward_test(self):
+        self.check_multi_gpu_forward(False)
 
     def check_backward(
             self, h_data, xs_data, gh_data, gys_data):


### PR DESCRIPTION
This PR resolves #6262.

> `NStepLSTM` raises `cudaErrorIllegalAddress` when `n_layers>1` *and* `device>0` with multi-gpu environment.
> 
> This phenomenon is not observed when `n_layers=1` or `device=0`.

