### PR TITLE
Fix `ConcatWithAsyncTransfer`

### DIFF
--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -459,7 +459,7 @@ class Conveyor(object):
                                              array.dtype,
                                              array.size
                                              ).reshape(array.shape)
-                cp_array = cuda.cupy.empty_like(array)
+                cp_array = cuda.cupy.empty(array.shape, array.dtype)
 
             pin_array[...] = array  # copy(CPU): paged -> pinned
             cp_array.set(pin_array, self._stream)  # copy: CPU to GPU

--- a/tests/chainer_tests/dataset_tests/test_convert.py
+++ b/tests/chainer_tests/dataset_tests/test_convert.py
@@ -170,7 +170,12 @@ class _XFailConcatWithAsyncTransfer(object):
         )
 
 
-@_inject_backend_tests
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        # NumPy
+        {},
+    ])
 class TestConcatWithAsyncTransfer(
         _XFailConcatWithAsyncTransfer,
         ConverterTestBase, unittest.TestCase):

--- a/tests/chainer_tests/dataset_tests/test_convert.py
+++ b/tests/chainer_tests/dataset_tests/test_convert.py
@@ -143,8 +143,37 @@ class TestConcatExamples(ConverterTestBase, unittest.TestCase):
         self.converter = dataset.concat_examples
 
 
+class _XFailConcatWithAsyncTransfer(object):
+
+    @attr.chainerx
+    @unittest.expectedFailure
+    def test_concat_arrays_to_chainerx(self, *args, **kwargs):
+        (
+            super(_XFailConcatWithAsyncTransfer, self)
+            .test_concat_arrays_to_chainerx(*args, **kwargs)
+        )
+
+    @attr.chainerx
+    @unittest.expectedFailure
+    def test_concat_tuples_to_chainerx(self, *args, **kwargs):
+        (
+            super(_XFailConcatWithAsyncTransfer, self)
+            .test_concat_tuples_to_chainerx(*args, **kwargs)
+        )
+
+    @attr.chainerx
+    @unittest.expectedFailure
+    def test_concat_dicts_to_chainerx(self, *args, **kwargs):
+        (
+            super(_XFailConcatWithAsyncTransfer, self)
+            .test_concat_dicts_to_chainerx(*args, **kwargs)
+        )
+
+
 @_inject_backend_tests
-class TestConcatWithAsyncTransfer(ConverterTestBase, unittest.TestCase):
+class TestConcatWithAsyncTransfer(
+        _XFailConcatWithAsyncTransfer,
+        ConverterTestBase, unittest.TestCase):
 
     def setUp(self):
         self.converter = chainer.dataset.ConcatWithAsyncTransfer()


### PR DESCRIPTION
The PR fixes #6838.

Note: `ConcatWithAsyncTransfer` does not support the new device specifiers, but I left it.