### PR TITLE
Rewrite ChainerX `batch_norm` test

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -119,7 +119,7 @@ class TestBatchNorm(op_utils.ChainerOpTest):
         else:
             self.check_forward_options.update({'rtol': 1e-6, 'atol': 1e-5})
             self.check_backward_options.update({
-                'eps': 1e-3, 'rtol': 1e-3, 'atol': 1e-4})
+                'eps': 1e-3, 'rtol': 5e-3, 'atol': 5e-4})
             self.check_double_backward_options.update({
                 'rtol': 5e-2, 'atol': 5e-3})
 

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -1,7 +1,7 @@
+import chainer
 import numpy
 import pytest
 
-import chainer
 import chainerx
 
 from chainerx_tests import array_utils

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -1,3 +1,5 @@
+import unittest
+
 import chainer
 import numpy
 import pytest
@@ -99,9 +101,9 @@ class TestBatchNorm(op_utils.ChainerOpTest):
         # contiguous copy in the cuDNN wrapper.
         self.is_cuda = chainerx.get_default_device().backend.name == 'cuda'
         if self.is_cuda and self.contiguous is None:
-            self.skip_forward_test = True
-            self.skip_backward_test = True
-            self.skip_double_backward_test = True
+            raise unittest.SkipTest(
+                'batch_norm with CUDA currently has limited support for '
+                'non-contiguous inputs.')
 
         # Float16 backward is unstable.
         if float_dtype == 'float16':

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -1,10 +1,11 @@
-import chainer
 import numpy
 import pytest
 
+import chainer
 import chainerx
 
 from chainerx_tests import array_utils
