### PR TITLE
Allow `ArrayBody::GetArrayNode` to return null

### DIFF
--- a/chainerx_cc/chainerx/array_body.cc
+++ b/chainerx_cc/chainerx/array_body.cc
@@ -41,6 +41,8 @@ std::shared_ptr<ArrayBody> CreateArrayBody(ArrayBody::Params params) {
     return CreateArrayBody(params.shape, params.strides, params.dtype, params.device, std::move(params.data), params.offset);
 }
 
+const std::shared_ptr<ArrayNode> ArrayBody::kNullArrayNode{nullptr};
+
 ArrayBody::ArrayBody(
         const Shape& shape,  // NOLINT(modernize-pass-by-value)
         const Strides& strides,  // NOLINT(modernize-pass-by-value)

--- a/chainerx_cc/chainerx/array_body.h
+++ b/chainerx_cc/chainerx/array_body.h
@@ -94,8 +94,11 @@ public:
 
     const std::shared_ptr<ArrayNode>& GetArrayNode(const BackpropId& backprop_id) const {
         nonstd::optional<size_t> index = GetNodeIndex(backprop_id);
-        assert(index.has_value());
-        return nodes_[*index];
+        if (index.has_value()) {
+            return nodes_[*index];
+        }
+
+        return kNullArrayNode;
     }
 
     bool HasArrayNode(const BackpropId& backprop_id) const { return GetNodeIndex(backprop_id).has_value(); }
@@ -153,6 +156,10 @@ private:
     static ReturnType GetGradImpl(ThisPtr this_ptr, const BackpropId& backprop_id);
 
     nonstd::optional<size_t> GetNodeIndex(const BackpropId& backprop_id) const;
+
+    // The use of non-POD static storage object here is safe, because destructing a shared_ptr with nullptr does not incur any
+    // destruction order problem.
+    static const std::shared_ptr<ArrayNode> kNullArrayNode;
 
     Shape shape_;
     Strides strides_;

--- a/chainerx_cc/chainerx/backward.cc
+++ b/chainerx_cc/chainerx/backward.cc
@@ -146,8 +146,8 @@ std::unordered_map<OpNode*, std::vector<uint8_t>> CreateSubgraph(
         // Initialize array node queue with inputs.
         for (const Array& input : inputs) {
             const std::shared_ptr<ArrayBody>& array_body = internal::GetArrayBody(input);
-            if (array_body->HasArrayNode(backprop_id)) {
-                PushNodeIfNotSeen(candidate_input_array_nodes, array_body->GetArrayNode(backprop_id).get(), seen_array_nodes);
+            if (const std::shared_ptr<ArrayNode>& array_node = array_body->GetArrayNode(backprop_id)) {
+                PushNodeIfNotSeen(candidate_input_array_nodes, array_node.get(), seen_array_nodes);
             }
         }
 
@@ -601,8 +601,7 @@ std::vector<nonstd::optional<Array>> Grad(
     std::unordered_map<ArrayNode*, internal::GradRef> array_node_grad_map;
     for (const Array& input : inputs) {
         const std::shared_ptr<ArrayBody>& array_body = internal::GetArrayBody(input);
-        if (array_body->HasArrayNode(actual_backprop_id)) {
-            const std::shared_ptr<ArrayNode>& input_array_node = array_body->GetArrayNode(actual_backprop_id);
+        if (const std::shared_ptr<ArrayNode>& input_array_node = array_body->GetArrayNode(actual_backprop_id)) {
             input_grads.emplace_back(nonstd::optional<Array>{});
             array_node_grad_map.emplace(input_array_node.get(), internal::GradRef{&input_grads.back()});
         } else {

--- a/chainerx_cc/chainerx/backward_context.cc
+++ b/chainerx_cc/chainerx/backward_context.cc
@@ -215,7 +215,7 @@ Array BackwardContext::GetRetainedOutput(const RetainedOutputToken& token) {
         }
 
         // If the weak ptr to old output array node was dead, replenish it with the fabricated one.
-        if (output_array_node == nullptr && array_body->HasArrayNode(op_node_->backprop_id())) {
+        if (output_array_node == nullptr) {
             output_array_nodes_[output_index] = array_body->GetArrayNode(op_node_->backprop_id());
         }
 

--- a/chainerx_cc/chainerx/check_backward.cc
+++ b/chainerx_cc/chainerx/check_backward.cc
@@ -47,8 +47,10 @@ std::vector<nonstd::optional<Array>> BackwardGradients(
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kEnable) {
     for (const auto& input : inputs) {
         const std::shared_ptr<internal::ArrayBody>& input_body = internal::GetArrayBody(input);
-        if (input_body->HasArrayNode(backprop_id) && input_body->GetArrayNode(backprop_id)->creator_op_node() != nullptr) {
-            throw GradientCheckError{"BackwardGradients: All inputs must be leaf nodes of computational graph"};
+        if (const std::shared_ptr<internal::ArrayNode>& node = input_body->GetArrayNode(backprop_id)) {
+            if (node->creator_op_node() != nullptr) {
+                throw GradientCheckError{"BackwardGradients: All inputs must be leaf nodes of computational graph"};
+            }
         }
     }
 


### PR DESCRIPTION
Reduces duplicate lookups.