### PR TITLE
Fix subview of zero-sized arrays

### DIFF
--- a/chainerx_cc/chainerx/routines/indexing.cc
+++ b/chainerx_cc/chainerx/routines/indexing.cc
@@ -103,6 +103,11 @@ Array At(const Array& a, const std::vector<ArrayIndex>& indices) {
         out_strides.emplace_back(a.strides()[i]);
     }
 
+    // Empty arrays should all have offsets of 0 to avoid e.g. out-of-memory errors.
+    if (a.GetTotalSize() == 0) {
+        out_offset = 0;
+    }
+
     Array out = MakeArray(out_shape, out_strides, a.dtype(), a.device(), a.data(), out_offset);
 
     BackwardBuilder bb{"get_item", a, out};

--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -646,13 +646,18 @@ std::vector<Array> Split(const Array& ary, int64_t sections, int8_t axis) {
     out_shape[axis_norm] = out_dim;
     int64_t out_stride = ary.strides()[axis_norm];
     int64_t out_offset = ary.offset();
+    bool is_empty = ary.GetTotalSize() == 0;
 
     std::vector<Array> out{};
     out.reserve(sections);
 
     for (int64_t i = 0; i < sections; ++i) {
         out.emplace_back(internal::MakeArray(out_shape, ary.strides(), ary.dtype(), ary.device(), ary.data(), out_offset));
-        out_offset += out_stride * out_dim;
+
+        // Empty arrays should all have offsets of 0 to e.g. avoid out-of-memory errors.
+        if (!is_empty) {
+            out_offset += out_stride * out_dim;
+        }
     }
 
     DefineSplitBackward(ary, out, axis_norm);

--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -674,6 +674,7 @@ std::vector<Array> Split(const Array& ary, std::vector<int64_t> indices, int8_t 
     int64_t out_stride = ary.strides()[axis_norm];
     int64_t out_offset = ary.offset();
     int64_t slice_start = 0;
+    bool is_empty = ary.GetTotalSize() == 0;
 
     std::vector<Array> out{};
     out.reserve(indices.size());
@@ -687,7 +688,11 @@ std::vector<Array> Split(const Array& ary, std::vector<int64_t> indices, int8_t 
 
         out.emplace_back(internal::MakeArray(out_shape, ary.strides(), ary.dtype(), ary.device(), ary.data(), out_offset));
 
-        out_offset += out_stride * slice_step;
+        // Empty arrays should all have offsets of 0 to e.g. avoid out-of-memory errors.
+        if (!is_empty) {
+            out_offset += out_stride * slice_step;
+        }
+
         slice_start = slice_stop;
     }
 

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_indexing.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_indexing.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 
 import chainer.testing
 import chainerx
@@ -121,6 +122,15 @@ class TestGetitem(op_utils.NumpyOpTest):
         x, = inputs
         y = x[self.indices]
         return y,
+
+
+@pytest.mark.parametrize_device(['native:0', 'cuda:0'])
+def test_getitem_zero_sized_no_offset(device):
+    # An (sub-)array of size 0 should always have 0 offset.
+    a = chainerx.random.uniform(-1, 1, (7, 0))
+    assert a.offset == 0  # Test pre-condition.
+    b = a[2:]
+    assert b.offset == 0
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -617,6 +617,18 @@ class TestSplit(op_utils.NumpyOpTest):
         return tuple(b)
 
 
+@pytest.mark.parametrize_device(['native:0', 'cuda:0'])
+@pytest.mark.parametrize('shape,indices_or_sections,axis', [
+    ((7, 0), [2, 5], 0),
+])
+def test_split_zero_sized_no_offset(device, shape, indices_or_sections, axis):
+    # An (sub-)array of size 0 should always have 0 offset.
+    a = chainerx.random.uniform(-1, 1, shape)
+    assert a.offset == 0  # Test pre-condition.
+    b = chainerx.split(a, indices_or_sections, axis)
+    assert all(bi.offset == 0 for bi in b)
+
+
 @chainerx.testing.numpy_chainerx_array_equal(
     accept_error=(
         chainerx.DimensionError, IndexError, ValueError, TypeError,

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -620,6 +620,7 @@ class TestSplit(op_utils.NumpyOpTest):
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
 @pytest.mark.parametrize('shape,indices_or_sections,axis', [
     ((7, 0), [2, 5], 0),
+    ((0, 6), 3, 1),
 ])
 def test_split_zero_sized_no_offset(device, shape, indices_or_sections, axis):
     # An (sub-)array of size 0 should always have 0 offset.


### PR DESCRIPTION
A sub-view of a zero-sized array (e.g. a sub-view of shape `(2, 0)` of an array one that has a shape of `(7. 0)`) should always have an offset of 0. Having a non-zero offset would yield an invalid address when for instance creating a new array based on it.

In short, this fix was missing for ChainerX.
https://github.com/cupy/cupy/blob/master/cupy/core/_routines_indexing.pyx#L322-L323

~_TODO: Need to add tests._~ Done.