### PR TITLE
Support ChainerX in `F.copy`

### DIFF
--- a/chainer/functions/array/copy.py
+++ b/chainer/functions/array/copy.py
@@ -1,13 +1,17 @@
+import chainer
+from chainer import backend
 from chainer.backends import cuda
 from chainer import function_node
 from chainer.utils import type_check
+import chainerx
 
 
 class Copy(function_node.FunctionNode):
 
     """Copies the input variable onto the specified device."""
 
-    def __init__(self, out_device):
+    def __init__(self, in_device, out_device):
+        self._in_device = in_device
         self.out_device = out_device
 
     def check_type_forward(self, in_types):
@@ -15,16 +19,18 @@ class Copy(function_node.FunctionNode):
 
     def forward(self, inputs):
         x, = inputs
-        self._in_device = cuda.get_device_from_array(x).id
-        if int(self.out_device) == -1:
-            return cuda.to_cpu(x),
-        else:
-            return cuda.to_gpu(x, self.out_device),
+        return self.out_device.send(x),
+
+    def forward_chainerx(self, inputs):
+        x, = inputs
+        return x.to_device(self.out_device.device),
 
     def backward(self, indexes, grad_outputs):
-        return Copy(self._in_device).apply(grad_outputs)
+        f = Copy(self.out_device, self._in_device)
+        return f.apply(grad_outputs)
 
 
+# TODO(niboshi): Link from `dst` to an appropriate device specifier docs.
 def copy(x, dst):
     """Copies the input variable onto the specified device.
 
@@ -36,7 +42,7 @@ def copy(x, dst):
     Args:
         x (:class:`~chainer.Variable` or :ref:`ndarray`):
             Variable to be copied.
-        dst (int): Target device specifier.
+        dst: Target device specifier.
 
     Returns:
         ~chainer.Variable: Output variable.
@@ -44,16 +50,34 @@ def copy(x, dst):
     .. admonition:: Example
 
         >>> import chainer.backends.cuda as cuda
-        >>> x = np.random.uniform(-1, 1, (5, 10))
-        >>> cuda.get_device_from_array(x).id
-        -1
-        >>> y = F.copy(x, 0) # from host to device0
-        >>> cuda.get_device_from_array(y.array).id
-        0
-        >>> z = F.copy(y, -1) # from device0 to host
-        >>> cuda.get_device_from_array(z.array).id
-        -1
+        >>> x_arr = np.random.uniform(-1, 1, (5, 10))
+        >>> x = chainer.Variable(x_arr)
+        >>> x.device
+        <CpuDevice (numpy)>
+        >>> y = F.copy(x, '@cupy:0') # from CPU (NumPy) to GPU 0 (CuPy)
+        >>> y.device
+        <GpuDevice (cupy):0>
+
+    .. note::
+        Copies between non-ChainerX devices and ChainerX devices are not
+        supported.
 
     """
-    y, = Copy(dst).apply((x,))
+    # For backward compatibility
+    if dst is cuda.DummyDevice:
+        dst = chainer.get_device('@numpy')
+
+    in_device = backend.get_device_from_array(
+        x.array if isinstance(x, chainer.Variable) else x)
+    out_device = chainer.get_device(dst)
+
+    is_chainerx = in_device.xp is chainerx
+    if is_chainerx != (out_device.xp is chainerx):
+        raise RuntimeError(
+            'F.copy does not support copies between non-ChainerX devices and '
+            'ChainerX devices.\n'
+            'From: {}\n'
+            'To: {}'.format(in_device, out_device))
+
+    y, = Copy(in_device, out_device).apply((x,))
     return y

--- a/tests/chainer_tests/functions_tests/array_tests/test_copy.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_copy.py
@@ -1,14 +1,15 @@
 import unittest
 
 import numpy
-
+import pytest
 
 import chainer
+from chainer import backend
+from chainer.backends import _cpu
 from chainer.backends import cuda
 from chainer import functions
-from chainer import gradient_check
 from chainer import testing
-from chainer.testing import attr
+import chainerx
 
 
 def _to_gpu(x, device_id):
@@ -18,106 +19,203 @@ def _to_gpu(x, device_id):
         return x
 
 
