### PR TITLE
Change the deprecated `collections`

### DIFF
--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -1,10 +1,9 @@
-from chainer.utils import collections_abc
-
 import mpi4py
 import numpy
 
 import chainer.backends
 import chainer.utils
+from chainer.utils import collections_abc
 from chainermn.communicators import _communication_utility
 from chainermn.communicators._communication_utility import chunked_bcast_obj
 from chainermn.communicators import _memory_utility

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -1,4 +1,4 @@
-import collections
+from chainer.utils import collections_abc
 
 import mpi4py
 import numpy
@@ -65,7 +65,7 @@ class _MessageType(object):
             self.ndims = [obj.ndim]
             self.shapes = [obj.shape]
             self.dtype = obj.dtype
-        elif isinstance(obj, collections.Iterable):
+        elif isinstance(obj, collections_abc.Iterable):
             if all(map(_is_numpy_array, obj)):
                 self.is_host = True
             elif all(map(_is_cupy_array, obj)):


### PR DESCRIPTION
This commit solves the Issue #6637. It removes the deprecated usage
of abc from `collections`, which will be removed in Python3.8.

The abc is now imported as `from chainer.utils import collections_abc`,
which aligns with `chainer` code base.

For more details of deprecated usage of abc in collections, please refer
to issue #6637.

Thank you for creating a pull request!

Please double-check the following.

- Read [our contribution guide](https://docs.chainer.org/en/stable/contribution.html).
  - Does your code conform to our coding guidelines?
  - Did you write sufficient test code?
  - Did you write sufficient documentation?
- Also, take a look at [our compatibility policy](https://docs.chainer.org/en/stable/compatibility.html).
