### PR TITLE
Fix `parameterize_pytest` to allow parameterizing with tuples

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -99,9 +99,9 @@ def parameterize_pytest(names, values):
     assert isinstance(values, (tuple, list))
 
     def safe_zip(ns, vs):
-        if not isinstance(vs, (tuple, list)):
-            vs = (vs,)
-        assert len(ns) == len(vs)
+        if len(ns) == 1:
+            return [(ns[0], vs)]
+        assert isinstance(vs, (tuple, list)) and len(ns) == len(vs)
         return zip(ns, vs)
 
     names = names.split(',')


### PR DESCRIPTION
This PR makes the following code work.
```py
shapes = [
    (1, 2),
    (3, 4, 5)
]

@chainer.testing.parameterize_pytest('shape', shapes)
class TestFoo...
```