### PR TITLE
Fix `Evaluator` for `chainer.dataset.converter`

### DIFF
--- a/chainer/training/extensions/evaluator.py
+++ b/chainer/training/extensions/evaluator.py
@@ -1,11 +1,9 @@
 import copy
 import warnings
 
-import numpy
 import six
 
 from chainer import backend
-from chainer.backends import cuda
 from chainer import configuration
 from chainer.dataset import convert
 from chainer.dataset import iterator as iterator_module
@@ -214,7 +212,8 @@ class Evaluator(extension.Extension):
         for batch in it:
             observation = {}
             with reporter_module.report_scope(observation):
-                in_arrays = self._call_converter(batch, self.device)
+                in_arrays = convert._call_converter(
+                    self.converter, batch, self.device)
                 with function.no_backprop_mode():
                     if isinstance(in_arrays, tuple):
                         eval_func(*in_arrays)
@@ -226,25 +225,6 @@ class Evaluator(extension.Extension):
             summary.add(observation)
 
         return summary.compute_mean()
-
-    def _call_converter(self, batch, device):
-        # TODO(niboshi): This is a temporary workaround to keep backward
-        # compatibility about user-defined custom converters. Existing
-        # converters expect int values as the `device` argument, so they
-        # can't handle ChainerX devices. We should either break backward
-        # compatibility at some time or introduce a sparate API.
-        converter = self.converter
-        if converter is convert.concat_examples:
-            return converter(batch, device)
-        else:
-            if device is None:
-                return converter(batch, None)
-            if device.xp is numpy:
-                return converter(batch, -1)
-            if device.xp is cuda.cupy:
-                return converter(batch, device.device.id)
-            raise NotImplementedError(
-                'Currently only `concat_examples` supports ChainerX.')
 
     def finalize(self):
         """Finalizes the evaluator object.


### PR DESCRIPTION
`Evaluator` was not aware of `chainer.dataset.converter` (#5832).