### PR TITLE
[backport] Avoid using ImportError during `import cupy`

### DIFF
--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -7,7 +7,7 @@ import chainer.backends
 try:
     import cupy as cp
     _cupy_avail = True
-except ImportError:
+except Exception:
     _cupy_avail = False
 
 

--- a/chainermn/nccl.py
+++ b/chainermn/nccl.py
@@ -10,5 +10,5 @@ try:
     from cupy.cuda.nccl import NcclCommunicator  # NOQA
     from cupy.cuda.nccl import NcclError  # NOQA
     _available = True
-except ImportError:
+except Exception:
     _available = False


### PR DESCRIPTION
Backport of #6954