### PR TITLE
Support non-float cast in `F.cast`

### DIFF
--- a/chainer/functions/array/cast.py
+++ b/chainer/functions/array/cast.py
@@ -1,3 +1,5 @@
+import numpy
+
 import chainer
 from chainer import function_node
 from chainer.utils import type_check
@@ -12,16 +14,17 @@ class Cast(function_node.FunctionNode):
 
     def check_type_forward(self, in_types):
         type_check._argname(in_types, ('x',))
-        x_type = in_types[0]
-
-        type_check.expect(x_type.dtype.kind == 'f')
 
     def forward(self, x):
         self._in_type = x[0].dtype.type
         return x[0].astype(self.type, copy=False),
 
     def backward(self, indexes, g):
-        return cast(g[0], self._in_type),
+        if numpy.dtype(self._in_type).kind != 'f':
+            gx = None
+        else:
+            gx = cast(g[0], self._in_type)
+        return gx,
 
 
 def cast(x, typ):
@@ -30,7 +33,7 @@ def cast(x, typ):
     Args:
         x (:class:`~chainer.Variable` or :ref:`ndarray`):
             Input variable to be casted. A \
-            :math:`(s_1, s_2, ..., s_N)`-shaped float array.
+            :math:`(s_1, s_2, ..., s_N)`-shaped array.
         typ (:class:`str` of dtype or :class:`numpy.dtype`):
             Typecode or data type to cast.
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_cast.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_cast.py
@@ -16,11 +16,21 @@ from chainer.testing import attr
         {'shape': ()},
     ],
     [
+        {'in_type': numpy.bool_},
+        {'in_type': numpy.uint8},
+        {'in_type': numpy.uint64},
+        {'in_type': numpy.int8},
+        {'in_type': numpy.int64},
         {'in_type': numpy.float16},
         {'in_type': numpy.float32},
         {'in_type': numpy.float64},
     ],
     [
+        {'out_type': numpy.bool_},
+        {'out_type': numpy.uint8},
+        {'out_type': numpy.uint64},
+        {'out_type': numpy.int8},
+        {'out_type': numpy.int64},
         {'out_type': numpy.float16},
         {'out_type': numpy.float32},
         {'out_type': numpy.float64},
@@ -46,6 +56,10 @@ class TestCast(unittest.TestCase):
         self.check_forward(cuda.to_gpu(self.x))
 
     def check_backward(self, x_data, g_data):
+        if (numpy.dtype(self.in_type).kind != 'f'
+                or numpy.dtype(self.out_type).kind != 'f'):
+            raise unittest.SkipTest('Non-float dtypes')
+
         def func(x):
             return functions.cast(x, self.out_type)
 


### PR DESCRIPTION
With this fix, `F.cast` supports casts involving non-float dtypes.