### PR TITLE
BatchNormalization to only allocate dummy mean and var in cuDNN path

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -117,8 +117,6 @@ class BatchNormalization(function_node.FunctionNode):
         self.retain_inputs((0, 1))
         x, gamma, beta = inputs
 
-        xp = backend.get_array_module(x)
-
         self.axis = _compute_axis(x.ndim, gamma.ndim, self.axis)
         self.key_axis = _compute_key_axis(x.ndim, gamma.ndim, self.axis)
 
@@ -154,6 +152,7 @@ class BatchNormalization(function_node.FunctionNode):
         self.expander = expander
 
         self.mode = _BNMode(x, gamma, self.key_axis)
+        xp = backend.get_array_module(x)
         self.use_cudnn = self.mode.can_use_cudnn(xp)
         self.use_ideep = self.mode.can_use_ideep()
 

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -118,9 +118,6 @@ class BatchNormalization(function_node.FunctionNode):
         x, gamma, beta = inputs
 
         xp = backend.get_array_module(x)
-        if self.running_mean is None:
-            self.running_mean = xp.zeros_like(gamma, dtype=x.dtype)
-            self.running_var = xp.zeros_like(gamma, dtype=x.dtype)
 
         self.axis = _compute_axis(x.ndim, gamma.ndim, self.axis)
         self.key_axis = _compute_key_axis(x.ndim, gamma.ndim, self.axis)
@@ -178,38 +175,47 @@ class BatchNormalization(function_node.FunctionNode):
                 ))
             y = y.astype(x.dtype, copy=False)
 
-            m = x.size // gamma.size
-            adjust = m / max(m - 1., 1.)
-
-            # Update running_mean
-            if isinstance(self.running_mean, intel64.ideep.mdarray):
-                self.running_mean.inplace_axpby(
-                    self.decay, (1 - self.decay), self.mean)
-            else:
-                self.running_mean *= self.decay
-                self.running_mean += self.mean * (1 - self.decay)
-
-            # Update running_var
-            if isinstance(self.running_var, intel64.ideep.mdarray):
-                self.running_var.inplace_axpby(
-                    self.decay, (1 - self.decay), self.var * adjust)
-            else:
-                self.running_var *= self.decay
-                self.running_var += self.var * adjust * (1 - self.decay)
-
             if expand_dim:
                 y = numpy.squeeze(y, axis=(2, 3))
 
+            # Update running statistics if given
+            if self.running_mean is not None:
+                m = x.size // gamma.size
+                adjust = m / max(m - 1., 1.)
+
+                # Update running_mean
+                if isinstance(self.running_mean, intel64.ideep.mdarray):
+                    self.running_mean.inplace_axpby(
+                        self.decay, (1 - self.decay), self.mean)
+                else:
+                    self.running_mean *= self.decay
+                    self.running_mean += self.mean * (1 - self.decay)
+
+                # Update running_var
+                if isinstance(self.running_var, intel64.ideep.mdarray):
+                    self.running_var.inplace_axpby(
+                        self.decay, (1 - self.decay), self.var * adjust)
+                else:
+                    self.running_var *= self.decay
+                    self.running_var += self.var * adjust * (1 - self.decay)
+
         elif self.use_cudnn:
+            if self.running_mean is not None:
+                mean = self.running_mean
+                var = self.running_var
+            else:
+                # Create dummies.
+                mean = xp.zeros_like(gamma, dtype=x.dtype)
+                var = xp.zeros_like(gamma, dtype=x.dtype)
+
             # self.mean and self.inv_std are used as buffers to save
             # intermediate results computed during forward pass. These buffers
             # are used to speed-up backward pass.
             y, self.mean, self.inv_std = (
                 cudnn.batch_normalization_forward_training(
-                    x, gamma, beta, self.running_mean, self.running_var,
-                    None, None, self.eps, self.decay,
-                    self.mode.is_for_conv2d, self.mode.get_cudnn_mode(),
-                    chainer.is_debug()))
+                    x, gamma, beta, mean, var, None, None,
+                    self.eps, self.decay, self.mode.is_for_conv2d,
+                    self.mode.get_cudnn_mode(), chainer.is_debug()))
         else:
             # Generic CPU and GPU implementation
 
@@ -228,23 +234,27 @@ class BatchNormalization(function_node.FunctionNode):
 
             y = _apply_bn_fwd(xp, x, self.mean[expander],
                               self.inv_std[expander], gamma, beta)
-            # Update running statistics
-            m = x.size // gamma.size
-            adjust = m / max(m - 1., 1.)  # unbiased estimation
 
-            xp = backend.get_array_module(self.running_mean, self.running_var)
-            if xp is chainerx:
-                self.running_mean, self.running_var = backend.from_chx(
-                    (self.running_mean, self.running_var))
+            # Update running statistics if given
+            if self.running_mean is not None:
+                m = x.size // gamma.size
+                adjust = m / max(m - 1., 1.)  # unbiased estimation
 
-            self.running_mean *= self.decay
-            self.running_mean += (1 - self.decay) * self.mean
-            self.running_var *= self.decay
-            self.running_var += (1 - self.decay) * adjust * var
+                xp = backend.get_array_module(
+                    self.running_mean, self.running_var)
 
-            if xp is chainerx:
-                self.running_mean = backend.to_chx(self.running_mean)
-                self.running_var = backend.to_chx(self.running_var)
+                if xp is chainerx:
+                    self.running_mean, self.running_var = backend.from_chx(
+                        (self.running_mean, self.running_var))
+
+                self.running_mean *= self.decay
+                self.running_mean += (1 - self.decay) * self.mean
+                self.running_var *= self.decay
+                self.running_var += (1 - self.decay) * adjust * var
+
+                if xp is chainerx:
+                    self.running_mean = backend.to_chx(self.running_mean)
+                    self.running_var = backend.to_chx(self.running_var)
 
         return y,
 


### PR DESCRIPTION
`F.batch_normalization` always allocates and updates dummy mean and var if they aren't given by the caller. Those dummies are only required when calling cuDNN so I changed the logic to condition these allocations/updates.