### PR TITLE
Replace deprecated URLopener in `download.py`

### DIFF
--- a/examples/memnn/download.py
+++ b/examples/memnn/download.py
@@ -4,9 +4,7 @@ from six.moves.urllib import request
 
 
 def main():
-    opener = request.FancyURLopener()
-    opener.addheaders = [('User-Agent', '')]
-    opener.retrieve(
+    request.urlretrieve(
         'http://www.thespermwhale.com/jaseweston/babi/tasks_1-20_v1-2.tar.gz',
         'tasks_1-20_v1-2.tar.gz')
 


### PR DESCRIPTION
(Fancy)URLopener is deprecated since Python 3.3.
https://docs.python.org/3/library/urllib.request.html#urllib.request.FancyURLopener