### PR TITLE
Add FP16 test to multi_node_chain_list

### DIFF
--- a/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
+++ b/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
@@ -7,6 +7,20 @@ import numpy as np
 import pytest
 
 
+class Param(object):
+    def __init__(self, param):
+        self.dtype = None
+        self.__dict__.update(param)
+
+
+params = [Param(p) for p in [
+    {
+        'dtype': np.float16,
+    }, {
+        'dtype': np.float32,
+    }]]
+
+
 class Cycle0SubA(chainer.Chain):
     def __init__(self, size):
         super(Cycle0SubA, self).__init__()
@@ -218,16 +232,64 @@ def create_communicator(gpu):
     return communicator, rank_next, rank_prev
 
 
-def check_cycle_model(gpu):
+def check_cycle_model(gpu, param):
     communicator, rank_next, rank_prev = create_communicator(gpu)
 
     n, d = 100, 10
 
-    if communicator.rank == 0:
-        X = np.random.randn(n, d).astype(np.float32)
-        Y = (np.random.rand(n) * 2).astype(np.int32)
-        model = L.Classifier(
-            Cycle0(d, communicator, rank_next, rank_prev))
+    with chainer.using_config('dtype', param.dtype):
+        if communicator.rank == 0:
+            X = np.random.randn(n, d).astype(param.dtype)
+            Y = (np.random.rand(n) * 2).astype(np.int32)
+            model = L.Classifier(
+                Cycle0(d, communicator, rank_next, rank_prev))
+
+            if gpu:
+                model.to_gpu()
+                X = chainer.cuda.to_gpu(X)
+                Y = chainer.cuda.to_gpu(Y)
+
+            for i in range(n):
+                err = model(X[i:i + 1], Y[i:i + 1])
+                err.backward()
+        else:
+            model = Cycle1(
+                d, communicator, rank_next, rank_prev)
+            if gpu:
+                model.to_gpu()
+
+            for i in range(n):
+                err = model()
+                err.backward()
+
+
+@pytest.mark.parametrize('param', params)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_cycle_model_cpu(param):
+    check_cycle_model(False, param)
+
+
+@pytest.mark.parametrize('param', params)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@chainer.testing.attr.gpu
+def test_cycle_model_gpu(param):
+    check_cycle_model(True, param)
+
+
+def check_crossing_model(gpu, param):
+    communicator, rank_next, rank_prev = create_communicator(gpu)
+
+    n, d = 100, 10
+    X = np.random.randn(n, d).astype(param.dtype)
+    Y = (np.random.rand(n) * 2).astype(np.int32)
+
+    with chainer.using_config('dtype', param.dtype):
+        if communicator.rank == 0:
+            model = L.Classifier(Cross0(
+                d, communicator, rank_next, rank_prev))
+        else:
+            model = L.Classifier(Cross1(
+                d, communicator, rank_next, rank_prev))
 
         if gpu:
             model.to_gpu()
@@ -237,73 +299,96 @@ def check_cycle_model(gpu):
         for i in range(n):
             err = model(X[i:i + 1], Y[i:i + 1])
             err.backward()
-    else:
-        model = Cycle1(
-            d, communicator, rank_next, rank_prev)
-        if gpu:
-            model.to_gpu()
-
-        for i in range(n):
-            err = model()
-            err.backward()
 
 
+@pytest.mark.parametrize('param', params)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_cycle_model_cpu():
-    check_cycle_model(False)
+def test_crossing_model_cpu(param):
+    check_crossing_model(False, param)
 
 
+@pytest.mark.parametrize('param', params)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @chainer.testing.attr.gpu
-def test_cycle_model_gpu():
-    check_cycle_model(True)
-
-
-def check_crossing_model(gpu):
-    communicator, rank_next, rank_prev = create_communicator(gpu)
-
-    n, d = 100, 10
-    X = np.random.randn(n, d).astype(np.float32)
-    Y = (np.random.rand(n) * 2).astype(np.int32)
-
-    if communicator.rank == 0:
-        model = L.Classifier(Cross0(
-            d, communicator, rank_next, rank_prev))
-    else:
-        model = L.Classifier(Cross1(
-            d, communicator, rank_next, rank_prev))
-
-    if gpu:
-        model.to_gpu()
-        X = chainer.cuda.to_gpu(X)
-        Y = chainer.cuda.to_gpu(Y)
-
-    for i in range(n):
-        err = model(X[i:i + 1], Y[i:i + 1])
-        err.backward()
-
-
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_crossing_model_cpu():
-    check_crossing_model(False)
-
-
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-@chainer.testing.attr.gpu
-def test_crossing_model_gpu():
-    check_crossing_model(True)
+def test_crossing_model_gpu(param):
+    check_crossing_model(True, param)
 
 
 def check_branching_model(gpu, communicator, rank_next, rank_prev,
-                          parent_model):
+                          parent_model, param):
     n, d = 100, 10
