### PR TITLE
Use __future__.division in imagenet example with Python2

### DIFF
--- a/examples/imagenet/dali_util.py
+++ b/examples/imagenet/dali_util.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 
 try:


### PR DESCRIPTION
This PR follows #6429 to use `__future__.division` so that the imagenet example correctly runs with DALI in Python2. This change is tested in chainer/chainer-test#495.
