### PR TITLE
Fix `chainer.backend.get_array_module` documentation

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -162,7 +162,7 @@ def get_array_module(*args):
 
     Returns:
         module: :mod:`cupy`, :mod:`numpy`, or :mod:`chainerx` is returned based
-            on the types of the arguments.
+        on the types of the arguments.
 
     """
     is_chainerx_available = chainerx.is_available()

--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -158,11 +158,11 @@ def get_array_module(*args):
 
     Args:
         args: Values to determine whether NumPy, CuPy, or ChainerX should be
-        used.
+            used.
 
     Returns:
         module: :mod:`cupy`, :mod:`numpy`, or :mod:`chainerx` is returned based
-        on the types of the arguments.
+            on the types of the arguments.
 
     """
     is_chainerx_available = chainerx.is_available()

--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -12,6 +12,7 @@ Utilities across backends
    :nosignatures:
 
    chainer.backend.copyto
+   chainer.backend.get_array_module
 
 CUDA
 ----


### PR DESCRIPTION
(found during writing #4986.)