### PR TITLE
Add support for fp16 and fp64 to cudnn RNN

### DIFF
--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -66,7 +66,7 @@ if cuda.cudnn_enabled and _cudnn_version >= 5000:
         elif dtype == numpy.float64:
             return libcudnn.CUDNN_DATA_DOUBLE, 8
         else:
-            raise RuntimeError()
+            raise ValueError('Invalid dtype of {}'.format(dtype))
 
 
 class CudnnRNNWeightConcat(function.Function):
@@ -124,8 +124,7 @@ class CudnnRNNWeightConcat(function.Function):
                         w_type.ndim == 2,
                         w_type.shape[0] == out_size,
                         w_type.shape[1] == w_in,
-                        w_type.dtype == b_type.dtype,
-                        b_type.dtype.kind == 'f',
+                        b_type.dtype == w_type.dtype,
                         b_type.ndim == 1,
                         b_type.shape[0] == out_size,
                     )
@@ -247,8 +246,7 @@ class BaseNStepRNN(function.Function):
             h_size = self.n_layers * self.rnn_direction
             type_check.expect(
                 h_type.dtype.kind == 'f',
-                c_type.dtype.kind == 'f',
-                h_type.dtype == c_type.dtype,
+                c_type.dtype == h_type.dtype,
 
                 h_type.ndim == 3,
                 h_type.shape[0] == h_size,
@@ -274,7 +272,6 @@ class BaseNStepRNN(function.Function):
             )
 
         type_check.expect(
-            x_type.dtype.kind == 'f',
             x_type.dtype == h_type.dtype,
             x_type.ndim == 2,
             x_type.shape[0] == self.sections[-1],

--- a/chainer/functions/connection/n_step_rnn.py
+++ b/chainer/functions/connection/n_step_rnn.py
@@ -110,12 +110,12 @@ class CudnnRNNWeightConcat(function.Function):
                             w_in = out_size
 
                     type_check.expect(
-                        w_type.dtype == numpy.float32,
+                        w_type.dtype.kind == 'f',
                         w_type.ndim == 2,
                         w_type.shape[0] == out_size,
                         w_type.shape[1] == w_in,
-
-                        b_type.dtype == numpy.float32,
+                        w_type.dtype == b_type.dtype,
+                        b_type.dtype.kind == 'f',
                         b_type.ndim == 1,
                         b_type.shape[0] == out_size,
                     )
@@ -234,8 +234,9 @@ class BaseNStepRNN(function.Function):
             h_type, c_type, w_type, x_type = in_types
             h_size = self.n_layers * self.rnn_direction
             type_check.expect(
-                h_type.dtype == numpy.float32,
-                c_type.dtype == numpy.float32,
+                h_type.dtype.kind == 'f',
+                c_type.dtype.kind == 'f',
+                h_type.dtype == c_type.dtype,
 
                 h_type.ndim == 3,
                 h_type.shape[0] == h_size,
@@ -254,14 +255,15 @@ class BaseNStepRNN(function.Function):
             h_type, w_type, x_type = in_types
             h_size = self.n_layers * self.rnn_direction
             type_check.expect(
-                h_type.dtype == numpy.float32,
+                h_type.dtype.kind == 'f',
 
                 h_type.ndim == 3,
                 h_type.shape[0] == h_size,
             )
 
         type_check.expect(
-            x_type.dtype == numpy.float32,
+            x_type.dtype.kind == 'f',
+            x_type.dtype == h_type.dtype,
             x_type.ndim == 2,
             x_type.shape[0] == self.sections[-1],
         )

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_gru.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_gru.py
@@ -82,6 +82,9 @@ class TestNStepGRU(unittest.TestCase):
 
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
         self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3, 'eps': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 1e-2, 'rtol': 1e-2})
+            self.check_backward_options.update({'atol': 1e-1, 'rtol': 5e-2})
 
     def check_forward(self, h_data, xs_data, ws_data, bs_data):
         h = _wrap_variable(h_data)
