### PR TITLE
Avoid mutating `LinkTestCase` and `LinkInitializersTestCase` class attributes

### DIFF
--- a/chainer/testing/function_link.py
+++ b/chainer/testing/function_link.py
@@ -437,19 +437,11 @@ class FunctionTestCase(FunctionTestBase, unittest.TestCase):
 class _LinkTestBase(object):
 
     backend_config = None
-    check_forward_options = None
-    check_backward_options = None
-    check_initializers_options = None
     contiguous = None
 
     # List of parameter names represented as strings.
     # I.e. ('gamma', 'beta') for BatchNormalization.
     param_names = ()
-
-    def __init__(self):
-        self.check_forward_options = {}
-        self.check_backward_options = {}
-        self.check_initializers_options = {}
 
     def before_test(self, test_name):
         pass
@@ -706,9 +698,17 @@ class LinkTestCase(_LinkTestBase, unittest.TestCase):
 
     """
 
+    check_forward_options = None
+    check_backward_options = None
     skip_forward_test = False
     skip_backward_test = False
     dodge_nondifferentiable = False
+
+    def __init__(self, *args, **kwargs):
+        self.check_forward_options = {}
+        self.check_backward_options = {}
+
+        super(LinkTestCase, self).__init__(*args, **kwargs)
 
     def forward_expected(self, link, inputs):
         raise NotImplementedError('forward_expected() is not implemented.')
@@ -975,6 +975,13 @@ class LinkInitializersTestCase(_LinkTestBase, unittest.TestCase):
         :class:`~chainer.testing.FunctionTestCase`
 
     """
+
+    check_initializers_options = None
+
+    def __init__(self, *args, **kwargs):
+        self.check_initializers_options = {}
+
+        super(LinkInitializersTestCase, self).__init__(*args, **kwargs)
 
     def get_initializers(self):
         raise NotImplementedError('get_initializers is not implemented.')

--- a/chainer/testing/function_link.py
+++ b/chainer/testing/function_link.py
@@ -436,12 +436,20 @@ class FunctionTestCase(FunctionTestBase, unittest.TestCase):
 
 class _LinkTestBase(object):
 
-    contiguous = None
     backend_config = None
+    check_forward_options = None
+    check_backward_options = None
+    check_initializers_options = None
+    contiguous = None
 
     # List of parameter names represented as strings.
     # I.e. ('gamma', 'beta') for BatchNormalization.
     param_names = ()
+
+    def __init__(self):
+        self.check_forward_options = {}
+        self.check_backward_options = {}
+        self.check_initializers_options = {}
 
     def before_test(self, test_name):
         pass
@@ -698,8 +706,6 @@ class LinkTestCase(_LinkTestBase, unittest.TestCase):
 
     """
 
-    check_forward_options = {}
-    check_backward_options = {}
     skip_forward_test = False
     skip_backward_test = False
     dodge_nondifferentiable = False
@@ -969,8 +975,6 @@ class LinkInitializersTestCase(_LinkTestBase, unittest.TestCase):
         :class:`~chainer.testing.FunctionTestCase`
 
     """
-
-    check_initializers_options = {}
 
     def get_initializers(self):
         raise NotImplementedError('get_initializers is not implemented.')


### PR DESCRIPTION
See also #6599.