### PR TITLE
`mixed16` mode and its support in `L.BatchNormalization`

### DIFF
--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -1,3 +1,5 @@
+import numpy
+
 import chainer
 from chainer import configuration
 from chainer import functions
@@ -204,6 +206,8 @@ class BatchNormalization(link.Link):
             axis = (axis,)
         self.axis = axis
         self._dtype = chainer.get_dtype(dtype)
+        if self._dtype == numpy.float16:
+            self._dtype = numpy.float32
 
         with self.init_scope():
             if use_gamma:
@@ -276,13 +280,13 @@ class BatchNormalization(link.Link):
         if gamma is None:
             with chainer.using_device(self.device):
                 gamma = self.xp.ones(
-                    self.avg_mean.shape, dtype=x.dtype)
+                    self.avg_mean.shape, dtype=self._dtype)
 
         beta = self.beta
         if beta is None:
             with chainer.using_device(self.device):
                 beta = self.xp.zeros(
-                    self.avg_mean.shape, dtype=x.dtype)
+                    self.avg_mean.shape, dtype=self._dtype)
 
         if configuration.config.train:
             if finetune:

--- a/docs/source/reference/configuration.rst
+++ b/docs/source/reference/configuration.rst
@@ -48,7 +48,10 @@ Configuration Keys
 
    Chainer uses this dtype to construct arrays when the dtype is not specified (e.g. initializers).
 
-   You can change the default value by setting ``CHAINER_DTYPE`` environment variable to ``float16``, ``float32`` or ``float64``.
+   You can change the default value by setting ``CHAINER_DTYPE`` environment variable to ``mixed16``, ``float16``, ``float32``, ``float64``.
+
+   .. note::
+      If you want to use float16 for better performance, it is recommended to use ``mixed16`` instead of ``float16``.
 
 * ``enable_backprop`` (default: ``True``)
    Flag to enable backpropagation support.
@@ -266,6 +269,7 @@ Related functions
    :nosignatures:
 
    chainer.get_dtype
+   chainer.mixed16
 
 
 Environment Variables
@@ -305,7 +309,7 @@ Here are the environment variables Chainer uses.
 |                                           | See :ref:`configuration` for details.                                                                 |
 +-------------------------------------------+-------------------------------------------------------------------------------------------------------+
 | ``CHAINER_DTYPE``                         | Used as the default value for ``chainer.config.dtype`` configuration.                                 |
-|                                           | The value must be any of ``'float16'``, ``'float32'`` or ``'float64'``.                               |
+|                                           | The value must be any of ``'mixed16'``, ``'float16'``, ``'float32'`` or ``'float64'``.                |
 |                                           | See :ref:`configuration` for details.                                                                 |
 +-------------------------------------------+-------------------------------------------------------------------------------------------------------+
 | ``CHAINER_TYPE_CHECK``                    | Used as the default value for ``chainer.config.type_check`` configuration.                            |

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -368,10 +368,6 @@ class TestDefaultInitializer(unittest.TestCase):
         self.size = 3
         with chainer.using_config('dtype', self.dtype):
             self.link = links.BatchNormalization(self.size, self.decay)
-        assert self.link.beta.dtype == self.dtype
-        assert self.link.gamma.dtype == self.dtype
-        assert self.link.avg_mean.dtype == self.dtype
-        assert self.link.avg_var.dtype == self.dtype
 
         self.x = numpy.arange(6, dtype=self.dtype).reshape(2, 3)
 

--- a/tests/chainer_tests/test_init.py
+++ b/tests/chainer_tests/test_init.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 import chainer
 from chainer.backends import cuda
 from chainer import testing
@@ -48,6 +50,34 @@ class TestUseCuDNN(unittest.TestCase):
         with chainer.using_config('use_cudnn', 'always'):
             self.assertFalse(chainer.should_use_cudnn(
                 '>=auto', cuda.cuda.cudnn.getVersion() + 1))
+
+
+class TestDtype(unittest.TestCase):
+
+    def test_numpy_dtypes(self):
+        for dtype in (numpy.float16, numpy.float32, numpy.float64):
+            with chainer.using_config('dtype', dtype):
+                self.assertEqual(chainer.get_dtype(), numpy.dtype(dtype))
+
+    def test_specified_dtype(self):
+        with chainer.using_config('dtype', numpy.float64):
+            dtype = numpy.float16
+            self.assertEqual(chainer.get_dtype(dtype), numpy.dtype(dtype))
+
+    def test_mixed16_dtype(self):
+        with chainer.using_config('dtype', chainer.mixed16):
+            self.assertEqual(chainer.get_dtype(),
+                             numpy.dtype(numpy.float16))
+            self.assertEqual(chainer.get_dtype(map_mixed16=numpy.float32),
+                             numpy.dtype(numpy.float32))
+
+    def test_specified_mixed16_dtype(self):
+        with chainer.using_config('dtype', numpy.float64):
+            self.assertEqual(chainer.get_dtype(chainer.mixed16),
+                             numpy.dtype(numpy.float16))
+            self.assertEqual(
+                chainer.get_dtype(chainer.mixed16, map_mixed16=numpy.float32),
+                numpy.dtype(numpy.float32))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR introduces a new default dtype mode named `mixed16`. With this mode, Chainer basically uses `float16` as the default float dtype, but when Chainer decides that it is better to use higher precision representation for numerical stability and computational efficiency, it uses other float dtypes, esp. `float32`.

The batch normalization fix is based on #6265.

## General API

`chainer.mixed16` is a new dtype-like object. It can be passed to any numpy/cupy functions, where the dtype is interpreted as `float16`. Therefore, most existing code will just behave like the conventional FP16 mode. Specifying environment variable `CHAINER_DTYPE=mixed16` is equivalent to `chainer.global_config.dtype = chainer.mixed16`.

`chainer.get_dtype()` is extended to handle `mixed16` in a special manner. By passing an option `max_mixed16=np.float32`, we can get `float32` when the given (or default) dtype is `mixed16`. In this way, developers can choose the appropriate dtype when the users specify `mixed16`. Note that when `float16` is directly specified (either via `dtype` argument or `config.dtype`), `get_dtype()` still returns `float16` regardless of the `map_mixed16` option; i.e., `map_mixed16` is only used in `mixed16` case.

## Mixed precision batch normalization

cuDNN's batch normalization requires float32 beta/gamma parameters for mixed precision computation. Currently, Chainer (strictly speaking, CuPy) automatically casts these parameters to float32 on demand, which may cause a prohibitive overhead. In this PR, `L.BatchNormalization` is fixed to store these parameters in FP32 when `mixed16` dtype is specified, with which the conversion is not needed. Running mean and variance are also stored in float32 on mixed16 mode. `F.batch_normalization` and `F.fixed_batch_normalization` are fixed accordingly to accept arguments with mixed precisions.