### PR TITLE
[backport] Use `F.matmul` instead of `F.batch_matmul` in memnn example

### DIFF
--- a/examples/memnn/memnn.py
+++ b/examples/memnn/memnn.py
@@ -116,8 +116,8 @@ class Memory(object):
         tc = self.TC(inds)
         tm = F.broadcast_to(tm, self.m.shape)
         tc = F.broadcast_to(tc, self.c.shape)
-        p = F.softmax(F.batch_matmul(self.m + tm, u))
-        o = F.batch_matmul(F.swapaxes(self.c + tc, 2, 1), p)
+        p = F.softmax(F.matmul(self.m + tm, F.expand_dims(u, -1)))
+        o = F.matmul(F.swapaxes(self.c + tc, 2, 1), p)
         o = F.squeeze(o, -1)
         u = o + u
         return u


### PR DESCRIPTION
Backport of #6611