### PR TITLE
Simplify `F.expand_dims` test

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_expand_dims.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_expand_dims.py
@@ -1,12 +1,8 @@
-import unittest
-
 import numpy
 
-import chainer
 from chainer.backends import cuda
 from chainer import functions
 from chainer import testing
-from chainer.testing import attr
 
 
 @testing.parameterize(*testing.product_dict(
@@ -26,46 +22,39 @@ from chainer.testing import attr
         {'dtype': numpy.float64},
     ],
 ))
-class TestExpandDims(unittest.TestCase):
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestExpandDims(testing.FunctionTestCase):
 
-    def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+        return x,
 
-    def check_forward(self, x_data):
-        x = chainer.Variable(x_data)
+    def forward_expected(self, inputs):
+        x, = inputs
+        y_expect = numpy.expand_dims(cuda.to_cpu(x), self.axis)
+        return y_expect,
+
+    def forward(self, inputs, device):
+        x, = inputs
         y = functions.expand_dims(x, self.axis)
-        self.assertEqual(y.data.shape, self.out_shape)
-        y_expect = numpy.expand_dims(cuda.to_cpu(x_data), self.axis)
-        self.assertEqual(y.data.dtype, self.dtype)
-        numpy.testing.assert_array_equal(cuda.to_cpu(y.data), y_expect)
-
-    def check_backward(self, x_data):
-        x = chainer.Variable(x_data)
-        y = functions.expand_dims(x, self.axis)
-        y.grad = y.data
-        y.backward()
-        testing.assert_allclose(x.data, x.grad, atol=0, rtol=0)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x)
-
-    @attr.gpu
-    def test_backward(self):
-        self.check_backward(cuda.to_gpu(self.x))
-
-    def test_invalid_dim(self):
-        x = chainer.Variable(self.x)
-        with self.assertRaises(chainer.utils.type_check.InvalidType):
-            functions.expand_dims(x, self.x.ndim + 1)
-        with self.assertRaises(chainer.utils.type_check.InvalidType):
-            functions.expand_dims(x, -self.x.ndim - 2)
+        return y,
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Simplifies `test_expand_dims` using testing.FunctionTestCase

Solves part of issue #6071