### PR TITLE
Add `TweakLink`: abstraction for weight normalization methods

### DIFF
--- a/chainer/link_hooks/__init__.py
+++ b/chainer/link_hooks/__init__.py
@@ -1,3 +1,4 @@
 from chainer.link_hooks.spectral_normalization import SpectralNormalization  # NOQA
 from chainer.link_hooks.timer import TimerHook  # NOQA
+from chainer.link_hooks.tweak_link import TweakLink  # NOQA
 from chainer.link_hooks.weight_standardization import WeightStandardization  # NOQA

--- a/chainer/link_hooks/tweak_link.py
+++ b/chainer/link_hooks/tweak_link.py
@@ -1,0 +1,175 @@
+from chainer import link_hook
+
+
+class TweakLink(link_hook.LinkHook):
+
+    """LinkHook abstraction to manipulate any attributes of the \
+:class:`~chainer.link.Link`.
+
+    This class is aimed at easing to tweak the added
+    :class:`~chainer.link.Link` attributes including
+    its parameters and persistents. For example, masking and normalizing
+    the weight of added :class:`~chainer.link.Link` like
+    `Masked AutoEncoder for Density Estimation
+    <https://arxiv.org/abs/1502.03509>`_ (MADE) and
+    :class:`~chainer.link_hooks.SpectralNormalization`.
+
+    .. rubric:: Required methods
+
+    Each concrete class must at least override the following method.
+
+    ``adjust_target(self, cb_args)``
+        Implements the desired manipulation to the target of
+        :class:`~chainer.link.Link` specified by `target_name` and/or
+        inputs for the link.
+        This method is expected to return an object of the same type and shape
+        of the the target with `target_name` attribute.
+        Even if you do not touch the target of `target_name` attribute,
+        return it as is for the consistency. Therefore, the simplest
+        implementation of this method is just returning the target, i.e.,
+        `return getattr(cb_args.link, self.target_name)`.
+
+    .. rubric:: Optional methods
+
+    ``prepare_params(self, link)``
+        Defines states of a concrete class. Foe example, a scaling and shifting
+        parameters unique to it. If you register :class:`~chainer.Parameter`\\s
+        or :ref:`ndarray`\\s to the link, you need to delete them
+        when :meth:`deleted` is called.
+        See.. :class:`~chainer.link_hooks.SpectralNormalization`.
+
+    .. admonition:: Example
+
+        1. Scaling the weight randomly if it's called for the even number
+           of times.
+
+            import random
+
+            from chainer import link_hooks
+
+
+            class RandomWeightScaling(link_hooks.TweakLink):
+
+                name = "RandomWeightScaling"
+
+                def __init__(self):
+                    self.n = 0
+                    super(RandomWeightScaling, self)__init__()
+
+                def adjust_target(self, cb_args):
+                    link = cb_args.link
+                    weight = getattr(link, self.target_name)
+                    if self.n % 2 == 0:
+                        return weight * random.random()
+                    return weight
+
+        2. Masking the weight of :class:`~chainer.links.Linear`
+
+            from chainer import link_hooks
+
+
+            class MaskingLinearRandomly(link_hooks.TweakLink):
+
+                name = "MaskingLinearRandomly"
+
+                def adjust_target(self, cb_args):
+                    link = cb_args.link
+                    weight = getattr(link, self.target_name)
+                    mask = link.xp.random.randint(
+                        0, 2, weight.shape, link.xp.uint8)
+                    return weight * mask
+
+        3. Perturb the input using the statistics of the weight.
+
+            from chainer import link_hooks
+
+
+            class InputsPerturbation(link_hooks.TweakLink):
+
+                name = "InputsPerturbation"
+
+                def __init__(self, scale=0.001):
+                    self.scale = scale
+                    super(InputsPerturbation, self).__init__()
+
+                def adjust_target(self, cb_args):
+                    link = cb_args.link
+                    weight = getattr(link, self.target_name)
+                    mu = link.xp.mean(weight.array)
+                    for x in cb_args.args:
+                        x += cb_args.link.xp.random.uniform(
+                            -self.scale, self.scale, x.shape
+                        ).astype(x.dtype) * mu
+                    return weight
+
+    Args:
+        target_name (str): The name of the link's attribute which this hook
+            manipulate. The default value is `'W'`.
+        name (str): If not ``Nonee``, override the name of this hook.
+            The default value is ``None``.
+        axis (int): The axis of the target attribute representing the size of
+            output feature. The default value is ``None``.
+
+    """
+
+    name = 'TweakLink'
+
+    def __init__(self, target_name='W', name=None, axis=None, **kwargs):
+        self.target_name = target_name
+        if name is not None:
+            self.name = name
+        if axis is not None:
+            self.axis = axis
+        self.is_link_initialized = False
+
+    def __enter__(self):
+        raise NotImplementedError(
+            '"{}" is not supposed to be used as a context manager.'.format(
+                self.name))
+
+    def __exit__(self):
+        raise NotImplementedError(
+            '"{}" is not supposed to be used as a context manager.'.format(
+                self.name))
+
+    def added(self, link):
+        if not hasattr(link, self.target_name):
+            raise ValueError(
+                'Weight \'{}\' does not exist'.format(self.target_name))
+        if getattr(link, self.target_name).array is not None:
+            self.is_link_initialized = True
+            self.prepare_params(link)
+
+    def deleted(self, link):
+        pass
+
+    def forward_preprocess(self, cb_args):
+        if not self.is_link_initialized:
+            # We need to initialize the link before `link.forward`
+            # that basically initializes the link is called.
+            self.initialize_link(cb_args)
+            self.prepare_params(cb_args.link)
+        # Normalize the target weight and set the normalized as
+        # the target link's attribute
+        self.original_target = getattr(cb_args.link, self.target_name)
+        adjusted_target = self.adjust_target(cb_args)
+        setattr(cb_args.link, self.target_name, adjusted_target)
+
+    def forward_postprocess(self, cb_args):
+        setattr(cb_args.link, self.target_name, self.original_target)
+
+    def adjust_target(self, cb_args):
+        raise NotImplementedError()
+
+    def initialize_link(self, cb_args):
+        link = cb_args.link
+        inputs = cb_args.args
+        if not hasattr(link, '_initialize_params'):
+            raise ValueError(
+                'Link cannot be initialized by "{}"'.format(self.name))
+        x = inputs[0]
+        link._initialize_params(x.shape[1])
+        self.is_link_initialized = True
+
+    def prepare_params(self, link):
+        pass