+from chainerx_tests import op_utils
 
 
 def _create_batch_norm_ndarray_args(
@@ -67,57 +68,137 @@ _batch_norm_invalid_dimensions_params = [
 ]
 
 
-@pytest.mark.parametrize('x_shape,reduced_shape,axis', _batch_norm_params)
-@pytest.mark.parametrize('eps', [None, 3e-5, 1.2])
-@pytest.mark.parametrize('decay', [None, 0.5])
-@pytest.mark.parametrize_device(['native:0', 'cuda:0'])
-def test_batch_norm(
-        device, x_shape, reduced_shape, eps, decay, axis, float_dtype):
-    def create_args(xp):
-        return _create_batch_norm_ndarray_args(
-            xp, device, x_shape, reduced_shape, reduced_shape, reduced_shape,
-            reduced_shape, float_dtype)
+@op_utils.op_test(['native:0', 'cuda:0'])
+@chainer.testing.parameterize_pytest(
+    'x_shape,reduced_shape,axis', _batch_norm_params)
+@chainer.testing.parameterize_pytest('eps', [2e-5, 5e-1])
+@chainer.testing.parameterize_pytest('decay', [None, 0.5])
+@chainer.testing.parameterize_pytest('contiguous', [None, 'C'])
+class TestBatchNorm(op_utils.ChainerOpTest):
 
-    x_chx, gamma_chx, beta_chx, running_mean_chx, running_var_chx = (
-        create_args(chainerx))
-    x_np, gamma_np, beta_np, running_mean_np, running_var_np = (
-        create_args(numpy))
+    def setup(self, float_dtype):
+        self.dtype = float_dtype
 
-    # Save copies of running values before updating to later check that they
-    # are updated.
-    initial_running_mean = running_mean_chx.copy()
-    initial_running_var = running_var_chx.copy()
+        eps = self.eps
+        decay = self.decay
+        axis = self.axis
 
-    optional_args = {}
-    if eps is not None:
-        optional_args['eps'] = eps
-    if decay is not None:
-        optional_args['decay'] = decay
-    if axis is not None:
-        optional_args['axis'] = axis
+        optional_args = {}
+        if eps is not None:
+            optional_args['eps'] = eps
+        if decay is not None:
+            optional_args['decay'] = decay
+        if axis is not None:
+            optional_args['axis'] = axis
+        self.optional_args = optional_args
 
-    y_chx = chainerx.batch_norm(
-        x_chx, gamma_chx, beta_chx, running_mean=running_mean_chx,
-        running_var=running_var_chx, **optional_args)
-    y_np = chainer.functions.batch_normalization(
-        x_np, gamma_np, beta_np, running_mean=running_mean_np,
-        running_var=running_var_np, **optional_args).data
+        # - Non-contiguous running values which are updated in-place are not
+        # supported by CUDA.
+        # - Non-contiguous gamma and beta is not supported by CUDA.
+        # TODO(hvy): Support non-contiguous gamma and beta with CUDA. Create a
+        # contiguous copy in the cuDNN wrapper.
+        self.is_cuda = chainerx.get_default_device().backend.name == 'cuda'
+        if self.is_cuda and self.contiguous is None:
+            self.skip_forward_test = True
+            self.skip_backward_test = True
+            self.skip_double_backward_test = True
 
-    # Check that the running values are updated.
-    assert not numpy.allclose(chainerx.to_numpy(
-        initial_running_mean), chainerx.to_numpy(running_mean_chx))
-    assert not numpy.allclose(chainerx.to_numpy(
-        initial_running_var), chainerx.to_numpy(running_var_chx))
+        # Float16 backward is unstable.
+        if float_dtype == 'float16':
+            self.skip_backward_test = True
+            self.skip_double_backward_test = True
 
-    chainerx.testing.assert_allclose_ex(
-        y_chx, y_np, rtol=1e-6, atol=1e-5,
-        float16_rtol=1e-2, float16_atol=1e-2)
-    chainerx.testing.assert_allclose_ex(
-        running_mean_chx, running_mean_np,
-        rtol=1e-6, atol=1e-6, float16_rtol=1e-2, float16_atol=1e-2)
-    chainerx.testing.assert_allclose_ex(
-        running_var_chx, running_var_np,
-        rtol=1e-6, atol=1e-6, float16_rtol=1e-2, float16_atol=1e-2)
+        if float_dtype == 'float16':
+            self.check_forward_options.update({'rtol': 1e-1, 'atol': 1e-1})
+            self.check_backward_options.update({
+                'eps': 1e-3, 'rtol': 1e-1, 'atol': 1e-2})
+            self.check_double_backward_options.update({
+                'rtol': 1e-1, 'atol': 1e-2})
+        else:
+            self.check_forward_options.update({'rtol': 1e-6, 'atol': 1e-5})
+            self.check_backward_options.update({
+                'eps': 1e-3, 'rtol': 1e-3, 'atol': 1e-4})
+            self.check_double_backward_options.update({
+                'rtol': 5e-2, 'atol': 5e-3})
+
+        reduced_shape = self.reduced_shape
+        running_mean = numpy.random.uniform(
+            -1, 1, reduced_shape).astype(float_dtype)
+        running_var = numpy.random.uniform(
+            .1, 1, reduced_shape).astype(float_dtype)
+        self.running_mean = running_mean
+        self.running_var = running_var
+
+        # Used to verify running mean and variance similarity with Chainer.
+        self.running_mean_chx = None
+        self.running_var_chx = None
+        self.running_mean_ch = None
+        self.running_var_ch = None
+
+    def generate_inputs(self):
+        x_shape = self.x_shape
+        reduced_shape = self.reduced_shape
+        dtype = self.dtype
+
+        x = numpy.random.uniform(-1, 1, x_shape).astype(dtype)
+        gamma = numpy.random.uniform(-1, 1, reduced_shape).astype(dtype)
+        beta = numpy.random.uniform(-1, 1, reduced_shape).astype(dtype)
+
+        return x, gamma, beta,
+
+    def forward_chainerx(self, inputs):
+        x, gamma, beta = inputs
+
+        if self.is_cuda and self.contiguous == 'C':
+            # Testing pre-condition.
+            assert x.is_contiguous
+            assert gamma.is_contiguous
+            assert beta.is_contiguous
+
+        running_mean = chainerx.array(
+            self.running_mean, copy=True).astype(x.dtype)
+        running_var = chainerx.array(
+            self.running_var, copy=True).astype(x.dtype)
+
+        y = chainerx.batch_norm(
+            x, gamma, beta, running_mean=running_mean, running_var=running_var,
+            **self.optional_args)
+
+        self.running_mean_chx = running_mean
+        self.running_var_chx = running_var
+
+        return y,
+
+    def forward_chainer(self, inputs):
+        x, gamma, beta = inputs
+
+        running_mean = numpy.array(
+            self.running_mean, copy=True).astype(x.dtype)
+        running_var = numpy.array(self.running_var, copy=True).astype(x.dtype)
+
+        y = chainer.functions.batch_normalization(
+            x, gamma, beta, running_mean=running_mean, running_var=running_var,
+            **self.optional_args)
+
+        self.running_mean_ch = running_mean
+        self.running_var_ch = running_var
+
+        return y,
+
+    def check_forward_outputs(self, outputs, expected_outputs):
+        super().check_forward_outputs(outputs, expected_outputs)
+
+        # Check that running values are updated.
+        if self.dtype == 'float16':
+            check_running_options = {'rtol': 1e-3, 'atol': 1e-3}
+        else:
+            check_running_options = {'rtol': 1e-6, 'atol': 1e-5}
+
+        chainerx.testing.assert_allclose(
+            self.running_mean_chx, self.running_mean_ch,
+            **check_running_options)
+        chainerx.testing.assert_allclose(
+            self.running_var_chx, self.running_var_ch, **check_running_options)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Partially fixes https://github.com/chainer/chainer/issues/6401

Also fixes a bug in `BatchNorm` for "None" upstream gradients.