### PR TITLE
Set `allow_pickle=True` 

### DIFF
--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -8,6 +8,18 @@ from chainer import serializer
 import chainerx
 
 
+# For historical reasons, NPZ serializers in Chainer allow pickle despite their
+# potential security issues. This behavior may be changed in future.
+
+# `numpy.save` and `numpy.load` have `allow_pickle` option. `numpy.savez` and
+# `numpy.savez_compressed` do not have an option to disable pickle.
+# Before NumPy 1.10, pickle was always allowed. Since NumPy 1.16.3, pickle is
+# not allowed by default.
+_allow_pickle_kwargs = {}
+if numpy.lib.NumpyVersion(numpy.__version__) >= '1.10.0':
+    _allow_pickle_kwargs['allow_pickle'] = True
+
+
 class DictionarySerializer(serializer.Serializer):
 
     """Serializer for dictionary.
@@ -224,7 +236,7 @@ def load_npz(file, obj, path='', strict=True, ignore_names=None):
         :func:`chainer.serializers.save_npz`
 
     """
-    with numpy.load(file) as f:
+    with numpy.load(file, **_allow_pickle_kwargs) as f:
         d = NpzDeserializer(
             f, path=path, strict=strict, ignore_names=ignore_names)
         d.load(obj)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -207,14 +207,10 @@ class TestNpzDeserializer(unittest.TestCase):
         with pytest.raises(TypeError):
             self.deserializer('zf32', z)
 
-    # TODO(kataoka): fix (de)serializing issues with allow_pickle=False
-    @testing.with_requires('numpy<1.16.3')
     def test_deserialize_none(self):
         ret = self.deserializer('w', None)
         self.assertIs(ret, None)
 
-    # TODO(kataoka): fix (de)serializing issues with allow_pickle=False
-    @testing.with_requires('numpy<1.16.3')
     def test_deserialize_by_passing_array(self):
         y = numpy.empty((1,), dtype=numpy.float32)
         ret = self.deserializer('w', y)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -107,7 +107,10 @@ class TestNpzDeserializer(unittest.TestCase):
                       'zi64': numpy.array(-2**60, dtype=numpy.int64),
                       'w': None})
 
-        self.npzfile = numpy.load(path)
+        try:
+            self.npzfile = numpy.load(path, allow_pickle=True)
+        except TypeError:
+            self.npzfile = numpy.load(path)
         self.deserializer = npz.NpzDeserializer(self.npzfile)
 
     def tearDown(self):


### PR DESCRIPTION
This PR fixes the issues with NumPy 1.16.3.

- #4530 is postponed.
- ChainerCV: chainer/chainercv#853