### PR TITLE
Support for fp16 and mixed16 in `MultiNodeBatchNormalization` of ChainerMN

### DIFF
--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -45,7 +45,6 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.batched_copy = batched_copy
         self.grad_dtype_to_allreduce_dtype_kernel = None
         self.allreduce_dtype_to_grad_dtype_kernel = None
-        self.div_by_size = None
         self.params_data = None
 
     def _init_comms(self):
@@ -168,12 +167,11 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.nccl_comm.allReduce(gpu_buffer_a.ptr(),
                                  gpu_buffer_b.ptr(), n_elems,
                                  type_id, nccl.NCCL_SUM, stream.ptr)
-        if self.div_by_size is None:
-            self.div_by_size = chainer.cuda.cupy.ElementwiseKernel(
-                '{} x'.format(dtype.name),
-                '{} y'.format(dtype.name),
-                'y = x*(1.0/{})'.format(self.size), 'div_by_size')
-        self.div_by_size(
+        div_by_size = chainer.cuda.cupy.ElementwiseKernel(
+            '{} x'.format(dtype.name),
+            '{} y'.format(dtype.name),
+            'y = x*(1.0/{})'.format(self.size), 'div_by_size')
+        div_by_size(
             gpu_buffer_b.array(n_elems, dtype=dtype),
             gpu_buffer_a.array(n_elems, dtype=dtype),
             stream=stream)

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -249,7 +249,7 @@ def _batched_unpack_params(params_data, buffer, dtype):
 
 def _cupy_batched_pack_params():
     return chainer.cuda.cupy.RawKernel(r'''
-#include <cuda_fp16.h>
+#include <cupy/carray.cuh>
 #define NCCL_FLOAT16  6
 #define NCCL_FLOAT32  7
     extern "C" __global__
@@ -302,7 +302,7 @@ def _cupy_batched_pack_params():
 
 def _cupy_batched_unpack_params():
     return chainer.cuda.cupy.RawKernel(r'''
-#include <cuda_fp16.h>
+#include <cupy/carray.cuh>
 #define NCCL_FLOAT16  6
 #define NCCL_FLOAT32  7
     extern "C" __global__

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -36,9 +36,9 @@ class _MpiBackend(_MultiNodeBatchNormalizationBackend):
         self.comm = comm
 
     def forward(self, axis, gamma, x, xp):
-        tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
-        x.mean(axis=axis, out=tmp[:gamma.size])
-        xp.square(x).mean(axis=axis, out=tmp[gamma.size:])
+        tmp = xp.empty(gamma.size * 2, dtype=gamma.dtype)
+        x.mean(axis=axis, out=tmp[:gamma.size], dtype=gamma.dtype)
+        xp.square(x).mean(axis=axis, out=tmp[gamma.size:], dtype=gamma.dtype)
         if xp is cuda.cupy:
             chainer.cuda.Stream.null.synchronize()
         self.comm.multi_node_mean(None, tmp)
@@ -48,9 +48,9 @@ class _MpiBackend(_MultiNodeBatchNormalizationBackend):
         return mean, var
 
     def backward(self, axis, gamma, gy, x_hat, x, xp):
-        tmp = xp.empty(gamma.size * 2, dtype=x.dtype)
-        gy.sum(axis=axis, out=tmp[:gamma.size])
-        (gy * x_hat).sum(axis=axis, out=tmp[gamma.size:])
+        tmp = xp.empty(gamma.size * 2, dtype=gamma.dtype)
+        gy.sum(axis=axis, out=tmp[:gamma.size], dtype=gamma.dtype)
+        (gy * x_hat).sum(axis=axis, out=tmp[gamma.size:], dtype=gamma.dtype)
         if xp is cuda.cupy:
             chainer.cuda.Stream.null.synchronize()
         self.comm.multi_node_mean(None, tmp)
@@ -70,22 +70,24 @@ class _NcclBackend(_MultiNodeBatchNormalizationBackend):
 
     def forward(self, axis, gamma, x, xp):
         gpu_buffer_n_elems = gamma.size * 2
-        gpu_buffer_size = x.dtype.itemsize * gpu_buffer_n_elems
+        gpu_buffer_size = gamma.dtype.itemsize * gpu_buffer_n_elems
         gpu_buffer_a = self.memory_utility_module.DeviceMemory()
         gpu_buffer_b = self.memory_utility_module.DeviceMemory()
         gpu_buffer_a.assign(gpu_buffer_size)
         gpu_buffer_b.assign(gpu_buffer_size)
         gpu_buffer_a_array = gpu_buffer_a.array(
-            gpu_buffer_n_elems, dtype=x.dtype)
-        x.mean(axis=axis, out=gpu_buffer_a_array[:gamma.size])
-        xp.square(x).mean(axis=axis, out=gpu_buffer_a_array[gamma.size:])
+            gpu_buffer_n_elems, dtype=gamma.dtype)
+        x.mean(axis=axis, out=gpu_buffer_a_array[:gamma.size],
+            dtype = gamma.dtype)
+        xp.square(x).mean(axis=axis, out=gpu_buffer_a_array[gamma.size:],
+            dtype = gamma.dtype)
         self.comm.multi_node_mean_nccl(gpu_buffer_a,
                                        gpu_buffer_b,
                                        gpu_buffer_n_elems,
-                                       x.dtype)
+                                       gamma.dtype)
         gpu_buffer_a_array = gpu_buffer_a.array(
             gpu_buffer_n_elems,
-            dtype=x.dtype)
+            dtype=gamma.dtype)
 
         mean = gpu_buffer_a_array[:gamma.size]
         sqmean = gpu_buffer_a_array[gamma.size:]
