### PR TITLE
Add float16 and float 64 to `F.group_normalization` test

### DIFF
--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -362,7 +362,6 @@ def group_normalization(x, groups, gamma, beta, eps=1e-5):
     the mean and variance, then normalize by these statistics,
     scales and shifts them.
 
-
     Args:
         x (:class:`~chainer.Variable` or :ref:`ndarray`): Batch tensors.
             First dimension of this value must be the size of minibatch and
@@ -377,7 +376,6 @@ def group_normalization(x, groups, gamma, beta, eps=1e-5):
         beta (:class:`~chainer.Variable` or :ref:`ndarray`):
             Shifting parameter.
         eps (float): Epsilon value for numerical stability of normalization.
-
 
     Returns:
         ~chainer.Variable: The output variable which has the same shape

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -62,7 +62,7 @@ class GroupNormalization(function_node.FunctionNode):
         var += self.eps
         self.inv_std = var
         del var
-        xp.sqrt(self.inv_std, out=self.inv_std)
+        xp.sqrt(self.inv_std, out=self.inv_std, dtype=x.dtype)
         xp.reciprocal(self.inv_std, out=self.inv_std)
         x_hat *= self.inv_std[:, None]
 

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -13,7 +13,6 @@ class GroupNormalization(link.Link):
     Parameter initialization will be deferred until
     the first forward data pass at which time the size will be determined.
 
-
     Args:
         groups (int):
             The number of channel groups.

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -63,7 +63,7 @@ class GroupNormalization(link.Link):
         self.gamma.initialize(size)
         self.beta.initialize(size)
 
-    def __call__(self, x):
+    def forward(self, x):
         """Apply group normalization to given input.
 
         Args:

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
@@ -13,7 +13,7 @@ def _simple_group_normalization(x, groups, gamma, beta, eps=1e-5):
 
     mean = numpy.mean(x_reshape, axis=(2, 3), keepdims=True)
     var = numpy.var(x_reshape, axis=(2, 3), keepdims=True)
-    std = numpy.sqrt(var + eps)
+    std = numpy.sqrt(var + eps, dtype=x.dtype)
 
     x_hat = (x_reshape - mean) / std
     x_hat = x_hat.reshape(x.shape)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
@@ -29,7 +29,7 @@ def _simple_group_normalization(x, groups, gamma, beta, eps=1e-5):
 @testing.parameterize(*(testing.product({
     'shape': [(1, 4, 5, 5), (5, 4, 15)],
     'groups': [1, 2, 4],
-    'dtype': [numpy.float32],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'eps': [1e-5, 1e-1],
 })))
 @testing.inject_backend_tests(
@@ -56,6 +56,11 @@ class TestGroupNormalization(testing.FunctionTestCase):
         self.check_forward_options.update({'atol': 1e-4, 'rtol': 1e-3})
         self.check_backward_options.update({'atol': 1e-3, 'rtol': 1e-2})
         self.check_double_backward_options.update({'atol': 1e-3, 'rtol': 1e-2})
+        if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 1e-2, 'rtol': 1e-2})
+            self.check_backward_options.update({'atol': 1e-2, 'rtol': 1e-2})
+            self.check_double_backward_options.update(
+                {'atol': 1e-2, 'rtol': 1e-2})
 
     def generate_inputs(self):
         x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)


### PR DESCRIPTION
This PR aims to complete `F.group_normalization` tests by adding np.float16 and np.float64.

Tolerance for fp16 is the same as that of `F.batch_normalization` test.