### PR TITLE
Update supported MPI list

### DIFF
--- a/docs/source/chainermn/installation/guide.rst
+++ b/docs/source/chainermn/installation/guide.rst
@@ -91,6 +91,8 @@ You can install MPI4py by::
 Please make be sure to properly configure environment variables so that MPI is available at installation time, because MPI4py links to MPI library at installation time.
 In particular, if you have multiple MPI implementations installed in your environment, please expose the implementation that you want to use both when you install and use ChainerMN.
 
+As of writing, MPI4py does not support Open MPI 4.x. Please use versions from the :ref:`tested-environments` section below.
+
 .. _cupy-install:
 
 CuPy
@@ -108,6 +110,8 @@ Chainer and ChainerMN can be installed without CuPy, in which case the correspon
 See :ref:`non-gpu-env` for more details.
 
 
+.. _tested-environments:
+
 Tested Environments
 -------------------
 
@@ -121,10 +125,19 @@ We tested ChainerMN on all the following environments.
 * Python 2.7.13, 3.5.1, 3.6.1
 * MPI
 
-  * openmpi 2.1.2
+  * Open MPI 2.1.6, 3.0.4, 3.1.4
 
 * MPI4py 3.0.0
 * NCCL 2.3.2 2.4.2
+
+.. note::
+
+  Note that certain versions of Open MPI have a bug that might cause a ChainerMN program to hang.
+  The versions are 3.0.[0-2] , 3.1.[0-2].
+
+  Also, mpi4py does not support Open MPI 4.0.x
+
+
 
 .. _non-gpu-env:
 

--- a/docs/source/chainermn/installation/guide.rst
+++ b/docs/source/chainermn/installation/guide.rst
@@ -132,8 +132,8 @@ We tested ChainerMN on all the following environments.
 
 .. note::
 
-  Note that certain versions of Open MPI have a bug that might cause ChainerMN program to hang.
-  The versions are 3.0.[0-2] , 3.1.[0-2].
+  Note that the following versions of Open MPI have a bug that might cause ChainerMN program to hang:
+  3.0.[0-2] and 3.1.[0-2].
   For more details, see `Open MPI Issue #3972 <https://github.com/open-mpi/ompi/issues/3972>`__ and
   `Chainer Issue #5740 <https://github.com/chainer/chainer/issues/5740>`__ .
 

--- a/docs/source/chainermn/installation/guide.rst
+++ b/docs/source/chainermn/installation/guide.rst
@@ -91,7 +91,8 @@ You can install MPI4py by::
 Please make be sure to properly configure environment variables so that MPI is available at installation time, because MPI4py links to MPI library at installation time.
 In particular, if you have multiple MPI implementations installed in your environment, please expose the implementation that you want to use both when you install and use ChainerMN.
 
-As of writing, MPI4py does not support Open MPI 4.x. Please use versions from the :ref:`tested-environments` section below.
+As of writing, `MPI4py does not support Open MPI 4.x <https://bitbucket.org/mpi4py/mpi4py/issues/123/mpi4py-does-not-build-with-openmpi4>`__.
+Please use versions from the :ref:`tested-environments` section below.
 
 .. _cupy-install:
 
@@ -137,7 +138,7 @@ We tested ChainerMN on all the following environments.
   For more details, see `Open MPI Issue #3972 <https://github.com/open-mpi/ompi/issues/3972>`__ and
   `Chainer Issue #5740 <https://github.com/chainer/chainer/issues/5740>`__ .
 
-  Also, mpi4py does not support Open MPI 4.0.x
+  Also, mpi4py does not support Open MPI 4.0.x.
 
 
 

--- a/docs/source/chainermn/installation/guide.rst
+++ b/docs/source/chainermn/installation/guide.rst
@@ -132,8 +132,10 @@ We tested ChainerMN on all the following environments.
 
 .. note::
 
-  Note that certain versions of Open MPI have a bug that might cause a ChainerMN program to hang.
+  Note that certain versions of Open MPI have a bug that might cause ChainerMN program to hang.
   The versions are 3.0.[0-2] , 3.1.[0-2].
+  For more details, see `Open MPI Issue #3972 <https://github.com/open-mpi/ompi/issues/3972>`__ and
+  `Chainer Issue #5740 <https://github.com/chainer/chainer/issues/5740>`__ .
 
   Also, mpi4py does not support Open MPI 4.0.x
 

--- a/docs/source/chainermn/installation/guide.rst
+++ b/docs/source/chainermn/installation/guide.rst
@@ -132,7 +132,7 @@ We tested ChainerMN on all the following environments.
 
 .. note::
 
-  Note that the following versions of Open MPI have a bug that might cause ChainerMN program to hang:
+  Note that the following versions of Open MPI have some bugs that might cause ChainerMN programs to hang:
   3.0.[0-2] and 3.1.[0-2].
   For more details, see `Open MPI Issue #3972 <https://github.com/open-mpi/ompi/issues/3972>`__ and
   `Chainer Issue #5740 <https://github.com/chainer/chainer/issues/5740>`__ .


### PR DESCRIPTION
This PR updates the document for latest information about supported versions of MPI.
This PR fixes #5740 .

Memo:

To review the document locally,  do
```
$ cd docs
$ make html
```