@@ -275,6 +278,9 @@ class TestNStepBiGRU(unittest.TestCase):
 
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
         self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3, 'eps': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 1e-2, 'rtol': 1e-2})
+            self.check_backward_options.update({'atol': 1e-1, 'rtol': 5e-2})
 
     def check_forward(self, h_data, xs_data, ws_data, bs_data):
         h = chainer.Variable(h_data)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -297,7 +297,7 @@ class TestNStepBiLSTM(unittest.TestCase):
     def setUp(self):
         self.xs = _shaped_random(
             [(b, self.in_size) for b in self.batches], self.dtype)
-        h_shape = (self.n_layers, self.batches[0], self.out_size)
+        h_shape = (self.n_layers * 2, self.batches[0], self.out_size)
         self.cx = _shaped_random(h_shape, self.dtype)
         self.hx = _shaped_random(h_shape, self.dtype)
 

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_lstm.py
@@ -85,6 +85,9 @@ class TestNStepLSTM(unittest.TestCase):
 
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
         self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3, 'eps': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 1e-2, 'rtol': 1e-2})
+            self.check_backward_options.update({'atol': 1e-1, 'rtol': 5e-2})
 
     def check_forward(
             self, h_data, c_data, xs_data, ws_data, bs_data):
@@ -325,6 +328,9 @@ class TestNStepBiLSTM(unittest.TestCase):
 
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
         self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3, 'eps': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 1e-2, 'rtol': 1e-2})
+            self.check_backward_options.update({'atol': 1e-1, 'rtol': 5e-2})
 
     def check_forward(
             self, h_data, c_data, xs_data, ws_data, bs_data):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -350,6 +350,9 @@ class TestNStepBiRNN(unittest.TestCase):
 
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
         self.check_backward_options = {'atol': 5e-2, 'rtol': 1e-2}
+        if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 1e-2, 'rtol': 1e-2})
+            self.check_backward_options.update({'atol': 1e-1, 'rtol': 5e-2})
 
     def check_forward(
             self, h_data, xs_data, ws_data, bs_data):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_n_step_rnn.py
@@ -80,7 +80,7 @@ class TestNStepRNN(unittest.TestCase):
             [(b, self.out_size) for b in self.batches], self.dtype)
         self.dhy = _shaped_random(h_shape, self.dtype)
 
-        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-4}
+        self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
         self.check_backward_options = {'atol': 5e-2, 'rtol': 1e-2}
         if self.dtype == numpy.float16:
             self.check_forward_options.update({'atol': 1e-2, 'rtol': 1e-2})
@@ -137,9 +137,9 @@ class TestNStepRNN(unittest.TestCase):
 
     def check_backward(self, h_data, xs_data, ws_data, bs_data,
                        dhy_data, dys_data):
-        args = tuple([h_data, ] + sum(ws_data, []) + sum(bs_data, []) +
+        args = tuple([h_data] + sum(ws_data, []) + sum(bs_data, []) +
                      xs_data)
-        grads = tuple([dhy_data, ] + dys_data)
+        grads = tuple([dhy_data] + dys_data)
 
         def f(*inputs):
             (hx, ), inputs = _split(inputs, 1)
@@ -434,9 +434,9 @@ class TestNStepBiRNN(unittest.TestCase):
 
     def check_backward(self, h_data, xs_data, ws_data, bs_data,
                        dhy_data, dys_data):
-        args = tuple([h_data, ] + sum(ws_data, []) + sum(bs_data, []) +
+        args = tuple([h_data] + sum(ws_data, []) + sum(bs_data, []) +
                      xs_data)
-        grads = tuple([dhy_data, ] + dys_data)
+        grads = tuple([dhy_data] + dys_data)
 
         def f(*inputs):
             (hx, ), inputs = _split(inputs, 1)


### PR DESCRIPTION
This PR enables `NStepRNN`s to handle inputs of float16/float64.

- [x] fix TestNStepBiLSTM of test_n_step_lstm.py