### PR TITLE
[backport] Fix flaky ChainerX `max_pool` test

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_pooling.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_pooling.py
@@ -1,3 +1,5 @@
+import functools
+from operator import mul
 import unittest
 
 import chainer
@@ -48,7 +50,14 @@ class TestMaxPool(op_utils.ChainerOpTest):
     def generate_inputs(self):
         x_shape = self.x_shape
         dtype = self.dtype
-        x = numpy.random.uniform(-1, 1, x_shape).astype(dtype)
+
+        if self.test_name in ('test_backward', 'test_double_backward'):
+            x = numpy.arange(functools.reduce(mul, x_shape), dtype=dtype)
+            x = x.reshape(x_shape)
+            x = 2 * x / x.size - 1
+        else:
+            x = numpy.random.randn(*x_shape).astype(dtype, copy=False)
+
         return x,
 
     def forward_chainerx(self, inputs):


### PR DESCRIPTION
Backport of #6975