### PR TITLE
Fix a bug in `Bernoulli.log_prob`

### DIFF
--- a/chainer/distributions/bernoulli.py
+++ b/chainer/distributions/bernoulli.py
@@ -6,9 +6,9 @@ from chainer.backends import cuda
 from chainer import distribution
 import chainer.distributions.utils
 from chainer.functions.activation import sigmoid
-from chainer.functions.math import sum
 from chainer.functions.math import exponential
 from chainer.functions.math import logarithm_1p
+from chainer.functions.math import sum
 from chainer import utils
 from chainer.utils import cache
 

--- a/chainer/distributions/bernoulli.py
+++ b/chainer/distributions/bernoulli.py
@@ -5,6 +5,7 @@ from chainer import backend
 from chainer.backends import cuda
 from chainer import distribution
 import chainer.distributions.utils
+from chainer.functions import sum_to
 from chainer.functions.activation import sigmoid
 from chainer.functions.math import exponential
 from chainer.functions.math import logarithm_1p
@@ -53,7 +54,7 @@ class BernoulliLogProb(chainer.function_node.FunctionNode):
         nan_dlogit[self.logit_isminf] = numpy.nan
         dlogit += nan_dlogit
 
-        return gy * dlogit, None
+        return sum_to(gy * dlogit, logit.shape), None
 
 
 def _bernoulli_log_prob(logit, x, binary_check=False):

--- a/chainer/distributions/bernoulli.py
+++ b/chainer/distributions/bernoulli.py
@@ -5,8 +5,8 @@ from chainer import backend
 from chainer.backends import cuda
 from chainer import distribution
 import chainer.distributions.utils
-from chainer.functions import sum_to
 from chainer.functions.activation import sigmoid
+from chainer.functions.math import sum
 from chainer.functions.math import exponential
 from chainer.functions.math import logarithm_1p
 from chainer import utils
@@ -54,7 +54,7 @@ class BernoulliLogProb(chainer.function_node.FunctionNode):
         nan_dlogit[self.logit_isminf] = numpy.nan
         dlogit += nan_dlogit
 
-        return sum_to(gy * dlogit, logit.shape), None
+        return sum.sum_to(gy * dlogit, logit.shape), None
 
 
 def _bernoulli_log_prob(logit, x, binary_check=False):

--- a/chainer/distributions/bernoulli.py
+++ b/chainer/distributions/bernoulli.py
@@ -6,6 +6,7 @@ from chainer.backends import cuda
 from chainer import distribution
 import chainer.distributions.utils
 from chainer.functions.activation import sigmoid
+from chainer.functions.array import where
 from chainer.functions.math import exponential
 from chainer.functions.math import logarithm_1p
 from chainer.functions.math import sum
@@ -47,12 +48,11 @@ class BernoulliLogProb(chainer.function_node.FunctionNode):
         dlogit = x - 1. / (1. + exponential.exp(-logit))
 
         # extreme logit
-        nan_dlogit = xp.zeros_like(dlogit.array)
+        nan = xp.array(xp.nan).astype(dlogit.dtype)
+        logit_isinf = xp.bitwise_or(self.logit_ispinf, self.logit_isminf)
+        dlogit = where.where(logit_isinf, nan, dlogit)
         if self.binary_check:
-            nan_dlogit[self.invalid] = numpy.nan
-        nan_dlogit[self.logit_ispinf] = numpy.nan
-        nan_dlogit[self.logit_isminf] = numpy.nan
-        dlogit += nan_dlogit
+            dlogit = where.where(self.invalid, nan, dlogit)
 
         return sum.sum_to(gy * dlogit, logit.shape), None
 

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -106,16 +106,19 @@ class TestBernoulli(testing.distribution_unittest):
         [(2, 3), (2, 3)],
         [(), ()],
         [(), (3,)]
-        ],
+    ],
     'dtype': [numpy.float32, numpy.float64],
 }))
 class TestBernoulliLogProb(unittest.TestCase):
 
     def setUp(self):
-        self.logit = numpy.random.normal(size=self.logit_shape).astype(self.dtype)
-        self.x = numpy.random.randint(0, 2, size=self.x_shape).astype(self.dtype)
+        self.logit = numpy.random.normal(
+            size=self.logit_shape).astype(self.dtype)
+        self.x = numpy.random.randint(
+            0, 2, size=self.x_shape).astype(self.dtype)
         self.gy = numpy.random.normal(size=self.x_shape).astype(self.dtype)
