### PR TITLE
[chainerx][tests] fix skipped_backward tests to return as PASS

### DIFF
--- a/tests/chainerx_tests/op_utils.py
+++ b/tests/chainerx_tests/op_utils.py
@@ -99,7 +99,7 @@ class OpTest(chainer.testing.function_link.FunctionTestBase):
         if self.skip_double_backward_test:
             return
 
-        super(OpTest, self).run_test_backward(backend_config)
+        super(OpTest, self).run_test_double_backward(backend_config)
 
 
 class ChainerOpTest(OpTest):

--- a/tests/chainerx_tests/op_utils.py
+++ b/tests/chainerx_tests/op_utils.py
@@ -85,7 +85,7 @@ class OpTest(chainer.testing.function_link.FunctionTestBase):
         if self.skip_forward_test:
             raise unittest.SkipTest('skip_forward_test is set')
 
-        super(OpTest, self).run_test_forward
+        super(OpTest, self).run_test_forward(backend_config)
 
     def run_test_backward(self, backend_config):
         # Skipping Backward -> Test PASS

--- a/tests/chainerx_tests/op_utils.py
+++ b/tests/chainerx_tests/op_utils.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+import unittest
 
 import numpy
 import pytest
@@ -78,6 +79,27 @@ class OpTest(chainer.testing.function_link.FunctionTestBase):
     def forward_chainerx(self, inputs):
         raise NotImplementedError(
             'Op test implementation must override `forward_chainerx`.')
+
+    def run_test_forward(self, backend_config):
+        # Skipping Forward -> Test Skipped
+        if self.skip_forward_test:
+            raise unittest.SkipTest('skip_forward_test is set')
+
+        super(OpTest, self).run_test_forward
+
+    def run_test_backward(self, backend_config):
+        # Skipping Backward -> Test PASS
+        if self.skip_backward_test:
+            return
+
+        super(OpTest, self).run_test_backward(backend_config)
+
+    def run_test_double_backward(self, backend_config):
+        # Skipping Double Backward -> Test PASS
+        if self.skip_double_backward_test:
+            return
+
+        super(OpTest, self).run_test_backward(backend_config)
 
 
 class ChainerOpTest(OpTest):


### PR DESCRIPTION
If `skip_backward/skip_double_back` is False, the test
is marked as skipped, even when the Forward is checked
and passes successfully. This change will make sure that,
even these tests are marked as PASS by Pytest.

I have a feeling that I saw an issue regarding the same.
But I am unable to find it. Would put a reference to it if
I am able to do so.
