### PR TITLE
Adding fp16 support to the chainermn Communicators

### DIFF
--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -1,7 +1,7 @@
-import collections
-import pickle
-import numpy as np
 from chainermn import nccl
+import collections
+import numpy as np
+import pickle
 
 import mpi4py.MPI
 
@@ -171,6 +171,7 @@ def chunked_bcast_obj(obj, mpi_comm, max_buf_len=256 * 1024 * 1024,
         obj = pickle.loads(pickled_bytes)
 
     return obj
+
 
 def _get_nccl_type_id(dtype):
     if dtype == np.float16:

--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -1,5 +1,7 @@
 import collections
 import pickle
+import numpy as np
+from chainermn import nccl
 
 import mpi4py.MPI
 
@@ -169,3 +171,14 @@ def chunked_bcast_obj(obj, mpi_comm, max_buf_len=256 * 1024 * 1024,
         obj = pickle.loads(pickled_bytes)
 
     return obj
+
+def _get_nccl_type_id(dtype):
+    if dtype == np.float16:
+        return nccl.NCCL_FLOAT16
+    elif dtype == np.float32:
+        return nccl.NCCL_FLOAT32
+    elif dtype == np.float64:
+        return nccl.NCCL_FLOAT64
+    else:
+        raise ValueError(
+            'dtype must be float16, float32, or float64.')

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -98,8 +98,7 @@ def pack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype
     offset = 0
     for param in params:
         v = getattr(param, attr_name)
-        comp_dtype = v.dtype
-        if comp_dtype != transfer_dtype:
+        if v.dtype != transfer_dtype:
             v = v.astype(transfer_dtype)
 
         size = v.size * itemsize

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -94,30 +94,32 @@ def extract_params_set_grad(model):
             if param.grad is not None]
 
 
-def pack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype=None):
+def pack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype=np.float32):
     offset = 0
     for param in params:
         v = getattr(param, attr_name)
-        if None is not transfer_dtype:
+        comp_dtype = v.dtype
+        if comp_dtype != transfer_dtype:
             v = v.astype(transfer_dtype)
 
         size = v.size * itemsize
         buffer.from_device(v, size, offset, stream)
         offset += size
 
-def unpack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype=None):
+
+def unpack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype=np.float32):
     offset = 0
     for param in params:
         v = getattr(param, attr_name)
         size = v.size * itemsize
         comp_dtype = v.dtype
-        if None is not transfer_dtype:
-            v = cp.array(v, copy=False, dtype = transfer_dtype)
+        if comp_dtype != transfer_dtype:
+            v = cp.array(v, copy=False, dtype=transfer_dtype)
 
         buffer.to_device(v, size, offset, stream)
         offset += size
 
-        if None is not transfer_dtype and comp_dtype != transfer_dtype:
+        if comp_dtype != transfer_dtype:
             setattr(param, attr_name, v.astype(comp_dtype))
 
 

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -94,7 +94,8 @@ def extract_params_set_grad(model):
             if param.grad is not None]
 
 
-def pack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype=np.float32):
+def pack_params(params, itemsize, attr_name, buffer,
+                stream=None, transfer_dtype=np.float32):
     offset = 0
     for param in params:
         v = getattr(param, attr_name)
@@ -106,7 +107,8 @@ def pack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype
         offset += size
 
 
-def unpack_params(params, itemsize, attr_name, buffer, stream=None, transfer_dtype=np.float32):
+def unpack_params(params, itemsize, attr_name, buffer,
+                  stream=None, transfer_dtype=np.float32):
     offset = 0
     for param in params:
         v = getattr(param, attr_name)

--- a/chainermn/communicators/flat_communicator.py
+++ b/chainermn/communicators/flat_communicator.py
@@ -1,4 +1,5 @@
 import mpi4py.MPI
+import numpy as np
 
 from chainermn.communicators import _memory_utility
 from chainermn.communicators import mpi_communicator_base
@@ -20,8 +21,14 @@ class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_a.assign(n_bytes_total)
         self.gpu_buffer_b.assign(n_bytes_total)
 