--- a/chainer/link_hooks/tweak_link.py
+++ b/chainer/link_hooks/tweak_link.py
@@ -12,9 +12,10 @@ class TweakLink(link_hook.LinkHook):
     link's attributes including its parameters and persistents (a.k.a.
     buffers or states).
     For example, masking and normalizing
-    the weight of the added link like `Masked AutoEncoder for
-    Density Estimation <https://arxiv.org/abs/1502.03509>`_ (MADE) and
-    :class:`~chainer.link_hooks.SpectralNormalization`.
+    the weight of the added link.
+    :class:`~chainer.link_hooks.SpectralNormalization` is one example
+    implementation that normalizes the weight of the link before
+    :func:`~chainer.Link.forward` is invoked.
 
     By design, you can modify attributes other than the weight such as
     bias and ``avg_mean`` and ``avg_var`` of

--- a/chainer/link_hooks/tweak_link.py
+++ b/chainer/link_hooks/tweak_link.py
@@ -9,14 +9,14 @@ class TweakLink(link_hook.LinkHook):
 :class:`~chainer.Link`.
 
     This class is aimed at easing to tweak the added
-    links attributes including its parameters and persistents (a.k.a.
+    link's attributes including its parameters and persistents (a.k.a.
     buffers or states).
     For example, masking and normalizing
