### PR TITLE
Deprecate old NCCL versions and related communicators

### DIFF
--- a/chainermn/communicators/__init__.py
+++ b/chainermn/communicators/__init__.py
@@ -1,8 +1,10 @@
+import warnings
+
 from chainermn.communicators.communicator_base import CommunicatorBase  # NOQA
 
 
 def create_communicator(
-        communicator_name='hierarchical', mpi_comm=None,
+        communicator_name='pure_nccl', mpi_comm=None,
         allreduce_grad_dtype=None, batched_copy=False):
     """Create a ChainerMN communicator.
 
@@ -105,14 +107,20 @@ def create_communicator(
     elif communicator_name == 'hierarchical':
         from chainermn.communicators.hierarchical_communicator \
             import HierarchicalCommunicator
+        warnings.warn('hierarchical communicator is deprecated.',
+                      DeprecationWarning)
         return HierarchicalCommunicator(mpi_comm=mpi_comm)
 
     elif communicator_name == 'two_dimensional':
         from chainermn.communicators.two_dimensional_communicator \
             import TwoDimensionalCommunicator
+        warnings.warn('two_dimensional communicator is deprecated.',
+                      DeprecationWarning)
         return TwoDimensionalCommunicator(mpi_comm=mpi_comm)
 
     elif communicator_name == 'single_node':
+        warnings.warn('single_node communicator is deprecated.',
+                      DeprecationWarning)
         from chainermn.communicators.single_node_communicator \
             import SingleNodeCommunicator
         return SingleNodeCommunicator(mpi_comm=mpi_comm)

--- a/chainermn/communicators/hierarchical_communicator.py
+++ b/chainermn/communicators/hierarchical_communicator.py
@@ -1,5 +1,6 @@
 import math
 import numpy as np
+import warnings
 
 import chainer.cuda
 from chainermn.communicators import _communication_utility
@@ -17,6 +18,9 @@ class HierarchicalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
                 'NCCL is not available. '
                 'Please confirm that NCCL is enabled in CuPy.'
             )
+        if nccl.get_version() < 2302:
+            warnings.warn('NCCL 2.2 and older versions are deprecated.',
+                          DeprecationWarning)
 
         # We have to delay the initialization of communicators. This is because
         # NCCL's communicators use the current CUDA devices at the time of

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -1,3 +1,5 @@
+import warnings
+
 import chainer.cuda
 import math
 import mpi4py.MPI
@@ -18,6 +20,9 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
                 'NCCL is not available. '
                 'Please confirm that NCCL is enabled in CuPy.'
             )
+        if nccl.get_version() < 2302:
+            warnings.warn('NCCL 2.2 and older versions are deprecated.',
+                          DeprecationWarning)
 
         # We have to delay the initialization of communicators. This is because
         # NCCL's communicators use the current CUDA devices at the time of

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -1,3 +1,5 @@
+import warnings
+
 import chainer.cuda
 
 from chainermn.communicators import _communication_utility
@@ -16,6 +18,10 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         if not nccl._available or nccl.get_build_version() < 2000:
             raise RuntimeError(
                 'PureNcclCommunicator is only supported on NCCL 2.0+')
+
+        if nccl.get_version() < 2302:
+            warnings.warn('NCCL 2.2 and older versions are deprecated.',
+                          DeprecationWarning)
 
         # We have to delay the initialization of communicators. This is because
         # NCCL's communicators use the current CUDA devices at the time of

--- a/chainermn/communicators/single_node_communicator.py
+++ b/chainermn/communicators/single_node_communicator.py
@@ -1,3 +1,5 @@
+import warnings
+
 import chainer.cuda
 
 from chainermn.communicators import _communication_utility
@@ -19,6 +21,10 @@ class SingleNodeCommunicator(mpi_communicator_base.MpiCommunicatorBase):
                 'NCCL is not available. '
                 'Please confirm that NCCL is enabled in CuPy.'
             )
+        if nccl.get_version() < 2302:
+            warnings.warn('NCCL 2.2 and older versions are deprecated.',
+                          DeprecationWarning)
+
         # We have to delay the initialization of communicators. This is because
         # NCCL's communicators use the current CUDA devices at the time of
         # initialization. Therefore, we have to initialize NCCL communicators

--- a/chainermn/communicators/two_dimensional_communicator.py
+++ b/chainermn/communicators/two_dimensional_communicator.py
@@ -1,6 +1,7 @@
 import math
 import mpi4py.MPI
 import numpy as np
+import warnings
 
 import chainer.cuda
 from chainermn.communicators import _communication_utility
@@ -19,6 +20,9 @@ class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
                 'NCCL is not available. '
                 'Please confirm that NCCL is enabled in CuPy.'
             )
+        if nccl.get_version() < 2302:
+            warnings.warn('NCCL 2.2 and older versions are deprecated.',
+                          DeprecationWarning)
 
         # We have to delay the initialization of communicators. This is because
         # NCCL's communicators use the current CUDA devices at the time of

--- a/docs/source/chainermn/installation/guide.rst
+++ b/docs/source/chainermn/installation/guide.rst
@@ -124,7 +124,7 @@ We tested ChainerMN on all the following environments.
   * openmpi 2.1.2
 
 * MPI4py 3.0.0
-* NCCL 2.2.13
+* NCCL 2.3.2 2.4.2
 
 .. _non-gpu-env:
 

--- a/docs/source/upgrade.rst
+++ b/docs/source/upgrade.rst
@@ -20,6 +20,21 @@ You need to manually update CuPy package when updating Chainer package.
 This is because the automatic update made users difficult to switch between CuPy packages (e.g. ``cupy-cuda90`` and ``cupy-cuda92`` etc).
 See `#5425 <https://github.com/chainer/chainer/pull/5425>`__ for details.
 
+Deprecation Notice on Communicators and Old NCCL versions
+---------------------------------------------------------
+
+Chainer v6 only supports NCCL 2.3 and newer versions.
+Old NCCL versions are to be deprecated and will be removed in future versions.
+As of old NCCL deprecation, several communicators built for them are to be deprecated as well:
+
+- ``hierarchical``
+- ``two_dimensional``
+- ``single_node``
+
+They will be removed in future versions. Also, default communicator
+changed to `pure_nccl` from `hierarchical`.
+
+
 CuPy v6
 -------
 

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -487,7 +487,7 @@ class TestDifferentDtype(unittest.TestCase):
 
     def setup(self, gpu):
         if gpu:
-            self.communicator = chainermn.create_communicator('hierarchical')
+            self.communicator = chainermn.create_communicator('flat')
             self.device = self.communicator.intra_rank
             chainer.cuda.get_device_from_id(self.device).use()
         else:
@@ -767,7 +767,7 @@ class TestNonContiguousArray(unittest.TestCase):
 
     def setup(self, gpu):
         if gpu:
-            self.communicator = chainermn.create_communicator('hierarchical')
+            self.communicator = chainermn.create_communicator('flat')
             self.device = self.communicator.intra_rank
             chainer.cuda.get_device_from_id(self.device).use()
         else:
@@ -820,3 +820,23 @@ class TestNonContiguousArray(unittest.TestCase):
         self.setup(True)
         self.check_alltoall()
         self.teardown()
+
+
+@chainer.testing.attr.gpu
+def test_deprecation():
+    with chainer.testing.assert_warns(DeprecationWarning):
+        chainermn.create_communicator('hierarchical')
+
+    with chainer.testing.assert_warns(DeprecationWarning):
+        chainermn.create_communicator('two_dimensional')
+
+
+@chainer.testing.attr.gpu
+def test_deprecation_single():
+    ranks = _communication_utility.init_ranks(mpi_comm)
+    inter_size = ranks[4]
+    if inter_size > 1:
+        pytest.skip('This test is for single node only')
+
+    with chainer.testing.assert_warns(DeprecationWarning):
+        chainermn.create_communicator('single_node')

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -42,7 +42,7 @@ class TestAllreducePersistent(unittest.TestCase):
 
     @chainer.testing.attr.gpu
     def test_allreduce_persistent_gpu(self):
-        comm = chainermn.create_communicator('hierarchical')
+        comm = chainermn.create_communicator('flat')
         device = comm.intra_rank
         chainer.cuda.get_device_from_id(device).use()
 

--- a/tests/chainermn_tests/functions_tests/test_collective_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_collective_communication.py
@@ -15,7 +15,7 @@ class TestCollectiveCommunication(unittest.TestCase):
         numpy.random.seed(42)
 
         if gpu:
-            self.communicator = chainermn.create_communicator('hierarchical')
+            self.communicator = chainermn.create_communicator('flat')
             self.device = self.communicator.intra_rank
             chainer.cuda.get_device_from_id(self.device).use()
         else:

--- a/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
@@ -17,7 +17,7 @@ class TestPointToPointCommunication(unittest.TestCase):
     def setup(self, gpu):
         self.gpu = gpu
         if self.gpu:
-            self.communicator = chainermn.create_communicator('hierarchical')
+            self.communicator = chainermn.create_communicator('flat')
             device = self.communicator.intra_rank
             chainer.cuda.get_device_from_id(device).use()
         else:

--- a/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
+++ b/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
@@ -205,7 +205,7 @@ class TupleDataChild(chainermn.MultiNodeChainList):
 
 def create_communicator(gpu):
     if gpu:
-        communicator = chainermn.create_communicator('hierarchical')
+        communicator = chainermn.create_communicator('flat')
         chainer.cuda.get_device_from_id(communicator.intra_rank).use()
     else:
         communicator = chainermn.create_communicator('naive')

--- a/tests/chainermn_tests/links_tests/test_n_step_rnn.py
+++ b/tests/chainermn_tests/links_tests/test_n_step_rnn.py
@@ -43,7 +43,7 @@ class TestNStepRNN(unittest.TestCase):
 
     def setup(self, gpu):
         if gpu:
-            self.communicator = chainermn.create_communicator('hierarchical')
+            self.communicator = chainermn.create_communicator('flat')
             chainer.cuda.get_device_from_id(self.communicator.intra_rank).use()
         else:
             self.communicator = chainermn.create_communicator('naive')

--- a/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
@@ -31,7 +31,7 @@ class TestMultiNodeOptimizer(unittest.TestCase):
         self.actual_optimizer.create_update_rule = mock.MagicMock
 
     def setup_gpu(self, device=None):
-        self.comm = chainermn.create_communicator('hierarchical')
+        self.comm = chainermn.create_communicator('flat')
         device = self.comm.intra_rank
         chainer.cuda.get_device_from_id(device).use()
         self.target = ExampleModel()
@@ -127,7 +127,7 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
         self.actual_optimizer.create_update_rule = mock.MagicMock
 
     def setup_gpu(self, device=None):
-        self.comm = chainermn.create_communicator('hierarchical')
+        self.comm = chainermn.create_communicator('flat')
         device = self.comm.intra_rank
         chainer.cuda.get_device_from_id(device).use()
         self.target = DynamicExampleModel()


### PR DESCRIPTION
From https://github.com/chainer/chainer/pull/6482#issuecomment-472272599 :
* We'll deprecate NCCL 2.2 and older version at Chainer v6
* We'll drop NCCL 2.2 support at Chainer v7
* We'll change Chainer(MN) according to deprecation schedule above.

I concluded we don't have to change any of cupy code and range of supported NCCL versions. Thoughts?