### PR TITLE
[backport] Dodge nondifferentiable inputs in `chainerx.max` test

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -1976,6 +1976,8 @@ _max_params = [
 ))
 class TestMax(UnaryMathTestBase, op_utils.NumpyOpTest):
 
+    dodge_nondifferentiable = True
+
     def generate_inputs(self):
         in_dtype, = self.in_dtypes
         if hasattr(self, 'array'):


### PR DESCRIPTION
Backport of #6761