### PR TITLE
Fix docment in `TimerHook`

### DIFF
--- a/chainer/function_hooks/timer.py
+++ b/chainer/function_hooks/timer.py
@@ -35,9 +35,9 @@ class TimerHook(function_hook.FunctionHook):
 
                    FunctionName  ElapsedTime  Occurrence
                  LinearFunction      1.24sec        3900
-                           ReLU     593.05ms        2600
-            SoftmaxCrossEntropy     824.11ms        1300
-                       Accuracy     176.54ms         700
+                           ReLU      0.59sec        2600
+            SoftmaxCrossEntropy      0.82sec        1300
+                       Accuracy      0.18sec         700
 
         where *FunctionName* is the name of function that calls the hook,
         and *ElapsedTime* is the elapsed time the function consumed,


### PR DESCRIPTION
The PR renew the example output (L36--40) to present the behavior of the new (#6254) default value `unit='auto'`.
This change is same as https://github.com/chainer/chainer/pull/6256#pullrequestreview-210474886.