### PR TITLE
Make `InvalidType` picklable

### DIFF
--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -503,6 +503,10 @@ Invalid operation is performed in: {0} (Forward)
         self.expect = expect
         self.actual = actual
 
+    def __reduce__(self):
+        msg, = self.args
+        return (InvalidType, (self.expect, self.actual, msg))
+
 
 def _argname(in_types, names):
     """Assigns user friendly names for the input types.

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 import unittest
 import warnings
@@ -395,5 +396,13 @@ class TestSameTypes(unittest.TestCase):
         z = cuda.cupy.array([2])
         self.assertFalse(T.same_types(x, y, z))
 
+
+class TestInvalidType(unittest.TestCase):
+    def test_pickle(self):
+        exc = T.InvalidType('foo', 'bar')
+        new = pickle.loads(pickle.dumps(exc))
+        self.assertEqual(exc.args, new.args)
+        self.assertEqual(exc.expect, new.expect)
+        self.assertEqual(exc.actual, new.actual)
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -405,4 +405,5 @@ class TestInvalidType(unittest.TestCase):
         self.assertEqual(exc.expect, new.expect)
         self.assertEqual(exc.actual, new.actual)
 
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -399,7 +399,7 @@ class TestSameTypes(unittest.TestCase):
 
 class TestInvalidType(unittest.TestCase):
     def test_pickle(self):
-        exc = T.InvalidType('foo', 'bar')
+        exc = T.InvalidType('foo', 'bar', 'baz')
         new = pickle.loads(pickle.dumps(exc))
         self.assertEqual(exc.args, new.args)
         self.assertEqual(exc.expect, new.expect)


### PR DESCRIPTION
The following error is often occurred while using multiprocessing, then hide details of InvalidType exception.
This PR fixes this problem.

```pycon
>>> from chainer.utils.type_check import InvalidType
>>> import pickle
>>> pickle.loads(pickle.dumps(InvalidType('foo', 'bar')))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() missing 1 required positional argument: 'actual'
```