### PR TITLE
Remove `chainerx.square` fallback since it is implemented in C++

### DIFF
--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -37,7 +37,6 @@ if _available:
     from chainerx.manipulation.shape import ravel  # NOQA
 
     from chainerx.math.misc import clip  # NOQA
-    from chainerx.math.misc import square  # NOQA
 
     from chainerx import random  # NOQA
 

--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -979,6 +979,25 @@ Note:
 """)
 
     _docs.set_doc(
+        chainerx.square,
+        """square(x)
+Returns the element-wise square of the input.
+
+Args:
+    x (~chainerx.ndarray or scalar): Input data
+
+Returns:
+    ~chainerx.ndarray: Returned array: :math:`y = x * x`.
+    A scalar is returned if ``x`` is a scalar.
+
+Note:
+    During backpropagation, this function propagates the gradient
+    of the output array to the input array ``x``.
+
+.. seealso:: :data:`numpy.square`
+""")
+
+    _docs.set_doc(
         chainerx.sqrt,
         """sqrt(x)
 Non-negative square-root, element-wise

--- a/chainerx/math/misc.py
+++ b/chainerx/math/misc.py
@@ -2,27 +2,6 @@ import chainerx
 
 
 # TODO(sonots): Implement in C++
-def square(x):
-    """Returns the element-wise square of the input.
-
-    Args:
-        x (~chainerx.ndarray or scalar): Input data
-
-    Returns:
-        ~chainerx.ndarray: Returned array: :math:`y = x * x`.
-        A scalar is returned if ``x`` is a scalar.
-
-    Note:
-        During backpropagation, this function propagates the gradient
-        of the output array to the input array ``x``.
-
-    .. seealso:: :data:`numpy.square`
-
-    """
-    return x * x
-
-
-# TODO(sonots): Implement in C++
 def clip(a, a_min, a_max):
     """Clips the values of an array to a given interval.
 


### PR DESCRIPTION
`chainerx.square` was implemented in C++ in https://github.com/chainer/chainer/pull/6486 in but the fallback Python implementation was hiding it. This PR removes the fallback. Verified the C++ implementation at least locally using existing tests and it seemed fine.