### PR TITLE
Op registration: creation

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device.h
+++ b/chainerx_cc/chainerx/cuda/cuda_device.h
@@ -80,16 +80,6 @@ public:
 
     void Fill(const Array& out, Scalar value) override;
 
-    void Arange(Scalar start, Scalar step, const Array& out) override;
-
-    void Identity(const Array& out) override;
-
-    void Eye(int64_t k, const Array& out) override;
-
-    void Diagflat(const Array& v, int64_t k, const Array& out) override;
-
-    void Linspace(double start, double stop, const Array& out) override;
-
     // arithmetic.cu
 
     void Add(const Array& x1, const Array& x2, const Array& out) override;
@@ -113,8 +103,6 @@ public:
     void AMax(const Array& a, const Axes& axis, const Array& out) override;
 
     // copy.cu
-
-    void Copy(const Array& a, const Array& out) override;
 
     void AsType(const Array& a, const Array& out) override;
 

--- a/chainerx_cc/chainerx/cuda/cuda_device/dot.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/dot.cu
@@ -9,6 +9,7 @@
 #include <cuda_fp16.hpp>
 
 #include "chainerx/array.h"
+#include "chainerx/backend.h"
 #include "chainerx/backend_util.h"
 #include "chainerx/cuda/cublas.h"
 #include "chainerx/cuda/cuda_runtime.h"
@@ -173,7 +174,7 @@ void CudaDevice::Dot(const Array& a, const Array& b, const Array& out) {
     }
 
     if (!is_out_contiguous) {
-        Copy(out_contiguous, out);
+        backend().CallOp<CopyOp>(out_contiguous, out);
     }
 }
 

--- a/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
@@ -12,10 +12,13 @@
 #include "chainerx/cuda/cuda_runtime.h"
 #include "chainerx/cuda/cuda_set_device_scope.h"
 #include "chainerx/cuda/elementwise.cuh"
+#include "chainerx/cuda/op_regist.h"
+#include "chainerx/device.h"
 #include "chainerx/dtype.h"
 #include "chainerx/indexable_array.h"
 #include "chainerx/indexer.h"
 #include "chainerx/macro.h"
+#include "chainerx/routines/creation.h"
 #include "chainerx/scalar.h"
 #include "chainerx/shape.h"
 
@@ -31,38 +34,20 @@ struct ArangeImpl {
     CudaType step;
 };
 
-}  // namespace
-
-void CudaDevice::Arange(Scalar start, Scalar step, const Array& out) {
-    CudaSetDeviceScope scope{index()};
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
-        using CudaType = cuda_internal::DataType<T>;
-        Elementwise<T>(ArangeImpl<T>{static_cast<CudaType>(start), static_cast<CudaType>(step)}, out);
-    });
-}
-
-namespace {
-
-template <typename T>
-struct FillImpl {
-    using CudaType = cuda_internal::DataType<T>;
-    __device__ void operator()(int64_t /*i*/, CudaType& out) { out = value; }
-    CudaType value;
+class CudaArangeOp : public ArangeOp {
+public:
+    void Call(Scalar start, Scalar step, const Array& out) override {
+        Device& device = out.device();
+        CudaSetDeviceScope scope{device.index()};
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
+            using CudaType = cuda_internal::DataType<T>;
+            Elementwise<T>(ArangeImpl<T>{static_cast<CudaType>(start), static_cast<CudaType>(step)}, out);
+        });
+    }
 };
 