-    X = np.random.randn(n, d).astype(np.float32)
+    X = np.random.randn(n, d).astype(param.dtype)
     Y = (np.random.rand(n) * 2).astype(np.int32)
 
-    if communicator.rank == 0:
-        rank_children = [rank for rank in range(1, communicator.size)]
-        model = L.Classifier(parent_model(
-            d, communicator, rank_children))
+    with chainer.using_config('dtype', param.dtype):
+        if communicator.rank == 0:
+            rank_children = [rank for rank in range(1, communicator.size)]
+            model = L.Classifier(parent_model(
+                d, communicator, rank_children))
+            if gpu:
+                model.to_gpu()
+                X = chainer.cuda.to_gpu(X)
+                Y = chainer.cuda.to_gpu(Y)
+
+            for i in range(n):
+                err = model(X[i:i + 1], Y[i:i + 1])
+                err.backward()
+        else:
+            model = BranchChild(d, communicator, 0)
+            if gpu:
+                model.to_gpu()
+
+            for i in range(n):
+                err = model()
+                err.backward()
+
+
+def check_branching_models(gpu, param):
+    communicator, rank_next, rank_prev = create_communicator(gpu)
+    check_branching_model(gpu, communicator, rank_next, rank_prev,
+                          BranchParent1, param)
+
+    check_branching_model(gpu, communicator, rank_next, rank_prev,
+                          BranchParent2, param)
+
+    check_branching_model(gpu, communicator, rank_next, rank_prev,
+                          BranchParent3, param)
+
+    check_branching_model(gpu, communicator, rank_next, rank_prev,
+                          BranchParent4, param)
+
+
+@pytest.mark.parametrize('param', params)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_branching_models_cpu(param):
+    check_branching_models(False, param)
+
+
+@pytest.mark.parametrize('param', params)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@chainer.testing.attr.gpu
+def test_branching_models_gpu(param):
+    check_branching_models(True, param)
+
+
+def check_twisting_model(gpu, param):
+    communicator, rank_next, rank_prev = create_communicator(gpu)
+
+    n, d = 100, 10
+    X = np.random.randn(n, d).astype(param.dtype)
+    Y = (np.random.rand(n) * 2).astype(np.int32)
+
+    with chainer.using_config('dtype', param.dtype):
+        if communicator.rank == 0:
+            model = L.Classifier(
+                TwistFirst(d, communicator, rank_next))
+        elif communicator.rank == communicator.size - 1:
+            model = L.Classifier(
+                TwistLast(d, communicator, rank_prev))
+        else:
+            model = L.Classifier(Twist(
+                d, communicator, rank_prev, rank_next))
+
         if gpu:
             model.to_gpu()
             X = chainer.cuda.to_gpu(X)
