### PR TITLE
[WIP] Fix Travis MacOS `pyenv install` error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   - ccache
 
 matrix:
+
   include:
     - name: "Python Static Check"
       dist: xenial


### PR DESCRIPTION
The MacOS job is failing on Travis due to an error in `pyenv install`.

_Do not merge yet._