-}  // namespace
-
-void CudaDevice::Fill(const Array& out, Scalar value) {
-    CudaSetDeviceScope scope{index()};
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
-        using CudaType = cuda_internal::DataType<T>;
-        Elementwise<T>(FillImpl<T>{static_cast<CudaType>(value)}, out);
-    });
-}
-
-namespace {
+CHAINERX_REGISTER_OP_CUDA(ArangeOp, CudaArangeOp);
 
 template <typename T>
 struct IdentityImpl {
@@ -72,20 +57,22 @@ struct IdentityImpl {
     int64_t n_plus_one;
 };
 
-}  // namespace
+class CudaIdentityOp : public IdentityOp {
+public:
+    void Call(const Array& out) override {
+        CHAINERX_ASSERT(out.ndim() == 2);
+        CHAINERX_ASSERT(out.shape()[0] == out.shape()[1]);
 
-void CudaDevice::Identity(const Array& out) {
-    CHAINERX_ASSERT(out.ndim() == 2);
-    CHAINERX_ASSERT(out.shape()[0] == out.shape()[1]);
+        Device& device = out.device();
+        CudaSetDeviceScope scope{device.index()};
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
+            Elementwise<T>(IdentityImpl<T>{out.shape()[0]}, out);
+        });
+    }
+};
 
-    CudaSetDeviceScope scope{index()};
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
-        Elementwise<T>(IdentityImpl<T>{out.shape()[0]}, out);
-    });
-}
-
-namespace {
+CHAINERX_REGISTER_OP_CUDA(IdentityOp, CudaIdentityOp);
 
 template <typename T>
 struct EyeImpl {
@@ -99,17 +86,19 @@ struct EyeImpl {
     int64_t step;
 };
 
-}  // namespace
+class CudaEyeOp : public EyeOp {
+public:
+    void Call(int64_t k, const Array& out) override {
+        Device& device = out.device();
+        CudaSetDeviceScope scope{device.index()};
+        VisitDtype(out.dtype(), [k, &out](auto pt) {
+            using T = typename decltype(pt)::type;
+            Elementwise<T>(EyeImpl<T>{out.shape()[1], k}, out);
+        });
+    }
+};
 
-void CudaDevice::Eye(int64_t k, const Array& out) {
-    CudaSetDeviceScope scope{index()};
-    VisitDtype(out.dtype(), [k, &out](auto pt) {
-        using T = typename decltype(pt)::type;
-        Elementwise<T>(EyeImpl<T>{out.shape()[1], k}, out);
-    });
-}
-
-namespace {
+CHAINERX_REGISTER_OP_CUDA(EyeOp, CudaEyeOp);
 
 template <typename T>
 __global__ void SetVecInMat(
@@ -127,46 +116,48 @@ __global__ void SetVecInMat(
     }
 }
 
-}  // namespace
+class CudaDiagflatOp : public DiagflatOp {
+public:
+    void Call(const Array& v, int64_t k, const Array& out) override {
+        CHAINERX_ASSERT(v.ndim() == 1);
+        CHAINERX_ASSERT(out.ndim() == 2);
 
-void CudaDevice::Diagflat(const Array& v, int64_t k, const Array& out) {
-    CHAINERX_ASSERT(v.ndim() == 1);
-    CHAINERX_ASSERT(out.ndim() == 2);
+        Device& device = v.device();
+        CudaSetDeviceScope scope{device.index()};
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
 
-    CudaSetDeviceScope scope{index()};
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
+            // Start indices for the 2-D array axes with applied offset k.
+            int64_t row_start{0};
+            int64_t col_start{0};
 
-        // Start indices for the 2-D array axes with applied offset k.
-        int64_t row_start{0};
-        int64_t col_start{0};
+            if (k >= 0) {
+                col_start += k;
+            } else {
+                row_start -= k;
+            }
 
-        if (k >= 0) {
-            col_start += k;
-        } else {
-            row_start -= k;
-        }
+            // Initialize all elements to 0 first instead of conditionally filling in the diagonal.
+            device.Fill(out, T{0});
 
-        // Initialize all elements to 0 first instead of conditionally filling in the diagonal.
-        Fill(out, T{0});
+            IndexableArray<const T, 1> v_iarray{v};
+            IndexableArray<T, 2> out_iarray{out};
+            Indexer<1> v_indexer{v.shape()};
+            Indexer<2> out_indexer{out.shape()};
 
-        IndexableArray<const T, 1> v_iarray{v};
-        IndexableArray<T, 2> out_iarray{out};
-        Indexer<1> v_indexer{v.shape()};
-        Indexer<2> out_indexer{out.shape()};
+            // TODO(niboshi): Calculate kMaxBlockSize per device
+            std::lock_guard<std::mutex> lock{*cuda_internal::g_mutex};
+            static const int kMaxBlockSize = CudaOccupancyMaxPotentialBlockSize(&SetVecInMat<T>).block_size;
+            int64_t total_size = out_indexer.total_size();
+            int64_t grid_size = (total_size + kMaxBlockSize - 1) / kMaxBlockSize;
+            int64_t block_size = std::min<int64_t>(total_size, kMaxBlockSize);
 
-        // TODO(niboshi): Calculate kMaxBlockSize per device
-        std::lock_guard<std::mutex> lock{*cuda_internal::g_mutex};
-        static const int kMaxBlockSize = CudaOccupancyMaxPotentialBlockSize(&SetVecInMat<T>).block_size;
-        int64_t total_size = out_indexer.total_size();
-        int64_t grid_size = (total_size + kMaxBlockSize - 1) / kMaxBlockSize;
-        int64_t block_size = std::min<int64_t>(total_size, kMaxBlockSize);
+            SetVecInMat<<<grid_size, block_size>>>(v_iarray, out_iarray, v_indexer, out_indexer, row_start, col_start);
+        });
+    }
+};
 
