### PR TITLE
Fix style of `.clang-tidy`

### DIFF
--- a/chainerx_cc/.clang-tidy
+++ b/chainerx_cc/.clang-tidy
@@ -1,4 +1,18 @@
-Checks:          '-*,boost-*,bugprone-*,cert-*,cppcoreguidelines-*,clang-analyzer-*,google-*,misc-*,modernize-*,performance-*,readability-*,-google-runtime-references,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-modernize-use-auto'
+Checks: "-*,\
+boost-*,\
+bugprone-*,\
+cert-*,\
+cppcoreguidelines-*,\
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,\
+clang-analyzer-*,\
+google-*,\
+-google-runtime-references,\
+misc-*,\
+modernize-*,\
+-modernize-use-auto,\
+performance-*,\
+readability-*,\
+"
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^chainerx/chainerx/.*'
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
so that's it's easier to work with (`Checks:` is getting longer).