### PR TITLE
Fix construction of `std::shared_ptr` with custom deleter in `chianer_interop.cc`

### DIFF
--- a/chainerx_cc/chainerx/python/chainer_interop.cc
+++ b/chainerx_cc/chainerx/python/chainer_interop.cc
@@ -116,10 +116,12 @@ void InitChainerxChainerInterop(pybind11::module& m) {
               // Insert backward function
               BackwardBuilder bb{"chainer_function", std::move(reduced_input_array_refs), std::move(reduced_output_array_refs)};
               if (BackwardBuilder::Target bt = bb.CreateTarget()) {
-                  auto function_node_ptr = std::make_shared<py::object>(std::move(function_node), [](gsl::owner<py::object*> ptr) {
-                      py::gil_scoped_acquire acquire;
-                      delete ptr;
-                  });
+                  // Need to reallocate the function node in order to specify a custom deleter (that acquires the GIL before deletion).
+                  auto function_node_ptr =
+                          std::shared_ptr<py::object>{new py::object{std::move(function_node)}, [](gsl::owner<py::object*> ptr) {
+                                                          py::gil_scoped_acquire acquire;
+                                                          delete ptr;
+                                                      }};
 
                   // Retain inputs/outputs
                   auto retain_arrays = [](auto retain,


### PR DESCRIPTION
Instead of creating a `std::shared_ptr` with a custom deleter, an unintended constructor of `py::object` was called (argument were implicitly converted) without any custom deleters being set. This PR fixes this bug.