### PR TITLE
[backport] Make git ignore `chainerx/libchainerx.dylib`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyo
 *.cpp
 *.so
+*.dylib
 build
 \#*\#
 .\#*


### PR DESCRIPTION
Backport of #6666