### PR TITLE
Support device specifiers in MNIST data parallel example

### DIFF
--- a/examples/mnist/train_mnist_data_parallel.py
+++ b/examples/mnist/train_mnist_data_parallel.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 import argparse
+import sys
 
 import chainer
 import chainer.links as L
 from chainer import training
 from chainer.training import extensions
+import chainerx
 
 import train_mnist
 
@@ -18,25 +20,45 @@ def main():
                         help='Number of images in each mini-batch')
     parser.add_argument('--epoch', '-e', type=int, default=20,
                         help='Number of sweeps over the dataset to train')
-    parser.add_argument('--gpu0', '-g', type=int, default=0,
-                        help='First GPU ID')
-    parser.add_argument('--gpu1', '-G', type=int, default=1,
-                        help='Second GPU ID')
     parser.add_argument('--out', '-o', default='result_data_parallel',
                         help='Directory to output the result')
     parser.add_argument('--resume', '-r', default='',
                         help='Resume the training from snapshot')
     parser.add_argument('--unit', '-u', type=int, default=1000,
                         help='Number of units')
+    parser.add_argument('--device0', '-d', type=str, default='0',
+                        help='Device specifier of the first device.'
+                        'Either ChainerX device '
+                        'specifier or an integer. If non-negative integer, '
+                        'CuPy arrays with specified device id are used. If '
+                        'negative integer, NumPy arrays are used')
+    parser.add_argument('--device1', '-D', type=str, default='1',
+                        help='Device specifier of the second device. '
+                        'Either ChainerX device '
+                        'specifier or an integer. If non-negative integer, '
+                        'CuPy arrays with specified device id are used. If '
+                        'negative integer, NumPy arrays are used')
+    group = parser.add_argument_group('deprecated arguments')
+    group.add_argument('--gpu0', '-g', dest='device0', type=int, nargs='?',
+                       const=0,
+                       help='First GPU ID')
+    group.add_argument('--gpu1', '-G', dest='device1', type=int, nargs='?',
+                       const=1,
+                       help='Second GPU ID')
     args = parser.parse_args()
+    device0 = chainer.get_device(args.device0)
+    device1 = chainer.get_device(args.device1)
+    if device0.xp is chainerx or device1.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
-    print('GPU: {}, {}'.format(args.gpu0, args.gpu1))
+    print('Devices: {}, {}'.format(device0, device1))
     print('# unit: {}'.format(args.unit))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
 
-    chainer.backends.cuda.get_device_from_id(args.gpu0).use()
+    device0.use()
 
     model = L.Classifier(train_mnist.MLP(args.unit, 10))
     optimizer = chainer.optimizers.Adam()
@@ -48,18 +70,18 @@ def main():
                                                  repeat=False, shuffle=False)
 
     # ParallelUpdater implements the data-parallel gradient computation on
-    # multiple GPUs. It accepts "devices" argument that specifies which GPU to
-    # use.
+    # multiple devices. It accepts "devices" argument that specifies which
+    # device to use.
     updater = training.updaters.ParallelUpdater(
         train_iter,
         optimizer,
         # The device of the name 'main' is used as a "master", while others are
         # used as slaves. Names other than 'main' are arbitrary.
-        devices={'main': args.gpu0, 'second': args.gpu1},
+        devices={'main': device0, 'second': device1},
     )
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
 
-    trainer.extend(extensions.Evaluator(test_iter, model, device=args.gpu0))
+    trainer.extend(extensions.Evaluator(test_iter, model, device=device0))
     trainer.extend(extensions.DumpGraph('main/loss'))
     trainer.extend(extensions.snapshot(), trigger=(args.epoch, 'epoch'))
     trainer.extend(extensions.LogReport())


### PR DESCRIPTION
~Part of #6661~


~TODO: Needs `Variable.addgrad` support for ChainerX~

Some more internal fixes are needed to support ChainerX.