### PR TITLE
Rename the macro name for `AMinOp`

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/reduction.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/reduction.cu
@@ -146,7 +146,7 @@ public:
     }
 };
 
-CHAINERX_REGISTER_OP_CUDA(AMinOp, CudaAMinOp);
+CHAINERX_CUDA_REGISTER_OP(AMinOp, CudaAMinOp);
 
 }  // namespace
 }  // namespace cuda

--- a/chainerx_cc/chainerx/native/native_device/reduction.cc
+++ b/chainerx_cc/chainerx/native/native_device/reduction.cc
@@ -123,7 +123,7 @@ public:
     }
 };
 
-CHAINERX_REGISTER_OP_NATIVE(AMinOp, NativeAMinOp);
+CHAINERX_NATIVE_REGISTER_OP(AMinOp, NativeAMinOp);
 
 }  // namespace
 }  // namespace native


### PR DESCRIPTION
The macro `CHAINERX_REGISTER_OP_{NATIVE, CUDA}` was renamed to `CHAINERX_{NATIVE, CUDA}_REGISTER_OP` in #6865 but it is not applied to #6752. This PR fixes it.

Fixes #6923.