### PR TITLE
Make `BatchNorm` states public

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device.h
+++ b/chainerx_cc/chainerx/cuda/cuda_device.h
@@ -20,6 +20,8 @@
 #include "chainerx/cuda/cudnn.h"
 #include "chainerx/cuda/memory_pool.h"
 #include "chainerx/device.h"
+#include "chainerx/dtype.h"
+#include "chainerx/routines/normalization.h"
 #include "chainerx/routines/pooling.h"
 #include "chainerx/scalar.h"
 #include "chainerx/stack_vector.h"
@@ -80,6 +82,23 @@ private:
 DeviceInternals& GetDeviceInternals(CudaDevice& device);
 
 }  // namespace cuda_internal
+
+struct CudaBatchNormGradState : public BatchNormGradState {
+public:
+    CudaBatchNormGradState(Array x_cont, Array x_mean, Array x_inv_std, Dtype beta_dtype)
+        : x_cont_{std::move(x_cont)}, x_mean_{std::move(x_mean)}, x_inv_std_{std::move(x_inv_std)}, beta_dtype_{beta_dtype} {}
+
+    const Array& x_cont() const { return x_cont_; }
+    const Array& x_mean() const { return x_mean_; }
+    const Array& x_inv_std() const { return x_inv_std_; }
+    Dtype beta_dtype() const { return beta_dtype_; }
+
+private:
+    Array x_cont_;
+    Array x_mean_;
+    Array x_inv_std_;
+    Dtype beta_dtype_;
+};
 
 class CudaDevice : public Device {
 public:

--- a/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
@@ -12,7 +12,6 @@
 #include "chainerx/array.h"
 #include "chainerx/axes.h"
 #include "chainerx/backend_util.h"
-#include "chainerx/cuda/cuda_device.h"
 #include "chainerx/cuda/cuda_set_device_scope.h"
 #include "chainerx/cuda/cudnn.h"
 #include "chainerx/cuda/op_regist.h"

--- a/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
@@ -12,6 +12,7 @@
 #include "chainerx/array.h"
 #include "chainerx/axes.h"
 #include "chainerx/backend_util.h"
+#include "chainerx/cuda/cuda_device.h"
 #include "chainerx/cuda/cuda_set_device_scope.h"
 #include "chainerx/cuda/cudnn.h"
 #include "chainerx/cuda/op_regist.h"
@@ -69,23 +70,6 @@ cuda_internal::CudnnTensorDescriptor DeriveBatchNormTensorDescriptor(
     CheckCudnnError(cudnnDeriveBNTensorDescriptor(*derive_desc, *x_desc, mode));
     return derive_desc;
 }
-
-struct CudaBatchNormGradState : public BatchNormGradState {
-public:
-    CudaBatchNormGradState(Array x_cont, Array x_mean, Array x_inv_std, Dtype beta_dtype)
-        : x_cont_{std::move(x_cont)}, x_mean_{std::move(x_mean)}, x_inv_std_{std::move(x_inv_std)}, beta_dtype_{beta_dtype} {}
-
-    const Array& x_cont() const { return x_cont_; }
-    const Array& x_mean() const { return x_mean_; }
-    const Array& x_inv_std() const { return x_inv_std_; }
-    Dtype beta_dtype() const { return beta_dtype_; }
-
-private:
-    Array x_cont_;
-    Array x_mean_;
-    Array x_inv_std_;
-    Dtype beta_dtype_;
-};
 
 class CudaBatchNormOp : public BatchNormOp {
 public:

--- a/chainerx_cc/chainerx/routines/normalization.cc
+++ b/chainerx_cc/chainerx/routines/normalization.cc
@@ -108,21 +108,6 @@ Array ArrayOrZeros(const nonstd::optional<Array>& array, const Array& zeros_temp
     return Zeros(zeros_template.shape(), dtype, zeros_template.device());
 }
 
-class GenericBatchNormGradState : public BatchNormGradState {
-public:
-    GenericBatchNormGradState(Array x_mean, Array x_inv_std, Dtype beta_dtype)
-        : x_mean_{std::move(x_mean)}, x_inv_std_{std::move(x_inv_std)}, beta_dtype_{beta_dtype} {}
-
-    const Array& x_mean() const { return x_mean_; }
-    const Array& x_inv_std() const { return x_inv_std_; }
-    Dtype beta_dtype() const { return beta_dtype_; }
-
-private:
-    Array x_mean_;
-    Array x_inv_std_;
-    Dtype beta_dtype_;
-};
-
 std::tuple<Array, std::unique_ptr<BatchNormGradState>> ApplyGenericBatchNorm(
         const Array& x,
         const Array& gamma,

--- a/chainerx_cc/chainerx/routines/normalization.h
+++ b/chainerx_cc/chainerx/routines/normalization.h
@@ -2,12 +2,14 @@
 
 #include <memory>
 #include <tuple>
+#include <utility>
 
 #include <nonstd/optional.hpp>
 
 #include "chainerx/array.h"
 #include "chainerx/axes.h"
 #include "chainerx/constant.h"
+#include "chainerx/dtype.h"
 #include "chainerx/op.h"
 #include "chainerx/scalar.h"
 #include "chainerx/stack_vector.h"
@@ -55,6 +57,21 @@ public:
             const nonstd::optional<Array>& gx,
             const nonstd::optional<Array>& ggamma,
             const nonstd::optional<Array>& gbeta) = 0;
+};
+
+class GenericBatchNormGradState : public BatchNormGradState {
+public:
+    GenericBatchNormGradState(Array x_mean, Array x_inv_std, Dtype beta_dtype)
+        : x_mean_{std::move(x_mean)}, x_inv_std_{std::move(x_inv_std)}, beta_dtype_{beta_dtype} {}
+
+    const Array& x_mean() const { return x_mean_; }
+    const Array& x_inv_std() const { return x_inv_std_; }
+    Dtype beta_dtype() const { return beta_dtype_; }
+
+private:
+    Array x_mean_;
+    Array x_inv_std_;
+    Dtype beta_dtype_;
 };
 
 class GenericBatchNormOp : public BatchNormOp {


### PR DESCRIPTION
If a user wants to call a device op without going through the routines, the concrete state classes for each backend must be public. This PR addresses this issue for BN.

_See also https://github.com/chainer/chainer/pull/6800#issuecomment-482001492_