@@ -94,28 +96,27 @@ class _NcclBackend(_MultiNodeBatchNormalizationBackend):
 
     def backward(self, axis, gamma, gy, x_hat, x, xp):
         gpu_buffer_n_elems = gamma.size * 2
-        gpu_buffer_size = x.dtype.itemsize * gpu_buffer_n_elems
+        gpu_buffer_size = gamma.dtype.itemsize * gpu_buffer_n_elems
         gpu_buffer_a = self.memory_utility_module.DeviceMemory()
         gpu_buffer_b = self.memory_utility_module.DeviceMemory()
         gpu_buffer_a.assign(gpu_buffer_size)
         gpu_buffer_b.assign(gpu_buffer_size)
         gpu_buffer_a_array = gpu_buffer_a.array(
-            gpu_buffer_n_elems,
-            dtype=x.dtype)
-        gy.sum(axis=axis, out=gpu_buffer_a_array[:gamma.size])
-        (gy * x_hat).sum(axis=axis, out=gpu_buffer_a_array[gamma.size:])
-
+            gpu_buffer_n_elems, dtype=gamma.dtype)
+        gy.sum(axis=axis, out=gpu_buffer_a_array[:gamma.size],
+               dtype=gamma.dtype)
+        (gy * x_hat).sum(axis=axis, out=gpu_buffer_a_array[gamma.size:],
+               dtype=gamma.dtype)
         self.comm.multi_node_mean_nccl(gpu_buffer_a,
                                        gpu_buffer_b,
                                        gpu_buffer_n_elems,
-                                       x.dtype)
+                                       gamma.dtype)
         gpu_buffer_a_array = gpu_buffer_a.array(
             gpu_buffer_n_elems,
-            dtype=x.dtype)
+            dtype=gamma.dtype)
 
         gbeta = gpu_buffer_a_array[:gamma.size]
         ggamma = gpu_buffer_a_array[gamma.size:]
-
         return gbeta, ggamma
 
 
@@ -184,8 +185,8 @@ class MultiNodeBatchNormalizationFunction(function.Function):
             x_type.dtype.kind == 'f',
             x_type.ndim >= gamma_type.ndim + 1,
             x_type.shape[1:1 + M] == gamma_type.shape,
-            gamma_type.dtype == x_type.dtype,
-            beta_type.dtype == x_type.dtype,
+            gamma_type.dtype.kind == 'f',
+            gamma_type.dtype == beta_type.dtype,
             gamma_type.shape == beta_type.shape,
         )
         if len(in_types) == 5:
@@ -202,8 +203,8 @@ class MultiNodeBatchNormalizationFunction(function.Function):
         x, gamma, beta = inputs[:3]
         if chainer.configuration.config.train:
             if self.running_mean is None:
-                self.running_mean = xp.zeros_like(gamma)
-                self.running_var = xp.zeros_like(gamma)
+                self.running_mean = xp.zeros_like(gamma, dtype=x.dtype)
+                self.running_var = xp.zeros_like(gamma, dtype=x.dtype)
             else:
                 self.running_mean = xp.array(self.running_mean)
                 self.running_var = xp.array(self.running_var)
