### PR TITLE
Use search index

### DIFF
--- a/docs/source/_templates/search.html
+++ b/docs/source/_templates/search.html
@@ -1,0 +1,16 @@
+{% extends "sphinx_rtd_theme/search.html" %}
+
+{% block footer %}
+
+{{ super() }}
+
+<script type="text/javascript">
+  jQuery(function() {
+    if ("undefined" != typeof Search && Search.query_fallback) {
+      console.log("Overriding search feature of ReadTheDocs");
+      Search.query = Search.query_fallback;
+    }
+  });
+</script>
+
+{% endblock %}


### PR DESCRIPTION
Closes #6876.

It seems [Elasticsearch index](https://docs.readthedocs.io/en/stable/development/search.html) generated by RTD is broken.
Added workaround to use Sphinx search by default.

* before: https://kmaehashi-chainer.readthedocs.io/en/latest/search.html?q=PlotReport&check_keywords=yes&area=default
* after: https://kmaehashi-chainer.readthedocs.io/en/use-search-index/search.html?q=PlotReport&check_keywords=yes&area=default