### PR TITLE
Fix unchain gradient pull

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -1107,7 +1107,9 @@ def _backprop(outputs, inputs, grad_required, retain_grad, grads, loss_scale):
 
         # Collect the gradients w.r.t. the outputs
         ys = [y() for y in func.outputs]  # access via weak ref
-        gys = tuple([grads.pop(y) for y in ys])
+        gys = tuple([grads.pop(y)
+                     if y is not None and y.creator_node is not None else None
+                     for y in ys])
 
         for node, gy in six.moves.zip(ys, gys):
             if node is not None:

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1614,7 +1614,9 @@ def _backprop_to_all(outputs, retain_grad, loss_scale):
             i for i, x in enumerate(inputs) if x.requires_grad
         ])
         outputs = [y() for y in func.outputs]  # access via weak ref
-        out_grad = tuple([grads.pop(y) if y.creator_node else None
+        out_grad = tuple([grads.pop(y)
+                          if y is not None and y.creator_node is not None
+                          else None
                           for y in outputs])
         if not target_input_indexes:
             continue

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1614,7 +1614,8 @@ def _backprop_to_all(outputs, retain_grad, loss_scale):
             i for i, x in enumerate(inputs) if x.requires_grad
         ])
         outputs = [y() for y in func.outputs]  # access via weak ref
-        out_grad = tuple([grads.pop(y) if y.creator_node else None for y in outputs])
+        out_grad = tuple([grads.pop(y) if y.creator_node else None
+                          for y in outputs])
         if not target_input_indexes:
             continue
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1614,7 +1614,7 @@ def _backprop_to_all(outputs, retain_grad, loss_scale):
             i for i, x in enumerate(inputs) if x.requires_grad
         ])
         outputs = [y() for y in func.outputs]  # access via weak ref
-        out_grad = tuple([grads.pop(y) for y in outputs])
+        out_grad = tuple([grads.pop(y) if y.creator_node else None for y in outputs])
         if not target_input_indexes:
             continue
 

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -869,29 +869,6 @@ class TestGradValueCheck(unittest.TestCase):
             chainer.grad([y], [x], [None], [None, None])
 
 
-class TestUnchainSplit(unittest.TestCase):
-
-    def test_unchain_split(self):
-        x = chainer.Variable(numpy.arange(4).astype('f').reshape(2, 2))
-        h0, h1 = chainer.functions.split_axis(x, [1], axis=0)
-        y = chainer.functions.sum(h0)
-        z = chainer.functions.sum(h1)
-        w = y + z
-        h0.unchain()
-
-        dy_dh0 = numpy.array([[1., 1.]])
-        dz_dh1 = numpy.array([[1., 1.]])
-        dy_dx = None
-        dz_dx = numpy.array([[0., 0.], [1., 1.]])
-        dw_dx = numpy.array([[0., 0.], [1., 1.]])
-
-        assert numpy.all(chainer.grad([y], [h0])[0].array == dy_dh0)
-        assert numpy.all(chainer.grad([z], [h1])[0].array == dz_dh1)
-        assert chainer.grad([y], [x])[0] is dy_dx
-        assert numpy.all(chainer.grad([z], [x])[0].array == dz_dx)
-        assert numpy.all(chainer.grad([w], [x])[0].array == dw_dx)
-
-
 class GradTestBase(object):
 
     shape = 3,
@@ -1160,6 +1137,29 @@ class TestGradDelRetainedOutput2(unittest.TestCase):
         xp.testing.assert_allclose(
             gx_.array,
             gx.array * x_grad_grad)
+
+
+class TestUnchainSplitGrad(unittest.TestCase):
+
+    def test_unchain_split(self):
+        x = chainer.Variable(numpy.arange(4).astype('f').reshape(2, 2))
+        h0, h1 = chainer.functions.split_axis(x, [1], axis=0)
+        y = chainer.functions.sum(h0)
+        z = chainer.functions.sum(h1)
+        w = y + z
+        h0.unchain()
+
+        dy_dh0 = numpy.array([[1., 1.]])
+        dz_dh1 = numpy.array([[1., 1.]])
+        dy_dx = None
+        dz_dx = numpy.array([[0., 0.], [1., 1.]])
+        dw_dx = numpy.array([[0., 0.], [1., 1.]])
+
+        testing.assert_allclose(chainer.grad([y], [h0])[0].array, dy_dh0)
+        testing.assert_allclose(chainer.grad([z], [h1])[0].array, dz_dh1)
+        assert chainer.grad([y], [x])[0] is dy_dx
+        testing.assert_allclose(chainer.grad([z], [x])[0].array, dz_dx)
+        testing.assert_allclose(chainer.grad([w], [x])[0].array, dw_dx)
 
 
 class TestGradV3Compat1(unittest.TestCase):

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -869,6 +869,29 @@ class TestGradValueCheck(unittest.TestCase):
             chainer.grad([y], [x], [None], [None, None])
 
 
