### PR TITLE
Allow snapshot_object have condition and writer option

### DIFF
--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -4,8 +4,11 @@ from chainer.training.extensions import snapshot_writers
 from chainer.utils import argument
 
 
-def snapshot_object(target, filename, savefun=npz.save_npz, **kwargs):
-    """Returns a trainer extension to take snapshots of a given object.
+def snapshot_object(target, filename, **kwargs):
+    """snapshot_object(target, filename, savefun=None, \
+*, condition=None, writer=None, snapshot_on_error=False)
+
+    Returns a trainer extension to take snapshots of a given object.
 
     This extension serializes the given object and saves it to the output
     directory.
@@ -27,6 +30,19 @@ def snapshot_object(target, filename, savefun=npz.save_npz, **kwargs):
             ``'snapshot_10000'`` at the 10,000th iteration.
         savefun: Function to save the object. It takes two arguments: the
             output file path and the object to serialize.
+        condition: Condition object. It must be a callable object that returns
+            boolean without any arguments. If it returns ``True``, the snapshot
+            will be done.
+            If not, it will be skipped. The default is a function that always
+            returns ``True``.
+        writer: Writer object.
+            It must be a callable object.
+            See below for the list of built-in writers.
+            If ``savefun`` is other than ``None``, this argument must be
+            ``None``. In that case, a
+            :class:`~chainer.training.extensions.snapshot_writers.SimpleWriter`
+            object instantiated with specified ``savefun`` argument will be
+            used.
         snapshot_on_error (bool): Whether to take a snapshot in case trainer
             loop has been failed.
 
@@ -37,15 +53,8 @@ def snapshot_object(target, filename, savefun=npz.save_npz, **kwargs):
 
         - :meth:`chainer.training.extensions.snapshot`
     """
-    snapshot_on_error = argument.parse_kwargs(
-        kwargs, ('snapshot_on_error', False))
-    argument.assert_kwargs_empty(kwargs)
 
-    return _Snapshot(
-        target=target,
-        writer=snapshot_writers.SimpleWriter(savefun=savefun),
-        filename=filename,
-        snapshot_on_error=snapshot_on_error)
+    return snapshot(target=target, filename=filename, **kwargs)
 
 
 def snapshot(savefun=None,

--- a/chainer/training/extensions/_snapshot.py
+++ b/chainer/training/extensions/_snapshot.py
@@ -4,7 +4,7 @@ from chainer.training.extensions import snapshot_writers
 from chainer.utils import argument
 
 
-def snapshot_object(target, filename, **kwargs):
+def snapshot_object(target, filename, savefun=None, **kwargs):
     """snapshot_object(target, filename, savefun=None, \
 *, condition=None, writer=None, snapshot_on_error=False)
 
@@ -54,7 +54,8 @@ def snapshot_object(target, filename, **kwargs):
         - :meth:`chainer.training.extensions.snapshot`
     """
 
-    return snapshot(target=target, filename=filename, **kwargs)
+    return snapshot(target=target, filename=filename, savefun=savefun,
+                    **kwargs)
 
 
 def snapshot(savefun=None,

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot.py
@@ -31,6 +31,10 @@ class TestSnapshot(unittest.TestCase):
         with pytest.raises(TypeError):
             extensions.snapshot(savefun=savefun, writer=writer)
 
+        trainer = mock.MagicMock()
+        with pytest.raises(TypeError):
+            extensions.snapshot_object(trainer, savefun=savefun, writer=writer)
+
 
 class TestSnapshotSaveFile(unittest.TestCase):
 
@@ -44,7 +48,9 @@ class TestSnapshotSaveFile(unittest.TestCase):
             os.remove('myfile.dat')
 
     def test_save_file(self):
-        snapshot = extensions.snapshot_object(self.trainer, 'myfile.dat')
+        w = extensions.snapshot_writers.SimpleWriter()
+        snapshot = extensions.snapshot_object(self.trainer, 'myfile.dat',
+                                              writer=w)
         snapshot(self.trainer)
 
         self.assertTrue(os.path.exists('myfile.dat'))


### PR DESCRIPTION
This commit also aligns behaviour of `snapshot_object` to `snapshot` for future potential extensions of both functions.