### PR TITLE
Remove `-v` option from Travis CI ChainerMN tests

### DIFF
--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -155,7 +155,7 @@ step_chainerx_python_tests() {
 step_chainermn_tests() {
     for NP in 1 2; do
         OMP_NUM_THREADS=1 \
-            mpiexec -n ${NP} pytest -s -v -m 'not gpu and not slow' "$REPO_DIR"/tests/chainermn_tests
+            mpiexec -n ${NP} pytest -s -m 'not gpu and not slow' "$REPO_DIR"/tests/chainermn_tests
     done
 }
 


### PR DESCRIPTION
The same motivation as #6948

With `-v` option, each test item name is printed in a separate line.
Without it, the progress is rendered with a file name and dots (`.`) in each line.