+        is_float16 = params[0].grad.dtype == np.float16
+        if is_float16:
+            transfer_dtype = np.float32
+        else:
+            transfer_dtype = None
+
         _memory_utility.pack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a)
+            params, itemsize, 'grad', self.gpu_buffer_a, transfer_dtype=transfer_dtype)
 
         self.mpi_comm.Allreduce(
             [self.gpu_buffer_a.buffer(n_bytes_total), mpi4py.MPI.FLOAT],
@@ -30,4 +37,5 @@ class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         arr *= (1.0 / self.size)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'grad', self.gpu_buffer_b)
+            params, itemsize, 'grad', self.gpu_buffer_b,
+            transfer_dtype=transfer_dtype)

--- a/chainermn/communicators/flat_communicator.py
+++ b/chainermn/communicators/flat_communicator.py
@@ -1,5 +1,4 @@
 import mpi4py.MPI
-import numpy as np
 
 from chainermn.communicators import _memory_utility
 from chainermn.communicators import mpi_communicator_base
@@ -21,14 +20,8 @@ class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_a.assign(n_bytes_total)
         self.gpu_buffer_b.assign(n_bytes_total)
 
-        is_float16 = params[0].grad.dtype == np.float16
-        if is_float16:
-            transfer_dtype = np.float32
-        else:
-            transfer_dtype = None
-
         _memory_utility.pack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a, transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_a)
 
         self.mpi_comm.Allreduce(
             [self.gpu_buffer_a.buffer(n_bytes_total), mpi4py.MPI.FLOAT],
@@ -37,5 +30,4 @@ class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         arr *= (1.0 / self.size)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'grad', self.gpu_buffer_b,
-            transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_b)

--- a/chainermn/communicators/hierarchical_communicator.py
+++ b/chainermn/communicators/hierarchical_communicator.py
@@ -1,6 +1,5 @@
 import chainer.cuda
 import math
-import numpy as np
 
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
@@ -54,14 +53,8 @@ class HierarchicalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_a.assign(n_bytes_buffer)
         self.gpu_buffer_b.assign(n_bytes_buffer)
 
-        is_float16 = params[0].grad.dtype == np.float16
-        if is_float16:
-            transfer_dtype = np.float32
-        else:
-            transfer_dtype = None
-
         _memory_utility.pack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a, transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_a)
 
         # Intra-node reduce
         self.intra_nccl_comm.reduce(
@@ -81,5 +74,4 @@ class HierarchicalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             stream.ptr)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'grad', self.gpu_buffer_b,
-            transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_b)

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -75,14 +75,8 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_a.assign(n_bytes_buffer)
         self.gpu_buffer_b.assign(n_bytes_buffer)
 
-        is_float16 = params[0].grad.dtype == np.float16
-        if is_float16:
-            transfer_dtype = np.float32
-        else:
-            transfer_dtype = None
-
         _memory_utility.pack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a, transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_a)
 
         # Intra-node reduce
         self.intra_nccl_comm.reduce(
@@ -121,5 +115,4 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             stream.ptr)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'grad', self.gpu_buffer_b,
-            transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_b)

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -47,7 +47,6 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         for _, param in sorted(model.namedparams()):
             if param.data is not None:
                 data = param.data
-                
                 tmp_cpu = chainer.cuda.to_cpu(data)
 
                 is_float16 = tmp_cpu.dtype == np.float16

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -61,7 +61,8 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             params, data_dtype.itemsize, 'data',
             self.gpu_tmp_buffer, stream, transfer_dtype=data_dtype)
         self.nccl_comm.bcast(self.gpu_tmp_buffer.ptr(), n_elems,
-                             _communication_utility._get_nccl_type_id(data_dtype),
+                             _communication_utility._get_nccl_type_id(
+                                 data_dtype),
                              0, stream.ptr)
         _memory_utility.unpack_params(
             params, data_dtype.itemsize, 'data',
@@ -90,7 +91,8 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
                                     n_elems, stream)
         self.nccl_comm.allReduce(self.gpu_buffer_a.ptr(),
                                  self.gpu_buffer_b.ptr(), n_elems,
-                                 _communication_utility._get_nccl_type_id(allreduce_grad_dtype),
+                                 _communication_utility._get_nccl_type_id(
+                                     allreduce_grad_dtype),
                                  nccl.NCCL_SUM,
                                  stream.ptr)
         if self.div_by_size is None:

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -1,5 +1,4 @@
 import chainer.cuda
