### PR TITLE
Fix `At` output offset

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_indexing.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_indexing.py
@@ -125,12 +125,18 @@ class TestGetitem(op_utils.NumpyOpTest):
 
 
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
-def test_getitem_zero_sized_no_offset(device):
-    # An (sub-)array of size 0 should always have 0 offset.
-    a = chainerx.random.uniform(-1, 1, (7, 0))
-    assert a.offset == 0  # Test pre-condition.
-    b = a[2:]
-    assert b.offset == 0
+def test_getitem_zero_sized_offsets(device):
+    a = chainerx.arange(6)
+
+    b = a[3:3]
+    # Test pre-conditions.
+    assert b.size == 0
+    assert b.offset == 12
+
+    # The offset of `c` should be the same as `b` since `b` is empty.
+    c = b[2:]
+    assert c.size == 0
+    assert c.offset == b.offset
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])


### PR DESCRIPTION
Fixed offset calculation for `At`. The current implementation is similar to getitem of CuPy https://github.com/cupy/cupy/blob/master/cupy/core/_routines_indexing.pyx#L267.