### PR TITLE
Add gradient_check.check_double_backward in reference

### DIFF
--- a/docs/source/reference/check.rst
+++ b/docs/source/reference/check.rst
@@ -32,6 +32,7 @@ The :mod:`chainer.gradient_check` module makes it easy to implement the gradient
    :nosignatures:
 
    chainer.gradient_check.check_backward
+   chainer.gradient_check.check_double_backward
    chainer.gradient_check.numerical_grad
 
 Standard Assertions


### PR DESCRIPTION
Rel. 5408.

This PR adds `gradient_check.check_double_backward` to the reference.