### PR TITLE
Improve `link_hooks.SpectralNormalization`

### DIFF
--- a/chainer/link_hook.py
+++ b/chainer/link_hook.py
@@ -22,7 +22,7 @@ class _ForwardPreprocessCallbackArgs(object):
 
 
 class _ForwardPostprocessCallbackArgs(object):
-    """Callback data for LinkHook.forward_postrocess"""
+    """Callback data for LinkHook.forward_postprocess"""
 
     def __init__(self, link, forward_name, args, kwargs, out):
         # type: ('chainer.link.Link', str, tp.Tuple[tp.Any, ...], tp.Dict[str, tp.Any], tp.Any) -> None # NOQA

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -2,7 +2,6 @@ import numpy
 
 import chainer
 from chainer import backend
-from chainer.backends import intel64
 from chainer import configuration
 import chainer.functions as F
 from chainer import link_hook
@@ -275,12 +274,10 @@ class SpectralNormalization(link_hook.LinkHook):
             self.v = v
             with chainer.using_device(link.device):
                 if configuration.config.train:
-                    if (link.xp is chainerx or
-                            isinstance(getattr(link, vector_name),
-                                       intel64.ideep.mdarray)):
+                    if link.xp is chainerx:
                         getattr(link, vector_name)[:] = u
                     else:
-                        link.xp.copyto(getattr(link, vector_name), u)
+                        backend.copyto(getattr(link, vector_name), u)
         return W
 
     def reshape_W(self, W):

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -8,7 +8,7 @@ from chainer import link_hook
 import chainer.links as L
 from chainer import variable
 import chainerx
-from chainerx._fallback_workarounds import _from_chx as from_chx_workaround
+from chainerx import _fallback_workarounds as fallback
 
 
 def l2normalize(xp, v, eps=1e-12):
@@ -239,7 +239,7 @@ class SpectralNormalization(link_hook.LinkHook):
             weight_matrix = self.reshape_W(initialW.array)
             # TODO(crcrpar): Remove this when chainerx supports SVD.
             if link.xp is chainerx:
-                xp, device, array = from_chx_workaround(weight_matrix)
+                xp, device, array = fallback._from_chx(weight_matrix)
                 if xp is numpy:
                     _, s, _ = numpy.linalg.svd(array)
                 else:

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -108,7 +108,7 @@ class SpectralNormalization(link_hook.LinkHook):
     Args:
         n_power_iteration (int): Number of power iteration.
             The default value is 1.
-        eps (int): Numerical stability in norm calculation.
+        eps (float): Numerical stability in norm calculation.
             The default value is 1e-12.
         use_gamma (bool): If ``True``, weight scaling parameter gamma which is
             initialized by initial weight's max singular value is introduced.

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -9,8 +9,7 @@ from chainer import link_hook
 import chainer.links as L
 from chainer import variable
 import chainerx
-from chainerx._fallback_workarounds import _from_chx as from_chx
-from chainerx._fallback_workarounds import _to_chx as to_chx
+from chainerx._fallback_workarounds import _from_chx as from_chx_workaround
 
 
 def l2normalize(xp, v, eps=1e-12):
