### PR TITLE
Improve mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,6 @@
 pull_request_rules:
   - name: Auto merge
     conditions:
-      - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - label=st:test-and-merge
       - status-success=Jenkins
@@ -19,4 +18,4 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: smart
+        strict: false  # strict mode and manually-triggered CIs do not get along


### PR DESCRIPTION
* Disable strict mode (it does not get along with manually-triggered CIs)
* Do not require approval (it takes some steps to approve a PR. `st:test-and-merge` works as an alternative).