### PR TITLE
Fix Travis with macOS

### DIFF
--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -51,7 +51,7 @@ step_before_install_chainer_test() {
     # Remove oclint as it conflicts with GCC (indirect dependency of hdf5)
     if [[ $TRAVIS_OS_NAME = "osx" ]]; then
         brew update >/dev/null
-	brew uninstall openssl@1.1 || :  # tentative workaround: pyenv/pyenv#1302
+        brew uninstall openssl@1.1 || :  # tentative workaround: pyenv/pyenv#1302
         brew outdated pyenv || brew upgrade pyenv
 
         PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION

--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -51,6 +51,7 @@ step_before_install_chainer_test() {
     # Remove oclint as it conflicts with GCC (indirect dependency of hdf5)
     if [[ $TRAVIS_OS_NAME = "osx" ]]; then
         brew update >/dev/null
+	brew uninstall openssl@1.1 || :  # tentative workaround: pyenv/pyenv#1302
         brew outdated pyenv || brew upgrade pyenv
 
         PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION


### PR DESCRIPTION
The PR fixes Travis fails to install python (2.7.10 and 3.5.1) using pyenv.  I reproduced the same error on my MacBook by
```
brew install openssl@1.1
pyenv install 2.7.10  # fail
brew uninstall openssl@1.1
pyenv install 2.7.10  # pass
```

Updating `openssl@1.1` did not fix the problem.

The update of pyenv, which includes pyenv/pyenv#1302, probably caused the error, while I've not figured out why openssl 1.1 makes the installation fail.