### PR TITLE
Fix flaky `TestLogSumExp`

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -1609,6 +1609,12 @@ class TestLogSumExp(UnaryMathTestBase, op_utils.NumpyOpTest):
 
     input = 'random'
 
+    def setup(self):
+        super().setup()
+        if self.in_dtypes == 'float16':
+            # TODO(imanishi): Support device implementation and remove this.
+            self.check_forward_options.update({'rtol': 3e-3, 'atol': 3e-3})
+
     def forward_xp(self, inputs, xp):
         x, = inputs
         axis = self.axis


### PR DESCRIPTION
Part of #6912.

Currently, the pre-mapped array is casted to a float16 array before reduction. This loss of trailing digits seems avoidable by supporting reduction kernel for `LogSumExp` for each device.