### PR TITLE
Simplify `F.transpose` test

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_transpose.py
@@ -1,14 +1,7 @@
-import unittest
-
 import numpy
 
-import chainer
-from chainer import backend
-from chainer.backends import cuda
 from chainer import functions
 from chainer import testing
-from chainer.testing import attr
-import chainerx
 
 
 @testing.parameterize(*testing.product({
@@ -16,47 +9,38 @@ import chainerx
     'axes': [(-1, 0, 1), None],
     'dtype': [numpy.float16, numpy.float32, numpy.float32],
 }))
-class TestTranspose(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestTranspose(testing.FunctionTestCase):
 
-    def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+        return x,
 
-    def check_forward(self, x_data):
-        axes = self.axes
-        x = chainer.Variable(x_data)
-        y = functions.transpose(x, axes)
-        self.assertEqual(y.data.dtype, self.dtype)
-        self.assertTrue(
-            (self.x.transpose(axes) == backend.CpuDevice().send(y.data)).all())
+    def forward_expected(self, inputs):
+        x, = inputs
+        return x.transpose(self.axes),
 
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    @attr.chainerx
-    def test_forward_chainerx(self):
-        self.check_forward(chainerx.array(self.x))
-
-    def check_backward(self, x_data):
-        x = chainer.Variable(x_data)
+    def forward(self, inputs, device):
+        x, = inputs
         y = functions.transpose(x, self.axes)
-        y.grad = y.data
-        y.backward()
-        testing.assert_allclose(x.data, x.grad, atol=0, rtol=0)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x))
-
-    @attr.chainerx
-    def test_backward_chainerx(self):
-        self.check_backward(chainerx.array(self.x))
+        return y,
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Simplifies `test_transpose` using `testing.FunctionTestCase`.

Solves part of issue #6071