### PR TITLE
Fix TypeError during BN deserialization on win64

### DIFF
--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -178,6 +178,8 @@ class NpzDeserializer(serializer.Deserializer):
             value_type = type(value)
             dataset_arr = numpy.asarray(dataset)
             if (issubclass(dataset_arr.dtype.type, numpy.number)
+                    and not (issubclass(dataset_arr.dtype.type, numpy.integer)
+                             and value_type is int)
                     and not numpy.can_cast(
                         dataset_arr.dtype, value_type, casting='safe')):
                 raise TypeError(

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -4,6 +4,7 @@ import unittest
 
 import mock
 import numpy
+import pytest
 import six
 
 import chainer
@@ -194,19 +195,17 @@ class TestNpzDeserializer(unittest.TestCase):
     def test_deserialize_int64_to_int(self):
         z = int(5)
         ret = self.deserializer('zi64', z)
-        self.assertEqual(ret, -2**60)
+        assert ret == -2**60
 
     def test_deserialize_int64_to_uint32(self):
         z = numpy.uint32(5)
-        self.assertRaises(
-            TypeError,
-            lambda: self.deserializer('zi64', z))
+        with pytest.raises(TypeError):
+            self.deserializer('zi64', z)
 
     def test_deserialize_float32_to_uint32(self):
         z = int(5)
-        self.assertRaises(
-            TypeError,
-            lambda: self.deserializer('zf32', z))
+        with pytest.raises(TypeError):
+            self.deserializer('zf32', z)
 
     def test_deserialize_none(self):
         ret = self.deserializer('w', None)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -102,6 +102,8 @@ class TestNpzDeserializer(unittest.TestCase):
             savez = numpy.savez_compressed if self.compress else numpy.savez
             savez(
                 f, **{'x/': None, 'y': self.data, 'z': numpy.asarray(10),
+                      'zf32': numpy.array(-2**60, dtype=numpy.float32),
+                      'zi64': numpy.array(-2**60, dtype=numpy.int64),
                       'w': None})
 
         self.npzfile = numpy.load(path)
@@ -188,6 +190,23 @@ class TestNpzDeserializer(unittest.TestCase):
         z = 5
         ret = self.deserializer('z', z)
         self.assertEqual(ret, 10)
+
+    def test_deserialize_int64_to_int(self):
+        z = int(5)
+        ret = self.deserializer('zi64', z)
+        self.assertEqual(ret, -2**60)
+
+    def test_deserialize_int64_to_uint32(self):
+        z = numpy.uint32(5)
+        self.assertRaises(
+            TypeError,
+            lambda: self.deserializer('zi64', z))
+
+    def test_deserialize_float32_to_uint32(self):
+        z = int(5)
+        self.assertRaises(
+            TypeError,
+            lambda: self.deserializer('zf32', z))
 
     def test_deserialize_none(self):
         ret = self.deserializer('w', None)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -202,7 +202,7 @@ class TestNpzDeserializer(unittest.TestCase):
         with pytest.raises(TypeError):
             self.deserializer('zi64', z)
 
-    def test_deserialize_float32_to_uint32(self):
+    def test_deserialize_float32_to_int(self):
         z = int(5)
         with pytest.raises(TypeError):
             self.deserializer('zf32', z)


### PR DESCRIPTION
A `chainer.links.BatchNormalization` serialized on Linux/x64 cannot be deserialized on Windows/x64 by `TypeError`.
This PR fixes the problem by adding a special case for type check introduced by #5483.


I've noticed the problem by calling `chainercv.links.ResNet50(pretrained_model='imagenet', arch='he')` on ChainerCV 0.12.0 + Chainer 6.0.0RC1 on Windows/x64.
But it also reproduces without ChainerCV, as follows:

1. Serialize a `chainer.link.BatchNormalization` on Linux/x64
```
Python 3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34) 
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import chainer
>>> chainer.__version__
'6.0.0rc1'
>>> chainer.serializers.save_npz('bn.npz', chainer.links.BatchNormalization(1))
>>>
>>> np.iinfo(chainer.links.BatchNormalization(1).N)
iinfo(min=-9223372036854775808, max=9223372036854775807, dtype=int64)
```

2. Try to deserialize it on Windows/x64
```
Python 3.7.3 (default, Mar 27 2019, 17:13:21) [MSC v.1915 64 bit (AMD64)] :: Anaconda, Inc. on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import chainer
>>> chainer.__version__
'6.0.0rc1'
>>> chainer.serializers.load_npz('bn.npz', chainer.links.BatchNormalization(1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\XXX\Miniconda3\envs\work\lib\site-packages\chainer\serializers\npz.py", line 221, in load_npz
    d.load(obj)
  File "C:\Users\XXXX\Miniconda3\envs\work\lib\site-packages\chainer\serializer.py", line 83, in load
    obj.serialize(self)
  File "C:\Users\XXXX\Miniconda3\envs\work\lib\site-packages\chainer\link.py", line 664, in serialize
    d[name] = serializer(name, d[name])
  File "C:\Users\XXXX\Miniconda3\envs\work\lib\site-packages\chainer\serializers\npz.py", line 186, in __call__
    dataset.dtype, type(value)))
TypeError: Cannot safely deserialize from numpy array with dtype=int64 into a variable of type <class 'int'>.
>>>
>>> np.iinfo(chainer.links.BatchNormalization(1).N)
iinfo(min=-2147483648, max=2147483647, dtype=int32)
```

The root cause of the problem is `int` size difference between the platforms:
 * on Linux/x64, an `int` value is serialized as `np.int64`
 * on Windows, the value is to be deserialized as `int`, but type check prevents it
    (`np.can_cast(np.int64, int)` -> `False`)

For a scalar value, any `np.intXX` values can be safely converted to `int`, as [Python's `int` has unlimited precision](https://docs.python.org/dev/library/stdtypes.html#typesnumeric).
This PR allows such a conversion as a special case.