### PR TITLE
Increase the default columns in Travis CI

### DIFF
--- a/scripts/ci/travis/run-tests.sh
+++ b/scripts/ci/travis/run-tests.sh
@@ -36,6 +36,9 @@ export REPO_DIR
 export WORK_DIR
 export CHAINER_BASH_ENV
 
+# Increase the default columns for better browsability
+export COLUMNS=120
+
 
 run_prestep() {
     # Failure immediately stops the script.


### PR DESCRIPTION
In Travis CI, pytest renders the progress of the tests in 80 columns.
This requires quite a bit of scroll to reach the end of outputs.

Merge #6949 first.