### PR TITLE
Add ChainerX test to `FunctionTestCase`s

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_rrelu.py
@@ -20,6 +20,11 @@ from chainer.testing import attr
         'use_cuda': [True],
         'cuda_device': [0, 1],
     })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
 )
 @testing.parameterize(*testing.product({
     'train': [True, False],

--- a/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_softplus.py
@@ -21,6 +21,11 @@ from chainer import utils
         'use_cuda': [True],
         'cuda_device': [0, 1],
     })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
 )
 class TestSoftplus(testing.FunctionTestCase):
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_diagonal.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_diagonal.py
@@ -25,6 +25,11 @@ from chainer import testing
     })
     # GPU tests
     + [{'use_cuda': True}]
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
 )
 class TestDiagonal(testing.FunctionTestCase):
 


### PR DESCRIPTION
This PR adds testcases to input ChainerX arrays, even if the tested functions don't have ChainerX specific implementations.  @niboshi suggested the change.