### PR TITLE
Use intermediate dtype in `F.mean_absolute_error` for FP16

### DIFF
--- a/chainer/functions/loss/mean_absolute_error.py
+++ b/chainer/functions/loss/mean_absolute_error.py
@@ -2,8 +2,18 @@ import numpy
 
 import chainer
 from chainer import backend
+from chainer.backends import cuda
 from chainer import function_node
 from chainer.utils import type_check
+
+
+def _get_intermediate_dtype(dtype):
+    # Returns the dtype for intermediate calculation.
+    # For float16 input, float32 is used.
+    # Otherwise the same dtype as the parameter is used.
+    if dtype == numpy.float16:
+        return numpy.float32
+    return dtype
 
 
 class MeanAbsoluteError(function_node.FunctionNode):
@@ -21,14 +31,19 @@ class MeanAbsoluteError(function_node.FunctionNode):
     def forward_cpu(self, inputs):
         x0, x1 = inputs
         self.diff = x0 - x1
-        diff = self.diff.ravel()
-        return numpy.array(abs(diff).sum() / diff.size, dtype=diff.dtype),
+        orig_dtype = self.diff.dtype
+        dtype = _get_intermediate_dtype(orig_dtype)
+        diff = self.diff.ravel().astype(dtype, copy=False)
+        return numpy.array(abs(diff).sum() / diff.size, dtype=orig_dtype),
 
     def forward_gpu(self, inputs):
         x0, x1 = inputs
         self.diff = x0 - x1
-        diff = self.diff.ravel()
-        return abs(diff).sum() / diff.dtype.type(diff.size),
+        orig_dtype = self.diff.dtype
+        dtype = _get_intermediate_dtype(orig_dtype)
+        diff = self.diff.ravel().astype(dtype, copy=False)
+        return (abs(diff).sum() / diff.dtype.type(diff.size)).astype(
+            orig_dtype, copy=False),
 
     def backward(self, indexes, grad_outputs):
         gy, = grad_outputs

--- a/chainer/functions/loss/mean_absolute_error.py
+++ b/chainer/functions/loss/mean_absolute_error.py
@@ -2,7 +2,6 @@ import numpy
 
 import chainer
 from chainer import backend
-from chainer.backends import cuda
 from chainer import function_node
 from chainer.utils import type_check
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
@@ -7,6 +7,7 @@ from chainer.backends import cuda
 from chainer import functions
 from chainer import testing
 from chainer import utils
+from chainer.testing import attr
 from chainer.utils import type_check
 
 
@@ -98,6 +99,7 @@ class TestMeanAbsoluteErrorFP16Overflow(unittest.TestCase):
     def test_fp16_overflow_cpu(self):
         self.check_fp16_overflow(numpy)
 
+    @attr.gpu
     def test_fp16_overflow_gpu(self):
         self.check_fp16_overflow(cuda.cupy)
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
@@ -89,9 +89,9 @@ class TestMeanAbsoluteErrorFP16Overflow(unittest.TestCase):
 
     def check_fp16_overflow(self, xp):
         x0 = chainer.Variable(xp.full(
-            shape=(64,1,16,16), fill_value=2, dtype=xp.float16))
+            shape=(64, 1, 16, 16), fill_value=2, dtype=xp.float16))
         x1 = chainer.Variable(xp.full(
-            shape=(64,1,16,16), fill_value=-2, dtype=xp.float16))
+            shape=(64, 1, 16, 16), fill_value=-2, dtype=xp.float16))
         loss = functions.mean_absolute_error(x0, x1)
         self.assertFalse(xp.isinf(loss.array))
 

--- a/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_mean_absolute_error.py
@@ -3,6 +3,7 @@ import unittest
 import numpy
 
 import chainer
+from chainer.backends import cuda
 from chainer import functions
 from chainer import testing
 from chainer import utils
@@ -81,6 +82,24 @@ class TestMeanAbsoluteErrorTypeCheck(unittest.TestCase):
             numpy.random.uniform(-1, 1, (4, 3)).astype(numpy.float16))
         with self.assertRaises(type_check.InvalidType):
             functions.mean_absolute_error(x0, x1)
+
+
+# See chainer#6702.
+class TestMeanAbsoluteErrorFP16Overflow(unittest.TestCase):
+
+    def check_fp16_overflow(self, xp):
+        x0 = chainer.Variable(xp.full(
+            shape=(64,1,16,16), fill_value=2, dtype=xp.float16))
+        x1 = chainer.Variable(xp.full(
+            shape=(64,1,16,16), fill_value=-2, dtype=xp.float16))
+        loss = functions.mean_absolute_error(x0, x1)
+        self.assertFalse(xp.isinf(loss.array))
+
+    def test_fp16_overflow_cpu(self):
+        self.check_fp16_overflow(numpy)
+
+    def test_fp16_overflow_gpu(self):
+        self.check_fp16_overflow(cuda.cupy)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Close #6702.

This PR fixes `F.mean_absolute_error` to use an intermediate dtype for FP16 inputs. `numpy.mean` is not used because old numpy does not use extra precision for FP16.

https://docs.scipy.org/doc/numpy-1.9.2/reference/generated/numpy.mean.html
https://docs.scipy.org/doc/numpy-1.16.1/reference/generated/numpy.mean.html
