### PR TITLE
Use cuDNN in ReLU

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_relu.py
@@ -64,7 +64,7 @@ class TestReLUCudnnCall(unittest.TestCase):
         self.x = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
         self.gy = cuda.cupy.random.uniform(-1, 1, (2, 3)).astype(self.dtype)
         with chainer.using_config('use_cudnn', self.use_cudnn):
-            self.expect = chainer.should_use_cudnn('==always')
+            self.expect = chainer.should_use_cudnn('>=auto')
 
     def forward(self):
         x = chainer.Variable(self.x)


### PR DESCRIPTION
`cudnnActivationBackward` requests input layer data. Current ReLU implementation uses CuPy one.
But, In ReLU case we can pass output layer data as input layer data.

- Speed up with FP16. cuDNN method is faster than CuPy.
- Reduce memory consumption with cuDNN mode.