-        SetVecInMat<<<grid_size, block_size>>>(v_iarray, out_iarray, v_indexer, out_indexer, row_start, col_start);
-    });
-}
-
-namespace {
+CHAINERX_REGISTER_OP_CUDA(DiagflatOp, CudaDiagflatOp);
 
 template <typename T>
 struct LinspaceImpl {
@@ -180,17 +171,39 @@ struct LinspaceImpl {
     double stop;
 };
 
+class CudaLinspaceOp : public LinspaceOp {
+public:
+    void Call(double start, double stop, const Array& out) override {
+        CHAINERX_ASSERT(out.ndim() == 1);
+        CHAINERX_ASSERT(out.shape()[0] > 0);
+
+        Device& device = out.device();
+        CudaSetDeviceScope scope{device.index()};
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
+            int64_t n = out.shape()[0];
+            Elementwise<T>(LinspaceImpl<T>{n, start, stop}, out);
+        });
+    }
+};
+
+CHAINERX_REGISTER_OP_CUDA(LinspaceOp, CudaLinspaceOp);
+
+template <typename T>
+struct FillImpl {
+    using CudaType = cuda_internal::DataType<T>;
+    __device__ void operator()(int64_t /*i*/, CudaType& out) { out = value; }
+    CudaType value;
+};
+
 }  // namespace
 
