### PR TITLE
Fix ChainerX optimzer fallback for non-default devices

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -280,11 +280,7 @@ class UpdateRule(object):
         """
         grad_array = param.grad
         backend_name = param.array.device.backend.name
-        if backend_name == 'native':
-            update_core = self.update_core_cpu
-        elif backend_name == 'cuda':
-            update_core = self.update_core_gpu
-        else:
+        if backend_name not in ('native', 'cuda'):
             raise RuntimeError(
                 'Default implementation of Optimizer.update_core_chainerx is '
                 'only provided for native or cuda backends (actual: {}). '
@@ -316,7 +312,7 @@ class UpdateRule(object):
                 backend.from_chx(grad_array))
 
         # Update
-        update_core(temp_param)
+        self.update_core(temp_param)
 
         # Restore state arrays
         for state_name, (arr, fallback_arr) in chainerx_state_arrays.items():


### PR DESCRIPTION
This PR fixes optimizer fallback from ChainerX with non-default devices. The issue was that the current device was never set when falling back meaning that running MNIST with a non-default device e.g. `--device='cuda:2'` lead to an array-current-device mismatch error.