### PR TITLE
Fix cuDNN descriptor double destroy

### DIFF
--- a/chainerx_cc/chainerx/cuda/cudnn.cc
+++ b/chainerx_cc/chainerx/cuda/cudnn.cc
@@ -1,7 +1,5 @@
 #include "chainerx/cuda/cudnn.h"
 
-#include <utility>
-
 #include <cudnn.h>
 #include <nonstd/optional.hpp>
 
@@ -97,11 +95,6 @@ CudnnTensorDescriptor::~CudnnTensorDescriptor() {
         cudnnDestroyTensorDescriptor(desc_);
     }
 }
-
-CudnnTensorDescriptor::CudnnTensorDescriptor(CudnnTensorDescriptor&& other) {
-    std::swap(desc_, other.desc_);
-    other.desc_ = nullptr;
-};
 
 CudnnTensorDescriptor::CudnnTensorDescriptor(const Array& arr) : CudnnTensorDescriptor{} {
     CHAINERX_ASSERT(arr.IsContiguous());

--- a/chainerx_cc/chainerx/cuda/cudnn.cc
+++ b/chainerx_cc/chainerx/cuda/cudnn.cc
@@ -1,5 +1,7 @@
 #include "chainerx/cuda/cudnn.h"
 
+#include <utility>
+
 #include <cudnn.h>
 #include <nonstd/optional.hpp>
 
@@ -95,6 +97,11 @@ CudnnTensorDescriptor::~CudnnTensorDescriptor() {
         cudnnDestroyTensorDescriptor(desc_);
     }
 }
+
+CudnnTensorDescriptor::CudnnTensorDescriptor(CudnnTensorDescriptor&& other) {
+    std::swap(desc_, other.desc_);
+    other.desc_ = nullptr;
+};
 
 CudnnTensorDescriptor::CudnnTensorDescriptor(const Array& arr) : CudnnTensorDescriptor{} {
     CHAINERX_ASSERT(arr.IsContiguous());

--- a/chainerx_cc/chainerx/cuda/cudnn.h
+++ b/chainerx_cc/chainerx/cuda/cudnn.h
@@ -51,7 +51,13 @@ class CudnnTensorDescriptor {
 public:
     CudnnTensorDescriptor();
     explicit CudnnTensorDescriptor(const Array& arr);
+
     ~CudnnTensorDescriptor();
+
+    CudnnTensorDescriptor(const CudnnTensorDescriptor&) = delete;
+    CudnnTensorDescriptor(CudnnTensorDescriptor&& other);
+    CudnnTensorDescriptor& operator=(const CudnnTensorDescriptor&) = delete;
+    CudnnTensorDescriptor& operator=(CudnnTensorDescriptor&&) = delete;
 
     cudnnTensorDescriptor_t descriptor() const { return desc_; }
     cudnnTensorDescriptor_t operator*() const { return desc_; }
@@ -65,7 +71,14 @@ private:
 class CudnnFilterDescriptor {
 public:
     explicit CudnnFilterDescriptor(const Array& w);
+
     ~CudnnFilterDescriptor();
+
+    // TODO(hvy): Allow move semantics as needed.
+    CudnnFilterDescriptor(const CudnnFilterDescriptor&) = delete;
+    CudnnFilterDescriptor(CudnnFilterDescriptor&&) = delete;
+    CudnnFilterDescriptor& operator=(const CudnnFilterDescriptor&) = delete;
+    CudnnFilterDescriptor& operator=(CudnnFilterDescriptor&&) = delete;
 
     cudnnFilterDescriptor_t descriptor() const { return desc_; }
     cudnnFilterDescriptor_t operator*() const { return desc_; }
@@ -83,7 +96,14 @@ public:
             const StackVector<int64_t, kMaxNdim>& stride,
             const nonstd::optional<StackVector<int64_t, kMaxNdim>>& dilation,
             int groups);
+
     ~CudnnConvolutionDescriptor();
+
+    // TODO(hvy): Allow move semantics as needed.
+    CudnnConvolutionDescriptor(const CudnnConvolutionDescriptor&) = delete;
+    CudnnConvolutionDescriptor(CudnnConvolutionDescriptor&&) = delete;
+    CudnnConvolutionDescriptor& operator=(const CudnnConvolutionDescriptor&) = delete;
+    CudnnConvolutionDescriptor& operator=(CudnnConvolutionDescriptor&&) = delete;
 
     cudnnConvolutionDescriptor_t descriptor() const { return desc_; }
     cudnnConvolutionDescriptor_t operator*() const { return desc_; }
@@ -101,7 +121,14 @@ public:
             const StackVector<int64_t, kMaxNdim>& kernel_size,
             const StackVector<int64_t, kMaxNdim>& pad,
             const StackVector<int64_t, kMaxNdim>& stride);
+
     ~CudnnPoolingDescriptor();
+
+    // TODO(hvy): Allow move semantics as needed.
+    CudnnPoolingDescriptor(const CudnnPoolingDescriptor&) = delete;
+    CudnnPoolingDescriptor(CudnnPoolingDescriptor&&) = delete;
+    CudnnPoolingDescriptor& operator=(const CudnnPoolingDescriptor&) = delete;
+    CudnnPoolingDescriptor& operator=(CudnnPoolingDescriptor&&) = delete;
 
     cudnnPoolingDescriptor_t descriptor() const { return desc_; }
     cudnnPoolingDescriptor_t operator*() const { return desc_; }

--- a/chainerx_cc/chainerx/cuda/cudnn.h
+++ b/chainerx_cc/chainerx/cuda/cudnn.h
@@ -55,7 +55,7 @@ public:
     ~CudnnTensorDescriptor();
 
     CudnnTensorDescriptor(const CudnnTensorDescriptor&) = delete;
-    CudnnTensorDescriptor(CudnnTensorDescriptor&& other);
+    CudnnTensorDescriptor(CudnnTensorDescriptor&& other) : desc_{other.desc_} { other.desc_ = nullptr; }
     CudnnTensorDescriptor& operator=(const CudnnTensorDescriptor&) = delete;
     CudnnTensorDescriptor& operator=(CudnnTensorDescriptor&&) = delete;
 


### PR DESCRIPTION
cuDNN descriptor move semantics were implicitly defined and could lead to double free/destroy. This issue was present in `DeriveBatchNormTensorDescriptor` but was hidden because of NRVO. 

This PR fixes those issues by simply disallowing move and copy, except for the ones currently required. We can allow more as needed and this is explained in the TODOs.