-void CudaDevice::Linspace(double start, double stop, const Array& out) {
-    CHAINERX_ASSERT(out.ndim() == 1);
-    CHAINERX_ASSERT(out.shape()[0] > 0);
-
+void CudaDevice::Fill(const Array& out, Scalar value) {
     CudaSetDeviceScope scope{index()};
     VisitDtype(out.dtype(), [&](auto pt) {
         using T = typename decltype(pt)::type;
-        int64_t n = out.shape()[0];
-        Elementwise<T>(LinspaceImpl<T>{n, start, stop}, out);
+        using CudaType = cuda_internal::DataType<T>;
+        Elementwise<T>(FillImpl<T>{static_cast<CudaType>(value)}, out);
     });
 }
 

--- a/chainerx_cc/chainerx/device.h
+++ b/chainerx_cc/chainerx/device.h
@@ -134,9 +134,8 @@ public:
     // src_ptr must reside in the host memory.
     virtual std::shared_ptr<void> FromHostMemory(const std::shared_ptr<void>& src_ptr, size_t bytesize) = 0;
 
+    // TODO(hvy): Implement as an Op and remove this method.
     virtual void Fill(const Array& out, Scalar value) = 0;
-
-    virtual void Arange(Scalar start, Scalar step, const Array& out) = 0;
 
     // Calculate the sum of an array.
     // It will be summed over the specified axes.
@@ -151,12 +150,8 @@ public:
     // See Sum() for the explanation of arguments.
     virtual void AMax(const Array& src, const Axes& axis, const Array& out) = 0;
 
-    // Copies the elements from one array to the other.
-    //
-    // The arrays must match in shape and dtype and need to reside on this device.
-    virtual void Copy(const Array& a, const Array& out) = 0;
-
     // Casts the elements from one array to the other dtype, and store into the other.
+    // TODO(hvy): Implement as an Op and remove this method.
     virtual void AsType(const Array& a, const Array& out) = 0;
 
     virtual void Add(const Array& x1, const Array& x2, const Array& out) = 0;
@@ -201,20 +196,6 @@ public:
 
     virtual void IsNan(const Array& x, const Array& out) = 0;
     virtual void IsInf(const Array& x, const Array& out) = 0;
-
-    // Creates the identity array.
-    // out must be a square 2-dim array.
-    virtual void Identity(const Array& out) = 0;
-
-    // Creates a 2-dimensional array with ones along the k-th diagonal and zeros elsewhere.
-    // out must be a square 2-dim array.
-    virtual void Eye(int64_t k, const Array& out) = 0;
-
-    virtual void Diagflat(const Array& v, int64_t k, const Array& out) = 0;
-
-    // Creates an evenly spaced 1-d array.
-    // `out.ndim()` must be 1 with at least 1 elements.
-    virtual void Linspace(double start, double stop, const Array& out) = 0;
 
     // Computes the n-dimensional convolution.
     //

--- a/chainerx_cc/chainerx/native/im2col.cc
+++ b/chainerx_cc/chainerx/native/im2col.cc
@@ -6,6 +6,7 @@
 
 #include "chainerx/array.h"
 #include "chainerx/array_index.h"
+#include "chainerx/backend.h"
 #include "chainerx/constant.h"
 #include "chainerx/device.h"
 #include "chainerx/indexable_array.h"
@@ -101,7 +102,7 @@ Array Im2Col(
     }
     Array padded_x = static_cast<int64_t>(pad_value) == int64_t{0} ? Zeros(padded_shape, x.dtype(), device)
                                                                    : Full(padded_shape, pad_value, x.dtype(), device);
-    device.Copy(x, padded_x.At(unpadded_slice));
+    device.backend().CallOp<CopyOp>(x, padded_x.At(unpadded_slice));
     CHAINERX_ASSERT(ndim + 2 == padded_x.ndim());
 
     // Create the output array.

--- a/chainerx_cc/chainerx/native/native_device.h
+++ b/chainerx_cc/chainerx/native/native_device.h
@@ -42,16 +42,6 @@ public:
 
     void Fill(const Array& out, Scalar value) override;
 
-    void Arange(Scalar start, Scalar step, const Array& out) override;
-
-    void Identity(const Array& out) override;
-
-    void Eye(int64_t k, const Array& out) override;
-
-    void Diagflat(const Array& v, int64_t k, const Array& out) override;
-
-    void Linspace(double start, double stop, const Array& out) override;
-
     // arithmetic.cc
 
     void Add(const Array& x1, const Array& x2, const Array& out) override;
@@ -75,8 +65,6 @@ public:
     void AMax(const Array& a, const Axes& axis, const Array& out) override;
 
     // copy.cc
-
-    void Copy(const Array& a, const Array& out) override;
 
     void AsType(const Array& a, const Array& out) override;
 

--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -9,6 +9,7 @@
 #endif  // CHAINERX_ENABLE_BLAS
 
 #include "chainerx/array.h"
+#include "chainerx/backend.h"
 #include "chainerx/device.h"
 #include "chainerx/dtype.h"
 #include "chainerx/indexable_array.h"
@@ -113,7 +114,7 @@ void Gemm(const Array& a, const Array& b, const Array& out) {
     }
 
     if (!is_out_contiguous) {
-        out.device().Copy(out_contiguous, out);
+        out.device().backend().CallOp<CopyOp>(out_contiguous, out);
     }
 }
 