+class TestUnchainSplit(unittest.TestCase):
+
+    def test_unchain_split(self):
+        x = chainer.Variable(numpy.arange(4).astype('f').reshape(2, 2))
+        h0, h1 = chainer.functions.split_axis(x, [1], axis=0)
+        y = chainer.functions.sum(h0)
+        z = chainer.functions.sum(h1)
+        w = y + z
+        h0.unchain()
+
+        dy_dh0 = numpy.array([[1., 1.]])
+        dz_dh1 = numpy.array([[1., 1.]])
+        dy_dx = None
+        dz_dx = numpy.array([[0., 0.], [1., 1.]])
+        dw_dx = numpy.array([[0., 0.], [1., 1.]])
+
+        assert numpy.all(chainer.grad([y], [h0])[0].array == dy_dh0)
+        assert numpy.all(chainer.grad([z], [h1])[0].array == dz_dh1)
+        assert chainer.grad([y], [x])[0] is None
+        assert numpy.all(chainer.grad([z], [x])[0].array == dz_dx)
+        assert numpy.all(chainer.grad([w], [x])[0].array == dw_dx)
+
+
 class GradTestBase(object):
 
     shape = 3,

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -887,7 +887,7 @@ class TestUnchainSplit(unittest.TestCase):
 
         assert numpy.all(chainer.grad([y], [h0])[0].array == dy_dh0)
         assert numpy.all(chainer.grad([z], [h1])[0].array == dz_dh1)
-        assert chainer.grad([y], [x])[0] is None
+        assert chainer.grad([y], [x])[0] is dy_dx
         assert numpy.all(chainer.grad([z], [x])[0].array == dz_dx)
         assert numpy.all(chainer.grad([w], [x])[0].array == dw_dx)
 

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -508,15 +508,15 @@ class TestVariable(unittest.TestCase):
         self.check_backward((ret[1],), (ret[2],), (ret[3],), False)
 
     def test_unchain_split(self):
-        if not len(self.x.shape) > 0:
+        if self.x.ndim == 0:
             return
         ret = get_variable(np, self.x)
         ret.grad = np.zeros_like(ret.data)
         y1, y2 = F.split_axis(ret, [5], axis=0)
         y1.unchain()
         z1, z2 = F.sum(y1), F.sum(y2)
-        z1.backward()
-        self.check_backward((ret,), (y1, y2,), (z2,), False)
+        w = z1 + z2
+        self.check_backward((ret, y1), (y2, z1, z2), (w,), False)
 
     def check_set_none_to_creator(self, use_creator_node):
         ret = self.create_linear_chain(3, np)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -516,6 +516,8 @@ class TestVariable(unittest.TestCase):
         y1.unchain()
         z1, z2 = F.sum(y1), F.sum(y2)
         w = z1 + z2
+        for var in [y1, y2, z1, z2, w]:
+            var.grad = np.zeros_like(var.data)
         self.check_backward((ret, y1), (y2, z1, z2), (w,), False)
 
     def check_set_none_to_creator(self, use_creator_node):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -507,6 +507,17 @@ class TestVariable(unittest.TestCase):
         assert ret[1].rank == old_rank
         self.check_backward((ret[1],), (ret[2],), (ret[3],), False)
 
+    def test_unchain_split(self):
+        if not len(self.x.shape) > 0:
+            return
+        ret = get_variable(np, self.x)
+        ret.grad = np.zeros_like(ret.data)
+        y1, y2 = F.split_axis(ret, [5], axis=0)
+        y1.unchain()
+        z1, z2 = F.sum(y1), F.sum(y2)
+        z1.backward()
+        self.check_backward((ret,), (y1, y2,), (z2,), False)
+
     def check_set_none_to_creator(self, use_creator_node):
         ret = self.create_linear_chain(3, np)
         old_rank = ret[1].rank


### PR DESCRIPTION
This change would use Null gradients for child nodes that have been
unchained. References issue #6027. As opposed to current behavior:

```python
>>> import numpy as np; import chainer; import chainer.functions as F
>>> x = chainer.Variable(np.arange(4).astype('f').reshape(2, 2)); x
variable([[0., 1.],
          [2., 3.]])
>>> h0, h1 = F.split_axis(x, [1], axis=0); h0, h1
(variable([[0., 1.]]), variable([[2., 3.]]))
>>> y = F.sum(h0)
>>> z = F.sum(h1)
>>> h0.unchain()
>>> x.grad, h0.grad, h1.grad
(None, None, None)
>>> y.backward()
>>> x.grad, h0.grad, h1.grad
(None, array([[1., 1.]], dtype=float32), None)
>>> z.backward()
>>> x.grad, h0.grad, h1.grad
(array([[1., 1.],
       [1., 1.]], dtype=float32), None, None)
```
we would get this:

```python
>>> import numpy as np; import chainer; import chainer.functions as F
>>> x = chainer.Variable(np.arange(4).astype('f').reshape(2, 2)); x
variable([[0., 1.],
          [2., 3.]])
>>> h0, h1 = F.split_axis(x, [1], axis=0); h0, h1
(variable([[0., 1.]]), variable([[2., 3.]]))
>>> y = F.sum(h0)
>>> z = F.sum(h1)
>>> h0.unchain()
>>> x.grad, h0.grad, h1.grad
(None, None, None)
>>> y.backward()
>>> x.grad, h0.grad, h1.grad
(None, array([[1., 1.]], dtype=float32), None)
>>> z.backward()
>>> x.grad, h0.grad, h1.grad
(array([[0., 0.],
       [1., 1.]], dtype=float32), array([[1., 1.]], dtype=float32), None)
```

Thank you for creating a pull request!

Please double-check the following.

- Read [our contribution guide](https://docs.chainer.org/en/stable/contribution.html).
  - Does your code conform to our coding guidelines?
  - Did you write sufficient test code?
  - Did you write sufficient documentation?
- Also, take a look at [our compatibility policy](https://docs.chainer.org/en/stable/compatibility.html).
