### PR TITLE
Assert that input to array props formatter is a list or tuple

### DIFF
--- a/chainer/utils/error.py
+++ b/chainer/utils/error.py
@@ -1,5 +1,7 @@
 def _format_array_props(arrays):
     # Formats array shapes and dtypes for error messages.
+    assert isinstance(arrays, (list, tuple))
+
     return ', '.join([
         None if arr is None
         else '{}:{}'.format(arr.shape, arr.dtype.name)


### PR DESCRIPTION
Passing a single ndarray to `_format_array_props` yields unintuitive results. This PR simply asserts that it's never called that way.