### PR TITLE
implement NumPy-like pairwise reduction for stability

### DIFF
--- a/chainerx_cc/chainerx/native/reduce.h
+++ b/chainerx_cc/chainerx/native/reduce.h
@@ -41,12 +41,13 @@ struct ExpandedPairwiseReduction<In, ReductionImpl, InNdim, T, 1> {
 };
 
 constexpr int log2(int64_t v) { return v == 1 ? 0 : log2(v >> 1) + 1; }
+constexpr int64_t TreeDepth = 63 - log2(ExpandLen * SerialLen);
 
 template <typename In, typename ReductionImpl, int8_t InNdim, typename T>
 T PairwiseReduction(const IndexableArray<const In, InNdim>& in, IndexIterator<InNdim>& it_in, ReductionImpl&& impl, int64_t reduce_len) {
     int64_t i_reduce = 0;
     T accum = impl.Identity();
-    T tree_accum[63 - log2(ExpandLen * SerialLen)];
+    T tree_accum[TreeDepth];
 
     while (i_reduce < reduce_len / ExpandLen * ExpandLen) {
         // Invoke dynamic pairwise reduction if `i_reduce` is multiple of `SerialLen * ExpandLen`.

--- a/chainerx_cc/chainerx/native/reduce.h
+++ b/chainerx_cc/chainerx/native/reduce.h
@@ -12,8 +12,8 @@ namespace chainerx {
 namespace native {
 namespace reduce_detail {
 
-constexpr int64_t ExpandLen = 8;
-constexpr int64_t SerialLen = 16;
+constexpr int64_t ExpandLen = 4;
+constexpr int64_t SerialLen = 8;
 
 template <typename In, typename ReductionImpl, int8_t InNdim, typename T, int64_t n>
 struct ExpandedPairwiseReduction {

--- a/chainerx_cc/chainerx/native/reduce.h
+++ b/chainerx_cc/chainerx/native/reduce.h
@@ -17,9 +17,7 @@ constexpr int64_t SerialLen = 16;
 
 template <typename In, typename ReductionImpl, int8_t InNdim, typename T, int64_t n>
 struct ExpandedPairwiseReduction {
-    static T run(
-            const IndexableArray<const In, InNdim>& in, IndexIterator<InNdim>& it_in, ReductionImpl&& impl,
-            int64_t& i_reduce) {
+    static T run(const IndexableArray<const In, InNdim>& in, IndexIterator<InNdim>& it_in, ReductionImpl&& impl, int64_t& i_reduce) {
         T accum = ExpandedPairwiseReduction<In, ReductionImpl, InNdim, T, n / 2>::run(in, it_in, impl, i_reduce);
         impl.Reduce(ExpandedPairwiseReduction<In, ReductionImpl, InNdim, T, n / 2>::run(in, it_in, impl, i_reduce), accum);
         return accum;
@@ -28,23 +26,22 @@ struct ExpandedPairwiseReduction {
 
 template <typename In, typename ReductionImpl, int8_t InNdim, typename T>
 struct ExpandedPairwiseReduction<In, ReductionImpl, InNdim, T, 1> {
-    static T run(
-            const IndexableArray<const In, InNdim>& in, IndexIterator<InNdim>& it_in, ReductionImpl&& impl,
-            int64_t& i_reduce) {
+    static T run(const IndexableArray<const In, InNdim>& in, IndexIterator<InNdim>& it_in, ReductionImpl&& impl, int64_t& i_reduce) {
         T accum = impl.MapIn(native_internal::StorageToDataType<const In>(in[it_in]), i_reduce);
         ++it_in, ++i_reduce;
         return accum;
     }
 };
 
-inline int64_t pairwise_len(int64_t reduce_len) {
-    return ((reduce_len / ExpandLen + (SerialLen - 1)) / SerialLen);
-}
+inline int64_t pairwise_len(int64_t reduce_len) { return ((reduce_len / ExpandLen + (SerialLen - 1)) / SerialLen); }
 
 template <typename In, typename ReductionImpl, int8_t InNdim, typename T>
 T PairwiseReduction(
-        const IndexableArray<const In, InNdim>& in, IndexIterator<InNdim>& it_in, ReductionImpl&& impl,
-        int64_t reduce_len, std::vector<T>& tree_accum) {
+        const IndexableArray<const In, InNdim>& in,
+        IndexIterator<InNdim>& it_in,
+        ReductionImpl&& impl,
+        int64_t reduce_len,
+        std::vector<T>& tree_accum) {
     int64_t i_reduce = 0;
     T accum = impl.Identity();
 

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -1414,6 +1414,38 @@ class TestSum(UnaryMathTestBase, op_utils.NumpyOpTest):
             return a.sum(axis=self.axis, keepdims=self.keepdims)
 
 
+@op_utils.op_test(['native:0'])
+class TestSumStability(op_utils.NumpyOpTest):
+
+    skip_backward_test = True
+    skip_double_backward_test = True
+
+    def generate_inputs(self):
+        return numpy.full(2 ** 20, 0.1, dtype=numpy.float32),
+
+    def forward_xp(self, inputs, xp):
+        x, = inputs
+        if xp is chainerx:
+            return x.sum(),
+        else:
+            return (x[0] * x.size).astype(x.dtype),
+
+
+@op_utils.op_test(['native:0'])
+@chainer.testing.parameterize_pytest('size', list(range(1024)))
+class TestSumEachSize(op_utils.NumpyOpTest):
+
+    skip_backward_test = True
+    skip_double_backward_test = True
+
+    def generate_inputs(self):
+        return numpy.arange(self.size, dtype=numpy.int32) + 1,
+
+    def forward_xp(self, inputs, xp):
+        x, = inputs
+        return x.sum(),
+
+
 @chainerx.testing.numpy_chainerx_array_equal(
     accept_error=(chainerx.DimensionError, ValueError))
 @pytest.mark.parametrize('keepdims', [False, True])


### PR DESCRIPTION
This fixes #7038.

- [x] Pairwise reduction implementation and manual test
- [x] Test codes to ensure correctness of reduction (if required)
- [x] Test codes to ensure stability of reduction
- [x] Performance measure

```python
import chainerx as chx
import cupy as cp
import numpy as np


def _unstable_sum(xp, **kwargs):
    # Sum larger numbers first, then small numbers.
    a = xp.zeros((2, 512*512), **kwargs)
    a[0, :] = 1.0
    a[1, :] = 0.1
    return a.sum()

print(_unstable_sum(np, dtype=np.float32))                      # 288358.0
print(_unstable_sum(cp, dtype=cp.float32))                      # 288352.0
print(_unstable_sum(chx, dtype=chx.float32, device='cuda:0'))    # 288352.0
print(_unstable_sum(chx, dtype=chx.float32, device='native:0'))  # old 286720.0 new 288358.40625
```

I confirmed the correctness of the routine up to 1023.

```python
import chainerx as chx
for i in range(1024):
    a = chx.arange(i, device='native:0') + 1
    print(i, i * (i + 1) // 2, a.sum())
```

I'll remove WIP sign after test codes are added.