### PR TITLE
Fix: documentation for using cmake to build Python and C++ for ChainerX

### DIFF
--- a/docs/source/chainerx/contribution.rst
+++ b/docs/source/chainerx/contribution.rst
@@ -112,14 +112,14 @@ Test coverage
 -------------
 
 We use `gcov <https://gcc.gnu.org/onlinedocs/gcc/Gcov.html>`_ to the measure C++ code coverage.
-Build the Python package in ``Debug`` mode, and build C++ test suite as:
+From the root of the project, build the Python package in ``Debug`` mode, and build C++ test suite as:
 
 .. code-block:: console
 
     $ python setup.py build --debug --build-temp ./build --build-lib ./build develop
     $ mkdir -p build
     $ cd build
-    $ cmake -DCMAKE_BUILD_TYPE=Debug -DCHAINERX_BUILD_PYTHON=1 -DCHAINERX_ENABLE_COVERAGE ..
+    $ cmake -DCMAKE_BUILD_TYPE=Debug -DCHAINERX_BUILD_PYTHON=1 -DCHAINERX_ENABLE_COVERAGE ../chainerx_cc
     $ make
 
 Run both the Python and the C++ test suite:

--- a/docs/source/chainerx/contribution.rst
+++ b/docs/source/chainerx/contribution.rst
@@ -119,7 +119,7 @@ From the root of the project, build the Python package in ``Debug`` mode, and bu
     $ python setup.py build --debug --build-temp ./build --build-lib ./build develop
     $ mkdir -p build
     $ cd build
-    $ cmake -DCMAKE_BUILD_TYPE=Debug -DCHAINERX_BUILD_PYTHON=1 -DCHAINERX_ENABLE_COVERAGE=1 ../chainerx_cc
+    $ cmake ../chainerx_cc -DCMAKE_BUILD_TYPE=Debug -DCHAINERX_BUILD_PYTHON=1 -DCHAINERX_ENABLE_COVERAGE=1
     $ make
 
 Run both the Python and the C++ test suite:

--- a/docs/source/chainerx/contribution.rst
+++ b/docs/source/chainerx/contribution.rst
@@ -119,7 +119,7 @@ From the root of the project, build the Python package in ``Debug`` mode, and bu
     $ python setup.py build --debug --build-temp ./build --build-lib ./build develop
     $ mkdir -p build
     $ cd build
-    $ cmake -DCMAKE_BUILD_TYPE=Debug -DCHAINERX_BUILD_PYTHON=1 -DCHAINERX_ENABLE_COVERAGE ../chainerx_cc
+    $ cmake -DCMAKE_BUILD_TYPE=Debug -DCHAINERX_BUILD_PYTHON=1 -DCHAINERX_ENABLE_COVERAGE=1 ../chainerx_cc
     $ make
 
 Run both the Python and the C++ test suite:


### PR DESCRIPTION
The path to the CMakeLists.txt moved relative to the top level build directory I think, so it should now be `../chainerx_cc` instead of `..`, that's how I managed to get it to work.