### PR TITLE
Keep backward compatibility on cupy.cudnn.batch_normalization_forward_training

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -206,7 +206,7 @@ class BatchNormalization(function_node.FunctionNode):
             y, self.mean, self.inv_std = (
                 cudnn.batch_normalization_forward_training(
                     x, gamma, beta, self.running_mean, self.running_var,
-                    self.eps, self.decay,
+                    None, None, self.eps, self.decay,
                     self.mode.is_for_conv2d, self.mode.get_cudnn_mode(),
                     chainer.is_debug()))
         else:

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -94,8 +94,8 @@ class GroupNormalization(function_node.FunctionNode):
             self.dummy_gamma = xp.ones_like(dummy_beta)
         x_hat, self.mean, self.inv_std = \
             cudnn.batch_normalization_forward_training(
-                x, self.dummy_gamma, dummy_beta, dummy_beta, dummy_beta,
-                self.eps, 1.0, True, libcudnn.CUDNN_BATCHNORM_SPATIAL,
+                x, self.dummy_gamma, dummy_beta, dummy_beta, dummy_beta, None,
+                None, self.eps, 1.0, True, libcudnn.CUDNN_BATCHNORM_SPATIAL,
                 configuration.config.debug)
 
         y = x_hat.reshape((batch_size, channels, -1))


### PR DESCRIPTION
This PR follows https://github.com/cupy/cupy/pull/2060 and https://github.com/cupy/cupy/pull/2072 to make `cupy.cudnn.batch_normalization_forward_training` keep backward compatibility, and must be merged simultaneously with https://github.com/cupy/cupy/pull/2072 
