### PR TITLE
[backport] Avoid using pytest attributes during import

### DIFF
--- a/chainer/testing/attr.py
+++ b/chainer/testing/attr.py
@@ -28,9 +28,14 @@ def get_error():
 if _error is None:
     _gpu_limit = int(os.getenv('CHAINER_TEST_GPU_LIMIT', '-1'))
 
-    cudnn = pytest.mark.cudnn
-    ideep = pytest.mark.ideep
-    slow = pytest.mark.slow
+    def cudnn(*args, **kwargs):
+        return pytest.mark.cudnn(*args, **kwargs)
+
+    def ideep(*args, **kwargs):
+        return pytest.mark.ideep(*args, **kwargs)
+
+    def slow(*args, **kwargs):
+        return pytest.mark.slow(*args, **kwargs)
 
 else:
     def _dummy_callable(*args, **kwargs):


### PR DESCRIPTION
Backport of #6453