### PR TITLE
Simplify  `F.resize_image` test.

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -12,85 +12,135 @@ from chainer.testing import attr
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
 }))
-class TestResizeImagesForwardIdentity(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestResizeImagesForwardIdentity(testing.FunctionTestCase):
 
-    def setUp(self):
-        self.x = numpy.random.uniform(
+    def generate_inputs(self):
+        x = numpy.random.uniform(
             size=self.in_shape).astype(numpy.float32)
+        return x,
 
-    def check_forward(self, x, output_shape):
+    def forward_expected(self, inputs):
+        x, = inputs
+        return x,
+
+    def forward(self, inputs, device):
+        x, = inputs
+        output_shape = self.in_shape[2:]
         y = functions.resize_images(x, output_shape)
-        testing.assert_allclose(y.data, x)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x, output_shape=self.in_shape[2:])
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x), output_shape=self.in_shape[2:])
+        return y,
 
 
-class TestResizeImagesForwardDownScale(unittest.TestCase):
+@testing.parameterize(*testing.product({
+    'in_shape': [(2, 2, 4, 4)],
+    'output_shape': [(2, 2, 2, 2)],
+}))
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestResizeImagesForwardDownScale(testing.FunctionTestCase):
 
-    in_shape = (2, 2, 4, 4)
-    output_shape = (2, 2, 2, 2)
+    def generate_inputs(self):
+        x = numpy.zeros(self.in_shape, dtype=numpy.float32)
+        x[:, :, :2, :2] = 1
+        x[:, :, 2:, :2] = 2
+        x[:, :, :2, 2:] = 3
+        x[:, :, 2:, 2:] = 4
+        return x,
 
-    def setUp(self):
-        self.x = numpy.zeros(self.in_shape, dtype=numpy.float32)
-        self.x[:, :, :2, :2] = 1
-        self.x[:, :, 2:, :2] = 2
-        self.x[:, :, :2, 2:] = 3
-        self.x[:, :, 2:, 2:] = 4
+    def forward_expected(self, inputs):
+        y_expect = numpy.zeros(self.output_shape, dtype=numpy.float32)
+        y_expect[:, :, 0, 0] = 1
+        y_expect[:, :, 1, 0] = 2
+        y_expect[:, :, 0, 1] = 3
+        y_expect[:, :, 1, 1] = 4,
+        return y_expect,
 
-        self.out = numpy.zeros(self.output_shape, dtype=numpy.float32)
-        self.out[:, :, 0, 0] = 1
-        self.out[:, :, 1, 0] = 2
-        self.out[:, :, 0, 1] = 3
-        self.out[:, :, 1, 1] = 4
-
-    def check_forward(self, x, output_shape):
+    def forward(self, inputs, device):
+        x, = inputs
+        output_shape = self.output_shape[2:]
         y = functions.resize_images(x, output_shape)
-        testing.assert_allclose(y.data, self.out)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x, output_shape=self.output_shape[2:])
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(
-            cuda.to_gpu(self.x), output_shape=self.output_shape[2:])
+        return y,
 
 
-class TestResizeImagesForwardUpScale(unittest.TestCase):
+@testing.parameterize(*testing.product({
+    'in_shape': [(1, 1, 2, 2)],
+    'output_shape': [(1, 1, 3, 3)]
+}))
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestResizeImagesForwardUpScale(testing.FunctionTestCase):
 
-    in_shape = (1, 1, 2, 2)
-    output_shape = (1, 1, 3, 3)
+    def generate_inputs(self):
+        x = numpy.zeros(self.in_shape, dtype=numpy.float32)
+        x[:, :, 0, 0] = 1
+        x[:, :, 1, 0] = 2
+        x[:, :, 0, 1] = 3
+        x[:, :, 1, 1] = 4
+        return x,
 
-    def setUp(self):
-        self.x = numpy.zeros(self.in_shape, dtype=numpy.float32)
-        self.x[:, :, 0, 0] = 1
-        self.x[:, :, 1, 0] = 2
-        self.x[:, :, 0, 1] = 3
-        self.x[:, :, 1, 1] = 4
-
-        self.out = numpy.zeros(self.output_shape, dtype=numpy.float32)
-        self.out[0, 0, :, :] = numpy.array(
+    def forward_expected(self, inputs):
+        y_expect = numpy.zeros(self.output_shape, dtype=numpy.float32)
+        y_expect[0, 0, :, :] = numpy.array(
             [[1., 2., 3.],
              [1.5, 2.5, 3.5],
              [2., 3., 4.]],
             dtype=numpy.float32)
+        return y_expect,
 
-    def check_forward(self, x, output_shape):
+    def forward(self, inputs, device):
+        x, = inputs
+        output_shape = self.output_shape[2:]
         y = functions.resize_images(x, output_shape)
-        testing.assert_allclose(y.data, self.out)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x, output_shape=self.output_shape[2:])
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(
-            cuda.to_gpu(self.x), output_shape=self.output_shape[2:])
+        return y,
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Simplifies `test_resize_image` using `testing.FunctionTestCase`

Solves part of issue #6071