--- a/chainerx_cc/chainerx/native/native_device/fill.cc
+++ b/chainerx_cc/chainerx/native/native_device/fill.cc
@@ -10,11 +10,139 @@
 #include "chainerx/macro.h"
 #include "chainerx/native/data_type.h"
 #include "chainerx/native/elementwise.h"
+#include "chainerx/native/op_regist.h"
+#include "chainerx/routines/creation.h"
 #include "chainerx/scalar.h"
 #include "chainerx/shape.h"
 
 namespace chainerx {
 namespace native {
+namespace {
+
+class NativeArangeOp : public ArangeOp {
+public:
+    void Call(Scalar start, Scalar step, const Array& out) override {
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
+            struct Impl {
+                void operator()(int64_t i, T& out) { out = start + step * static_cast<T>(i); }
+                T start;
+                T step;
+            };
+            Elementwise<T>(Impl{static_cast<T>(start), static_cast<T>(step)}, out);
+        });
+    }
+};
+
+CHAINERX_REGISTER_OP_NATIVE(ArangeOp, NativeArangeOp);
+
+class NativeIdentityOp : public IdentityOp {
+public:
+    void Call(const Array& out) override {
+        CHAINERX_ASSERT(out.ndim() == 2);
+        CHAINERX_ASSERT(out.shape()[0] == out.shape()[1]);
+
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
+            struct Impl {
+                explicit Impl(int64_t n) : n_plus_one{n + 1} {}
+                void operator()(int64_t i, T& out) { out = i % n_plus_one == 0 ? T{1} : T{0}; }
+                int64_t n_plus_one;
+            };
+            Elementwise<T>(Impl{out.shape()[0]}, out);
+        });
+    }
+};
+
+CHAINERX_REGISTER_OP_NATIVE(IdentityOp, NativeIdentityOp);
+
+class NativeEyeOp : public EyeOp {
+public:
+    void Call(int64_t k, const Array& out) override {
+        VisitDtype(out.dtype(), [k, &out](auto pt) {
+            using T = typename decltype(pt)::type;
+            struct Impl {
+                Impl(int64_t m, int64_t k) : start{k < 0 ? -k * m : k}, stop{m * (m - k)}, step{m + 1} {}
+                void operator()(int64_t i, T& out) { out = start <= i && i < stop && (i - start) % step == 0 ? T{1} : T{0}; }
+                int64_t start;
+                int64_t stop;
+                int64_t step;
+            };
+            Elementwise<T>(Impl{out.shape()[1], k}, out);
+        });
+    }
+};
+
+CHAINERX_REGISTER_OP_NATIVE(EyeOp, NativeEyeOp);
+
+class NativeDiagflatOp : public DiagflatOp {
+public:
+    void Call(const Array& v, int64_t k, const Array& out) override {
+        CHAINERX_ASSERT(v.ndim() == 1);
+        CHAINERX_ASSERT(out.ndim() == 2);
+
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
+
+            // Start indices for the 2-D array axes with applied offset k.
+            int64_t row_start{0};
+            int64_t col_start{0};
+
+            if (k >= 0) {
+                col_start += k;
+            } else {
+                row_start -= k;
+            }
+
+            IndexableArray<const T, 1> v_iarray{v};
+            IndexableArray<T, 2> out_iarray{out};
+            Indexer<1> v_indexer{v.shape()};
+            Indexer<2> out_indexer{out.shape()};
+
+            // Initialize all elements to 0 first instead of conditionally filling in the diagonal.
+            for (auto out_it = out_indexer.It(0); out_it; ++out_it) {
+                out_iarray[out_it] = native_internal::DataToStorageType(T{0});
+            }
+
+            auto out_it = out_indexer.It(0);
+            for (auto v_it = v_indexer.It(0); v_it; ++v_it) {
+                out_it.index()[0] = row_start + v_it.raw_index();
+                out_it.index()[1] = col_start + v_it.raw_index();
+                out_iarray[out_it] = v_iarray[v_it];
+            }
+        });
+    }
+};
+
+CHAINERX_REGISTER_OP_NATIVE(DiagflatOp, NativeDiagflatOp);
+
+class NativeLinspaceOp : public LinspaceOp {
+public:
+    void Call(double start, double stop, const Array& out) override {
+        CHAINERX_ASSERT(out.ndim() == 1);
+        CHAINERX_ASSERT(out.shape()[0] > 0);
+
+        VisitDtype(out.dtype(), [&](auto pt) {
+            using T = typename decltype(pt)::type;
+            struct Impl {
+                void operator()(int64_t i, T& out) {
+                    double value = n == 1 ? start : (start * (n - 1 - i) + stop * i) / (n - 1);
+                    out = static_cast<T>(value);
+                }
+                int64_t n;
+                double start;
+                double stop;
+            };
+
+            int64_t n = out.shape()[0];
+            Elementwise<T>(Impl{n, start, stop}, out);
+        });
+    }
+};
+
+CHAINERX_REGISTER_OP_NATIVE(LinspaceOp, NativeLinspaceOp);
+
+}  // namespace
 
 void NativeDevice::Fill(const Array& out, Scalar value) {
     VisitDtype(out.dtype(), [&](auto pt) {
@@ -24,104 +152,6 @@ void NativeDevice::Fill(const Array& out, Scalar value) {
             T value;
         };
         Elementwise<T>(Impl{static_cast<T>(value)}, out);
-    });
-}
-
-void NativeDevice::Arange(Scalar start, Scalar step, const Array& out) {
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
-        struct Impl {
-            void operator()(int64_t i, T& out) { out = start + step * static_cast<T>(i); }
-            T start;
-            T step;
-        };
-        Elementwise<T>(Impl{static_cast<T>(start), static_cast<T>(step)}, out);
-    });
-}
-
-void NativeDevice::Identity(const Array& out) {
-    CHAINERX_ASSERT(out.ndim() == 2);
-    CHAINERX_ASSERT(out.shape()[0] == out.shape()[1]);
-
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
-        struct Impl {
-            explicit Impl(int64_t n) : n_plus_one{n + 1} {}
-            void operator()(int64_t i, T& out) { out = i % n_plus_one == 0 ? T{1} : T{0}; }
-            int64_t n_plus_one;
-        };
-        Elementwise<T>(Impl{out.shape()[0]}, out);
-    });
-}
-
-void NativeDevice::Eye(int64_t k, const Array& out) {
-    VisitDtype(out.dtype(), [k, &out](auto pt) {
-        using T = typename decltype(pt)::type;
-        struct Impl {
-            Impl(int64_t m, int64_t k) : start{k < 0 ? -k * m : k}, stop{m * (m - k)}, step{m + 1} {}
-            void operator()(int64_t i, T& out) { out = start <= i && i < stop && (i - start) % step == 0 ? T{1} : T{0}; }
-            int64_t start;
-            int64_t stop;
-            int64_t step;
-        };
-        Elementwise<T>(Impl{out.shape()[1], k}, out);
-    });
-}
-
-void NativeDevice::Diagflat(const Array& v, int64_t k, const Array& out) {
-    CHAINERX_ASSERT(v.ndim() == 1);
-    CHAINERX_ASSERT(out.ndim() == 2);
-
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
-
-        // Start indices for the 2-D array axes with applied offset k.
-        int64_t row_start{0};
-        int64_t col_start{0};
-
-        if (k >= 0) {
-            col_start += k;
-        } else {
-            row_start -= k;
-        }
-
-        IndexableArray<const T, 1> v_iarray{v};
-        IndexableArray<T, 2> out_iarray{out};
-        Indexer<1> v_indexer{v.shape()};
-        Indexer<2> out_indexer{out.shape()};
-
-        // Initialize all elements to 0 first instead of conditionally filling in the diagonal.
-        for (auto out_it = out_indexer.It(0); out_it; ++out_it) {
-            out_iarray[out_it] = native_internal::DataToStorageType(T{0});
-        }
-
-        auto out_it = out_indexer.It(0);
-        for (auto v_it = v_indexer.It(0); v_it; ++v_it) {
-            out_it.index()[0] = row_start + v_it.raw_index();
-            out_it.index()[1] = col_start + v_it.raw_index();
-            out_iarray[out_it] = v_iarray[v_it];
-        }
-    });
-}
-
-void NativeDevice::Linspace(double start, double stop, const Array& out) {
-    CHAINERX_ASSERT(out.ndim() == 1);
-    CHAINERX_ASSERT(out.shape()[0] > 0);
-
-    VisitDtype(out.dtype(), [&](auto pt) {
-        using T = typename decltype(pt)::type;
-        struct Impl {
-            void operator()(int64_t i, T& out) {
-                double value = n == 1 ? start : (start * (n - 1 - i) + stop * i) / (n - 1);
-                out = static_cast<T>(value);
-            }
-            int64_t n;
-            double start;
-            double stop;
-        };
-
-        int64_t n = out.shape()[0];
-        Elementwise<T>(Impl{n, start, stop}, out);
     });
 }
 

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "chainerx/array.h"
+#include "chainerx/backend.h"
 #include "chainerx/backprop_mode.h"
 #include "chainerx/backward_builder.h"
 #include "chainerx/backward_context.h"
