### PR TITLE
Avoid unnecessary updates in `F.batch_renormalization`, and related fixes

### DIFF
--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -110,7 +110,6 @@ class BatchRenormalizationFunction(function.Function):
                     self.r[expander], d[expander])
 
         if self.update_statistics:
-            # Update running statistics:
             m = x.size // gamma[expander].size
             self._running_mean *= self.decay
             adjust = m / max(m - 1., 1.)  # unbiased estimation
@@ -172,6 +171,7 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
     individual examples rather than the entire minibatch.
 
     .. note::
+
         This function does not perform in-place update to
         ``running_mean`` and ``running_var`` by default, contrary to
         :func:`~chainer.functions.batch_normalization`.
@@ -179,7 +179,19 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
         updated running mean and variance statistics, because they are members
         of the function object, which cannot be accessed by the caller.
         If it is desired to update the running statistics, call the function
-        with `update_statistics=True` option.
+        with ``update_statistics=True`` option.
+
+    .. note::
+
+        For the consistency with Batch Normalization, this function
+        intentionally ignores some of the theoretical flaws in Algorithm 1 of
+        the Batch Renormalization paper:
+
+        - The function maintains the moving average of variances
+          :math:`\\sigma^2`, while the original paper maintain the moving
+          average of standard deviations :math:`\\sigma`.
+        - The function applies Bessel's correction to update the moving average
+          of variances.
 
     See: `Batch Renormalization: Towards Reducing Minibatch Dependence in \
           Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -187,10 +187,10 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
         intentionally ignores some of the theoretical flaws in Algorithm 1 of
         the Batch Renormalization paper:
 
-        - The function maintains the moving average of variances
+        - ``F.batch_renormalization`` maintains the moving average of variances
           :math:`\\sigma^2`, while the original paper maintains the moving
           average of standard deviations :math:`\\sigma`.
-        - The function applies Bessel's correction to update the moving average
+        - ``F.batch_renormalization`` applies Bessel's correction to update the moving average
           of variances.
 
     See: `Batch Renormalization: Towards Reducing Minibatch Dependence in \

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -199,6 +199,10 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
     .. seealso:: :class:`~chainer.links.BatchRenormalization`
 
     """
+    if running_mean is None:
+        raise TypeError('running_mean is required')
+    if running_var is None:
+        raise TypeError('running_var is required')
     return BatchRenormalizationFunction(
         eps, running_mean, running_var, decay, rmax, dmax, update_statistics
     )(x, gamma, beta)

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -105,8 +105,9 @@ class BatchRenormalizationFunction(function.Function):
                 x_hat_renorm = x_hat * r + d;
                 y = gamma * x_hat_renorm + beta;
                 ''',
-                'bn_fwd')(x, mean[expander], self.std[expander], gamma,
-                          beta, self.r[expander], d[expander])
+                'brn_fwd')(
+                    x, mean[expander], self.std[expander], gamma, beta,
+                    self.r[expander], d[expander])
 
         if self.update_statistics:
             # Update running statistics:
@@ -154,9 +155,10 @@ class BatchRenormalizationFunction(function.Function):
                 'T gx',
                 'gx = (r * gamma / std) * (gy - (x_hat * gsigma_batch + gbeta) * \
                 inv_m)',
-                'bn_bwd')(gy, self.x_hat, gamma[expander],
-                          self.std[expander], gsigma_batch[expander],
-                          gbeta[expander], inv_m, self.r[expander])
+                'brn_bwd')(
+                    gy, self.x_hat, gamma[expander],
+                    self.std[expander], gsigma_batch[expander],
+                    gbeta[expander], inv_m, self.r[expander])
         return gx, ggamma, gbeta
 
 

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -190,8 +190,8 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
         - ``F.batch_renormalization`` maintains the moving average of variances
           :math:`\\sigma^2`, while the original paper maintains the moving
           average of standard deviations :math:`\\sigma`.
-        - ``F.batch_renormalization`` applies Bessel's correction to update the moving average
-          of variances.
+        - ``F.batch_renormalization`` applies Bessel's correction to update the
+          moving average of variances.
 
     See: `Batch Renormalization: Towards Reducing Minibatch Dependence in \
           Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -188,7 +188,7 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
         the Batch Renormalization paper:
 
         - The function maintains the moving average of variances
-          :math:`\\sigma^2`, while the original paper maintain the moving
+          :math:`\\sigma^2`, while the original paper maintains the moving
           average of standard deviations :math:`\\sigma`.
         - The function applies Bessel's correction to update the moving average
           of variances.


### PR DESCRIPTION
Each commit fixes a minor error.  The biggest change is to exclude `eps` from `running_var`.