### PR TITLE
Simplify `F.repeat` test

### DIFF
--- a/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_repeat.py
@@ -2,13 +2,35 @@ import unittest
 
 import numpy
 
-from chainer import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
-from chainer.testing import attr
 
 
+def repeat(arr, repeats, axis=None):
+    # Workaround NumPy 1.9 issue.
+    if isinstance(repeats, tuple) and len(repeats) == 1:
+        repeats = repeats[0]
+    return numpy.repeat(arr, repeats, axis)
+
+
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ]
+)
 @testing.parameterize(*testing.product({
     # repeats is any of (int, bool or tuple) and
     # axis is any of (int or None).
@@ -46,74 +68,33 @@ from chainer.testing import attr
     ),
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestRepeat(unittest.TestCase):
+class TestRepeat(testing.FunctionTestCase):
 
     def setUp(self):
         self.in_shape = self.params['shape']
         self.repeats = self.params['repeats']
         self.axis = self.params['axis']
-        self.x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
-        out_shape = self._repeat(self.x, self.repeats, self.axis).shape
-        self.gy = numpy.random.uniform(-1, 1, out_shape).astype(self.dtype)
-        self.ggx = numpy.random.uniform(-1, 1, self.in_shape) \
-            .astype(self.dtype)
 
         self.check_forward_options = {}
-        self.check_backward_options = {'dtype': numpy.float64}
+        self.check_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+                'atol': 2 ** -4, 'rtol': 2 ** -4}
 
-    @classmethod
-    def _repeat(cls, arr, repeats, axis=None):
-        # Workaround NumPy 1.9 issue.
-        if isinstance(repeats, tuple) and len(repeats) == 1:
-            repeats = repeats[0]
-        return numpy.repeat(arr, repeats, axis)
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
+        return x,
 
-    def check_forward(self, x_data):
-        y = functions.repeat(x_data, self.repeats, self.axis)
-        y_expected = self._repeat(self.x, self.repeats, self.axis)
-        self.assertEqual(y.dtype, y_expected.dtype)
-        testing.assert_allclose(
-            y.data, y_expected, **self.check_forward_options)
+    def forward_expected(self, inputs):
+        x, = inputs
+        y_expected = repeat(x, self.repeats, self.axis)
+        return y_expected,
 
-    def test_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    def check_backward(self, x_data, y_grad):
-        def f(x):
-            return functions.repeat(x, self.repeats, self.axis)
-
-        gradient_check.check_backward(
-            f, x_data, y_grad, **self.check_backward_options)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        def f(x):
-            return functions.repeat(x, self.repeats, self.axis)
-
-        gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, **self.check_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.gy, self.ggx)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy),
-                                   cuda.to_gpu(self.ggx))
+    def forward(self, inputs, device):
+        x, = inputs
+        y = functions.repeat(x, self.repeats, self.axis)
+        return y,
 
 
 @testing.parameterize(*testing.product({


### PR DESCRIPTION
Simplifies `test_repeat` using `testing.FunctionTestCase`

Solves part of issue #6071 