### PR TITLE
Fix trigger constructors to raise errors instead of assertion failures

### DIFF
--- a/chainer/training/triggers/interval_trigger.py
+++ b/chainer/training/triggers/interval_trigger.py
@@ -23,8 +23,11 @@ class IntervalTrigger(object):
     """
 
     def __init__(self, period, unit):
+        if unit not in ('epoch', 'iteration'):
+            raise ValueError(
+                'Trigger unit must be either \'epoch\' or \'iteration\'.')
+
         self.period = period
-        assert unit == 'epoch' or unit == 'iteration'
         self.unit = unit
 
         self._previous_iteration = 0

--- a/chainer/training/triggers/manual_schedule_trigger.py
+++ b/chainer/training/triggers/manual_schedule_trigger.py
@@ -26,7 +26,10 @@ class ManualScheduleTrigger(object):
     """
 
     def __init__(self, points, unit):
-        assert unit == 'epoch' or unit == 'iteration'
+        if unit not in ('epoch', 'iteration'):
+            raise ValueError(
+                'Trigger unit must be either \'epoch\' or \'iteration\'.')
+
         self.points = (points if isinstance(points, list) else [points])
         self.unit = unit
         self.finished = False

--- a/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
@@ -117,4 +117,11 @@ class TestIntervalTrigger(unittest.TestCase):
                 self.assertEqual(trigger(trainer), expected)
 
 
+class TestInvalidIntervalTrigger(unittest.TestCase):
+
+    def test_invalid_unit(self):
+        with self.assertRaises(ValueError):
+            training.triggers.IntervalTrigger(1, 'day')
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_manual_schedule_trigger.py
@@ -68,7 +68,7 @@ def expected_finished(pos, num):
         'expected': [True, False, False, False, False, False, False],
         'finished': expected_finished(0, 7)},
 )
-class TestTrigger(unittest.TestCase):
+class TestManualScheduleTrigger(unittest.TestCase):
 
     def test_trigger(self):
         trainer = testing.get_trainer_with_mock_updater(
@@ -162,6 +162,13 @@ class TestTrigger(unittest.TestCase):
                 trainer.updater.update()
                 self.assertEqual(trigger(trainer), expected)
                 self.assertEqual(trigger.finished, finished)
+
+
+class TestInvalidManualScheduleTrigger(unittest.TestCase):
+
+    def test_invalid_unit(self):
+        with self.assertRaises(ValueError):
+            training.triggers.ManualScheduleTrigger(1, 'day')
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Some triggers with public interfaces used to assert on the user-given inputs. This PR changes those assertions to checks that raise errors.