### PR TITLE
[backport] Fix flaky `TestLogSumExp`

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -1596,6 +1596,12 @@ class TestLogSumExp(UnaryMathTestBase, op_utils.NumpyOpTest):
 
     input = 'random'
 
+    def setup(self):
+        super().setup()
+        if self.in_dtypes == 'float16':
+            # TODO(imanishi): Support device implementation and remove this.
+            self.check_forward_options.update({'rtol': 3e-3, 'atol': 3e-3})
+
     def forward_xp(self, inputs, xp):
         x, = inputs
         axis = self.axis


### PR DESCRIPTION
Backport of #6988