### PR TITLE
Fix ChainerX CBLAS link issue

### DIFF
--- a/chainerx_cc/cmake/FindBLAS.cmake
+++ b/chainerx_cc/cmake/FindBLAS.cmake
@@ -409,12 +409,28 @@ endif ()
 if (BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All")
   if(NOT BLAS_LIBRARIES)
     # OpenBLAS (http://www.openblas.net)
+    # ChainerX modification: check `cblas_sgemm` since ChianerX uses CBLAS API.
     check_fortran_libraries(
       BLAS_LIBRARIES
       BLAS
-      sgemm
+      cblas_sgemm
       ""
       "openblas"
+      ""
+      )
+  endif()
+endif ()
+
+if (BLA_VENDOR STREQUAL "OpenBLAS" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    # ChainerX modification: search libcblas if `cblas_sgemm` not found.
+    # OpenBLAS might be built without cblas functions (e.g. on Arch Linux.)
+    check_fortran_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      cblas_sgemm
+      ""
+      "openblas;cblas"
       ""
       )
   endif()

--- a/chainerx_cc/cmake/FindBLAS.cmake
+++ b/chainerx_cc/cmake/FindBLAS.cmake
@@ -450,6 +450,22 @@ if (BLA_VENDOR STREQUAL "FLAME" OR BLA_VENDOR STREQUAL "All")
   endif()
 endif ()
 
+if (BLA_VENDOR STREQUAL "ATLAS" OR BLA_VENDOR STREQUAL "All")
+  if(NOT BLAS_LIBRARIES)
+    # BLAS in ATLAS library? (http://math-atlas.sourceforge.net/)
+    # ChainerX modification: search libcblas as well and check the function
+    # `cblas_sgemm`, since ATLAS provides libcblas as a separate library.
+    check_fortran_libraries(
+      BLAS_LIBRARIES
+      BLAS
+      cblas_sgemm
+      ""
+      "f77blas;atlas;cblas"
+      ""
+      )
+  endif()
+endif ()
+
 # BLAS in PhiPACK libraries? (requires generic BLAS lib, too)
 if (BLA_VENDOR STREQUAL "PhiPACK" OR BLA_VENDOR STREQUAL "All")
   if(NOT BLAS_LIBRARIES)
@@ -729,28 +745,6 @@ if (BLA_VENDOR STREQUAL "Generic" OR BLA_VENDOR STREQUAL "All")
   endif()
 endif ()
 
-# NOTE: ChainerX does not support ATLAS because we encountered
-# `undefined reference 'cblas_sgemm'` errors, at least on Ubuntu16.04.
-# Also, it is well known that ATLAS is significantly slower than OpenBLAS.
-if (BLA_VENDOR STREQUAL "ATLAS" OR BLA_VENDOR STREQUAL "All")
-  if(NOT BLAS_LIBRARIES)
-    # BLAS in ATLAS library? (http://math-atlas.sourceforge.net/)
-    check_fortran_libraries(
-      BLAS_LIBRARIES
-      BLAS
-      dgemm
-      ""
-      "f77blas;atlas"
-      ""
-      )
-    if(BLAS_LIBRARIES)
-      message(WARNING "ATLAS is found (library: ${BLAS_LIBRARIES}), but ChainerX does not support ATLAS.")
-      set(BLAS_LIBRARIES FALSE)
-    endif()
-  endif()
-endif ()
-
-# Set BLAS_FOUND
 if(BLA_F95)
   find_package_handle_standard_args(BLAS REQUIRED_VARS BLAS95_LIBRARIES)
   set(BLAS95_FOUND ${BLAS_FOUND})


### PR DESCRIPTION
This should fix #6607.

@HiroakiMikami Could you try ChainerX build with this branch? I don't have Arch Linux environment.

Probably the cause of the error is Arch Linux's OpenBLAS is built [without CBLAS API](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/openblas#n22). CBLAS functions are separately provided in libcblas package.

This PR

* guards `<cblas.h>` by `extern "C"` and
* searches `libcblas.so` in `FindCBLAS.cmake` if required.

Those changes also fixes the issue with ATLAS on Ubuntu 18.04. ATLAS ships `cblas.h` without `__cplusplus` checking, so guards should be added at include place.

Note that the PR don't address header file detection. Notably MKL wouldn't work since it ships `mkl_cblas.h`. Though it is a different issue, I think it is better to bundle our own `cblas.h` in ChainerX as [numpy does](https://github.com/numpy/numpy/blob/master/numpy/core/src/common/npy_cblas.h).