### PR TITLE
Add infinity check in debug mode

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -36,6 +36,23 @@ def _contains_nan(x):
         return False
 
 
+def _contains_inf(x):
+    """Returns whether the input array has inf values.
+
+    Args:
+        x (numpy.ndarray or cupy.ndarray): Array to be checked.
+
+    Returns:
+        bool: True if the input has inf values.
+
+    """
+    if x.dtype.kind in ('f', 'c'):
+        with cuda.get_device_from_array(x):
+            return get_array_module(x).isinf(x).any()
+    else:
+        return False
+
+
 def copyto(dst, src):
     """Copies the elements of an ndarray to those of another one.
 

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -337,13 +337,14 @@ Use apply() method instead.\
         for hook in hooks:
             hook.forward_postprocess(self, in_data)
 
-        # NaN check of output values
+        # NaN and inf check of output values
         if is_debug:
-            if any(chainer.backend._contains_nan(out)
-                   for out in outputs):
-                msg = ('NaN is detected on forward computation of '
-                       '{}'.format(self.label))
-                raise RuntimeError(msg)
+            for name, fn in [('NaN', chainer.backend._contains_nan),
+                             ('Inf', chainer.backend._contains_inf)]:
+                if any(fn(out) for out in outputs):
+                    msg = ('{} is detected on forward computation of '
+                           '{}'.format(name, self.label))
+                    raise RuntimeError(msg)
 
         self._output_count = len(outputs)
 


### PR DESCRIPTION
Currently Chainer checks the existence of `NaN` in the outputs of Chainer functions in the debug mode. This PR adds infinity check as well, which is helpful on debugging in FP16 mode since FP16 values are easily become infinity values.