@@ -27,6 +26,8 @@ def l2normalize(xp, v, eps=1e-12):
     """
     # TODO(crcrpar): Remove this when chainerx.linalg.norm becomes available.
     if xp is chainerx:
+        # NOTE(crcrpar): `chainerx.power` is not available as of 2019/03/27.
+        # See https://github.com/chainer/chainer/pull/6522
         norm = chainerx.sqrt(chainerx.sum(v * v))
     else:
         norm = xp.linalg.norm(v)
@@ -241,7 +242,7 @@ class SpectralNormalization(link_hook.LinkHook):
             # TODO(crcrpar): Remove this when chainerx supports SVD and
             # it is allowed to initialize Parameter from chainerx.ndarray.
             if link.xp is chainerx:
-                xp, device, array = from_chx(weight_matrix)
+                xp, device, array = from_chx_workaround(weight_matrix)
                 if xp is numpy:
                     _, s, _ = numpy.linalg.svd(array)
                 else:

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -251,6 +251,10 @@ class SpectralNormalization(link_hook.LinkHook):
                 link.gamma = variable.Parameter(s[0], ())
         self._initialized = True
 
+        # N.B.(crcrpar): Tentative adjustment for half precision.
+        if initialW.dtype == numpy.float16:
+            self.eps = 1e-6
+
     def normalize_weight(self, link):
         """Normalize target weight before every single forward computation."""
         weight_name, vector_name = self.weight_name, self.vector_name

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -275,6 +275,8 @@ class SpectralNormalization(link_hook.LinkHook):
             with chainer.using_device(link.device):
                 if configuration.config.train:
                     if link.xp is chainerx:
+                        # TODO(crcrpar): Remove this when
+                        # chainerx supports `copyto`.
                         getattr(link, vector_name)[:] = u
                     else:
                         backend.copyto(getattr(link, vector_name), u)

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -239,8 +239,7 @@ class SpectralNormalization(link_hook.LinkHook):
         if self.use_gamma:
             # Initialize the scaling parameter with the max singular value.
             weight_matrix = self.reshape_W(initialW.array)
-            # TODO(crcrpar): Remove this when chainerx supports SVD and
-            # it is allowed to initialize Parameter from chainerx.ndarray.
+            # TODO(crcrpar): Remove this when chainerx supports SVD.
             if link.xp is chainerx:
                 xp, device, array = from_chx_workaround(weight_matrix)
                 if xp is numpy:

--- a/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
+++ b/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
@@ -11,8 +11,7 @@ import chainer
 from chainer.backends._cpu import _to_cpu as to_cpu
 from chainer.link_hooks.spectral_normalization import SpectralNormalization
 import chainer.links as L
-from chainer.serializers import load_npz
-from chainer.serializers import save_npz
+from chainer import serializers
 from chainer import testing
 from chainer.testing import attr
 from chainer.testing.backend import BackendConfig
@@ -205,7 +204,6 @@ class BaseTest(object):
 
     def check_serialization(self, backend_config):
         root = tempfile.mkdtemp()
-        self._root = root
         filename = os.path.join(root, 'tmp.npz')
 
         layer1 = self.layer.copy('copy')
@@ -218,7 +216,7 @@ class BaseTest(object):
             layer1(x)
             with chainer.using_config('train', False):
                 y1 = layer1(x)
-        save_npz(filename, layer1)
+        serializers.save_npz(filename, layer1)
 
         layer2 = self.layer.copy('copy')
         hook2 = copy.deepcopy(self.hook)
@@ -227,7 +225,7 @@ class BaseTest(object):
         # Test loading is nice.
         msg = None
         try:
-            load_npz(filename, layer2)
+            serializers.load_npz(filename, layer2)
         except Exception as e:
             msg = e
         assert msg is None
@@ -244,7 +242,7 @@ class BaseTest(object):
             orig_vector, getattr(layer2, hook2.vector_name))
         testing.assert_allclose(y1.array, y2.array, **self.allclose_options)
 
-        shutil.rmtree(self._root)
+        shutil.rmtree(root)
 
     def test_serialization(self, backend_config):
         if not self.lazy_init:

--- a/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
+++ b/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
@@ -4,12 +4,12 @@ import numpy
 import pytest
 
 import chainer
-from chainer.backends import cuda
+from chainer.backends._cpu import _to_cpu as to_cpu
 from chainer.link_hooks.spectral_normalization import SpectralNormalization
 import chainer.links as L
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
+from chainer.testing.backend import BackendConfig
 
 
 class TestExceptions(unittest.TestCase):
@@ -35,6 +35,8 @@ class TestExceptions(unittest.TestCase):
 
 
 class BaseTest(object):
+
+    allclose_option = {'atol': 1e-6, 'rtol': 1e-4}
 
     def test_add_sn_hook(self):
         layer, hook = self.layer, self.hook
@@ -63,31 +65,23 @@ class BaseTest(object):
                 layer(self.x)
         return layer, hook
 
-    def check_weight_is_parameter(self, gpu):
+    def check_weight_is_parameter(self, backend_config):
         layer, hook = self._init_layer()
-        if gpu:
-            layer = layer.to_gpu()
+        layer.to_device(backend_config.device)
         source_weight = getattr(layer, hook.weight_name)
-        x = cuda.to_gpu(self.x) if gpu else self.x
+        x = backend_config.get_array(self.x)
         layer(x)
         assert getattr(layer, hook.weight_name) is source_weight
 
-    def test_weight_is_parameter_cpu(self):
+    def test_weight_is_parameter(self, backend_config):
         if not self.lazy_init:
-            self.check_weight_is_parameter(False)
+            self.check_weight_is_parameter(backend_config)
 
-    @attr.gpu
-    def test_weight_is_parameter_gpu(self):
-        if not self.lazy_init:
-            self.check_weight_is_parameter(True)
-
-    def check_in_recomputing(self, gpu):
+    def check_in_recomputing(self, backend_config):
         layer, hook = self.layer, self.hook
         layer.add_hook(hook)
-        if gpu:
-            layer = layer.to_gpu()
-        xp = cuda.cupy if gpu else numpy
-        x = xp.asarray(self.x)
+        layer.to_device(backend_config.device)
+        x = backend_config.get_array(self.x)
 
         y1 = layer(x).array
         u1 = getattr(layer, hook.vector_name).copy()
@@ -97,77 +91,61 @@ class BaseTest(object):
         u2 = getattr(layer, hook.vector_name)
         v2 = hook.v
 
-        xp.testing.assert_array_equal(u1, u2)
-        xp.testing.assert_array_equal(v1, v2)
-        testing.assert_allclose(y1, y2)
+        u1, u2 = to_cpu(u1), to_cpu(u2)
+        v1, v2 = to_cpu(v1), to_cpu(v2)
+        y1, y2 = to_cpu(y1), to_cpu(y2)
+        numpy.testing.assert_array_equal(u1, u2)
+        numpy.testing.assert_array_equal(v1, v2)
+        numpy.testing.assert_allclose(y1, y2, **self.allclose_option)
 
-    def test_in_recomputing_cpu(self):
+    def test_in_recomputing(self, backend_config):
         if not self.lazy_init:
-            self.check_in_recomputing(False)
+            self.check_in_recomputing(backend_config)
 
-    @attr.gpu
-    def test_in_recomputing_gpu(self):
-        if not self.lazy_init:
-            self.check_in_recomputing(True)
-
-    def check_deleted(self, gpu):
+    def check_deleted(self, backend_config):
         layer, hook = self.layer, self.hook
         layer.add_hook(hook)
-        if gpu:
-            layer = layer.to_gpu()
-        x = cuda.to_gpu(self.x) if gpu else self.x
+        layer.to_device(backend_config.device)
+        x = backend_config.get_array(self.x)
 
-        y1 = layer(x).array
-        with chainer.using_config('train', False):
-            y2 = layer(x).array
-        layer.delete_hook(hook.name)
-        assert not hasattr(layer, hook.vector_name)
-        y3 = layer(x).array
-        if gpu:
-            y1, y2, y3 = cuda.to_cpu(y1), cuda.to_cpu(y2), cuda.to_cpu(y3)
+        with chainer.using_device(backend_config.device):
+            y1 = layer(x).array
+            with chainer.using_config('train', False):
+                y2 = layer(x).array
+            layer.delete_hook(hook.name)
+            assert not hasattr(layer, hook.vector_name)
+            y3 = layer(x).array
+        y1, y2, y3 = to_cpu(y1), to_cpu(y2), to_cpu(y3)
         assert not numpy.array_equal(y1, y3)
         assert not numpy.array_equal(y2, y3)
 
-    def test_deleted_cpu(self):
-        self.check_deleted(False)
+    def test_deleted(self, backend_config):
+        self.check_deleted(backend_config)
 
-    @attr.gpu
-    def test_deleted_gpu(self):
-        self.check_deleted(True)
-
-    def check_u_updated_in_train(self, gpu):
+    def check_u_updated_in_train(self, backend_config):
         layer, hook = self.layer, self.hook
         layer.add_hook(hook)
-        if gpu:
-            layer = layer.to_gpu()
-        x = cuda.to_gpu(self.x) if gpu else self.x
+        layer.to_device(backend_config.device)
+        x = backend_config.get_array(self.x)
 
         y1 = layer(x).array
         u1 = getattr(layer, hook.vector_name).copy()
         y2 = layer(x).array
         u2 = getattr(layer, hook.vector_name)
-        if gpu:
-            y1, y2 = cuda.to_cpu(y1), cuda.to_cpu(y2)
-            u1, u2 = cuda.to_cpu(u1), cuda.to_cpu(u2)
+        y1, y2 = to_cpu(y1), to_cpu(y2)
+        u1, u2 = to_cpu(u1), to_cpu(u2)
         assert not numpy.array_equal(u1, u2)
         assert not numpy.array_equal(y1, y2)
 
-    def test_u_updated_in_train_cpu(self):
+    def test_u_updated_in_train(self, backend_config):
         if not self.lazy_init:
-            self.check_u_updated_in_train(False)
+            self.check_u_updated_in_train(backend_config)
 
-    @attr.gpu
-    def test_u_updated_in_train_gpu(self):
-        if not self.lazy_init:
-            self.check_u_updated_in_train(True)
-
-    def check_u_not_updated_in_test(self, gpu):
+    def check_u_not_updated_in_test(self, backend_config):
         layer, hook = self.layer, self.hook
         layer.add_hook(hook)
-        if gpu:
-            layer = layer.to_gpu()
-        xp = cuda.cupy if gpu else numpy
-        x = xp.asarray(self.x)
+        layer.to_device(backend_config.device)
+        x = backend_config.get_array(self.x)
 
         with chainer.using_config('train', False):
             y1 = layer(x).array
@@ -177,57 +155,74 @@ class BaseTest(object):
             u2 = getattr(layer, hook.vector_name)
             v2 = hook.v.copy()
 
-        xp.testing.assert_array_equal(u1, u2)
-        xp.testing.assert_array_equal(v1, v2)
-        testing.assert_allclose(y1, y2)
+        u1, u2 = to_cpu(u1), to_cpu(u2)
+        v1, v2 = to_cpu(v1), to_cpu(v2)
+        y1, y2 = to_cpu(y1), to_cpu(y2)
+        numpy.testing.assert_array_equal(u1, u2)
+        numpy.testing.assert_array_equal(v1, v2)
+        numpy.testing.assert_allclose(y1, y2, **self.allclose_option)
 
-    def test_u_not_updated_in_test_cpu(self):
+    def test_u_not_updated_in_test(self, backend_config):
         if not self.lazy_init:
-            self.check_u_not_updated_in_test(False)
+            self.check_u_not_updated_in_test(backend_config)
 
-    @attr.gpu
-    def test_u_not_updated_in_test_gpu(self):
-        if not self.lazy_init:
-            self.check_u_not_updated_in_test(True)
+    def check_multi_devices_forward(self, device_0, device_1):
+        layer, hook = self.layer, self.hook
+        layer.add_hook(hook)
+        layer.to_device(device_1)
+        x = device_1.send(self.x)
 
-    @attr.chainerx
-    def test_forward_chx(self):
-        if not self.lazy_init:
-            layer, hook = self.layer, self.hook
-            layer.add_hook(hook)
-            layer.to_chx()
-            x = chainer.Variable(
-                self.x, requires_grad=self.x.dtype.kind == 'f')
-            x.to_chx()
-            msg = None
+        msg = None
+        with chainer.using_device(device_0):
             try:
                 layer(x)
             except Exception as e:
                 msg = e
+        assert msg is None
 
-            assert msg is None
+    @attr.chainerx
+    @attr.multi_gpu(2)
+    def test_forward_chx_on_multi_devices(self):
+        if not self.lazy_init:
+            device_0 = BackendConfig(
+                {'use_chainerx': True, 'chainerx_device': 'cuda:0'}).device
+            device_1 = BackendConfig(
+                {'use_chainerx': True, 'chainerx_device': 'cuda:1'}).device
+            self.check_multi_devices_forward(device_0, device_1)
 
     @attr.multi_gpu(2)
-    @condition.retry(3)
-    def test_forward_multi_gpu(self):
+    def test_forward_multi_gpus(self):
         if not self.lazy_init:
-            layer, hook = self.layer, self.hook
-            layer.add_hook(hook)
-            with cuda.get_device_from_id(1):
-                layer.to_gpu()
-                x = cuda.to_gpu(self.x)
-            with cuda.get_device_from_id(0):
-                msg = None
-                try:
-                    layer(x)
-                except Exception as e:
-                    msg = e
-            assert msg is None
+            device_0 = BackendConfig(
+                {'use_cuda': True, 'cuda_device': 0}).device
+            device_1 = BackendConfig(
+                {'use_cuda': True, 'cuda_device': 1}).device
+            self.check_multi_devices_forward(device_0, device_1)
+
+
+_inject_backend_tests = testing.inject_backend_tests(
+    ['test_weight_is_parameter', 'test_in_recomputing', 'test_deleted',
+     'test_u_updated_in_train', 'test_u_not_updated_in_test'],
+    # CPU tests
+    testing.product({
+        'use_ideep': [True, False],
+    })
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0'],
+    })
+)
 
 
 @testing.parameterize(*testing.product({
     'use_gamma': [True, False],
 }))
+@_inject_backend_tests
 class TestEmbedID(unittest.TestCase, BaseTest):
 
     def setUp(self):
@@ -260,6 +255,7 @@ class TestEmbedID(unittest.TestCase, BaseTest):
     'lazy_init': [True, False],
     'use_gamma': [True, False],
 }))
+@_inject_backend_tests
 class TestLinear(unittest.TestCase, BaseTest):
 
     def setUp(self):
@@ -277,6 +273,7 @@ class TestLinear(unittest.TestCase, BaseTest):
     'lazy_init': [True, False],
     'link': [L.Convolution1D, L.Deconvolution1D],
 }))
+@_inject_backend_tests
 class TestConvolution1D(unittest.TestCase, BaseTest):
 
     def setUp(self):
@@ -296,6 +293,7 @@ class TestConvolution1D(unittest.TestCase, BaseTest):
     'lazy_init': [True, False],
     'link': [L.Convolution2D, L.Deconvolution2D],
 }))
+@_inject_backend_tests
 class TestConvolution2D(unittest.TestCase, BaseTest):
 
     def setUp(self):
@@ -315,6 +313,7 @@ class TestConvolution2D(unittest.TestCase, BaseTest):
     'lazy_init': [True, False],
     'link': [L.Convolution3D, L.Deconvolution3D],
 }))
+@_inject_backend_tests
 class TestConvolution3D(unittest.TestCase, BaseTest):
 
     def setUp(self):

--- a/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
+++ b/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
@@ -99,10 +99,9 @@ class BaseTest(object):
 
         u1, u2 = to_cpu(u1), to_cpu(u2)
         v1, v2 = to_cpu(v1), to_cpu(v2)
-        y1, y2 = to_cpu(y1), to_cpu(y2)
         numpy.testing.assert_array_equal(u1, u2)
         numpy.testing.assert_array_equal(v1, v2)
-        numpy.testing.assert_allclose(y1, y2, **self.allclose_options)
+        testing.assert_allclose(y1, y2, **self.allclose_options)
 
     def test_in_recomputing(self, backend_config):
         if not self.lazy_init:
@@ -163,10 +162,9 @@ class BaseTest(object):
 
         u1, u2 = to_cpu(u1), to_cpu(u2)
         v1, v2 = to_cpu(v1), to_cpu(v2)
-        y1, y2 = to_cpu(y1), to_cpu(y2)
         numpy.testing.assert_array_equal(u1, u2)
         numpy.testing.assert_array_equal(v1, v2)
-        numpy.testing.assert_allclose(y1, y2, **self.allclose_options)
+        testing.assert_allclose(y1, y2, **self.allclose_options)
 
     def test_u_not_updated_in_test(self, backend_config):
         if not self.lazy_init:
@@ -217,9 +215,9 @@ class BaseTest(object):
         layer1.to_device(backend_config.device)
         x = backend_config.get_array(self.x)
         with backend_config:
-            layer1(x).array
+            layer1(x)
             with chainer.using_config('train', False):
-                y1 = layer1(x).array
+                y1 = layer1(x)
         save_npz(filename, layer1)
 
         layer2 = self.layer.copy('copy')
@@ -235,7 +233,7 @@ class BaseTest(object):
         assert msg is None
 
         with chainer.using_config('train', False):
-            y2 = layer2(self.x.copy()).array
+            y2 = layer2(self.x.copy())
 
         # Test attributes are the same.
         orig_weight = to_cpu(getattr(layer1, hook1.weight_name).array)
@@ -244,7 +242,7 @@ class BaseTest(object):
             orig_weight, getattr(layer2, hook2.weight_name).array)
         numpy.testing.assert_array_equal(
             orig_vector, getattr(layer2, hook2.vector_name))
-        numpy.testing.assert_allclose(to_cpu(y1), y2, **self.allclose_options)
+        testing.assert_allclose(y1.array, y2.array, **self.allclose_options)
 
         shutil.rmtree(self._root)
 

--- a/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
+++ b/tests/chainer_tests/link_hooks_tests/test_spectral_normalization.py
@@ -36,7 +36,7 @@ class TestExceptions(unittest.TestCase):
 
 class BaseTest(object):
 
-    allclose_option = {'atol': 1e-6, 'rtol': 1e-4}
+    allclose_options = {'atol': 1e-6, 'rtol': 1e-4}
 
     def test_add_sn_hook(self):
         layer, hook = self.layer, self.hook
@@ -96,7 +96,7 @@ class BaseTest(object):
         y1, y2 = to_cpu(y1), to_cpu(y2)
         numpy.testing.assert_array_equal(u1, u2)
         numpy.testing.assert_array_equal(v1, v2)
-        numpy.testing.assert_allclose(y1, y2, **self.allclose_option)
+        numpy.testing.assert_allclose(y1, y2, **self.allclose_options)
 
     def test_in_recomputing(self, backend_config):
         if not self.lazy_init:
@@ -160,7 +160,7 @@ class BaseTest(object):
         y1, y2 = to_cpu(y1), to_cpu(y2)
         numpy.testing.assert_array_equal(u1, u2)
         numpy.testing.assert_array_equal(v1, v2)
-        numpy.testing.assert_allclose(y1, y2, **self.allclose_option)
+        numpy.testing.assert_allclose(y1, y2, **self.allclose_options)
 
     def test_u_not_updated_in_test(self, backend_config):
         if not self.lazy_init:


### PR DESCRIPTION
This PR enables `chainer.link_hooks.SpectralNormalziation` to support ideep, chainerx, and multiple GPUs.