-    the weight of added link like `Masked AutoEncoder for Density Estimation
-    <https://arxiv.org/abs/1502.03509>`_ (MADE) and
+    the weight of the added link like `Masked AutoEncoder for
+    Density Estimation <https://arxiv.org/abs/1502.03509>`_ (MADE) and
     :class:`~chainer.link_hooks.SpectralNormalization`.
 
-    By design, you can edit attributes other than the weight of link such as
+    By design, you can modify attributes other than the weight such as
     bias and ``avg_mean`` and ``avg_var`` of
     :class:`~chainer.links.BatchNormalization` by specifying ``target_name``
     appropriately.

--- a/chainer/link_hooks/tweak_link.py
+++ b/chainer/link_hooks/tweak_link.py
@@ -189,7 +189,6 @@ class TweakLink(link_hook.LinkHook):
         pass
 
     def forward_preprocess(self, cb_args):
-        # type: (_ForwardPreprocessCallbackArgs) -> None
         """Callback function invoked before a forward call of a link.
 
         Basically, this function does not need to be overridden.
@@ -217,7 +216,6 @@ class TweakLink(link_hook.LinkHook):
         setattr(cb_args.link, self.target_name, adjusted_target)
 
     def forward_postprocess(self, cb_args):
-        # type: (_ForwardPostprocessCallbackArgs) -> None
         """Callback function invoked after a forward call of a link.
 
         This method also does not need to be overridden like
@@ -242,7 +240,6 @@ class TweakLink(link_hook.LinkHook):
         setattr(cb_args.link, self.target_name, self.original_target)
 
     def adjust_target(self, cb_args):
-        # type: (_ForwardPreprocessCallbackArgs) -> 'chainer.variable.Variable'  # NOQA
         """Adjust the target.
 
         This method implements the processing you want to apply to the link.
@@ -258,11 +255,13 @@ class TweakLink(link_hook.LinkHook):
                     Non-keyword arguments given to the forward method.
                 * kwargs (:class:`dict`)
                     Keyword arguments given to the forward method.
+
+        Returns:
+            ~chainer.Variable: Adjusted :class:`~chainer.Parameter`.
         """
         raise NotImplementedError()
 
     def initialize_link(self, cb_args):
-        # type: (_ForwardPreprocessCallbackArgs) -> 'chainer.variable.Variable'  # NOQA
         """Initialize the link if it is not in its declaration."""
         link = cb_args.link
         inputs = cb_args.args