-import numpy as np
 
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -1,4 +1,5 @@
 import chainer.cuda
+import numpy as np
 
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -50,7 +50,7 @@ class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_a.assign(n_bytes_total)
 
         _memory_utility.pack_params(
-            params, itemsize, 'data', self.gpu_buffer_a)
+            params, itemsize, 'data', self.gpu_buffer_a, transfer_dtype=dtype)
 
         self.intra_nccl_comm.bcast(
             self.gpu_buffer_a.ptr(), n_elems_total,
@@ -58,7 +58,7 @@ class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             0, stream.ptr)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'data', self.gpu_buffer_a)
+            params, itemsize, 'data', self.gpu_buffer_a, transfer_dtype=dtype)
 
     def allreduce_grad(self, model):
         self._init_comms()
@@ -73,7 +73,7 @@ class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_b.assign(n_bytes_total)
 
         _memory_utility.pack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a)
+            params, itemsize, 'grad', self.gpu_buffer_a, transfer_dtype=dtype)
 
         self.intra_nccl_comm.allReduce(
             self.gpu_buffer_a.ptr(), self.gpu_buffer_b.ptr(), n_elems_total,
@@ -84,4 +84,4 @@ class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         arr *= (1.0 / self.size)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'grad', self.gpu_buffer_b)
+            params, itemsize, 'grad', self.gpu_buffer_b, transfer_dtype=dtype)

--- a/chainermn/communicators/two_dimensional_communicator.py
+++ b/chainermn/communicators/two_dimensional_communicator.py
@@ -1,7 +1,6 @@
 import chainer.cuda
 import math
 import mpi4py.MPI
-import numpy as np
 
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
@@ -58,14 +57,8 @@ class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_a.assign(n_bytes_buffer)
         self.gpu_buffer_b.assign(n_bytes_buffer)
 
-        is_float16 = params[0].grad.dtype == np.float16
-        if is_float16:
-            transfer_dtype = np.float32
-        else:
-            transfer_dtype = None
-
         _memory_utility.pack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a, transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_a)
 
         # Intra-node reduce-scatter (1st dimension)
         self.intra_nccl_comm.reduceScatter(
@@ -85,5 +78,4 @@ class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             n_elems_per_node_1d, nccl.NCCL_FLOAT, stream.ptr)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a,
-            transfer_dtype=transfer_dtype)
+            params, itemsize, 'grad', self.gpu_buffer_a)

--- a/chainermn/communicators/two_dimensional_communicator.py
+++ b/chainermn/communicators/two_dimensional_communicator.py
@@ -1,6 +1,7 @@
 import chainer.cuda
 import math
 import mpi4py.MPI
+import numpy as np
 
 from chainermn.communicators import _communication_utility
 from chainermn.communicators import _memory_utility
@@ -56,8 +57,15 @@ class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
         self.gpu_buffer_a.assign(n_bytes_buffer)
         self.gpu_buffer_b.assign(n_bytes_buffer)
+
+        is_float16 = params[0].grad.dtype == np.float16
+        if is_float16:
+            transfer_dtype = np.float32
+        else:
+            transfer_dtype = None
+
         _memory_utility.pack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a)
