### PR TITLE
Support Tagged communication with MPI_Status.

### DIFF
--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -499,7 +499,7 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         self.mpi_comm.send(obj, dest=dest, tag=tag)
 
     def recv_obj(self, source, status=None, tag=mpi4py.MPI.ANY_TAG):
-        return self.mpi_comm.recv(source=source, status=None, tag=tag)
+        return self.mpi_comm.recv(source=source, status=status, tag=tag)
 
     def bcast_obj(self, obj, max_buf_len=256 * 1024 * 1024, root=0):
         return chunked_bcast_obj(obj, self.mpi_comm,

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -495,11 +495,11 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
         return dbuf.reshape(shape)
 
     # Objects
-    def send_obj(self, obj, dest):
-        self.mpi_comm.send(obj, dest=dest)
+    def send_obj(self, obj, dest, tag=0):
+        self.mpi_comm.send(obj, dest=dest, tag=tag)
 
-    def recv_obj(self, source):
-        return self.mpi_comm.recv(source=source)
+    def recv_obj(self, source, status=None, tag=mpi4py.MPI.ANY_TAG):
+        return self.mpi_comm.recv(source=source, status=None, tag=tag)
 
     def bcast_obj(self, obj, max_buf_len=256 * 1024 * 1024, root=0):
         return chunked_bcast_obj(obj, self.mpi_comm,

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -867,7 +867,7 @@ class TestMpiCommunicatorBase(unittest.TestCase):
                                                status=status)
 
             if use_status:
-                status_src = status.Get_status()
+                status_src = status.Get_source()
                 self.assertEqual(0, status_src)
                 status_tag = status.Get_tag()
                 self.assertEqual(tag, status_tag)

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -835,6 +835,59 @@ class TestNonContiguousArray(unittest.TestCase):
         self.teardown()
 
 
+class TestMpiCommunicatorBase(unittest.TestCase):
+
+    def setup(self):
+        self.communicator = chainermn.create_communicator('naive')
+
+        if self.communicator.size != 2:
+            pytest.skip('This test is for two processes')
+
+    def teardown(self):
+        if self.communicator:
+            destroy_communicator(self.communicator)
+
+    def check_send_recv_obj(self, x, tag=0,
+                            use_any_recv=True, use_status=False):
+        if self.communicator.rank == 0:
+            self.communicator.send_obj(x, dest=1, tag=tag)
+            y = x
+
+        elif self.communicator.rank == 1:
+            status = None
+            if use_status:
+                status = mpi4py.MPI.Status()
+
+            if use_any_recv:
+                y = self.communicator.recv_obj(source=0,
+                                               status=status)
+            else:
+                y = self.communicator.recv_obj(source=0,
+                                               tag=tag,
+                                               status=status)
+
+            if use_status:
+                status_src = status.Get_status()
+                self.assertEqual(0, status_src)
+                status_tag = status.Get_tag()
+                self.assertEqual(tag, status_tag)
+
+        self.assertEqual(x, y)
+
+    def test_send_recv_obj(self):
+        self.setup()
+
+        self.check_send_recv_obj(0)
+        self.check_send_recv_obj(1, tag=1)
+        self.check_send_recv_obj(2, tag=2, use_any_recv=False)
+
+        self.check_send_recv_obj(3, use_status=True)
+        self.check_send_recv_obj(4, tag=4, use_status=True)
+        self.check_send_recv_obj(5, tag=5, use_any_recv=False, use_status=True)
+
+        self.teardown()
+
+
 @chainer.testing.attr.gpu
 def test_deprecation():
     with chainer.testing.assert_warns(DeprecationWarning):


### PR DESCRIPTION
This PR aims to support Tagged communication of send_obj and recv_obj on `MpiCommunicatorBase`.
MPI_Status support is also included.

Please check https://github.com/mpi4py/mpi4py/blob/master/src/mpi4py/MPI/Comm.pyx#L1168 .
Default behavior of mpi4py's recv without tag is interpreted as `ANY_TAG`, therefore I followed it.