@@ -18,11 +19,10 @@
 #include "chainerx/dtype.h"
 #include "chainerx/graph.h"
 #include "chainerx/macro.h"
+#include "chainerx/routines/type_util.h"
 #include "chainerx/scalar.h"
 #include "chainerx/shape.h"
 #include "chainerx/strides.h"
-
-#include "chainerx/routines/type_util.h"
 
 namespace chainerx {
 namespace internal {
@@ -126,7 +126,7 @@ Array Arange(Scalar start, Scalar stop, Scalar step, Dtype dtype, Device& device
     }
 
     Array out = Empty({size}, dtype, device);
-    device.Arange(start, step, out);
+    device.backend().CallOp<ArangeOp>(start, step, out);
     return out;
 }
 
@@ -158,7 +158,7 @@ Array Copy(const Array& a) {
     Array out = EmptyLike(a, a.device());
     {
         NoBackpropModeScope scope{};
-        a.device().Copy(a, out);
+        a.device().backend().CallOp<CopyOp>(a, out);
     }
 
     BackwardBuilder bb{"copy", a, out};
@@ -180,7 +180,7 @@ Array Identity(int64_t n, Dtype dtype, Device& device) {
     Array out = Empty(Shape{n, n}, dtype, device);
     {
         NoBackpropModeScope scope{};
-        device.Identity(out);
+        device.backend().CallOp<IdentityOp>(out);
     }
     return out;
 }
@@ -202,7 +202,7 @@ Array Eye(int64_t n, nonstd::optional<int64_t> m, nonstd::optional<int64_t> k, n
     Array out = Empty({n, m.value()}, dtype.value(), device);
     {
         NoBackpropModeScope scope{};
-        device.Eye(k.value(), out);
+        device.backend().CallOp<EyeOp>(k.value(), out);
     }
     return out;
 }
@@ -267,7 +267,7 @@ Array Diag(const Array& v, int64_t k, Device& device) {
         out = Empty(Shape{n, n}, v.dtype(), device);
         {
             NoBackpropModeScope scope{};
-            device.Diagflat(v, k, out);
+            device.backend().CallOp<DiagflatOp>(v, k, out);
         }
     } else if (ndim == 2) {
         // Return the diagonal as a 1D array.
@@ -337,7 +337,7 @@ Array Linspace(
         }
         {
             NoBackpropModeScope scope{};
-            device.Linspace(start_value, stop_value, out);
+            device.backend().CallOp<LinspaceOp>(start_value, stop_value, out);
         }
     }
     return out;

--- a/chainerx_cc/chainerx/routines/creation.h
+++ b/chainerx_cc/chainerx/routines/creation.h
@@ -12,6 +12,7 @@
 #include "chainerx/device.h"
 #include "chainerx/dtype.h"
 #include "chainerx/graph.h"
+#include "chainerx/op.h"
 #include "chainerx/scalar.h"
 #include "chainerx/shape.h"
 
@@ -53,6 +54,57 @@ Array FromData(
         const nonstd::optional<Strides>& strides = nonstd::nullopt,
         int64_t offset = 0,
         Device& device = GetDefaultDevice());
+
+class ArangeOp : public Op {
+public:
+    static const char* name() { return "Arange"; }
+
+    virtual void Call(Scalar start, Scalar step, const Array& out) = 0;
+};
+
+class CopyOp : public Op {
+public:
+    static const char* name() { return "Copy"; }
+
+    // Copies the elements from one array to the other.
+    //
+    // The arrays must match in shape and dtype and need to reside on this device.
+    virtual void Call(const Array& a, const Array& out) = 0;
+};
+
+class IdentityOp : public Op {
+public:
+    static const char* name() { return "Identity"; }
+
+    // Creates the identity array.
+    // out must be a square 2-dim array.
+    virtual void Call(const Array& out) = 0;
+};
+
+class EyeOp : public Op {
+public:
+    static const char* name() { return "Eye"; }
+
+    // Creates a 2-dimensional array with ones along the k-th diagonal and zeros elsewhere.
+    // out must be a square 2-dim array.
+    virtual void Call(int64_t k, const Array& out) = 0;
+};
+
+class DiagflatOp : public Op {
+public:
+    static const char* name() { return "Diagflat"; }
+
+    virtual void Call(const Array& v, int64_t k, const Array& out) = 0;
+};
+
+class LinspaceOp : public Op {
+public:
+    static const char* name() { return "Linspace"; }
+
+    // Creates an evenly spaced 1-d array.
+    // `out.ndim()` must be 1 with at least 1 elements.
+    virtual void Call(double start, double stop, const Array& out) = 0;
+};
 
 Array Empty(const Shape& shape, Dtype dtype, Device& device = GetDefaultDevice());
 Array Full(const Shape& shape, Scalar fill_value, Dtype dtype, Device& device = GetDefaultDevice());

--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -14,6 +14,7 @@
 
 #include "chainerx/array.h"
 #include "chainerx/axes.h"
+#include "chainerx/backend.h"
 #include "chainerx/backprop_mode.h"
 #include "chainerx/backward_builder.h"
 #include "chainerx/backward_context.h"
@@ -22,11 +23,10 @@
 #include "chainerx/error.h"
 #include "chainerx/graph.h"
 #include "chainerx/macro.h"
-#include "chainerx/shape.h"
-#include "chainerx/strides.h"
-
 #include "chainerx/routines/creation.h"
 #include "chainerx/routines/type_util.h"
+#include "chainerx/shape.h"
+#include "chainerx/strides.h"
 
 namespace chainerx {
 
@@ -445,7 +445,7 @@ Array ConcatenateImpl(const std::vector<Array>& arrays, int8_t axis) {
             Dtype in_dtype = array.dtype();
             in_dtypes.emplace_back(in_dtype);
             if (in_dtype == out_dtype) {
-                device.Copy(array, sliced_out);
+                device.backend().CallOp<CopyOp>(array, sliced_out);
             } else {
                 device.AsType(array, sliced_out);
             }
@@ -573,7 +573,7 @@ Array Stack(const std::vector<Array>& arrays, int8_t axis) {
         int64_t out_offset = 0;
         for (const Array& array : arrays) {
             Array sliced_out = internal::MakeArray(array.shape(), strides, dtype, device, out.data(), out_offset);
-            device.Copy(array, sliced_out);
+            device.backend().CallOp<CopyOp>(array, sliced_out);
             out_offset += step;
         }
     }


### PR DESCRIPTION
Part of #6692.

Note that `Device::AsType` and `Device::Fill` are not covered in this PR. Although similar to other device methods covered in this PR, these methods do not have corresponding routines and are instead exposed as `Array` methods `Array::AsType`, `Array::Fill`.