### PR TITLE
Fix Python 3.4 NumPy Accelerate polyfit error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       - PYTHON_VERSION=3.4.4
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-      # if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
+      if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       - PYTHON_VERSION=3.4.4
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-      if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
+      # if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
     - os: osx
       language: generic
       env:

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -270,19 +270,6 @@ class NumericalGradientEpsTest(unittest.TestCase):
 default_eps = 1e-3
 
 
-def _skip_nondifferential_test():
-    # Skip if NumPy is installed with the Accelerate backend with Python 3.4
-    # because of a failure in NumPy's polyfit function.
-    # Please refer to the actual usage of this function.
-    with warnings.catch_warnings(record=True) as w:
-        chainer._environment_check._check_osx_numpy_backend()
-
-    return (
-        len(w) > 0  # Using Accelerate with MacOS.
-        and sys.version_info[0] == 3
-        and sys.version_info[1] == 4)
-
-
 # `result`: True if `func` is non-differentiable on `x`
 @testing.parameterize(*[
     {'func': 'zero', 'x': [-100.], 'result': False},
@@ -363,7 +350,7 @@ def _skip_nondifferential_test():
 # TODO(hvy): Stop skipping when NumPy addressed the below issue described in
 # the skip message.
 @unittest.skipIf(
-    _skip_nondifferential_test(),
+    sys.platform == 'darwin' and sys.version_info[:2] == (3, 4),
     'MacOS (darwin) with Python 3.4 will fail in gradient check because '
     'it may call numpy.polynomial.polynomial.polyfit, which may fail to '
     'allocate memory when using NumPy with the Accelerate backend.')

--- a/tests/chainer_tests/test_gradient_check.py
+++ b/tests/chainer_tests/test_gradient_check.py
@@ -274,15 +274,11 @@ def _skip_nondifferential_test():
     # Skip if NumPy is installed with the Accelerate backend with Python 3.4
     # because of a failure in NumPy's polyfit function.
     # Please refer to the actual usage of this function.
-    warnings.filterwarnings('error')
-    is_using_accelerate = False
-    try:
+    with warnings.catch_warnings(record=True) as w:
         chainer._environment_check._check_osx_numpy_backend()
-    except Warning:
-        is_using_accelerate = True
 
     return (
-        is_using_accelerate
+        len(w) > 0  # Using Accelerate with MacOS.
         and sys.version_info[0] == 3
         and sys.version_info[1] == 4)
 


### PR DESCRIPTION
Trying to work around the Travis CI failure for Python 3.4 on MacOS with Accelerate NumPy by skipping the test.