### PR TITLE
Destroy NCCL communicator after every use 

### DIFF
--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -247,7 +247,7 @@ def destroy_communicator(comm):
     destory NCCL communicator after every use."""
     if hasattr(comm, 'nccl_comm') and comm.nccl_comm is not None:
         comm.nccl_comm.destroy()
-    comm.nccl_comm = None
+        comm.nccl_comm = None
     if hasattr(comm, 'intra_nccl_cojmm') and comm.intra_nccl_comm is not None:
         comm.intra_nccl_comm.destroy()
         comm.intra_nccl_comm = None

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -1,3 +1,4 @@
+import gc
 import mock
 import mpi4py.MPI
 import numpy as np
@@ -358,6 +359,8 @@ def check_allreduce_grad_mixed_dtype(param, model, use_gpu):
     else:
         communicator = comm_class(mpi_comm)
 
+    communicator.mpi_comm.barrier()
+
     # answer type: see the document of `create_communicator`
     global_dtype = param.global_dtype
     allreduce_dtype = param.allreduce_grad_dtype
@@ -411,6 +414,8 @@ def check_allreduce_grad_mixed_dtype(param, model, use_gpu):
                                     (base + 1) * np.ones((4, 3)))
 
     communicator.mpi_comm.barrier()
+    del communicator
+    gc.collect()
 
 
 def check_collective_communication(param, use_gpu):

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -245,10 +245,12 @@ def destroy_communicator(comm):
     When too many NCCL communicator are alive, NCCL produces
     unhandled CUDA error. To avoid this, we need to make sure to
     destory NCCL communicator after every use."""
-    if hasattr(comm, 'nccl_comm'):
+    if hasattr(comm, 'nccl_comm') and comm.nccl_comm is not None:
         comm.nccl_comm.destroy()
-    if hasattr(comm, 'intra_nccl_cojmm'):
+    comm.nccl_comm = None
+    if hasattr(comm, 'intra_nccl_cojmm') and comm.intra_nccl_comm is not None:
         comm.intra_nccl_comm.destroy()
+        comm.intra_nccl_comm = None
 
 
 def check_send_and_recv(communicator, *shape):


### PR DESCRIPTION
This PR fixes NCCL_UNHANDLED_CUDA_ERROR during CI. 

The recently-added mixed16 tests creates PureNcclCommunicator repeatedly in very short intervals. This may cause unhandled cuda error from NCCL library. 
