### PR TITLE
Fix `DeviceResident.to_gpu` fallback argument

### DIFF
--- a/chainer/device_resident.py
+++ b/chainer/device_resident.py
@@ -90,7 +90,7 @@ class DeviceResident(utils.enable_final(meta_base=abc.ABCMeta)):
         device = chainer.backends.cuda.GpuDevice(cuda_device)
         visitor = _ToDeviceVisitor(
             device,
-            entry_method_info=('to_gpu', {'device': device}),
+            entry_method_info=('to_gpu', {'device': device.device}),
             skip_between_cupy_devices=True)
         self.__to_device(visitor)
         return self

--- a/tests/chainer_tests/test_link.py
+++ b/tests/chainer_tests/test_link.py
@@ -2361,6 +2361,7 @@ class TestLinkOverrideToDeviceMethods(unittest.TestCase):
 
             elif method_name == 'to_gpu':
                 def to_gpu(self, device=None):
+                    assert isinstance(device, (cuda.Device, int))
                     self.to_method_called += 1
 
             elif method_name == 'to_intel64':


### PR DESCRIPTION
In `DeviceResident.to_gpu`, `chainer.backend.GpuDevice`, which is incompatible with `to_gpu`, was incorrectly captured for backward-compatibility call to overridden `to_gpu`.