### PR TITLE
Simplify 'F.exp', 'F.log' test

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_exponential.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_exponential.py
@@ -1,23 +1,35 @@
-import unittest
-
 import numpy
 
-import chainer
-from chainer.backends import cuda
-import chainer.functions as F
-from chainer import gradient_check
+from chainer import functions
 from chainer import testing
-from chainer.testing import attr
-import chainerx
+from chainer import utils
 
 
-class UnaryFunctionsTestBase(unittest.TestCase):
-
-    def make_data(self):
-        raise NotImplementedError
+@testing.parameterize(*testing.product({
+    'shape': [(3, 2), ()],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+@testing.fix_random()
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestExp(testing.FunctionTestCase):
 
     def setUp(self):
-        self.x, self.gy = self.make_data()
         self.check_forward_options = {'atol': 1e-7, 'rtol': 1e-7}
         if self.dtype == numpy.float16:
             self.check_backward_options = {'atol': 3e-3, 'rtol': 1e-2}
@@ -26,227 +38,70 @@ class UnaryFunctionsTestBase(unittest.TestCase):
             self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
             self.check_double_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
 
-    def check_forward(self, op, op_np, x_data):
-        x = chainer.Variable(x_data)
-        y = op(x)
-        self.assertEqual(x.data.dtype, y.data.dtype)
-        testing.assert_allclose(
-            op_np(self.x), y.data, **self.check_forward_options)
-
-    def check_forward_cpu(self, op, op_np):
-        self.check_forward(op, op_np, self.x)
-
-    def check_forward_gpu(self, op, op_np):
-        self.check_forward(op, op_np, cuda.to_gpu(self.x))
-
-    def check_forward_chainerx(self, op, op_np):
-        self.check_forward(op, op_np, chainerx.array(self.x))
-
-    def check_backward(self, op, x_data, y_grad):
-        gradient_check.check_backward(
-            op, x_data, y_grad, dtype=numpy.float64,
-            **self.check_backward_options)
-
-    def check_backward_cpu(self, op):
-        self.check_backward(op, self.x, self.gy)
-
-    def check_backward_gpu(self, op):
-        self.check_backward(op, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_backward_chainerx(self, op):
-        self.check_backward(
-            op, chainerx.array(self.x), chainerx.array(self.gy))
-
-    def check_double_backward(self, op, x_data, y_grad, y_grad_grad):
-        gradient_check.check_double_backward(
-            op, x_data, y_grad, y_grad_grad, dtype=numpy.float64,
-            **self.check_double_backward_options)
-
-    def check_double_backward_cpu(self, op):
-        self.check_double_backward(op, self.x, self.gy, self.ggy)
-
-    def check_double_backward_gpu(self, op):
-        self.check_double_backward(op, cuda.to_gpu(
-            self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggy))
-
-    def check_double_backward_chainerx(self, op):
-        self.check_double_backward(op, chainerx.array(
-            self.x), chainerx.array(self.gy), chainerx.array(self.ggy))
-
-    def check_label(self, op, expected):
-        self.assertEqual(op().label, expected)
-
-
-@testing.parameterize(*testing.product({
-    'shape': [(3, 2), ()],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
-class TestExp(UnaryFunctionsTestBase):
-
-    def make_data(self):
+    def generate_inputs(self):
         x = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        return x, gy
+        return x,
 
-    def test_forward_cpu(self):
-        self.check_forward_cpu(F.exp, numpy.exp)
+    def forward(self, inputs, device):
+        x, = inputs
+        return functions.exp(x),
 
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward_gpu(F.exp, numpy.exp)
-
-    @attr.chainerx
-    def test_forward_chainerx(self):
-        self.check_forward_chainerx(F.exp, numpy.exp)
-
-    def test_backward_cpu(self):
-        self.check_backward_cpu(F.exp)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward_gpu(F.exp)
-
-    @attr.chainerx
-    def test_backward_chainerx(self):
-        self.check_backward_chainerx(F.exp)
-
-    def test_label(self):
-        self.check_label(chainer.functions.math.exponential.Exp, 'exp')
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward_cpu(F.exp)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward_gpu(F.exp)
-
-    @attr.chainerx
-    def test_double_backward_chainerx(self):
-        self.check_double_backward_chainerx(F.exp)
+    def forward_expected(self, inputs):
+        x, = inputs
+        expected = numpy.exp(x)
+        expected = utils.force_array(expected)
+        return expected,
 
 
 @testing.parameterize(*testing.product({
     'shape': [(3, 2), ()],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'function_name': ['log', 'log2', 'log10'],
 }))
-class TestLog(UnaryFunctionsTestBase):
+@testing.fix_random()
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class TestLog(testing.FunctionTestCase):
 
-    def make_data(self):
+    def setUp(self):
+        self.check_forward_options = {'atol': 1e-7, 'rtol': 1e-7}
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {'atol': 3e-3, 'rtol': 1e-2}
+            self.check_double_backward_options = {'atol': 3e-3, 'rtol': 1e-2}
+        else:
+            self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+            self.check_double_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+
+    def generate_inputs(self):
         x = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        return x, gy
+        return x,
 
-    def test_forward_cpu(self):
-        self.check_forward_cpu(F.log, numpy.log)
+    def forward(self, inputs, device):
+        x, = inputs
+        function = getattr(functions, self.function_name)
+        return function(x),
 
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward_gpu(F.log, numpy.log)
-
-    @attr.chainerx
-    def test_forward_chainerx(self):
-        self.check_forward_chainerx(F.log, numpy.log)
-
-    def test_backward_cpu(self):
-        self.check_backward_cpu(F.log)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward_gpu(F.log)
-
-    @attr.chainerx
-    def test_backward_chainerx(self):
-        self.check_backward_chainerx(F.log)
-
-    def test_label(self):
-        self.check_label(chainer.functions.math.exponential.Log, 'log')
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward_cpu(F.log)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward_gpu(F.log)
-
-    @attr.chainerx
-    def test_double_backward_chainerx(self):
-        self.check_double_backward_chainerx(F.log)
-
-
-@testing.parameterize(*testing.product({
-    'shape': [(3, 2), ()],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
-class TestLog2(UnaryFunctionsTestBase):
-
-    def make_data(self):
-        x = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        return x, gy
-
-    def test_forward_cpu(self):
-        self.check_forward_cpu(F.log2, numpy.log2)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward_gpu(F.log2, numpy.log2)
-
-    def test_backward_cpu(self):
-        self.check_backward_cpu(F.log2)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward_gpu(F.log2)
-
-    def test_label(self):
-        self.check_label(chainer.functions.math.exponential.Log2, 'log2')
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward_cpu(F.log2)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward_gpu(F.log2)
-
-
-@testing.parameterize(*testing.product({
-    'shape': [(3, 2), ()],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
-class TestLog10(UnaryFunctionsTestBase):
-
-    def make_data(self):
-        x = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
-        gy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        self.ggy = numpy.random.uniform(-1, 1, self.shape).astype(self.dtype)
-        return x, gy
-
-    def test_forward_cpu(self):
-        self.check_forward_cpu(F.log10, numpy.log10)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        self.check_forward_gpu(F.log10, numpy.log10)
-
-    def test_backward_cpu(self):
-        self.check_backward_cpu(F.log10)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.check_backward_gpu(F.log10)
-
-    def test_label(self):
-        self.check_label(chainer.functions.math.exponential.Log10, 'log10')
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward_cpu(F.log2)
-
-    @attr.gpu
-    def test_double_backward_gpu(self):
-        self.check_double_backward_gpu(F.log2)
+    def forward_expected(self, inputs):
+        x, = inputs
+        function = getattr(numpy, self.function_name)
+        expected = function(x)
+        expected = utils.force_array(expected)
+        return expected,
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Simplifies test_exponential using testing.FunctionTestCase
Refer to [#6071](https://github.com/chainer/chainer/issues/6071) 