### PR TITLE
Implemented ChainerX version of Clipped ReLU forward

### DIFF
--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -5,6 +5,7 @@ from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check
+import chainerx
 
 
 if cuda.cudnn_enabled:

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -36,6 +36,11 @@ class ClippedReLU(function_node.FunctionNode):
         x_type = in_types[0]
         type_check.expect(x_type.dtype.kind == 'f')
 
+    def forward_chainerx(self, inputs):
+        self.retain_inputs((0,))
+        x, = inputs
+        return chainerx.minimum(chainerx.maximum(0, x), self.cap)
+
     def forward_cpu(self, inputs):
         self.retain_inputs((0,))
         x, = inputs

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -40,7 +40,7 @@ class ClippedReLU(function_node.FunctionNode):
     def forward_chainerx(self, inputs):
         self.retain_inputs((0,))
         x, = inputs
-        return chainerx.minimum(chainerx.maximum(0, x), self.cap)
+        return chainerx.minimum(chainerx.maximum(0, x), self.cap),
 
     def forward_cpu(self, inputs):
         self.retain_inputs((0,))

--- a/chainer/functions/activation/clipped_relu.py
+++ b/chainer/functions/activation/clipped_relu.py
@@ -38,7 +38,6 @@ class ClippedReLU(function_node.FunctionNode):
         type_check.expect(x_type.dtype.kind == 'f')
 
     def forward_chainerx(self, inputs):
-        self.retain_inputs((0,))
         x, = inputs
         return chainerx.minimum(chainerx.maximum(0, x), self.cap),
 


### PR DESCRIPTION
With reference to #6622 , ChainerX version of Clipped ReLU forward is implemented using 'chainerx.minimum' implemented with respect to #6477 