### PR TITLE
[backport] Fix `chainer.backend.get_array_module` documentation

### DIFF
--- a/docs/source/reference/util/cuda.rst
+++ b/docs/source/reference/util/cuda.rst
@@ -12,6 +12,7 @@ Utilities across backends
    :nosignatures:
 
    chainer.backend.copyto
+   chainer.backend.get_array_module
 
 CUDA
 ----


### PR DESCRIPTION
Backport of #6663