### PR TITLE
ResultType to take kind into account

### DIFF
--- a/chainerx_cc/chainerx/dtype.h
+++ b/chainerx_cc/chainerx/dtype.h
@@ -227,17 +227,6 @@ Dtype GetDtype(const std::string& name);
 // Returns a vector of all possible dtype values.
 std::vector<Dtype> GetAllDtypes();
 
-inline uint8_t GetDtypeCategory(DtypeKind kind) {
-    switch (kind) {
-        case DtypeKind::kFloat:
-            return 2;
-        default:
-            return 1;
-    }
-}
-
-inline uint8_t GetDtypeCategory(Dtype dtype) { return GetDtypeCategory(GetKind(dtype)); }
-
 // Throws an exception if two dtypes mismatch.
 void CheckEqual(Dtype lhs, Dtype rhs);
 

--- a/chainerx_cc/chainerx/dtype.h
+++ b/chainerx_cc/chainerx/dtype.h
@@ -227,6 +227,17 @@ Dtype GetDtype(const std::string& name);
 // Returns a vector of all possible dtype values.
 std::vector<Dtype> GetAllDtypes();
 
+inline uint8_t GetDtypeCategory(DtypeKind kind) {
+    switch (kind) {
+        case DtypeKind::kFloat:
+            return 2;
+        default:
+            return 1;
+    }
+}
+
+inline uint8_t GetDtypeCategory(Dtype dtype) { return GetDtypeCategory(GetKind(dtype)); }
+
 // Throws an exception if two dtypes mismatch.
 void CheckEqual(Dtype lhs, Dtype rhs);
 

--- a/chainerx_cc/chainerx/routines/type_util.h
+++ b/chainerx_cc/chainerx/routines/type_util.h
@@ -60,7 +60,7 @@ private:
         AddArgsImpl(std::forward<Args>(args)...);
     }
 
-    static uint8_t GetDtypeCategory(Dtype dtype) {
+    static int GetDtypeCategory(Dtype dtype) {
         switch (GetKind(dtype)) {
             case DtypeKind::kFloat:
                 return 2;

--- a/chainerx_cc/chainerx/routines/type_util.h
+++ b/chainerx_cc/chainerx/routines/type_util.h
@@ -59,6 +59,15 @@ private:
         AddArg(std::forward<Arg>(arg));
         AddArgsImpl(std::forward<Args>(args)...);
     }
+
+    static uint8_t GetDtypeCategory(Dtype dtype) {
+        switch (GetKind(dtype)) {
+            case DtypeKind::kFloat:
+                return 2;
+            default:
+                return 1;
+        }
+    }
 };
 
 void ResultTypeResolver::AddArg(const Array& arg) {

--- a/chainerx_cc/chainerx/routines/type_util_test.cc
+++ b/chainerx_cc/chainerx/routines/type_util_test.cc
@@ -202,7 +202,7 @@ TEST(ResultTypeTest, Three) {
 }
 
 TEST(ResultTypeTest, ArraysAndScalars) {
-    // Arrays always take precedence
+    // Arrays take precedence unless Scalar is a wider floating kind.
 
     // same dtype
     CHECK_RESULT_TYPE2(Int16, Ai16, Si16);
@@ -211,19 +211,19 @@ TEST(ResultTypeTest, ArraysAndScalars) {
     CHECK_RESULT_TYPE2(Int8, Ai8, Si16);
     // float vs int
     CHECK_RESULT_TYPE2(Float32, Af32, Si32);
-    CHECK_RESULT_TYPE2(Int32, Ai32, Sf32);
+    CHECK_RESULT_TYPE2(Float32, Ai32, Sf32);
 
     // 3 arguments
     CHECK_RESULT_TYPE3(Int8, Ai8, Si16, Si32);
     CHECK_RESULT_TYPE3(Int16, Ai16, Si8, Si32);
     CHECK_RESULT_TYPE3(Int16, Ai8, Ai16, Si32);
-    CHECK_RESULT_TYPE3(Int8, Ai8, Si32, Sf64);
-    CHECK_RESULT_TYPE3(Int8, Ai8, Sf32, Sf64);
+    CHECK_RESULT_TYPE3(Float64, Ai8, Si32, Sf64);
+    CHECK_RESULT_TYPE3(Float64, Ai8, Sf32, Sf64);
     // unsigned
     CHECK_RESULT_TYPE3(UInt8, Au8, Si8, Si8);
     CHECK_RESULT_TYPE3(UInt8, Au8, Si8, Si16);
     CHECK_RESULT_TYPE3(Int16, Au8, Ai8, Si8);
-    CHECK_RESULT_TYPE3(Int16, Au8, Ai8, Sf16);
+    CHECK_RESULT_TYPE3(Float16, Au8, Ai8, Sf16);
     CHECK_RESULT_TYPE3(Float16, Au8, Af16, Si8);
     CHECK_RESULT_TYPE3(Int8, Ai8, Su8, Si8);
     // bool

--- a/chainerx_cc/chainerx/routines/type_util_test.cc
+++ b/chainerx_cc/chainerx/routines/type_util_test.cc
@@ -233,6 +233,8 @@ TEST(ResultTypeTest, ArraysAndScalars) {
     CHECK_RESULT_TYPE3(Int8, Ai8, Sb, Si8);
     CHECK_RESULT_TYPE3(Float32, Af32, Sb, Si8);
     CHECK_RESULT_TYPE3(Float32, Af32, Ab, Si8);
+    CHECK_RESULT_TYPE3(Float16, Ab, Ab, Sf16);
+    CHECK_RESULT_TYPE3(Float16, Ab, Af16, Sf16);
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes #6418.

Scalar types can take precedence if they have wider kinds than the arrays.