### PR TITLE
Remove unnecessary `unchain_backward()` in seq2seq example

### DIFF
--- a/examples/pix2pix/updater.py
+++ b/examples/pix2pix/updater.py
@@ -72,6 +72,5 @@ class FacadeUpdater(chainer.training.StandardUpdater):
         for z_ in z:
             z_.unchain_backward()
         dec_optimizer.update(self.loss_dec, dec, x_out, t_out, y_fake)
-        x_in.unchain_backward()
         x_out.unchain_backward()
         dis_optimizer.update(self.loss_dis, dis, y_real, y_fake)

--- a/examples/pix2pix/updater.py
+++ b/examples/pix2pix/updater.py
@@ -60,7 +60,6 @@ class FacadeUpdater(chainer.training.StandardUpdater):
         for i in range(batchsize):
             x_in[i, :] = xp.asarray(batch[i][0])
             t_out[i, :] = xp.asarray(batch[i][1])
-        x_in = Variable(x_in)
 
         z = enc(x_in)
         x_out = dec(z)

--- a/examples/pix2pix/updater.py
+++ b/examples/pix2pix/updater.py
@@ -5,8 +5,6 @@ from __future__ import print_function
 import chainer
 import chainer.functions as F
 
-from chainer import Variable
-
 
 class FacadeUpdater(chainer.training.StandardUpdater):
 


### PR DESCRIPTION
`x_in.unchain_backward()` seems unnecessary because `x_in` is a root in the computation graph.
