### PR TITLE
fix NCCL version check error in ChainerMN

### DIFF
--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -13,7 +13,7 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
     def __init__(self, mpi_comm, allreduce_grad_dtype=None,
                  batched_copy=False):
         super(PureNcclCommunicator, self).__init__(mpi_comm)
-        if not nccl._available or nccl.get_version() < 2000:
+        if not nccl._available or nccl.get_build_version() < 2000:
             raise RuntimeError(
                 'PureNcclCommunicator is only supported on NCCL 2.0+')
 

--- a/chainermn/nccl.py
+++ b/chainermn/nccl.py
@@ -1,5 +1,6 @@
 try:
     from cupy.cuda.nccl import get_unique_id  # NOQA
+    from cupy.cuda.nccl import get_build_version  # NOQA
     from cupy.cuda.nccl import get_version  # NOQA
     from cupy.cuda.nccl import NCCL_FLOAT  # NOQA
     from cupy.cuda.nccl import NCCL_FLOAT16  # NOQA

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -144,7 +144,7 @@ def create_communicator(param, use_gpu):
         if inter_size > 1:
             pytest.skip('This test is for single node only')
 
-    if use_gpu and not param.nccl1 and nccl.get_version() < 2000:
+    if use_gpu and not param.nccl1 and nccl.get_build_version() < 2000:
         pytest.skip('This test requires NCCL version >= 2.0')
 
     if param.communicator_class is PureNcclCommunicator:
@@ -291,7 +291,7 @@ def test_communicator_gpu(param):
 class TestPureNcclCommunicator(unittest.TestCase):
 
     def setUp(self):
-        if nccl.get_version() < 2000:
+        if nccl.get_build_version() < 2000:
             pytest.skip('This test requires NCCL version >= 2.0')
         self.mpi_comm = mpi4py.MPI.COMM_WORLD
 

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -171,7 +171,7 @@ def create_communicator(communicator_class, mpi_comm, use_gpu):
     else:
         use_nccl = False
 
-    if use_gpu and not use_nccl and nccl.get_version() < 2000:
+    if use_gpu and not use_nccl and nccl.get_build_version() < 2000:
         pytest.skip('This test requires NCCL version >= 2.0')
     communicator = communicator_class(mpi_comm)
     if use_gpu:

--- a/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
@@ -22,7 +22,7 @@ class ExampleModel(chainer.Chain):
 class TestDoubleBufferingOptimizer(unittest.TestCase):
 
     def setup_gpu(self, device=None):
-        if nccl.get_version() < 2000:
+        if nccl.get_build_version() < 2000:
             pytest.skip('This test requires NCCL version >= 2.0')
         self.comm = chainermn.create_communicator('pure_nccl')
         device = self.comm.intra_rank
@@ -103,7 +103,7 @@ class DynamicExampleModel(chainer.Chain):
 class TestDoubleBufferingOptimizerWithDynamicModel(unittest.TestCase):
 
     def setup_gpu(self, device=None):
-        if nccl.get_version() < 2000:
+        if nccl.get_build_version() < 2000:
             pytest.skip('This test requires NCCL version >= 2.0')
         self.comm = chainermn.create_communicator('pure_nccl')
         device = self.comm.intra_rank


### PR DESCRIPTION
'nccl.get_version()' in the CuPy master returns 0 when using the old version (such as 2.2) of NCCL.
It is the cause of a bug in `PureNcclCommunicator` in ChainerMN.
This PR fixes it. 