### PR TITLE
Refactor CUDA batch norm tensor descriptor

### DIFF
--- a/chainerx_cc/chainerx/cuda/cudnn.cc
+++ b/chainerx_cc/chainerx/cuda/cudnn.cc
@@ -110,6 +110,24 @@ CudnnTensorDescriptor::CudnnTensorDescriptor(const Array& arr) : CudnnTensorDesc
     }
 }
 
+Dtype CudnnTensorDescriptor::GetDtype() const {
+    cudnnDataType_t cudnn_dtype{};
+    int ndim{};
+
+    CheckCudnnError(cudnnGetTensorNdDescriptor(desc_, 0, &cudnn_dtype, &ndim, nullptr, nullptr));
+
+    switch (cudnn_dtype) {
+        case CUDNN_DATA_HALF:
+            return Dtype::kFloat16;
+        case CUDNN_DATA_FLOAT:
+            return Dtype::kFloat32;
+        case CUDNN_DATA_DOUBLE:
+            return Dtype::kFloat64;
+        default:
+            throw DtypeError{"Unsupported cudnn data type: ", cudnn_dtype};
+    }
+}
+
 CudnnFilterDescriptor::CudnnFilterDescriptor() { CheckCudnnError(cudnnCreateFilterDescriptor(&desc_)); }
 
 CudnnFilterDescriptor::~CudnnFilterDescriptor() {

--- a/chainerx_cc/chainerx/cuda/cudnn.h
+++ b/chainerx_cc/chainerx/cuda/cudnn.h
@@ -49,14 +49,16 @@ const void* GetCudnnCoefficientPtr(Dtype dtype) {
 
 class CudnnTensorDescriptor {
 public:
+    CudnnTensorDescriptor();
     explicit CudnnTensorDescriptor(const Array& arr);
     ~CudnnTensorDescriptor();
 
     cudnnTensorDescriptor_t descriptor() const { return desc_; }
     cudnnTensorDescriptor_t operator*() const { return desc_; }
 
+    Dtype GetDtype() const;
+
 private:
-    CudnnTensorDescriptor();
     cudnnTensorDescriptor_t desc_{};
 };
 


### PR DESCRIPTION
I feel `CudnnBNTensorDescriptor` was a bit obscure.
This PR makes it apparent that it's a "derived tensor descriptor".