### PR TITLE
Simplify `F.expm1` test

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_exponential_m1.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_exponential_m1.py
@@ -1,70 +1,53 @@
-import unittest
-
 import numpy
 
-import chainer
-from chainer.backends import cuda
-import chainer.functions as F
-from chainer import gradient_check
+from chainer import functions
 from chainer import testing
-from chainer.testing import attr
+from chainer import utils
 
 
 @testing.parameterize(*testing.product({
+    'dtype': [numpy.float32],
     'shape': [(), (3, 2)],
 }))
-class Expm1FunctionTest(unittest.TestCase):
+@testing.fix_random()
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class Expm1FunctionTest(testing.FunctionTestCase):
 
     def setUp(self):
-        self.x = numpy.random.uniform(.5, 1, self.shape).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
-        self.ggx = \
-            numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+        self.check_backward_options.update(
+            {'atol': 1e-3, 'rtol': 1e-2})
+        self.check_double_backward_options.update(
+            {'atol': 1e-3, 'rtol': 1e-2})
 
-        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
-        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-2}
+    def generate_inputs(self):
+        x = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
+        return x,
 
-    def check_forward(self, x_data):
-        x = chainer.Variable(x_data)
-        y = F.expm1(x)
-        testing.assert_allclose(
-            numpy.expm1(self.x), y.data, atol=1e-7, rtol=1e-7)
+    def forward(self, inputs, device):
+        x, = inputs
+        return functions.expm1(x),
 
-    def test_expm1_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_expm1_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(
-            F.expm1, x_data, y_grad,
-            **self.check_backward_options)
-
-    def test_expm1_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_expm1_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        gradient_check.check_double_backward(
-            F.expm1, x_data, y_grad, x_grad_grad,
-            **self.check_double_backward_options)
-
-    def test_expm1_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.gy, self.ggx)
-
-    @attr.gpu
-    def test_expm1_double_backward_gpu(self):
-        self.check_double_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
-
-    def test_expm1(self):
-        self.assertEqual(
-            chainer.functions.math.exponential_m1.Expm1().label, 'expm1')
+    def forward_expected(self, inputs):
+        x, = inputs
+        expected = numpy.expm1(x)
+        expected = utils.force_array(expected)
+        return expected,
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Simplifies test_exponential_m1 using testing.FunctionTestCase
Refer to [#6071](https://github.com/chainer/chainer/issues/6071) 