### PR TITLE
Make git ignore `chainerx/libchainerx.dylib`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyo
 *.cpp
 *.so
+*.dylib
 build
 \#*\#
 .\#*


### PR DESCRIPTION
This PR adds `*.dylib` to `.gitignore` for macOS.

```
% python -c 'import chainer; chainer.print_runtime_info()'
Platform: Darwin-18.2.0-x86_64-i386-64bit
Chainer: 6.0.0b3
NumPy: 1.17.0.dev0+e6147b9
CuPy: Not Available
iDeep: Not Available
```