### PR TITLE
Simplify `F.sign` test

### DIFF
--- a/chainer/testing/function_link.py
+++ b/chainer/testing/function_link.py
@@ -1134,7 +1134,8 @@ def _check_variable_types(vars, device, func_name, test_error_cls):
             '{}() must return a tuple of Variables of arrays supported by '
             'device {}.\n'
             'Actual: {}'.format(
-                func_name, device, ', '.join(type(a.array) for a in vars)))
+                func_name, device,
+                ', '.join(str(type(a.array)) for a in vars)))
 
 
 def _check_arrays_equal(

--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -140,6 +140,7 @@ def _populate_module_functions():
         xp, dev, arr = _from_chx(arr)
         with dev:
             ret = xp.sign(arr)
+            ret = xp.asarray(ret)
         return _to_chx(ret)
 
     chainerx.sign = _sign

--- a/tests/chainer_tests/functions_tests/math_tests/test_sign.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_sign.py
@@ -1,76 +1,57 @@
-import unittest
-
 import numpy
 
-import chainer
-from chainer.backends import cuda
-import chainer.functions as F
-from chainer import gradient_check
+from chainer import functions
 from chainer import testing
-from chainer.testing import attr
+from chainer import utils
 
 
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestSign(unittest.TestCase):
+@testing.fix_random()
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestSign(testing.FunctionTestCase):
+
+    skip_backward_test = True
+    skip_double_backward_test = True
 
     def setUp(self):
-        self.x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggx = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        self.check_forward_options.update({'atol': 1e-7, 'rtol': 1e-7})
+
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
 
         # Avoid non-differentiable point
-        self.x[(abs(self.x) < 1e-2)] = 1
+        x[(abs(x) < 1e-2)] = 1
+        return x,
 
-    def check_forward(self, x_data, xp):
-        x = chainer.Variable(x_data)
-        y = F.sign(x)
-        v = xp.sign(x_data)
+    def forward(self, inputs, device):
+        x, = inputs
+        y = functions.sign(x)
+        return y,
 
-        assert x.data.dtype == y.data.dtype
-        testing.assert_allclose(v, y.data, atol=1e-7, rtol=1e-7)
-
-    def test_forward_cpu(self):
-        self.check_forward(self.x, numpy)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x), cuda.cupy)
-
-    def check_forward_ndarray(self, x_data, xp):
-        y = F.sign(x_data)
-        v = xp.sign(x_data)
-
-        assert x_data.dtype == y.data.dtype
-        assert x_data.dtype == v.dtype
-        assert isinstance(y, chainer.Variable)
-        testing.assert_allclose(v, y.data, atol=1e-7, rtol=1e-7)
-
-    def test_forward_ndarray_cpu(self):
-        self.check_forward_ndarray(self.x, numpy)
-
-    @attr.gpu
-    def test_forward_ndarray_gpu(self):
-        self.check_forward_ndarray(cuda.to_gpu(self.x), cuda.cupy)
-
-    def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(
-            F.sign, x_data, y_grad)
-
-        # Explicitly check that gradients are `None`
-        x = chainer.Variable(x_data)
-        F.sign(x).backward()
-        assert x.grad is None
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+    def forward_expected(self, inputs):
+        x, = inputs
+        expected = numpy.sign(x)
+        expected = utils.force_array(expected)
+        return expected,
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Simplifies test_sign using testing.FunctionTestCase
Refer to [#6071](https://github.com/chainer/chainer/issues/6071) 