+            params, itemsize, 'grad', self.gpu_buffer_a, transfer_dtype=transfer_dtype)
 
         # Intra-node reduce-scatter (1st dimension)
         self.intra_nccl_comm.reduceScatter(
@@ -77,4 +85,5 @@ class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             n_elems_per_node_1d, nccl.NCCL_FLOAT, stream.ptr)
 
         _memory_utility.unpack_params(
-            params, itemsize, 'grad', self.gpu_buffer_a)
+            params, itemsize, 'grad', self.gpu_buffer_a,
+            transfer_dtype=transfer_dtype)

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -80,7 +80,7 @@ class _NcclBackend(_MultiNodeBatchNormalizationBackend):
 
         # We need to delay importing MPI4py (and momdules that import MPI4py)
         import chainermn.communicators._memory_utility as memory_utility_module
-        from chainermn.communicators.pure_nccl_communicator import \
+        from chainermn.communicators._communication_utility import \
             _get_nccl_type_id
         from chainermn import nccl
 

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -60,6 +60,7 @@ cpu_params = [Param(p) for p in [
         'communicator_class': NaiveCommunicator,
         'multi_node': True,
     }]]
+
 gpu_params = [Param(p) for p in [
     {
         'communicator_class': NaiveCommunicator,
@@ -72,10 +73,22 @@ gpu_params = [Param(p) for p in [
         'communicator_class': FlatCommunicator,
         'multi_node': True,
     }, {
+        'communicator_class': FlatCommunicator,
+        'model_dtype': np.float16,
+        'multi_node': True,
+    }, {
         'communicator_class': HierarchicalCommunicator,
         'multi_node': True,
     }, {
+        'communicator_class': HierarchicalCommunicator,
+        'model_dtype': np.float16,
+        'multi_node': True,
+    }, {
         'communicator_class': TwoDimensionalCommunicator,
+        'multi_node': True,
+    }, {
+        'communicator_class': TwoDimensionalCommunicator,
+        'model_dtype': np.float16,
         'multi_node': True,
     }, {
         'communicator_class': SingleNodeCommunicator,
@@ -83,6 +96,10 @@ gpu_params = [Param(p) for p in [
     }, {
         'communicator_class': NonCudaAwareCommunicator,
         'multi_node': True,
+    }, {
+        'communicator_class': NonCudaAwareCommunicator,
+        'model_dtype': np.float16,
+        'multi_node': False,
     }, {
         'communicator_class': PureNcclCommunicator,
         'multi_node': True,

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -5,7 +5,8 @@ import unittest
 
 import chainer
 import chainer.cuda
-import chainer.initializers import chainer.links
+import chainer.initializers
+import chainer.links
 import chainer.testing
 import chainer.testing.attr
 import chainermn

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -5,8 +5,7 @@ import unittest
 
 import chainer
 import chainer.cuda
-import chainer.initializers
-import chainer.links
+import chainer.initializers import chainer.links
 import chainer.testing
 import chainer.testing.attr
 import chainermn
@@ -92,6 +91,10 @@ gpu_params = [Param(p) for p in [
         'multi_node': True,
     }, {
         'communicator_class': SingleNodeCommunicator,
+        'multi_node': False,
+    }, {
+        'communicator_class': SingleNodeCommunicator,
+        'model_dtype': np.float16,
         'multi_node': False,
     }, {
         'communicator_class': NonCudaAwareCommunicator,

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -5,8 +5,7 @@ import unittest
 
 import chainer
 import chainer.cuda
-import chainer.initializers
-import chainer.links
+import chainer.initializers import chainer.links
 import chainer.testing
 import chainer.testing.attr
 import chainermn


### PR DESCRIPTION
This commit add fp16 support to the chainermn communicators including:
- flat_communicator
- hierarchical_communicator
- non_cuda_aware_communicator
- two_dimensional_communicator
- single_node_communicator

Since the MPI does not support Allreduce on fp16,
the model will first be converted into fp32 if it is originally in fp16
for Allreduce. The model will get converted back to fp16 after the all
reduce.

Thank you for creating a pull request!

Please double-check the following.

- Read [our contribution guide](https://docs.chainer.org/en/stable/contribution.html).
  - Does your code conform to our coding guidelines?
  - Did you write sufficient test code?
  - Did you write sufficient documentation?
- Also, take a look at [our compatibility policy](https://docs.chainer.org/en/stable/compatibility.html).
