### PR TITLE
[backport] Replace deprecated URLopener in `download.py`

### DIFF
--- a/examples/memnn/download.py
+++ b/examples/memnn/download.py
@@ -4,9 +4,7 @@ from six.moves.urllib import request
 
 
 def main():
-    opener = request.FancyURLopener()
-    opener.addheaders = [('User-Agent', '')]
-    opener.retrieve(
+    request.urlretrieve(
         'http://www.thespermwhale.com/jaseweston/babi/tasks_1-20_v1-2.tar.gz',
         'tasks_1-20_v1-2.tar.gz')
 


### PR DESCRIPTION
Backport of #6694