### PR TITLE
Trivial fixes to Wavenet example

### DIFF
--- a/examples/wavenet/README.md
+++ b/examples/wavenet/README.md
@@ -8,10 +8,10 @@ A Chainer implementation of mel-spectrogram vocoder using WaveNet.
     - `wget http://homepages.inf.ed.ac.uk/jyamagis/release/VCTK-Corpus.tar.gz`
     - `tar -xf VCTK-Corpus.tar.gz`
 3. Start training.
-    - `python3 train.py -g <gpu id> --dataset <directory of dataset e.g. ./VCTK-Corpus/>`
+    - `python train.py -g <gpu id> --dataset <directory of dataset e.g. ./VCTK-Corpus/>`
     - You can change other parameters. Please see args.
 4. Generate audio with trained model.
-    - `python3 generate.py -i <input file> -m <trained model e.g. snapshot_iter_500000>`
+    - `python generate.py -i <input file> -m <trained model e.g. snapshot_iter_500000>`
 
 ## Details
 - Default parameters of WaveNet are same as [nv-wavenet](https://github.com/NVIDIA/nv-wavenet/).

--- a/examples/wavenet/generate.py
+++ b/examples/wavenet/generate.py
@@ -11,9 +11,10 @@ from utils import MuLaw
 from utils import Preprocess
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--input', '-i', help='input file')
+parser.add_argument('--input', '-i', required=True, help='input file')
 parser.add_argument('--output', '-o', default='result.wav', help='output file')
-parser.add_argument('--model', '-m', help='snapshot of trained model')
+parser.add_argument('--model', '-m', required=True,
+                    help='snapshot of trained model')
 parser.add_argument('--n_loop', type=int, default=4,
                     help='Number of residual blocks')
 parser.add_argument('--n_layer', type=int, default=10,

--- a/examples/wavenet/train.py
+++ b/examples/wavenet/train.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import pathlib
 
 try:
@@ -63,6 +64,8 @@ if args.gpu >= 0:
     chainer.global_config.autotune = True
 
 # Datasets
+if not os.path.isdir(args.dataset):
+    raise RuntimeError('Dataset directory not found: {}'.format(args.dataset))
 paths = sorted([
     str(path) for path in pathlib.Path(args.dataset).glob('wav48/*/*.wav')])
 preprocess = Preprocess(


### PR DESCRIPTION
* Make `--input` and `--model` options mandatory in `generate.py`.
* Use `python` instead of `python3` in `README.txt`.
* Check existence of dataset directory.