--- a/chainer/link_hooks/tweak_link.py
+++ b/chainer/link_hooks/tweak_link.py
@@ -1,18 +1,25 @@
+import typing as tp  # NOQA
+
 from chainer import link_hook
 
 
 class TweakLink(link_hook.LinkHook):
 
     """LinkHook abstraction to manipulate any attributes of the \
-:class:`~chainer.link.Link`.
+:class:`~chainer.Link`.
 
     This class is aimed at easing to tweak the added
-    :class:`~chainer.link.Link` attributes including
-    its parameters and persistents. For example, masking and normalizing
-    the weight of added :class:`~chainer.link.Link` like
-    `Masked AutoEncoder for Density Estimation
+    links attributes including its parameters and persistents (a.k.a.
+    buffers or states).
+    For example, masking and normalizing
+    the weight of added link like `Masked AutoEncoder for Density Estimation
     <https://arxiv.org/abs/1502.03509>`_ (MADE) and
     :class:`~chainer.link_hooks.SpectralNormalization`.
+
+    By design, you can edit attributes other than the weight of link such as
+    bias and ``avg_mean`` and ``avg_var`` of
+    :class:`~chainer.links.BatchNormalization` by specifying ``target_name``
+    appropriately.
 
     .. rubric:: Required methods
 
@@ -20,92 +27,111 @@ class TweakLink(link_hook.LinkHook):
 
     ``adjust_target(self, cb_args)``
         Implements the desired manipulation to the target of
-        :class:`~chainer.link.Link` specified by `target_name` and/or
+        :class:`~chainer.Link` specified by ``target_name`` and/or
         inputs for the link.
         This method is expected to return an object of the same type and shape
-        of the the target with `target_name` attribute.
-        Even if you do not touch the target of `target_name` attribute,
+        of the target with ``target_name`` attribute.
+        Even if the target of ``target_name`` attribute is intact,
         return it as is for the consistency. Therefore, the simplest
-        implementation of this method is just returning the target, i.e.,
-        `return getattr(cb_args.link, self.target_name)`.
+        implementation of this method is as below:
+
+        .. code-block:: python
+
+            ...
+
+            def adjust_target(self, cb_args):
+                return getattr(cb_args.link, self.target_name)
+
+            ...
 
     .. rubric:: Optional methods
 
-    ``prepare_params(self, link)``
-        Defines states of a concrete class. Foe example, a scaling and shifting
-        parameters unique to it. If you register :class:`~chainer.Parameter`\\s
+    ``prepare_parameters(self, link)``
+        Defines and registers states of a concrete class.
+        Foe example, a scaling and shifting parameters unique to it.
+        If you register :class:`~chainer.Parameter`\\s
         or :ref:`ndarray`\\s to the link, you need to delete them
-        when :meth:`deleted` is called.
-        See.. :class:`~chainer.link_hooks.SpectralNormalization`.
+        in :meth:`deleted`. See
+        :class:`~chainer.link_hooks.SpectralNormalization` as an example.
+
+    ``deleted(self, link)``
+        Deletes all the objects you registered to the link via this hook if
+        :meth:`prepare_parameters` is overridden.
 
     .. admonition:: Example
 
         1. Scaling the weight randomly if it's called for the even number
            of times.
 
-            import random
+            .. code-block:: python
 
-            from chainer import link_hooks
+                import random
+
+                from chainer import link_hooks
 
 
-            class RandomWeightScaling(link_hooks.TweakLink):
+                class RandomWeightScaling(link_hooks.TweakLink):
 
-                name = "RandomWeightScaling"
+                   name = "RandomWeightScaling"
 
-                def __init__(self):
-                    self.n = 0
-                    super(RandomWeightScaling, self)__init__()
+                   def __init__(self):
+                       self.n = 0
+                       super(RandomWeightScaling, self)__init__()
 
-                def adjust_target(self, cb_args):
-                    link = cb_args.link
-                    weight = getattr(link, self.target_name)
-                    if self.n % 2 == 0:
-                        return weight * random.random()
-                    return weight
+                   def adjust_target(self, cb_args):
+                       link = cb_args.link
+                       weight = getattr(link, self.target_name)
+                       if self.n % 2 == 0:
+                           return weight * random.random()
+                       return weight
 
         2. Masking the weight of :class:`~chainer.links.Linear`
 
-            from chainer import link_hooks
+            .. code-block:: python
+
+                from chainer import link_hooks
 
 
-            class MaskingLinearRandomly(link_hooks.TweakLink):
+                class MaskingLinearRandomly(link_hooks.TweakLink):
 
-                name = "MaskingLinearRandomly"
+                    name = "MaskingLinearRandomly"
 
-                def adjust_target(self, cb_args):
-                    link = cb_args.link
-                    weight = getattr(link, self.target_name)
-                    mask = link.xp.random.randint(
-                        0, 2, weight.shape, link.xp.uint8)
-                    return weight * mask
+                    def adjust_target(self, cb_args):
+                        link = cb_args.link
+                        weight = getattr(link, self.target_name)
+                        mask = link.xp.random.randint(
+                            0, 2, weight.shape, link.xp.uint8)
+                        return weight * mask
 
         3. Perturb the input using the statistics of the weight.
 
-            from chainer import link_hooks
+            .. code-block:: python
+
+                from chainer import link_hooks
 
 
-            class InputsPerturbation(link_hooks.TweakLink):
+                class InputsPerturbation(link_hooks.TweakLink):
 
-                name = "InputsPerturbation"
+                    name = "InputsPerturbation"
 
-                def __init__(self, scale=0.001):
-                    self.scale = scale
-                    super(InputsPerturbation, self).__init__()
+                    def __init__(self, scale=0.001):
+                        self.scale = scale
+                        super(InputsPerturbation, self).__init__()
 
-                def adjust_target(self, cb_args):
-                    link = cb_args.link
-                    weight = getattr(link, self.target_name)
-                    mu = link.xp.mean(weight.array)
-                    for x in cb_args.args:
-                        x += cb_args.link.xp.random.uniform(
-                            -self.scale, self.scale, x.shape
-                        ).astype(x.dtype) * mu
-                    return weight
+                    def adjust_target(self, cb_args):
+                        link = cb_args.link
+                        weight = getattr(link, self.target_name)
+                        mu = link.xp.mean(weight.array)
+                        for x in cb_args.args:
+                            x += cb_args.link.xp.random.uniform(
+                                -self.scale, self.scale, x.shape
+                            ).astype(x.dtype) * mu
+                        return weight
 
     Args:
         target_name (str): The name of the link's attribute which this hook
-            manipulate. The default value is `'W'`.
-        name (str): If not ``Nonee``, override the name of this hook.
+            manipulate. The default value is 'W'.
+        name (str): If not ``None``, override the name of this hook.
             The default value is ``None``.
         axis (int): The axis of the target attribute representing the size of
             output feature. The default value is ``None``.
@@ -114,7 +140,8 @@ class TweakLink(link_hook.LinkHook):
 
     name = 'TweakLink'
 
-    def __init__(self, target_name='W', name=None, axis=None, **kwargs):
+    def __init__(self, target_name='W', name=None, axis=None):
+        # type: (str, tp.Optional[str], tp.Optional[int]) -> None
         self.target_name = target_name
         if name is not None:
             self.name = name
@@ -123,53 +150,130 @@ class TweakLink(link_hook.LinkHook):
         self.is_link_initialized = False
 
     def __enter__(self):
+        """TweakLink and its concrete classes cannot be a context manager."""
         raise NotImplementedError(
-            '"{}" is not supposed to be used as a context manager.'.format(
-                self.name))
+            '"%s" cannot be a context manager.' % self.name)
 
     def __exit__(self):
+        """TweakLink and its concrete classes cannot be a context manager."""
         raise NotImplementedError(
-            '"{}" is not supposed to be used as a context manager.'.format(
-                self.name))
+            '"%s" cannot be a context manager.' % self.name)
 
     def added(self, link):
+        # type: ('chainer.link.Link') -> None
+        """Callback function invoked when the link hook is registered.
+
+        Args:
+             link (~chainer.Link): Link object to which
+                the link hook is registered.
+
+        """
         if not hasattr(link, self.target_name):
             raise ValueError(
-                'Weight \'{}\' does not exist'.format(self.target_name))
+                'Weight of \'%s\' does not exist' % self.target_name)
         if getattr(link, self.target_name).array is not None:
             self.is_link_initialized = True
-            self.prepare_params(link)
+            self.prepare_parameters(link)
 
     def deleted(self, link):
+        # type: ('chainer.link.Link') -> None
+        """Callback function invoked when the link hook is unregistered.
+
+        This callback is supposed to be overridden if this hook add additional
+        parameters to the given link.
+
+        Args:
+            link (~chainer.Link): Link object to which
+                the link hook is unregistered.
+        """
         pass
 
     def forward_preprocess(self, cb_args):
+        # type: (_ForwardPreprocessCallbackArgs) -> None
+        """Callback function invoked before a forward call of a link.
+
+        Basically, this function does not need to be overridden.
+
+        Args:
+            args: Callback data. It has the following attributes:
+
+                * link (:class:`~chainer.Link`)
+                    Link object.
+                * forward_name (:class:`str`)
+                    Name of the forward method.
+                * args (:class:`tuple`)
+                    Non-keyword arguments given to the forward method.
+                * kwargs (:class:`dict`)
+                    Keyword arguments given to the forward method.
+        """
         if not self.is_link_initialized:
             # We need to initialize the link before `link.forward`
-            # that basically initializes the link is called.
+            # that usually initializes the link is called.
             self.initialize_link(cb_args)
-            self.prepare_params(cb_args.link)
-        # Normalize the target weight and set the normalized as
-        # the target link's attribute
+            self.prepare_parameters(cb_args.link)
         self.original_target = getattr(cb_args.link, self.target_name)
+        # Modify the target and set it as an attribute.
         adjusted_target = self.adjust_target(cb_args)
         setattr(cb_args.link, self.target_name, adjusted_target)
 
     def forward_postprocess(self, cb_args):
+        # type: (_ForwardPostprocessCallbackArgs) -> None
+        """Callback function invoked after a forward call of a link.
+
+        This method also does not need to be overridden like
+        :meth:`forward_preprocess`.
+
+        Args:
+            args: Callback data. It has the following attributes:
+
+                * link (:class:`~chainer.Link`)
+                    Link object.
+                * forward_name (:class:`str`)
+                    Name of the forward method.
+                * args (:class:`tuple`)
+                    Non-keyword arguments given to the forward method.
+                * kwargs (:class:`dict`)
+                    Keyword arguments given to the forward method.
+                * out
+                    Return value of the forward method.
+        """
+        # Here, the computational graph is already created,
+        # we can reset the target to the original.
         setattr(cb_args.link, self.target_name, self.original_target)
 
     def adjust_target(self, cb_args):
+        # type: (_ForwardPreprocessCallbackArgs) -> 'chainer.variable.Variable'  # NOQA
+        """Adjust the target.
+
+        This method implements the processing you want to apply to the link.
+
+        Args:
+            args: Callback data. It has the following attributes:
+
+                * link (:class:`~chainer.Link`)
+                    Link object.
+                * forward_name (:class:`str`)
+                    Name of the forward method.
+                * args (:class:`tuple`)
+                    Non-keyword arguments given to the forward method.
+                * kwargs (:class:`dict`)
+                    Keyword arguments given to the forward method.
+        """
         raise NotImplementedError()
 
     def initialize_link(self, cb_args):
+        # type: (_ForwardPreprocessCallbackArgs) -> 'chainer.variable.Variable'  # NOQA
+        """Initialize the link if it is not in its declaration."""
         link = cb_args.link
         inputs = cb_args.args
         if not hasattr(link, '_initialize_params'):
             raise ValueError(
-                'Link cannot be initialized by "{}"'.format(self.name))
+                'Link cannot be initialized by "%s"' % self.name)
         x = inputs[0]
         link._initialize_params(x.shape[1])
         self.is_link_initialized = True
 
-    def prepare_params(self, link):
+    def prepare_parameters(self, link):
+        # type: ('chainer.link.Link') -> None
+        """Prepare parameters and persistents if necessary."""
         pass

--- a/docs/source/reference/links.rst
+++ b/docs/source/reference/links.rst
@@ -237,6 +237,7 @@ Chainer provides a link-hook mechanism that enriches the behavior of :class:`~ch
 
    chainer.link_hooks.SpectralNormalization
    chainer.link_hooks.TimerHook
+   chainer.link_hooks.TweakLink
    chainer.link_hooks.WeightStandardization
 
 You can also implement your own link-hook to inject arbitrary code before/after the forward propagation.

--- a/tests/chainer_tests/link_hooks_tests/test_tweak_link.py
+++ b/tests/chainer_tests/link_hooks_tests/test_tweak_link.py
@@ -1,0 +1,95 @@
+import unittest
+
+import numpy
+import pytest
+
+import chainer
+import chainer.links as L
+from chainer import link_hooks
+from chainer import testing
+
+
+NAME = 'NAME'
+SHAPE = (100, 100)
+DTYPE = numpy.float32
+
+
+class SampleParamAddition(link_hooks.TweakLink):
+
+    name = 'NAME'
+
+    def adjust_target(self, cb_args):
+        return getattr(cb_args.link, self.target_name)
+
+    def prepare_params(self, link):
+        with link.init_scope():
+            link.p = chainer.Parameter(
+                numpy.random.uniform(-1, 1, SHAPE).astype(DTYPE))
+
+    def deleted(self, link):
+        del link.p
+
+
+class TestExceptions(unittest.TestCase):
+
+    def setUp(self):
+        self.x = chainer.Variable(numpy.ones((10, 5), dtype=numpy.float32))
+        self.layer = L.Linear(5, 20)
+
+    def test_wrong_weight_name(self):
+        wrong_target_name = 'w'
+        hook = link_hooks.TweakLink(target_name=wrong_target_name)
+        with pytest.raises(ValueError):
+            self.layer.add_hook(hook)
+
+    def test_raises_if_used_as_context_manager(self):
+        with pytest.raises(NotImplementedError):
+            with link_hooks.TweakLink():
+                self.layer(self.x)
+
+    def test_raises_if_call_TweakLink(self):
+        layer = L.Linear(10, 0).add_hook(link_hooks.TweakLink())
+        with pytest.raises(NotImplementedError):
+            layer(self.x)
+
+    def check_is_link_initialized(self, lazy=True):
+        layer = L.Linear(None if lazy else 10, 10)
+        hook = link_hooks.TweakLink()
+        layer.add_hook(hook)
+
+        assert hook.is_link_initialized is not lazy
+
+    def test_lazy_initialization(self):
+        self.check_is_link_initialized(False)
+
+    def test_initialization(self):
+        self.check_is_link_initialized(True)
+
+
+class TestSampleParamAddition(unittest.TestCase):
+
+    def setUp(self):
+        self.x = numpy.ones((10, 5), dtype=numpy.float32)
+        self.layer = L.Linear(5, 20)
+
+    def test_added_deleted(self):
+        x = self.x.copy()
+        layer = self.layer.copy('copy')
+        layer.add_hook(SampleParamAddition())
+
+        with chainer.using_config('train', False):
+            y1 = layer(x).array
+
+        assert layer.p.shape == SHAPE
+        assert layer.p.dtype == DTYPE
+
+        layer.delete_hook(NAME)
+        assert getattr(layer, 'p', None) is None
+
+        with chainer.using_config('train', False):
+            y2 = layer(x).array
+
+        testing.assert_allclose(y1, y2)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/link_hooks_tests/test_tweak_link.py
+++ b/tests/chainer_tests/link_hooks_tests/test_tweak_link.py
@@ -21,7 +21,7 @@ class SampleParamAddition(link_hooks.TweakLink):
     def adjust_target(self, cb_args):
         return getattr(cb_args.link, self.target_name)
 
-    def prepare_params(self, link):
+    def prepare_parameters(self, link):
         with link.init_scope():
             link.p = chainer.Parameter(
                 numpy.random.uniform(-1, 1, SHAPE).astype(DTYPE))
@@ -80,6 +80,7 @@ class TestSampleParamAddition(unittest.TestCase):
         with chainer.using_config('train', False):
             y1 = layer(x).array
 
+        assert getattr(layer, 'p', None) is not None
         assert layer.p.shape == SHAPE
         assert layer.p.dtype == DTYPE
 


### PR DESCRIPTION
This LinkHook aims at easier, simpler, and unified implementation of SpectralNormalization (#5742) and WeightStandardization (#6678) and another usage of LinkHook.

cc: @toslunar @hitsgub 

Related to #6689.