@@ -241,9 +242,10 @@ class MultiNodeBatchNormalizationFunction(function.Function):
             self.x_hat = _xhat(x, mean, self.std, expander)
             y = gamma * self.x_hat
             y += beta
+            y = y.astype(x.dtype)
         else:
             self.x_hat, y = cuda.elementwise(
-                'T x, T mean, T std, T gamma, T beta', 'T x_hat, T y',
+                'T x, U mean, U std, U gamma, U beta', 'T x_hat, T y',
                 '''
                 x_hat = (x - mean) / std;
                 y = gamma * x_hat + beta;
@@ -272,8 +274,8 @@ class MultiNodeBatchNormalizationFunction(function.Function):
                 del temp_ar
             else:
                 cuda.elementwise(
-                    'T mean, T var, T decay, T adjust',
-                    'T r_mean, T r_var',
+                    'U mean, U var, U decay, U adjust',
+                    'U r_mean, U r_var',
                     '''
                     r_mean = r_mean * decay + mean * (1 - decay);
                     r_var = r_var * decay + var * (1 - decay) * adjust;
@@ -304,6 +306,7 @@ class MultiNodeBatchNormalizationFunction(function.Function):
             gmean = -gs * gbeta
             gvar = -0.5 * gamma / var * ggamma
             gx = gs[expander] * gy
+            gx = gx.astype(x.dtype, copy=False)
             return gx, ggamma, gbeta, gmean, gvar
 
         # Note: If length of inputs is not 5, we must be in train mode.
@@ -314,11 +317,12 @@ class MultiNodeBatchNormalizationFunction(function.Function):
         if xp is numpy:
             gx = (gamma / self.std)[expander] * (
                 gy - (self.x_hat * ggamma[expander] + gbeta[expander]) / m)
+            gx = gx.astype(x.dtype, copy=False)
         else:
             inv_m = numpy.float32(1) / m
             gx = cuda.elementwise(
-                'T gy, T x_hat, T gamma, T std, T ggamma, T gbeta, \
-                T inv_m',
+                'T gy, T x_hat, U gamma, U std, U ggamma, U gbeta, \
+                U inv_m',
                 'T gx',
                 'gx = (gamma / std) * (gy - (x_hat * ggamma + gbeta) * \
                 inv_m)',

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -78,9 +78,9 @@ class _NcclBackend(_MultiNodeBatchNormalizationBackend):
         gpu_buffer_a_array = gpu_buffer_a.array(
             gpu_buffer_n_elems, dtype=gamma.dtype)
         x.mean(axis=axis, out=gpu_buffer_a_array[:gamma.size],
-            dtype = gamma.dtype)
+               dtype=gamma.dtype)
         xp.square(x).mean(axis=axis, out=gpu_buffer_a_array[gamma.size:],
-            dtype = gamma.dtype)
+                          dtype=gamma.dtype)
         self.comm.multi_node_mean_nccl(gpu_buffer_a,
                                        gpu_buffer_b,
                                        gpu_buffer_n_elems,
@@ -106,7 +106,7 @@ class _NcclBackend(_MultiNodeBatchNormalizationBackend):
         gy.sum(axis=axis, out=gpu_buffer_a_array[:gamma.size],
                dtype=gamma.dtype)
         (gy * x_hat).sum(axis=axis, out=gpu_buffer_a_array[gamma.size:],
-               dtype=gamma.dtype)
+                         dtype=gamma.dtype)
         self.comm.multi_node_mean_nccl(gpu_buffer_a,
                                        gpu_buffer_b,
                                        gpu_buffer_n_elems,

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -45,7 +45,7 @@ class MultiNodeBatchNormalization(link.Link):
             communication backend for each communicator.
     """
 
-    def __init__(self, size, comm, decay=0.9, eps=2e-5, dtype=numpy.float32,
+    def __init__(self, size, comm, decay=0.9, eps=2e-5, dtype=None,
                  use_gamma=True, use_beta=True,
                  initial_gamma=None, initial_beta=None,
                  communication_backend='auto'):
@@ -53,10 +53,12 @@ class MultiNodeBatchNormalization(link.Link):
             'chainermn.links.MultiNodeBatchNormalization')
 
         super(MultiNodeBatchNormalization, self).__init__()
+        self._highprec_dtype = chainer.get_dtype(
+            dtype, map_mixed16=numpy.float32)
         self.comm = comm
-        self.avg_mean = numpy.zeros(size, dtype=dtype)
+        self.avg_mean = numpy.zeros(size, dtype=self._highprec_dtype)
         self.register_persistent('avg_mean')
-        self.avg_var = numpy.zeros(size, dtype=dtype)
+        self.avg_var = numpy.zeros(size, dtype=self._highprec_dtype)
         self.register_persistent('avg_var')
         self.N = 0
         self.register_persistent('N')
@@ -71,13 +73,13 @@ class MultiNodeBatchNormalization(link.Link):
                 if initial_gamma is None:
                     initial_gamma = 1
                 initial_gamma = initializers._get_initializer(initial_gamma)
-                initial_gamma.dtype = dtype
+                initial_gamma.dtype = self._highprec_dtype
                 self.gamma = variable.Parameter(initial_gamma, size)
             if use_beta:
                 if initial_beta is None:
                     initial_beta = 0
                 initial_beta = initializers._get_initializer(initial_beta)
-                initial_beta.dtype = dtype
+                initial_beta.dtype = self._highprec_dtype
                 self.beta = variable.Parameter(initial_beta, size)
 
     def __call__(self, x, finetune=False):
@@ -86,13 +88,13 @@ class MultiNodeBatchNormalization(link.Link):
         else:
             with cuda.get_device_from_id(self._device_id):
                 gamma = variable.Variable(self.xp.ones(
-                    self.avg_mean.shape, dtype=x.dtype))
+                    self.avg_mean.shape, dtype=self._highprec_dtype))
         if hasattr(self, 'beta'):
             beta = self.beta
         else:
             with cuda.get_device_from_id(self._device_id):
                 beta = variable.Variable(self.xp.zeros(
-                    self.avg_mean.shape, dtype=x.dtype))
+                    self.avg_mean.shape, dtype=self._highprec_dtype))
 
         if chainer.configuration.config.train:
             if finetune:

--- a/chainermn/nccl.py
+++ b/chainermn/nccl.py
@@ -1,6 +1,6 @@
 try:
-    from cupy.cuda.nccl import get_unique_id  # NOQA
     from cupy.cuda.nccl import get_build_version  # NOQA
+    from cupy.cuda.nccl import get_unique_id  # NOQA
     from cupy.cuda.nccl import get_version  # NOQA
     from cupy.cuda.nccl import NCCL_FLOAT  # NOQA
     from cupy.cuda.nccl import NCCL_FLOAT16  # NOQA

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -244,7 +244,8 @@ def destroy_communicator(comm):
 
     When too many NCCL communicator are alive, NCCL produces
     unhandled CUDA error. To avoid this, we need to make sure to
-    destory NCCL communicator after every use."""
+    destory NCCL communicator after every use.
+    """
     if hasattr(comm, 'nccl_comm') and comm.nccl_comm is not None:
         comm.nccl_comm.destroy()
         comm.nccl_comm = None

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -92,15 +92,6 @@ def check_multi_node_bn(comm, use_gpu=False, backend='auto',
     y_local = comm.mpi_comm.scatter(
         y.reshape(comm.size, local_batchsize))
 
-    x = x.astype(dtype)
-    x_local = x_local.astype(dtype)
-
-    if use_gpu:
-        x = chainer.cuda.to_gpu(x)
-        y = chainer.cuda.to_gpu(y)
-        x_local = chainer.cuda.to_gpu(x_local)
-        y_local = chainer.cuda.to_gpu(y_local)
-
     io_dtype = dtype
     l_dtype = dtype
     bn_dtype = dtype
@@ -111,6 +102,12 @@ def check_multi_node_bn(comm, use_gpu=False, backend='auto',
 
     x = x.astype(io_dtype)
     x_local = x_local.astype(io_dtype)
+
+    if use_gpu:
+        x = chainer.cuda.to_gpu(x)
+        y = chainer.cuda.to_gpu(y)
+        x_local = chainer.cuda.to_gpu(x_local)
+        y_local = chainer.cuda.to_gpu(y_local)
 
     cls = chainer.links.Classifier
     with chainer.using_config('dtype', dtype):

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -32,15 +32,15 @@ class ModelNormalBN(chainer.Chain):
 
 
 class ModelDistributedBN(chainer.Chain):
-    def __init__(self, comm, n_in=3, n_units=3, n_out=2):
+    def __init__(self, comm, n_in=3, n_units=3, n_out=2, backend='auto'):
         super(ModelDistributedBN, self).__init__()
         with self.init_scope():
             self.l1 = chainer.links.Linear(n_in, n_units, nobias=True)
             self.bn1 = MultiNodeBatchNormalization(
-                n_units, comm)
+                n_units, comm, communication_backend=backend)
             self.l2 = chainer.links.Linear(n_in, n_units, nobias=True)
             self.bn2 = MultiNodeBatchNormalization(
-                n_units, comm)
+                n_units, comm, communication_backend=backend)
             self.l3 = chainer.links.Linear(n_in, n_out)
         self.train = True
 
@@ -50,7 +50,8 @@ class ModelDistributedBN(chainer.Chain):
         return self.l3(h)
 
 
-def check_multi_node_bn(comm, use_gpu=False):
+def check_multi_node_bn(comm, use_gpu=False, backend='auto',
+                        dtype=numpy.float32):
     """Tests correctness of MultiNodeBatchNormalization.
 
     This test verifies MultiNodeBatchNormalization by comparing
@@ -91,23 +92,38 @@ def check_multi_node_bn(comm, use_gpu=False):
     y_local = comm.mpi_comm.scatter(
         y.reshape(comm.size, local_batchsize))
 
+    x = x.astype(dtype)
+    x_local = x_local.astype(dtype)
+
     if use_gpu:
         x = chainer.cuda.to_gpu(x)
         y = chainer.cuda.to_gpu(y)
         x_local = chainer.cuda.to_gpu(x_local)
         y_local = chainer.cuda.to_gpu(y_local)
 
+    io_dtype = dtype
+    l_dtype = dtype
+    bn_dtype = dtype
+    if dtype == chainer.mixed16:
+        io_dtype = numpy.float16
+        l_dtype = numpy.float16
+        bn_dtype = numpy.float32
+
+    x = x.astype(io_dtype)
+    x_local = x_local.astype(io_dtype)
+
     cls = chainer.links.Classifier
-    # Single worker
-    m1 = cls(ModelNormalBN())
-    # Multi worker, Ghost BN
-    m2 = cls(ModelNormalBN())
-    # Single worker, MNBN
-    m3 = cls(ModelDistributedBN(comm))
-    # Multi worker, MNBN
-    m4 = cls(ModelDistributedBN(comm))
-    # NOTE: m1, m3 and m4 should behave in the same way.
-    # m2 may be different.
+    with chainer.using_config('dtype', dtype):
+        # Single worker
+        m1 = cls(ModelNormalBN())
+        # Multi worker, Ghost BN
+        m2 = cls(ModelNormalBN())
+        # Single worker, MNBN
+        m3 = cls(ModelDistributedBN(comm, backend=backend))
+        # Multi worker, MNBN
+        m4 = cls(ModelDistributedBN(comm, backend=backend))
+        # NOTE: m1, m3 and m4 should behave in the same way.
+        # m2 may be different.
 
     if use_gpu:
         m1.to_gpu()
@@ -148,8 +164,23 @@ def check_multi_node_bn(comm, use_gpu=False):
             assert (p3[0] == name)
             assert (p4[0] == name)
 
-            chainer.testing.assert_allclose(p1[1].grad, p3[1].grad)
-            chainer.testing.assert_allclose(p1[1].grad, p4[1].grad)
+            if '/l' in name:
+                param_dtype = l_dtype
+            else:
+                param_dtype = bn_dtype
+            assert (p1[1].data.dtype == param_dtype)
+            assert (p2[1].data.dtype == param_dtype)
+            assert (p3[1].data.dtype == param_dtype)
+            assert (p4[1].data.dtype == param_dtype)
+
+            assert_option = {'atol': 1e-4, 'rtol': 1e-3}
+            if param_dtype == numpy.float16:
+                assert_option = {'atol': 1e-3, 'rtol': 1e-2}
+
+            chainer.testing.assert_allclose(p1[1].grad, p3[1].grad,
+                                            **assert_option)
+            chainer.testing.assert_allclose(p1[1].grad, p4[1].grad,
+                                            **assert_option)
 
             # This is to see that this test is valid.
             if comm.size >= 2:
@@ -190,22 +221,30 @@ def test_version_check():
         MultiNodeBatchNormalization(3, comm)
 
 
-@pytest.mark.parametrize(('communicator_class'), [
-    (NaiveCommunicator)])
-def test_multi_node_bn_cpu(communicator_class):
+@pytest.mark.parametrize(('communicator_class', 'backend', 'dtype'), [
+    (NaiveCommunicator, 'mpi', numpy.float16),
+    (NaiveCommunicator, 'mpi', numpy.float32),
+    (NaiveCommunicator, 'mpi', chainer.mixed16)])
+def test_multi_node_bn_cpu(communicator_class, backend, dtype):
     comm = create_communicator(communicator_class, mpi_comm,
                                use_gpu=False)
-    check_multi_node_bn(comm)
+    check_multi_node_bn(comm, backend=backend, dtype=dtype)
     comm.mpi_comm.barrier()
 
 
-@pytest.mark.parametrize(('communicator_class'), [
-    (NaiveCommunicator), (PureNcclCommunicator)])
+@pytest.mark.parametrize(('communicator_class', 'backend', 'dtype'), [
+    (NaiveCommunicator, 'mpi', numpy.float32),
+    (PureNcclCommunicator, 'mpi', numpy.float32),
+    (PureNcclCommunicator, 'mpi', numpy.float16),
+    (PureNcclCommunicator, 'mpi', chainer.mixed16),
+    (PureNcclCommunicator, 'nccl', numpy.float32),
+    (PureNcclCommunicator, 'nccl', numpy.float16),
+    (PureNcclCommunicator, 'nccl', chainer.mixed16)])
 @chainer.testing.attr.gpu
-def test_multi_node_bn_gpu(communicator_class):
+def test_multi_node_bn_gpu(communicator_class, backend, dtype):
     comm = create_communicator(communicator_class, mpi_comm,
                                use_gpu=True)
-    check_multi_node_bn(comm, use_gpu=True)
+    check_multi_node_bn(comm, use_gpu=True, backend=backend, dtype=dtype)
     comm.mpi_comm.barrier()
 
 

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -79,8 +79,8 @@ def check_multi_node_bn(comm, use_gpu=False, backend='auto',
     (2) is different from them, to see that this test working correctly.
     """
 
-    local_batchsize = 10
-    global_batchsize = 10 * comm.size
+    local_batchsize = 8
+    global_batchsize = local_batchsize * comm.size
     ndim = 3
     numpy.random.seed(71)
     x = numpy.random.random(
@@ -172,7 +172,7 @@ def check_multi_node_bn(comm, use_gpu=False, backend='auto',
 
             assert_option = {'atol': 1e-4, 'rtol': 1e-3}
             if param_dtype == numpy.float16:
-                assert_option = {'atol': 1e-3, 'rtol': 1e-2}
+                assert_option = {'atol': 1e-2, 'rtol': 1e-2}
 
             chainer.testing.assert_allclose(p1[1].grad, p3[1].grad,
                                             **assert_option)
@@ -242,6 +242,7 @@ def test_multi_node_bn_gpu(communicator_class, backend, dtype):
     comm = create_communicator(communicator_class, mpi_comm,
                                use_gpu=True)
     check_multi_node_bn(comm, use_gpu=True, backend=backend, dtype=dtype)
+    chainer.cuda.Stream.null.synchronize()
     comm.mpi_comm.barrier()
 
 

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -244,8 +244,8 @@ def test_multi_node_bn_gpu(communicator_class, backend, dtype):
     check_multi_node_bn(comm, use_gpu=True, backend=backend, dtype=dtype)
     chainer.cuda.Stream.null.synchronize()
     comm.mpi_comm.barrier()
-    if hasattr(communicator, 'nccl_comm'):
-            communicator.nccl_comm.destroy()
+    if hasattr(comm, 'nccl_comm'):
+        comm.nccl_comm.destroy()
 
 
 @pytest.mark.parametrize(('communicator_class', 'backend'), [

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -244,6 +244,8 @@ def test_multi_node_bn_gpu(communicator_class, backend, dtype):
     check_multi_node_bn(comm, use_gpu=True, backend=backend, dtype=dtype)
     chainer.cuda.Stream.null.synchronize()
     comm.mpi_comm.barrier()
+    if hasattr(communicator, 'nccl_comm'):
+            communicator.nccl_comm.destroy()
 
 
 @pytest.mark.parametrize(('communicator_class', 'backend'), [


### PR DESCRIPTION
This PR adds support for fp16 and mixed16 in `MultiNodeBatchNormalization` of ChainerMN.
Solved https://github.com/chainer/chainer/issues/6198 and https://github.com/chainer/chainer/issues/6457
Related to https://github.com/chainer/chainer/pull/6331