-@testing.parameterize(*testing.product({
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-}))
-class TestCopy(unittest.TestCase):
+_nonchainerx_backend_configs = (
+    [
+        # NumPy
+        {},
+        # CuPy
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+    ])
+
+
+_chainerx_backend_configs = (
+    [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+
+_numpy_device = chainer.get_device('@numpy')
+
+
+class CopyTestBase(object):
 
     def setUp(self):
-        self.x_data = numpy.random.uniform(
-            -1, 1, (10, 5)).astype(self.dtype)
+        self.x = numpy.random.uniform(-1, 1, (10, 5)).astype(self.dtype)
         self.gy = numpy.random.uniform(-1, 1, (10, 5)).astype(self.dtype)
         self.ggx = numpy.random.uniform(-1, 1, (10, 5)).astype(self.dtype)
         self.check_double_backward_options = {}
         if self.dtype == numpy.float16:
             self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
 
-    def check_forward(self, src_id, dst_id):
-        x_data = _to_gpu(self.x_data, src_id)
-        x = chainer.Variable(x_data)
-        y = functions.copy(x, dst_id)
+    def check_forward(self, dst_device_spec, src_device, dst_device):
+        x = src_device.send(self.x)
 
-        self.assertEqual(self.x_data.dtype, self.dtype)
-        numpy.testing.assert_array_equal(self.x_data, cuda.to_cpu(y.data))
+        x_var = chainer.Variable(x)
+        y = functions.copy(x_var, dst_device_spec)
 
-    def check_backward(self, src_id, dst_id):
-        x_data = _to_gpu(self.x_data, src_id)
-        x = chainer.Variable(x_data)
+        assert y.device == dst_device
+        assert backend.get_device_from_array(y.array) == dst_device
+        assert y.dtype == self.dtype
+        numpy.testing.assert_array_equal(_numpy_device.send(y.array), self.x)
 
-        y = functions.copy(x, dst_id)
-        gy = _to_gpu(self.gy, dst_id)
-        y.grad = gy
+    def test_forward(self, src_backend_config, dst_backend_config):
+        self.check_forward(
+            dst_backend_config.device,
+            src_backend_config.device,
+            dst_backend_config.device)
 
-        y.backward()
+    def test_backward(self, src_backend_config, dst_backend_config):
+        x = src_backend_config.get_array(self.x)
+        gy = dst_backend_config.get_array(self.gy)
+        src_device = src_backend_config.device
+        dst_device = dst_backend_config.device
 
-        x_grad = x.grad
-        self.assertEqual(cuda.get_device_from_array(x_grad).id, src_id)
+        x_var = chainer.Variable(x, requires_grad=True)
+
+        y_var = functions.copy(x_var, dst_device)
+        y_var.grad = gy
+
+        y_var.backward()
+
+        x_grad = x_var.grad
+        assert x_var.grad_var.device == src_device
+        assert backend.get_device_from_array(x_grad) == src_device
+        numpy.testing.assert_array_equal(_numpy_device.send(x_grad), self.gy)
+
+    def test_double_backward(self, src_backend_config, dst_backend_config):
+        x = src_backend_config.get_array(self.x)
+        gy = dst_backend_config.get_array(self.gy)
+        ggx = src_backend_config.get_array(self.ggx)
+        dst_device = dst_backend_config.device
+
+        x_var = chainer.Variable(x, requires_grad=True)
+
+        y_var = functions.copy(x_var, dst_device)
+
+        # TODO(niboshi): Remove this workround after Variable.grad.setter is
+        # fixed so that it calls gy.require_grad() internally.
+        if dst_backend_config.xp is chainerx:
+            gy.require_grad()
+
+        y_var.grad = gy
+
+        gy_var = y_var.grad_var
+        y_var.backward(enable_double_backprop=True)
+
+        assert x_var.grad_var.requires_grad is True
+
+        x_var.grad_var.grad = ggx
+        x_var.grad_var.backward()
+
+        assert gy_var.grad_var.device == dst_device
+        assert (
+            backend.get_device_from_array(gy_var.grad_var.array)
+            == dst_device)
         numpy.testing.assert_array_equal(
-            cuda.to_cpu(x_grad), self.gy)
-
-    def test_forward_cpu(self):
-        self.check_forward(-1, -1)
-
-    def test_backward_cpu(self):
-        self.check_backward(-1, -1)
-
-    @attr.gpu
-    def test_forward_gpu(self):
-        device_id = cuda.Device().id
-        self.check_forward(device_id, device_id)
-
-    @attr.gpu
-    def test_check_backward_gpu(self):
-        device_id = cuda.Device().id
-        self.check_forward(device_id, device_id)
-
-    @attr.gpu
-    def test_forward_cpu_to_gpu(self):
-        device_id = cuda.Device().id
-        self.check_forward(-1, device_id)
-
-    @attr.gpu
-    def test_backward_cpu_to_gpu(self):
-        device_id = cuda.Device().id
-        self.check_backward(-1, device_id)
-
-    @attr.gpu
-    def test_forward_gpu_to_cpu(self):
-        device_id = cuda.Device().id
-        self.check_forward(device_id, -1)
-
-    @attr.gpu
-    def test_backward_gpu_to_cpu(self):
-        device_id = cuda.Device().id
-        self.check_backward(device_id, -1)
-
-    @attr.multi_gpu(2)
-    def test_forward_multigpu(self):
-        self.check_forward(0, 1)
-
-    @attr.multi_gpu(2)
-    def test_backward_multigpu(self):
-        self.check_backward(0, 1)
-
-    def check_double_backward(self, x_data, y_grad, x_grad_grad):
-        def f(x):
-            return functions.copy(x, -1)
-
-        gradient_check.check_double_backward(
-            f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
-            **self.check_double_backward_options)
-
-    def test_double_backward_cpu(self):
-        self.check_double_backward(self.x_data, self.gy, self.ggx)
+            _numpy_device.send(gy_var.grad_var.array), self.ggx)
 
 
-class TestCopyArgument(unittest.TestCase):
+@testing.inject_backend_tests(None, _nonchainerx_backend_configs)
+@testing.inject_backend_tests(None, _nonchainerx_backend_configs)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestCopyNonChainerx(CopyTestBase, unittest.TestCase):
 
-    def setUp(self):
-        self.x_data = numpy.zeros((2, 3))
+    def test_forward_int(self, src_backend_config, dst_backend_config):
+        src_device = src_backend_config.device
+        dst_device = dst_backend_config.device
+        if dst_device.xp is numpy:
+            dst_device_spec = -1
+        elif dst_device.xp is chainer.backends.cuda.cupy:
+            dst_device_spec = dst_device.device.id
+        else:
+            assert False, dst_device
 
-    def test_call_forward_with_device(self):
-        functions.copy(self.x_data, cuda.DummyDevice)
+        self.check_forward(
+            dst_device_spec,
+            src_device,
+            dst_device)
+
+    def test_forward_str(self, src_backend_config, dst_backend_config):
+        src_device = src_backend_config.device
+        dst_device = dst_backend_config.device
+        if dst_device.xp is numpy:
+            dst_device_spec = '@numpy'
+        elif dst_device.xp is chainer.backends.cuda.cupy:
+            dst_device_spec = '@cupy:{}'.format(dst_device.device.id)
+        else:
+            assert False, dst_device
+
+        self.check_forward(
+            dst_device_spec,
+            src_device,
+            dst_device)
+
+
+@testing.inject_backend_tests(None, _chainerx_backend_configs)
+@testing.inject_backend_tests(None, _chainerx_backend_configs)
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestCopyChainerx(CopyTestBase, unittest.TestCase):
+
+    def test_forward_str(self, src_backend_config, dst_backend_config):
+        src_device = src_backend_config.device
+        dst_device = dst_backend_config.device
+        dst_device_spec = dst_device.device.name
+
+        self.check_forward(
+            dst_device_spec,
+            src_device,
+            dst_device)
+
+
+@testing.inject_backend_tests(None, _chainerx_backend_configs)
+@testing.inject_backend_tests(None, _nonchainerx_backend_configs)
+class TestCopyBetweenChainerxAndNonChainerx(unittest.TestCase):
+    # Copy between non-ChainerX and ChainerX devices are not supported.
+
+    dtype = numpy.float32
+
+    def check_invalid(self, src_device, dst_device_spec):
+        x = src_device.send(
+            numpy.random.uniform(-1, 1, (10, 5)).astype(self.dtype))
+
+        x_var = chainer.Variable(x)
+
+        with pytest.raises(RuntimeError):
+            functions.copy(x_var, dst_device_spec)
+
+    def test_invalid(self, nonchx_backend_config, chx_backend_config):
+        assert nonchx_backend_config.xp is not chainerx
+        assert chx_backend_config.xp is chainerx
+
+        self.check_invalid(
+            nonchx_backend_config.device, chx_backend_config.device)
+        self.check_invalid(
+            chx_backend_config.device, nonchx_backend_config.device)
+        # cuda.DummyDevice is not supported either.
+        self.check_invalid(
+            chx_backend_config.device, cuda.DummyDevice)
+
+
+@testing.inject_backend_tests(None, _nonchainerx_backend_configs)
+@testing.inject_backend_tests(None, _nonchainerx_backend_configs)
+class TestCopyCudaDummyDevice(unittest.TestCase):
+
+    def test_dummy_device(self, src_backend_config, current_backend_config):
+
+        x_arr = src_backend_config.get_array(numpy.zeros((2, 3)))
+
+        with current_backend_config:
+            y = functions.copy(x_arr, cuda.DummyDevice)
+
+        # Always transferred to NumPy device, regardless of the current CUDA
+        # device.
+        assert isinstance(y.device, _cpu.CpuDevice)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
ChainerX support in `F.copy`.

(Required in #6857, separated from #6859)

~TODO: test~