### PR TITLE
[backport] Fix fp16 issue in batch normalization + Keep backward compatibility on cupy.cudnn.batch_normalization_forward_training

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -181,7 +181,7 @@ class BatchNormalization(function_node.FunctionNode):
             y, self.mean, self.inv_std = (
                 cudnn.batch_normalization_forward_training(
                     x, gamma, beta, self.running_mean, self.running_var,
-                    self.eps, self.decay,
+                    None, None, self.eps, self.decay,
                     self.mode.is_for_conv2d, self.mode.get_cudnn_mode(),
                     chainer.is_debug()))
         else:

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -175,16 +175,15 @@ class BatchNormalization(function_node.FunctionNode):
                 y = numpy.squeeze(y, axis=(2, 3))
 
         elif self.use_cudnn:
-            if self.mean is None:
-                # Output cache to speed up backward pass.
-                self.mean = xp.empty_like(gamma)
-                # Output cache to speed up backward pass.
-                self.inv_std = xp.empty_like(gamma)
-            y = cudnn.batch_normalization_forward_training(
-                x, gamma, beta, self.running_mean, self.running_var,
-                self.mean, self.inv_std, self.eps, self.decay,
-                self.mode.is_for_conv2d, self.mode.get_cudnn_mode(),
-                chainer.is_debug())
+            # self.mean and self.inv_std are used as buffers to save
+            # intermediate results computed during forward pass. These buffers
+            # are used to speed-up backward pass.
+            y, self.mean, self.inv_std = (
+                cudnn.batch_normalization_forward_training(
+                    x, gamma, beta, self.running_mean, self.running_var,
+                    self.eps, self.decay,
+                    self.mode.is_for_conv2d, self.mode.get_cudnn_mode(),
+                    chainer.is_debug()))
         else:
             # Generic CPU and GPU implementation
 


### PR DESCRIPTION
Backport of #6323 and #6497.

Merge cupy/cupy#2094 first.