### PR TITLE
Add `chainerx.testing.integral_dtypes`

### DIFF
--- a/chainerx/testing/__init__.py
+++ b/chainerx/testing/__init__.py
@@ -15,6 +15,7 @@ from chainerx.testing.array import assert_array_equal  # NOQA
 from chainerx.testing.array import assert_array_equal_ex  # NOQA
 from chainerx.testing.dtypes import all_dtypes  # NOQA
 from chainerx.testing.dtypes import float_dtypes  # NOQA
+from chainerx.testing.dtypes import integral_dtypes  # NOQA
 from chainerx.testing.dtypes import nonfloat_dtypes  # NOQA
 from chainerx.testing.dtypes import numeric_dtypes  # NOQA
 from chainerx.testing.dtypes import parametrize_dtype_specifier  # NOQA

--- a/chainerx/testing/dtypes.py
+++ b/chainerx/testing/dtypes.py
@@ -26,6 +26,15 @@ unsigned_dtypes = (
 )
 
 
+integral_dtypes = (
+    'uint8',
+    'int8',
+    'int16',
+    'int32',
+    'int64',
+)
+
+
 nonfloat_dtypes = (
     'bool_',
     'int8',

--- a/tests/chainerx_tests/unit_tests/testing_tests/test_dtypes.py
+++ b/tests/chainerx_tests/unit_tests/testing_tests/test_dtypes.py
@@ -4,30 +4,38 @@ import chainerx
 import chainerx.testing
 
 
-def test_float_dtypes():
-    # float_dtypes must be a subset of all_dtypes
-    assert all(
-        dtype in chainerx.testing.all_dtypes
-        for dtype in chainerx.testing.float_dtypes)
+def test_dtype_lists():
+    # Each dtype list must be a subset of all_dtypes.
+    dtype_lists = [
+        chainerx.testing.all_dtypes,
+        chainerx.testing.float_dtypes,
+        chainerx.testing.signed_dtypes,
+        chainerx.testing.unsigned_dtypes,
+        chainerx.testing.integral_dtypes,
+        chainerx.testing.nonfloat_dtypes,
+    ]
+    for dtype_list in dtype_lists:
+        assert isinstance(dtype_list, tuple)
+        assert all([
+            dtype in chainerx.testing.all_dtypes
+            for dtype in dtype_list])
 
     # Check dtype kind
     for dtype in chainerx.testing.all_dtypes:
         is_float = dtype in chainerx.testing.float_dtypes
-        assert is_float == (numpy.dtype(
-            getattr(numpy, dtype)).kind in ('f', 'c'))
+        assert is_float == (numpy.dtype(dtype).kind in ('f', 'c'))
 
-
-def test_signed_dtypes():
-    # signe_dtypes must be a subset of all_dtypes
-    assert all(
-        dtype in chainerx.testing.all_dtypes
-        for dtype in chainerx.testing.signed_dtypes)
-
-    # Check dtype kind
-    for dtype in chainerx.testing.all_dtypes:
         is_signed = dtype in chainerx.testing.signed_dtypes
-        assert is_signed == (numpy.dtype(
-            getattr(numpy, dtype)).kind in ('i', 'f', 'c'))
+        assert is_signed == (numpy.dtype(dtype).kind in ('i', 'f', 'c'))
+
+        is_unsigned = dtype in chainerx.testing.unsigned_dtypes
+        assert is_unsigned == (numpy.dtype(dtype).kind == 'u')
+
+        is_integral = dtype in chainerx.testing.integral_dtypes
+        assert is_integral == (numpy.dtype(dtype).kind in ('i', 'u'))
+
+        is_nonfloat = dtype in chainerx.testing.nonfloat_dtypes
+        assert is_nonfloat == (numpy.dtype(dtype).kind != 'f')
 
 
 @chainerx.testing.parametrize_dtype_specifier('spec')


### PR DESCRIPTION
Used in #6438.