### PR TITLE
`forward_chainerx` for `F.cast`

### DIFF
--- a/chainer/functions/array/cast.py
+++ b/chainer/functions/array/cast.py
@@ -15,6 +15,9 @@ class Cast(function_node.FunctionNode):
     def check_type_forward(self, in_types):
         type_check._argname(in_types, ('x',))
 
+    def forward_chainerx(self, x):
+        return x[0].astype(self.type, copy=False),
+
     def forward(self, x):
         self._in_type = x[0].dtype.type
         return x[0].astype(self.type, copy=False),


### PR DESCRIPTION
`F.cast` to use utilize `chainerx.astype` instead of falling back to NumPy/CuPy for ChainerX inputs.

~Depends on https://github.com/chainer/chainer/pull/7034 (that adds tests).~