### PR TITLE
Display `pytest` summary

### DIFF
--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -143,12 +143,12 @@ step_chainer_tests() {
         mark="$mark and not theano"
     fi
 
-    pytest -m "$mark" "$REPO_DIR"/tests/chainer_tests
+    pytest -rfEX -m "$mark" "$REPO_DIR"/tests/chainer_tests
 }
 
 
 step_chainerx_python_tests() {
-    pytest "$REPO_DIR"/tests/chainerx_tests
+    pytest -rfEX "$REPO_DIR"/tests/chainerx_tests
 }
 
 


### PR DESCRIPTION
Many times tests fail spuriously in CI.
Due to the dense error trace and warnings displayed by
pytest, it is hard to figure out the failed test cases.
One can suppress the information displayed with flags but
this becomes a problem when actual test fails.
This PR is a hack to display failed tests at the end without
suppressing the log and errors from pytest.

But I hope it will save some trouble of sailing through those
stack traces and warnings just to find out that those were irrelevant.

References : 
* https://stackoverflow.com/a/49450167/5602957
* https://stackoverflow.com/questions/24617397/how-to-print-to-console-in-py-test/38806934#38806934
* https://github.com/pytest-dev/pytest/issues/3952

Example:
![test_end](https://user-images.githubusercontent.com/19503980/54934779-137fef80-4f45-11e9-988f-8325e3159d2b.png)


