### PR TITLE
Force camel case class name for `OpTest`

### DIFF
--- a/tests/chainerx_tests/op_utils.py
+++ b/tests/chainerx_tests/op_utils.py
@@ -227,6 +227,17 @@ def _create_test_entry_function(
     # method_name:
     #    The name of the test method name defined in `FunctionTestBase` class.
 
+    # We enforce 'Test' prefix in OpTest implementations so that they look like
+    # unittest.TestCase implementations. OTOH generated entry function must
+    # have a prefix 'test_' in order for it to be found in pytest test
+    # collection.
+    if not cls.__name__.startswith('Test'):
+        raise TypeError(
+            'OpTest class name must start with \'Test\'. Actual: {!r}'.format(
+                cls.__name__))
+
+    func_name = 'test_{}_{}'.format(cls.__name__[len('Test'):], func_suffix)
+
     @pytest.mark.parametrize_device(devices)
     def entry_func(device, *args, **kwargs):
         obj = cls()
@@ -237,7 +248,6 @@ def _create_test_entry_function(
         finally:
             obj.teardown()
 
-    func_name = '{}_{}'.format(cls.__name__, func_suffix)
     entry_func.__name__ = func_name
 
     # Set the signature of the entry function

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_connection.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_connection.py
@@ -43,7 +43,7 @@ def _create_conv_args(
     ((2, 3, 2, 6, 3), (2, 3, 1, 3, 2), None, (1, 2, 3), (2, 0, 1)),
 ])
 @chainer.testing.parameterize_pytest('cover_all', [True, False])
-class test_conv(op_utils.ChainerOpTest):
+class TestConv(op_utils.ChainerOpTest):
 
     def setup(self, float_dtype):
 
@@ -139,7 +139,7 @@ def test_conv_invalid(
 ])
 # If None, outsize argument will be None.
 @chainer.testing.parameterize_pytest('cover_all', [None, True, False])
-class test_conv_transpose(op_utils.ChainerOpTest):
+class TestConvTranspose(op_utils.ChainerOpTest):
 
     def setup(self, float_dtype):
         self.dtype = float_dtype
@@ -262,7 +262,7 @@ def test_conv_transpose_invalid(
     ((5, 2, 3), (4, 3), (4,), 2),
     # TODO(imanishi): Add test cases for more than 2 ndim
 ])
-class test_linear(op_utils.OpTest):
+class TestLinear(op_utils.OpTest):
 
     def setup(self, dtype):
         device = chainerx.get_default_device()

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -587,7 +587,7 @@ def test_sqrt(xp, device, input, in_dtype, out_dtype):
 ])
 @pytest.mark.parametrize('contiguous', [None, 'C'])
 @pytest.mark.parametrize('in_dtype,out_dtype', _expected_dtypes_math_functions)
-class test_tanh(op_utils.NumpyOpTest):
+class TestTanh(op_utils.NumpyOpTest):
 
     def setup(self, input, contiguous, in_dtype, out_dtype):
         self.input = input.astype(in_dtype)


### PR DESCRIPTION
Fixes #6505 