### PR TITLE
Fix dimension check of `chainerx::Linear`

### DIFF
--- a/chainerx_cc/chainerx/routines/connection.cc
+++ b/chainerx_cc/chainerx/routines/connection.cc
@@ -302,7 +302,7 @@ Array Linear(const Array& x, const Array& w, const nonstd::optional<Array>& b, u
         CheckEqual(x.dtype(), b->dtype());
     }
 
-    if (w.ndim() < 1) {
+    if (x.ndim() < 1) {
         throw DimensionError{"x.ndim should be greater than or equal to 1"};
     }
     if (w.ndim() != 2) {


### PR DESCRIPTION
This PR fixes a weird dimension check in chainerx/routines/connection where chainerx::Linear evaluates `w.ndim()` twice and the first evaluation does not make sense.