### PR TITLE
Add option for caching `x_hat` to GroupNormalization

### DIFF
--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -122,14 +122,10 @@ class GroupNormalization(function_node.FunctionNode):
         reduced_shape = (batch_size * groups, -1)
         x = x.reshape(reduced_shape)
 
-        if self.cache_x_hat:
-            x_hat, = _XHat(
-                self.eps, self.mean, self.inv_std,
-                self.dummy_gamma, self.x_hat).apply((x,))
-        else:
-            x_hat, = _XHat(
-                self.eps, self.mean, self.inv_std,
-                self.dummy_gamma).apply((x,))
+        cached_x_hat = self.x_hat if self.cache_x_hat else None
+        x_hat, = _XHat(
+            self.eps, self.mean, self.inv_std,
+            self.dummy_gamma, cached_x_hat).apply((x,))
         gx_hat, ggamma, gbeta = _ScaleShiftGrad().apply((x_hat, gamma, gy))
         gx, = _XHatGrad(
             self.eps, self.mean, self.inv_std,

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -32,7 +32,7 @@ class GroupNormalization(link.Link):
             If a scalar, the vector is filled by it.
             If ``numpy.ndarray``, the vector is set by it.
         cache_x_hat (bool): If ``True``, cache normalized input ``x`` for
-            faster backward. The default value is ``Nonee`` because Group
+            faster backward. The default value is ``False`` because Group
             Normalization is a normalization technique for training with
             very small batchsizes.
 

--- a/chainer/links/normalization/group_normalization.py
+++ b/chainer/links/normalization/group_normalization.py
@@ -31,6 +31,10 @@ class GroupNormalization(link.Link):
             If ``None``, then the vector is filled by 0.
             If a scalar, the vector is filled by it.
             If ``numpy.ndarray``, the vector is set by it.
+        cache_x_hat (bool): If ``True``, cache normalized input ``x`` for
+            faster backward. The default value is ``Nonee`` because Group
+            Normalization is a normalization technique for training with
+            very small batchsizes.
 
     Attributes:
         groups (int): The number of channel groups.
@@ -42,18 +46,19 @@ class GroupNormalization(link.Link):
     """
 
     def __init__(self, groups, size=None, eps=1e-5, initial_gamma=None,
-                 initial_beta=None):
+                 initial_beta=None, cache_x_hat=False):
         super(GroupNormalization, self).__init__()
         if initial_gamma is None:
             initial_gamma = 1
         if initial_beta is None:
             initial_beta = 0
 
+        self.groups = groups
+        self.eps = eps
+        self.cache_x_hat = cache_x_hat
         with self.init_scope():
-            self.groups = groups
             self.gamma = variable.Parameter(initial_gamma)
             self.beta = variable.Parameter(initial_beta)
-            self.eps = eps
 
         if size is not None:
             self._initialize_params(size)
@@ -85,4 +90,4 @@ class GroupNormalization(link.Link):
             self._initialize_params(channels)
 
         return group_normalization.group_normalization(
-            x, self.groups, self.gamma, self.beta, self.eps)
+            x, self.groups, self.gamma, self.beta, self.eps, self.cache_x_hat)

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
@@ -31,6 +31,7 @@ def _simple_group_normalization(x, groups, gamma, beta, eps=1e-5):
     'groups': [1, 2, 4],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'eps': [1e-5, 1e-1],
+    'cache_x_hat': [True, False],
 })))
 @testing.inject_backend_tests(
     None,

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -54,8 +54,8 @@ class GroupNormalizationTest(unittest.TestCase):
 
     @attr.cudnn
     def test_forward_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
-        self.test_forward_gpu()
+        with chainer.using_config('use_cudnn', 'never'):
+            self.test_forward_gpu()
 
     @attr.multi_gpu(2)
     @condition.retry(3)
@@ -86,9 +86,9 @@ class GroupNormalizationTest(unittest.TestCase):
 
     @attr.cudnn
     def test_backward_gpu_without_cudnn(self):
-        self.link.use_cudnn = False
         self.link(numpy.zeros(self.shape, dtype='f'))
-        self.test_backward_gpu()
+        with chainer.using_config('use_cudnn', 'never'):
+            self.test_backward_gpu()
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
This PR aims at enabling GroupNormalization FunctionNode to cache `x_hat` in order to skip normalizing `x` of backward by adding an option.