### PR TITLE
Simplify `F.log1p` test

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_logarithm_1p.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_logarithm_1p.py
@@ -1,65 +1,47 @@
-import unittest
-
 import numpy
 
-import chainer
-from chainer.backends import cuda
-import chainer.functions as F
-from chainer import gradient_check
+from chainer import functions
 from chainer import testing
-from chainer.testing import attr
+from chainer.utils import force_array
 
 
 @testing.parameterize(*testing.product({
     'shape': [(), (3, 2)],
+    'dtype': [numpy.float32]
 }))
-class Log1pFunctionTest(unittest.TestCase):
+@testing.fix_random()
+@testing.inject_backend_tests(
+    None,
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
+    })
+)
+class Log1pFunctionTest(testing.FunctionTestCase):
 
-    def setUp(self):
-        self.x = numpy.random.uniform(.5, 1, self.shape).astype(numpy.float32)
-        self.gy = numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
-        self.ggx = \
-            numpy.random.uniform(-1, 1, self.shape).astype(numpy.float32)
+    def generate_inputs(self):
+        x = numpy.random.uniform(.5, 1, self.shape).astype(self.dtype)
+        return x,
 
-    def check_forward(self, x_data):
-        x = chainer.Variable(x_data)
-        y = F.log1p(x)
-        testing.assert_allclose(
-            numpy.log1p(self.x), y.data, atol=1e-7, rtol=1e-7)
+    def forward(self, inputs, device):
+        x, = inputs
+        return functions.log1p(x),
 
-    def test_log1p_forward_cpu(self):
-        self.check_forward(self.x)
-
-    @attr.gpu
-    def test_log1p_forward_gpu(self):
-        self.check_forward(cuda.to_gpu(self.x))
-
-    def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(F.log1p, x_data, y_grad, dtype='d')
-
-    def test_log1p_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_log1p_backward_gpu(self):
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        gradient_check.check_double_backward(
-            F.log1p, x_data, y_grad, x_grad_grad, dtype=numpy.float64)
-
-    def test_log1p_double_backward_cpu(self):
-        self.check_double_backward(self.x, self.gy, self.ggx)
-
-    @attr.gpu
-    def test_log1p_double_backward_gpu(self):
-        self.check_double_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.gy),
-            cuda.to_gpu(self.ggx))
-
-    def test_log1p(self):
-        self.assertEqual(
-            chainer.functions.math.logarithm_1p.Log1p().label, 'log1p')
+    def forward_expected(self, inputs):
+        x, = inputs
+        expected = numpy.log1p(x)
+        expected = force_array(expected)
+        return expected,
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Simplifies test_logarithm_1p using testing.FunctionTestCase
Refer to [#6071](https://github.com/chainer/chainer/issues/6071) 