### PR TITLE
Use larger eps in mnist example

### DIFF
--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -69,7 +69,9 @@ def main():
     device.use()
 
     # Setup an optimizer
-    optimizer = chainer.optimizers.Adam()
+    # Here used a larger eps in case of FP16 mode, the default value is enough
+    # for FP32 mode.
+    optimizer = chainer.optimizers.Adam(eps=1e-6)
     optimizer.setup(model)
 
     # Load the MNIST dataset

--- a/examples/mnist/train_mnist_custom_loop.py
+++ b/examples/mnist/train_mnist_custom_loop.py
@@ -57,7 +57,9 @@ def main():
     device.use()
 
     # Setup an optimizer
-    optimizer = chainer.optimizers.Adam()
+    # Here used a larger eps in case of FP16 mode, the default value is enough
+    # for FP32 mode.
+    optimizer = chainer.optimizers.Adam(eps=1e-6)
     optimizer.setup(model)
 
     if args.resume:

--- a/examples/mnist/train_mnist_data_parallel.py
+++ b/examples/mnist/train_mnist_data_parallel.py
@@ -39,7 +39,9 @@ def main():
     chainer.backends.cuda.get_device_from_id(args.gpu0).use()
 
     model = L.Classifier(train_mnist.MLP(args.unit, 10))
-    optimizer = chainer.optimizers.Adam()
+    # Here used a larger eps in case of FP16 mode, the default value is enough
+    # for FP32 mode.
+    optimizer = chainer.optimizers.Adam(eps=1e-6)
     optimizer.setup(model)
 
     train, test = chainer.datasets.get_mnist()

--- a/examples/mnist/train_mnist_model_parallel.py
+++ b/examples/mnist/train_mnist_model_parallel.py
@@ -95,7 +95,9 @@ def main():
     model = L.Classifier(ParallelMLP(args.unit, 10, args.gpu0, args.gpu1))
     chainer.backends.cuda.get_device_from_id(args.gpu0).use()
 
-    optimizer = chainer.optimizers.Adam()
+    # Here used a larger eps in case of FP16 mode, the default value is enough
+    # for FP32 mode.
+    optimizer = chainer.optimizers.Adam(eps=1e-6)
     optimizer.setup(model)
 
     train, test = chainer.datasets.get_mnist()


### PR DESCRIPTION
Rel. #6168.

This PR fixes the mnist example to use larger eps for `Adam` optimizer to make it work in FP16 mode as well.