### PR TITLE
Fix linspace

### DIFF
--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -318,8 +318,10 @@ Array Linspace(
         Device& device) {
     static const int64_t kDefaultNum = 50;
 
-    // TODO(niboshi): Determine dtype_a from both dtypes of start and stop.
-    Dtype dtype_a = dtype.value_or(internal::GetDefaultDtype(start.kind()));
+    // Always default to float type.
+    // Similar behavior to numpy
+    // Ref: https://github.com/numpy/numpy/issues/8597
+    Dtype dtype_a = dtype.value_or(internal::GetDefaultDtype(chainerx::DtypeKind::kFloat));
     int64_t num_a = num.value_or(kDefaultNum);
 
     if (num_a < 0) {

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -961,10 +961,9 @@ def test_linspace(xp, start, stop, num, endpoint, range_type, dtype, device):
     stop = range_type(stop)
     return xp.linspace(start, stop, num, endpoint=endpoint, dtype=dtype)
 
+
 # Check only for closeness to numpy not the dtype
 # as the default float of numpy and chainerx may differ.
-
-
 @chainerx.testing.numpy_chainerx_allclose(dtype_check=False, float16_rtol=1e-7)
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
 @pytest.mark.parametrize('start,stop', [

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -961,6 +961,31 @@ def test_linspace(xp, start, stop, num, endpoint, range_type, dtype, device):
     stop = range_type(stop)
     return xp.linspace(start, stop, num, endpoint=endpoint, dtype=dtype)
 
+# Check only for closeness to numpy not the dtype
+# as the default float of numpy and chainerx may differ.
+
+
+@chainerx.testing.numpy_chainerx_allclose(dtype_check=False, float16_rtol=1e-7)
+@pytest.mark.parametrize_device(['native:0', 'cuda:0'])
+@pytest.mark.parametrize('start,stop', [
+    (0, 0),
+    (0, 1),
+    (1, 0),
+    (-1, 0),
+    (0, -1),
+    (1, -1),
+    (-13.3, 352.5),
+    (13.3, -352.5),
+])
+@pytest.mark.parametrize('num', [0, 1, 2, 257])
+@pytest.mark.parametrize('endpoint', [True, False])
+@pytest.mark.parametrize('range_type', [float, int])
+def test_linspace_default_dtype(xp, start, stop, num, endpoint,
+                                range_type, device):
+    start = range_type(start)
+    stop = range_type(stop)
+    return xp.linspace(start, stop, num, endpoint=endpoint)
+
 
 @chainerx.testing.numpy_chainerx_allclose()
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])


### PR DESCRIPTION
Reference #6604 

After this PR, the return type of  `chainerx.linspace` will be the default float which is similar to what numpy does.