@@ -312,118 +397,62 @@ def check_branching_model(gpu, communicator, rank_next, rank_prev,
         for i in range(n):
             err = model(X[i:i + 1], Y[i:i + 1])
             err.backward()
-    else:
-        model = BranchChild(d, communicator, 0)
-        if gpu:
-            model.to_gpu()
-
-        for i in range(n):
-            err = model()
-            err.backward()
 
 
-def check_branching_models(gpu):
-    communicator, rank_next, rank_prev = create_communicator(gpu)
-    check_branching_model(gpu, communicator, rank_next, rank_prev,
-                          BranchParent1)
-
-    check_branching_model(gpu, communicator, rank_next, rank_prev,
-                          BranchParent2)
-
-    check_branching_model(gpu, communicator, rank_next, rank_prev,
-                          BranchParent3)
-
-    check_branching_model(gpu, communicator, rank_next, rank_prev,
-                          BranchParent4)
-
-
+@pytest.mark.parametrize('param', params)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_branching_models_cpu():
-    check_branching_models(False)
+def test_twisting_model_cpu(param):
+    check_twisting_model(False, param)
 
 
+@pytest.mark.parametrize('param', params)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @chainer.testing.attr.gpu
-def test_branching_models_gpu():
-    check_branching_models(True)
+def test_twisting_model_gpu(param):
+    check_twisting_model(True, param)
 
 
-def check_twisting_model(gpu):
-    communicator, rank_next, rank_prev = create_communicator(gpu)
-
-    n, d = 100, 10
-    X = np.random.randn(n, d).astype(np.float32)
-    Y = (np.random.rand(n) * 2).astype(np.int32)
-
-    if communicator.rank == 0:
-        model = L.Classifier(
-            TwistFirst(d, communicator, rank_next))
-    elif communicator.rank == communicator.size - 1:
-        model = L.Classifier(
-            TwistLast(d, communicator, rank_prev))
-    else:
-        model = L.Classifier(Twist(
-            d, communicator, rank_prev, rank_next))
-
-    if gpu:
-        model.to_gpu()
-        X = chainer.cuda.to_gpu(X)
-        Y = chainer.cuda.to_gpu(Y)
-
-    for i in range(n):
-        err = model(X[i:i + 1], Y[i:i + 1])
-        err.backward()
-
-
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_twisting_model_cpu():
-    check_twisting_model(False)
-
-
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-@chainer.testing.attr.gpu
-def test_twisting_model_gpu():
-    check_twisting_model(True)
-
-
-def check_tuple_data_model(gpu):
+def check_tuple_data_model(gpu, param):
     # This test only uses pairs (0, 1), (2, 3), ... (2m, 2m+1)
     communicator, rank_next, rank_prev = create_communicator(gpu)
 
     n, d = 100, 10
-    X = np.random.randn(n, d).astype(np.float32)
+    X = np.random.randn(n, d).astype(param.dtype)
     Y = (np.random.rand(n) * 2).astype(np.int32)
 
-    if communicator.rank % 2 == 0:
-        if communicator.rank == communicator.size - 1:
-            # in case 2m is the right end with odd number of nodes
-            return
-        model = L.Classifier(
-            TupleDataParent(communicator, d, rank_next))
-    elif communicator.rank % 2 == 1:
-        model = TupleDataChild(communicator, d, rank_prev)
-
-    assert model is not None
-    if gpu:
-        model.to_gpu()
-        X = chainer.cuda.to_gpu(X)
-        Y = chainer.cuda.to_gpu(Y)
-
-    for i in range(n):
+    with chainer.using_config('dtype', param.dtype):
         if communicator.rank % 2 == 0:
-            err = model(X[i:i + 1], Y[i:i + 1])
+            if communicator.rank == communicator.size - 1:
+                # in case 2m is the right end with odd number of nodes
+                return
+            model = L.Classifier(
+                TupleDataParent(communicator, d, rank_next))
         elif communicator.rank % 2 == 1:
-            err = model()
-        assert err is not None
-        err.backward()
+            model = TupleDataChild(communicator, d, rank_prev)
+
+        assert model is not None
+        if gpu:
+            model.to_gpu()
+            X = chainer.cuda.to_gpu(X)
+            Y = chainer.cuda.to_gpu(Y)
+
+        for i in range(n):
+            if communicator.rank % 2 == 0:
+                err = model(X[i:i + 1], Y[i:i + 1])
+            elif communicator.rank % 2 == 1:
+                err = model()
+            assert err is not None
+            err.backward()
 
 
+@pytest.mark.parametrize('param', params)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_tuple_data_model_cpu():
-    check_tuple_data_model(False)
+def test_tuple_data_model_cpu(param):
+    check_tuple_data_model(False, param)
 
 
+@pytest.mark.parametrize('param', params)
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @chainer.testing.attr.gpu
-def test_tuple_data_model_gpu():
-    check_tuple_data_model(True)
+def test_tuple_data_model_gpu(param):
+    check_tuple_data_model(True, param)


### PR DESCRIPTION
This commit add FP16 test to test_multi_node_chain_list.py along with
the FP32.
`pytest.mark.parametrize` is added to switch between `numpy.float32` and
`numpy.float16`.

Thank you for creating a pull request!

Please double-check the following.

- Read [our contribution guide](https://docs.chainer.org/en/stable/contribution.html).
  - Does your code conform to our coding guidelines?
  - Did you write sufficient test code?
  - Did you write sufficient documentation?
- Also, take a look at [our compatibility policy](https://docs.chainer.org/en/stable/compatibility.html).
