### PR TITLE
Fix flaky `chainerx.abs` test

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -1942,6 +1942,8 @@ class TestTan(UnaryMathTestBase, op_utils.NumpyOpTest):
 ))
 class TestAbs(UnaryMathTestBase, op_utils.NumpyOpTest):
 
+    dodge_nondifferentiable = True
+
     def func(self, xp, a):
         assert chainerx.abs is chainerx.absolute
         return xp.abs(a)


### PR DESCRIPTION
Fix #6912.
Fixed to avoid non-differentiable inputs.