### PR TITLE
Fix testing condition of `BatchNormalizationMultiGpuTest`

### DIFF
--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -203,7 +203,6 @@ class BatchNormalizationTest(BatchNormalizationTestBase, testing.LinkTestCase):
 # TODO(hvy): Safely remove this test class when BackendConfig no longer
 # modifies the current device since those cases should be covered by the tests
 # above.
-@attr.multi_gpu(2)
 @testing.inject_backend_tests(
     None,
     testing.product({
@@ -212,6 +211,7 @@ class BatchNormalizationTest(BatchNormalizationTestBase, testing.LinkTestCase):
         'cuda_device': [0],
     }))
 @_parameterize
+@attr.multi_gpu(2)
 class BatchNormalizationMultiGpuTest(
         BatchNormalizationTestBase, testing.LinkTestCase):
 


### PR DESCRIPTION
It seems `attr.multi_gpu` does not work after `@testing.parameterize` is applied.

Code to reproduce the issue:
`CHAINER_TEST_GPU_LIMIT=1 pytest tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py`