### PR TITLE
Minimize the Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
       python: "3.5"
       env:
       - CHAINER_TRAVIS_TEST="python-static-check"
+      if: type in (pull_request)
 
     - name: "C++ Static Check"
       language: python
@@ -18,13 +19,7 @@ matrix:
       python: "3.5"
       env:
       - CHAINER_TRAVIS_TEST="c-static-check"
-
-    - name: "Ubuntu14.04 Py27 | chainer, chainermn"
-      dist: trusty
-      python: "2.7"
-      env:
-      - CHAINER_TRAVIS_TEST="chainer"
-      - SKIP_CHAINERX=1
+      if: type in (pull_request)
 
     - name: "Ubuntu16.04 Py35 | chainer, chainermn, chainerx, docs"
       dist: xenial
@@ -32,13 +27,7 @@ matrix:
       env:
       - CHAINER_TRAVIS_TEST="chainer"
       - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-
-    - name: "Ubuntu16.04 Py35 | chainerx_cc"
-      dist: xenial
-      python: "3.5"
-      env:
-      - CHAINER_TRAVIS_TEST="chainerx-cpp"
-      - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+      if: type in (pull_request)
 
     - name: "macOS Py35 | chainer, chainermn, chainerx, docs"
       os: osx
@@ -48,15 +37,7 @@ matrix:
       - PYTHON_VERSION=3.5.1
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
-
-    - name: "Windows | chainer"
-      os: windows
-      language: shell
-      python: "3.7"
-      env:
-      - CHAINER_TRAVIS_TEST="chainer"
-      - SKIP_CHAINERX=1
-      - SKIP_CHAINERMN=1
+      if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
 
     - name: "macOS Py27 | chainer, chainermn"
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ matrix:
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
       - SKIP_CHAINERX=1
-      if: (branch = master OR branch = v5) AND (NOT type in (pull_request))
 
 before_install:
   - bash scripts/ci/travis/run-tests.sh before_install


### PR DESCRIPTION
I would like to redefine the purpose of Travis CI to quick automatic checks for all contributors. In this regard, recent situations of Travis CI's long job queue is not desirable. This change reduces the number of jobs running on Travis CI by reducing the jobs following the redefined purpose.

- Checks that are covered by Jenkins will only run for PRs (master/stable branches are removed).
- Windows tests are removed (we will use our new CI infrastructure for them).
- Only one combination of Ubuntu/py environment is used for each PR (namely Ubuntu16.04 py35).
- macOS py27 test will run for each PR instead of macOS py35 (for wider py versions coverage combined with Ubuntu test).