### PR TITLE
Remove `SPHINXOPTS` env from Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS   ?= -W
+SPHINXOPTS   ?=
 SPHINXBUILD  ?= sphinx-build
 PAPER        ?=
 BUILDDIR     ?= build

--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -157,7 +157,7 @@ step_chainermn_tests() {
 
 
 step_docs() {
-    make -C "$REPO_DIR"/docs html;
+    SPHINXOPTS=-W make -C "$REPO_DIR"/docs html;
 }
 
 


### PR DESCRIPTION
For first-time contributors, I'd like to make `make html` always finish.

Merge chainer/chainer-test#500 first.