### PR TITLE
Exclude protobuf 3.8.0rc1 from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,11 @@ requirements = {
         'typing_extensions',
         'filelock',
         'numpy>=1.9.0',
-        'protobuf>=3.0.0',
+        # protobuf 3.8.0rc1 causes CI errors.
+        # TODO(niboshi): Probably we should always use pip in CIs for
+        # installing chainer. It avoids pre-release dependencies by default.
+        # See also: https://github.com/pypa/setuptools/issues/855
+        'protobuf>=3.0.0,<3.8.0rc1',
         'six>=1.9.0',
     ],
     'stylecheck': [


### PR DESCRIPTION
Currently CI is broken in master.
It turned out that cause is protobuf==3.8.0rc1 being used in CIs.
In some CIs we install Chainer with `python setup.py install`, which causes pre-release dependencies to be installed (pypa/setuptools/issues/855).

This PR is a temporary workaround.
We should probably always use pip for installing chainer.