### PR TITLE
Generate shorter class names for parameterized tests

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -9,6 +9,12 @@ from chainer.testing import _bundle
 from chainer import utils
 
 
+def _param_to_str(obj):
+    if isinstance(obj, type):
+        return obj.__name__
+    return repr(obj)
+
+
 def _shorten(s, maxlen):
     # Shortens the string down to maxlen, by replacing the middle part with
     # a 3-dots string '...'.
@@ -27,7 +33,7 @@ def _make_class_name(base_class_name, i_param, param):
     SINGLE_PARAM_MAXLEN = 100  # Length limit of a single parameter value
     PARAMS_MAXLEN = 5000  # Length limit of the whole parameters part
     param_strs = [
-        '{}={}'.format(k, _shorten(repr(v), SINGLE_PARAM_MAXLEN))
+        '{}={}'.format(k, _shorten(_param_to_str(v), SINGLE_PARAM_MAXLEN))
         for k, v in param.items()]
     param_strs = _shorten(', '.join(param_strs), PARAMS_MAXLEN)
     cls_name = '{}_param_{}_{{{}}}'.format(


### PR DESCRIPTION
`{dtype=<class 'numpy.float32'>}` in a class name looks unnecessarily verbose.

- This PR changes it to `{dtype=float32}`.
- Modules (e.g. `<module 'numpy' from 'path/to/numpy/__init__.py'>`) are left, because `inject_backend_tests` is used.