### PR TITLE
Fix regex in `test_print_report`

### DIFF
--- a/tests/chainer_tests/function_hooks_tests/test_timer.py
+++ b/tests/chainer_tests/function_hooks_tests/test_timer.py
@@ -195,9 +195,9 @@ class TestTimerPrintReport(unittest.TestCase):
         self.f.apply((chainer.Variable(x),))
         io = six.StringIO()
         self.h.print_report(unit=self.unit, file=io)
-        expect = r'''\AFunctionName  ElapsedTime  Occurrence
- +Exp +[0-9.\-e]+(.s|sec) +[0-9]+$
-'''
+        expect = r'''\AFunctionName +ElapsedTime +Occurrence
+ +Exp +[0-9.\-e]+(.s|sec) +[0-9]+
+\Z'''
         actual = io.getvalue()
         six.assertRegex(self, actual, expect)
 


### PR DESCRIPTION
The PR fixes a test failure introduced by #6254.  With `unit='ns'`, a long cell can change the number of spaces.