### PR TITLE
Override `forward` in `LinkHook` documentation

### DIFF
--- a/chainer/link_hook.py
+++ b/chainer/link_hook.py
@@ -83,7 +83,7 @@ class LinkHook(object):
         ...     super(Model, self).__init__()
         ...     with self.init_scope():
         ...       self.l = L.Linear(10, 10)
-        ...   def __call__(self, x1):
+        ...   def forward(self, x1):
         ...     return F.exp(self.l(x1))
         >>> model1 = Model()
         >>> model2 = Model()


### PR DESCRIPTION
This PR updates the example of `chainer.LinkHook` docstring.