### PR TITLE
Add progress bar to sentiment analysis example

### DIFF
--- a/examples/sentiment/train_recursive_minibatch.py
+++ b/examples/sentiment/train_recursive_minibatch.py
@@ -240,6 +240,8 @@ def main():
         ['epoch', 'main/loss', 'validation/main/loss',
          'main/accuracy', 'validation/main/accuracy', 'elapsed_time']))
 
+    trainer.extend(extensions.ProgressBar(update_interval=10))
+
     trainer.run()
 
 

--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -202,6 +202,8 @@ def main():
         extensions.snapshot(filename='snapshot_epoch_{.updater.epoch}'),
         trigger=(epoch_per_eval, 'epoch'))
 
+    trainer.extend(extensions.ProgressBar(update_interval=10))
+
     if args.resume is not None:
         chainer.serializers.load_npz(args.resume, trainer)
     trainer.run()


### PR DESCRIPTION
Added progress bar for user-friendliness. Other examples also use this progress bar (setting).

Also, please see https://github.com/chainer/chainer/pull/7087#discussion_r282409705.
