### PR TITLE
Fix Snapshot Writers ignore keyword arguments to savefun

### DIFF
--- a/chainer/training/extensions/snapshot_writers.py
+++ b/chainer/training/extensions/snapshot_writers.py
@@ -43,7 +43,7 @@ class Writer(object):
         self.finalize()
 
     def finalize(self):
-        """Finalizes the wirter.
+        """Finalizes the writer.
 
         Like extensions in :class:`~chainer.training.Trainer`, this method
         is invoked at the end of the training.
@@ -55,7 +55,7 @@ class Writer(object):
         prefix = 'tmp' + filename
         with utils.tempdir(prefix=prefix, dir=outdir) as tmpdir:
             tmppath = os.path.join(tmpdir, filename)
-            savefun(tmppath, target)
+            savefun(tmppath, target, **kwds)
             shutil.move(tmppath, os.path.join(outdir, filename))
 
 

--- a/tests/chainer_tests/training_tests/extensions_tests/test_snapshot_writers.py
+++ b/tests/chainer_tests/training_tests/extensions_tests/test_snapshot_writers.py
@@ -16,7 +16,7 @@ class TestSimpleWriter(unittest.TestCase):
 
     @staticmethod
     def _touch(filename, target, **kwargs):
-        open(filename, 'w')
+        open(filename, 'w').close()
 
     def test_call_without_kwargs(self):
         target = mock.MagicMock()
@@ -48,7 +48,7 @@ class TestSimpleWriter(unittest.TestCase):
         assert len(args) == 2
         assert isinstance(args[0], str)
         assert args[1] is target
-        assert kwargs == { 'spam': 'ham', 'egg': 1 }
+        assert kwargs == {'spam': 'ham', 'egg': 1}
 
 
 class TestStandardWriter(unittest.TestCase):


### PR DESCRIPTION
[Snapshot Writers](https://docs.chainer.org/en/latest/reference/snapshot_writers.html) seem to ignore keyword arguments to `savefun` given via their constructors.  This PR fixes the problem.

The problem reproduces on Chainer 6.0.0rc1 with the following code:
```
import pathlib, zipfile
import chainer, chainercv

path = pathlib.Path('/tmp/vgg16.npz')
model = chainercv.links.VGG16(pretrained_model='imagenet')

# VGG-16's snapshot (including `Updater`) is so huge and compression takes almost a minute!
writer = chainer.training.extensions.snapshot_writers.SimpleWriter(compression=False)
writer(path.name, path.parent, model)

for info in zipfile.ZipFile(path).infolist():
    assert info.file_size == info.compress_size,\
        f'{info.filename} seems compressed!'
```