### PR TITLE
Use macro in exp_log.{cc/cu}

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/exp_log.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/exp_log.cu
@@ -19,71 +19,11 @@ namespace chainerx {
 namespace cuda {
 namespace {
 
-template <typename T>
-struct ExpImpl {
-    using CudaType = cuda_internal::DataType<T>;
-    __device__ void operator()(int64_t /*i*/, CudaType x, CudaType& out) { out = cuda::Exp(x); }
-};
+CHAINERX_CUDA_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(ExpKernel, { out = cuda::Exp(x); });
 
-class CudaExpKernel : public ExpKernel {
-public:
-    void Call(const Array& x, const Array& out) override {
-        Device& device = x.device();
-        device.CheckDevicesCompatible(x, out);
-        CudaSetDeviceScope scope{device.index()};
-        const Array& x_cast = x.dtype() == out.dtype() ? x : x.AsType(out.dtype());
-        VisitFloatingPointDtype(out.dtype(), [&x_cast, &out](auto pt) {
-            using T = typename decltype(pt)::type;
-            Elementwise<const T, T>(ExpImpl<T>{}, x_cast, out);
-        });
-    }
-};
+CHAINERX_CUDA_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(LogKernel, { out = cuda::Log(x); });
 
-CHAINERX_CUDA_REGISTER_KERNEL(ExpKernel, CudaExpKernel);
-
-template <typename T>
-struct LogImpl {
-    using CudaType = cuda_internal::DataType<T>;
-    __device__ void operator()(int64_t /*i*/, CudaType x, CudaType& out) { out = cuda::Log(x); }
-};
-
-class CudaLogKernel : public LogKernel {
-public:
-    void Call(const Array& x, const Array& out) override {
-        Device& device = x.device();
-        device.CheckDevicesCompatible(x, out);
-        CudaSetDeviceScope scope{device.index()};
-        const Array& x_cast = x.dtype() == out.dtype() ? x : x.AsType(out.dtype());
-        VisitFloatingPointDtype(out.dtype(), [&x_cast, &out](auto pt) {
-            using T = typename decltype(pt)::type;
-            Elementwise<const T, T>(LogImpl<T>{}, x_cast, out);
-        });
-    }
-};
-
-CHAINERX_CUDA_REGISTER_KERNEL(LogKernel, CudaLogKernel);
-
-template <typename T>
-struct Log10Impl {
-    using CudaType = cuda_internal::DataType<T>;
-    __device__ void operator()(int64_t /*i*/, CudaType x, CudaType& out) { out = cuda::Log10(x); }
-};
-
-class CudaLog10Kernel : public Log10Kernel {
-public:
-    void Call(const Array& x, const Array& out) override {
-        Device& device = x.device();
-        device.CheckDevicesCompatible(x, out);
-        CudaSetDeviceScope scope{device.index()};
-        const Array& x_cast = x.dtype() == out.dtype() ? x : x.AsType(out.dtype());
-        VisitFloatingPointDtype(out.dtype(), [&x_cast, &out](auto pt) {
-            using T = typename decltype(pt)::type;
-            Elementwise<const T, T>(Log10Impl<T>{}, x_cast, out);
-        });
-    }
-};
-
-CHAINERX_CUDA_REGISTER_KERNEL(Log10Kernel, CudaLog10Kernel);
+CHAINERX_CUDA_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(Log10Kernel, { out = cuda::Log10(x); });
 
 }  // namespace
 }  // namespace cuda

--- a/chainerx_cc/chainerx/native/native_device/exp_log.cc
+++ b/chainerx_cc/chainerx/native/native_device/exp_log.cc
@@ -14,56 +14,11 @@ namespace chainerx {
 namespace native {
 namespace {
 
-class NativeExpKernel : public ExpKernel {
-public:
-    void Call(const Array& x, const Array& out) override {
-        x.device().CheckDevicesCompatible(x, out);
-        const Array& x_cast = x.dtype() == out.dtype() ? x : x.AsType(out.dtype());
-        VisitFloatingPointDtype(out.dtype(), [&x_cast, &out](auto pt) {
-            using T = typename decltype(pt)::type;
-            struct Impl {
-                void operator()(int64_t /*i*/, T x, T& out) { out = chainerx::Exp(x); }
-            };
-            Elementwise<const T, T>(Impl{}, x_cast, out);
-        });
-    }
-};
+CHAINERX_NATIVE_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(ExpKernel, { out = chainerx::Exp(x); });
 
-CHAINERX_NATIVE_REGISTER_KERNEL(ExpKernel, NativeExpKernel);
+CHAINERX_NATIVE_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(LogKernel, { out = chainerx::Log(x); });
 
-class NativeLogKernel : public LogKernel {
-public:
-    void Call(const Array& x, const Array& out) override {
-        x.device().CheckDevicesCompatible(x, out);
-        const Array& x_cast = x.dtype() == out.dtype() ? x : x.AsType(out.dtype());
-        VisitFloatingPointDtype(out.dtype(), [&x_cast, &out](auto pt) {
-            using T = typename decltype(pt)::type;
-            struct Impl {
-                void operator()(int64_t /*i*/, T x, T& out) { out = chainerx::Log(x); }
-            };
-            Elementwise<const T, T>(Impl{}, x_cast, out);
-        });
-    }
-};
-
-CHAINERX_NATIVE_REGISTER_KERNEL(LogKernel, NativeLogKernel);
-
-class NativeLog10Kernel : public Log10Kernel {
-public:
-    void Call(const Array& x, const Array& out) override {
-        x.device().CheckDevicesCompatible(x, out);
-        const Array& x_cast = x.dtype() == out.dtype() ? x : x.AsType(out.dtype());
-        VisitFloatingPointDtype(out.dtype(), [&x_cast, &out](auto pt) {
-            using T = typename decltype(pt)::type;
-            struct Impl {
-                void operator()(int64_t /*i*/, T x, T& out) { out = chainerx::Log10(x); }
-            };
-            Elementwise<const T, T>(Impl{}, x_cast, out);
-        });
-    }
-};
-
-CHAINERX_NATIVE_REGISTER_KERNEL(Log10Kernel, NativeLog10Kernel);
+CHAINERX_NATIVE_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(Log10Kernel, { out = chainerx::Log10(x); });
 
 }  // namespace
 }  // namespace native


### PR DESCRIPTION
Simplify device implementation of `Exp`, `Log` and `Log10`.