### PR TITLE
[backport] Fix `chainerx.astype` casting from `float16` to `bool` in CUDA

### DIFF
--- a/chainerx_cc/chainerx/cuda/float16.cuh
+++ b/chainerx_cc/chainerx/cuda/float16.cuh
@@ -28,7 +28,7 @@ public:
     explicit __host__ Float16(Scalar v) : Float16{static_cast<chainerx::Float16>(v)} {}
     explicit __host__ Float16(chainerx::Float16 v) : Float16{v.data(), FromDataTag{}} {}
 
-    explicit __device__ operator bool() const { return *this == Float16{0}; }
+    explicit __device__ operator bool() const { return *this != Float16{0}; }
     // int8 conversion is not implemented in cuda_fp16
     explicit __device__ operator int8_t() const { return static_cast<int8_t>(static_cast<int16_t>(*this)); }
     explicit __device__ operator uint8_t() const { return static_cast<uint8_t>(static_cast<uint16_t>(*this)); }

--- a/tests/chainerx_tests/unit_tests/test_array.py
+++ b/tests/chainerx_tests/unit_tests/test_array.py
@@ -209,12 +209,12 @@ def test_view_must_not_share_properties():
 # TODO(beam2d): use fixtures.
 @pytest.mark.parametrize(
     'src_dtype',
-    ['bool_', 'uint8', 'int8', 'int16', 'int32', 'int64', 'float32',
-     'float64'])
+    ['bool_', 'uint8', 'int8', 'int16', 'int32', 'int64', 'float16',
+     'float32', 'float64'])
 @pytest.mark.parametrize(
     'dst_dtype',
-    ['bool_', 'uint8', 'int8', 'int16', 'int32', 'int64', 'float32',
-     'float64'])
+    ['bool_', 'uint8', 'int8', 'int16', 'int32', 'int64', 'float16',
+     'float32', 'float64'])
 def test_astype(xp, shape, device, copy, src_dtype, dst_dtype):
     a = array_utils.create_dummy_ndarray(xp, shape, src_dtype)
 


### PR DESCRIPTION
Backport of #6780