-        self.ggx = numpy.random.normal(size=self.logit_shape).astype(self.dtype)
+        self.ggx = numpy.random.normal(
+            size=self.logit_shape).astype(self.dtype)
         self.backward_options = {'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, logit_data, x_data):

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -166,11 +166,13 @@ class TestBernoulliLogProb(unittest.TestCase):
     def test_backward_where_logit_has_infinite_values(self):
         self.logit += numpy.inf
         with numpy.errstate(invalid='ignore'):
-            log_prob = distributions.bernoulli._bernoulli_log_prob(self.logit, self.x)
+            log_prob = distributions.bernoulli._bernoulli_log_prob(
+                self.logit, self.x)
 
         log_prob.backward()
 
-        assert True # just confirm that the backward method runs without raising error.
+        # just confirm that the backward method runs without raising error.
+        assert True
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -102,16 +102,20 @@ class TestBernoulli(testing.distribution_unittest):
 
 
 @testing.parameterize(*testing.product({
-    'shape': [(2, 3), ()],
+    'logit_shape,x_shape': [
+        [(2, 3), (2, 3)],
+        [(), ()],
+        [(), (3,)]
+        ],
     'dtype': [numpy.float32, numpy.float64],
 }))
 class TestBernoulliLogProb(unittest.TestCase):
 
     def setUp(self):
-        self.logit = numpy.random.normal(size=self.shape).astype(self.dtype)
-        self.x = numpy.random.randint(0, 2, size=self.shape).astype(self.dtype)
-        self.gy = numpy.random.normal(size=self.shape).astype(self.dtype)
-        self.ggx = numpy.random.normal(size=self.shape).astype(self.dtype)
+        self.logit = numpy.random.normal(size=self.logit_shape).astype(self.dtype)
+        self.x = numpy.random.randint(0, 2, size=self.x_shape).astype(self.dtype)
+        self.gy = numpy.random.normal(size=self.x_shape).astype(self.dtype)
+        self.ggx = numpy.random.normal(size=self.x_shape).astype(self.dtype)
         self.backward_options = {'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, logit_data, x_data):

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -163,5 +163,14 @@ class TestBernoulliLogProb(unittest.TestCase):
             cuda.to_gpu(self.logit), cuda.to_gpu(self.x),
             cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
 
+    def test_backward_where_logit_has_infinite_values(self):
+        self.logit += numpy.inf
+        with numpy.errstate(invalid='ignore'):
+            log_prob = distributions.bernoulli._bernoulli_log_prob(self.logit, self.x)
+
+        log_prob.backward()
+
+        assert True # just confirm that the backward method runs without raising error.
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -115,7 +115,7 @@ class TestBernoulliLogProb(unittest.TestCase):
         self.logit = numpy.random.normal(size=self.logit_shape).astype(self.dtype)
         self.x = numpy.random.randint(0, 2, size=self.x_shape).astype(self.dtype)
         self.gy = numpy.random.normal(size=self.x_shape).astype(self.dtype)
-        self.ggx = numpy.random.normal(size=self.x_shape).astype(self.dtype)
+        self.ggx = numpy.random.normal(size=self.logit_shape).astype(self.dtype)
         self.backward_options = {'atol': 1e-2, 'rtol': 1e-2}
 
     def check_forward(self, logit_data, x_data):

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -164,7 +164,7 @@ class TestBernoulliLogProb(unittest.TestCase):
             cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
 
     def test_backward_where_logit_has_infinite_values(self):
-        self.logit += numpy.inf
+        self.logit[...] = numpy.inf
         with numpy.errstate(invalid='ignore'):
             log_prob = distributions.bernoulli._bernoulli_log_prob(
                 self.logit, self.x)

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -169,10 +169,8 @@ class TestBernoulliLogProb(unittest.TestCase):
             log_prob = distributions.bernoulli._bernoulli_log_prob(
                 self.logit, self.x)
 
-        log_prob.backward()
-
         # just confirm that the backward method runs without raising error.
-        assert True
+        log_prob.backward()
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fixed a bug mentioned in https://github.com/chainer/chainer/issues/7057 .

This bug was caused by unintended broadcasting in the backward method.

I added a test that reproduces the bug and fixed it referencing this code https://github.com/chainer/chainer/blob/c92db3396d55a2a351d1bee1a47e33e85dd144b2/chainer/functions/math/basic_math.py#L176  .