### PR TITLE
Fix `Reshape` copy condition

### DIFF
--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -189,8 +189,8 @@ Array Reshape(const Array& a, const Shape& newshape) {
                 int64_t dim = in_shape[i];
                 int64_t st = in_strides[i];
                 CHAINERX_ASSERT(dim > 0);
-                if (dim == 1 && st == 0) {
-                    // If the axis has unit-length with no stride, skip this dimension.
+                if (dim == 1) {
+                    // If the axis has unit-length, skip this dimension.
                 } else if (dim * st == reduced_strides.back()) {
                     // If the pair is compatible with the previous stride, reduce the pair to it.
                     reduced_shape.back() *= dim;
@@ -642,6 +642,9 @@ Array ExpandDims(const Array& a, int8_t axis) {
     shape.insert(shape.begin() + axis, 1);
 
     Array out = a.Reshape(shape);
+
+    // A trivial reshape of adding a new axis should just return a view of the input.
+    CHAINERX_ASSERT(out.raw_data() == a.raw_data());
 
     return out;
 }

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -797,7 +797,7 @@ def test_swap_invalid(xp, shape, axis1, axis2):
     })
 ))
 @chainer.testing.parameterize_pytest('is_contiguous', [True, False])
-class TestExpandDIms(op_utils.NumpyOpTest):
+class TestExpandDims(op_utils.NumpyOpTest):
 
     # TODO(kshitij12345): Remove this when fixed
     check_numpy_strides_compliance = False
@@ -822,7 +822,13 @@ class TestExpandDIms(op_utils.NumpyOpTest):
         if self.is_contiguous:
             a = a.copy()
 
-        return xp.expand_dims(a, self.axis),
+        y = xp.expand_dims(a, self.axis)
+
+        # Result should be a view, not a copy.
+        if xp is chainerx:
+            assert y.data_ptr == a.data_ptr
+
+        return y,
 
 
 @chainerx.testing.numpy_chainerx_array_equal(


### PR DESCRIPTION
Copies were made by `chainerx::Reshape` where views would suffice, due to an unnecessarily strict check. This PR fixes that check.

A side note. `chainerx::ExpandDims` simply calls `chainexr::Reshape` to add an axis. This should in practice not incur a copy. However, it could in certain cases. The following assertion would e.g. fail. This is fixed and tested in this PR.

```python
import chainerx as chx

a = chx.random.uniform(-1, 1, (2, 1, 3)).T
b = a.reshape(1, 3, 1, 2)  # Just an "expand dims".
assert a.data_ptr == b.data_ptr  # Would fail, meaning a copy was created.
```