### PR TITLE
[backport] Override `forward` in `LinkHook` documentation

### DIFF
--- a/chainer/link_hook.py
+++ b/chainer/link_hook.py
@@ -77,7 +77,7 @@ class LinkHook(object):
         ...     super(Model, self).__init__()
         ...     with self.init_scope():
         ...       self.l = L.Linear(10, 10)
-        ...   def __call__(self, x1):
+        ...   def forward(self, x1):
         ...     return F.exp(self.l(x1))
         >>> model1 = Model()
         >>> model2 = Model()


### PR DESCRIPTION
Backport of #6546