### PR TITLE
Refactor Documentation of F.prelu

### DIFF
--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -160,6 +160,18 @@ def prelu(x, W):
     Returns:
         ~chainer.Variable: Output variable
 
+    .. admonition:: Example
+        >>> x = np.arange(-3, 3, dtype=np.float32).reshape((2, 3))
+        >>> x
+        array([[-3., -2., -1.],
+               [ 0.,  1.,  2.]], dtype=float32)
+        >>> W = np.array([0.01, 0.1, 1], dtype=np.float32)
+        >>> W
+        array([0.01, 0.1 , 1.  ], dtype=float32)
+        >>> F.prelu(x, W)
+        variable([[-0.03, -0.2 , -1.  ],
+                  [ 0.  ,  1.  ,  2.  ]])
+
     .. note::
         When the PReLU function is combined with two-dimensional convolution,
         the elements of parameter :math:`W` are typically shared across the

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -185,7 +185,7 @@ def prelu(x, W):
         where :math:`B` is the batch size and the number of trailing
         :math:`S`'s :math:`N` is an arbitrary non-negative integer.
 
-    .. seealso:: :class:`L.PReLU <chainer.links.PReLU>`
+    .. seealso:: :class:`chainer.links.PReLU`
 
     """
     return PReLUFunction().apply((x, W))[0]

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -161,6 +161,7 @@ def prelu(x, W):
         ~chainer.Variable: Output variable
 
     .. admonition:: Example
+
         >>> x = np.arange(-3, 3, dtype=np.float32).reshape((2, 3))
         >>> x
         array([[-3., -2., -1.],

--- a/chainer/functions/activation/prelu.py
+++ b/chainer/functions/activation/prelu.py
@@ -146,30 +146,33 @@ def prelu(x, W):
     """Parametric ReLU function.
 
     It accepts two arguments: an input ``x`` and a weight array ``W``
-    and computes the output as :math:`PReLU(x) = \\max(x, W*x)`,
-    where :math:`*` is an elementwise multiplication for each sample in the
-    batch.
+    and computes the output as
 
-    When the PReLU function is combined with two-dimensional convolution, the
-    elements of parameter :math:`W` are typically shared across the same filter
-    of different pixels. In order to support such usage, this function supports
-    the shape of parameter array that indicates leading dimensions of input
-    arrays except the batch dimension.
-
-    For example, if :math:`W` has the shape of :math:`(2, 3, 4)`,
-    :math:`x` must have the shape of :math:`(B, 2, 3, 4, S_1, ..., S_N)`
-    where :math:`B` is the batch size and the number of trailing :math:`S`'s
-    :math:`N` is an arbitrary non-negative integer.
+    .. math::
+        PReLU(x_i) = \\begin{cases}
+        x_i & (x_i>0) \\\\ W_i * x_i & (otherwise)\\end{cases}
 
     Args:
         x (:class:`~chainer.Variable` or :ref:`ndarray`): Input variable.
-            Its first argument is assumed to be the minibatch dimension.
+            Its first axis is assumed to be the minibatch dimension.
         W (:class:`~chainer.Variable` or :ref:`ndarray`): Weight variable.
 
     Returns:
         ~chainer.Variable: Output variable
 
-    .. seealso:: :class:`~chainer.links.PReLU`
+    .. note::
+        When the PReLU function is combined with two-dimensional convolution,
+        the elements of parameter :math:`W` are typically shared across the
+        same filter of different pixels. In order to support such usage,
+        this function supports the shape of parameter array that indicates
+        leading dimensions of input arrays except the batch dimension.
+
+        For example, if :math:`W` has the shape of :math:`(2, 3, 4)`,
+        :math:`x` must have the shape of :math:`(B, 2, 3, 4, S_1, ..., S_N)`
+        where :math:`B` is the batch size and the number of trailing
+        :math:`S`'s :math:`N` is an arbitrary non-negative integer.
+
+    .. seealso:: :class:`L.PReLU <chainer.links.PReLU>`
 
     """
     return PReLUFunction().apply((x, W))[0]


### PR DESCRIPTION
- fixed wrong explanation (#6454)
- fixed wrong explanation _Its first argument is assumed to be the minibatch dimension._ -> _Its first axis is assumed to be the minibatch dimension._
- moved explanation of broadcasting to note directive.