### PR TITLE
Fast integer scale unpooling

### DIFF
--- a/chainer/functions/pooling/unpooling_2d.py
+++ b/chainer/functions/pooling/unpooling_2d.py
@@ -1,7 +1,7 @@
 import numpy
 import numpy.lib.stride_tricks
 try:
-    import cupy.lib.stride_tricks
+    import cupy.lib.stride_tricks  # NOQA
 except ImportError:
     pass
 
@@ -21,7 +21,7 @@ class Unpooling2D(pooling_2d.Pooling2D):
                  outsize=None, cover_all=True):
         super(Unpooling2D, self).__init__(ksize, stride, pad, cover_all)
         self.outh, self.outw = (None, None) if outsize is None else outsize
-        self._use_integer_scale_forward = False
+        self._use_int_scale_forward = False
 
     def check_type_forward(self, in_types):
         n_in = in_types.size()
@@ -63,7 +63,7 @@ class Unpooling2D(pooling_2d.Pooling2D):
             self.outh // h == self.kh and self.outw // w == self.kw and
             self.ph == 0 and self.pw == 0 and
                 self.sx == self.kh and self.sy == self.kw):
-            self._use_integer_scale_forward = True
+            self._use_int_scale_forward = True
             return self._integer_scale_forward(x[0])
         xp = backend.get_array_module(*x)
         col = xp.tile(x[0][:, :, None, None],
@@ -92,7 +92,7 @@ class Unpooling2DGrad(function_node.FunctionNode):
         self.outh = unpooling2d.outh
         self.outw = unpooling2d.outw
         self.cover_all = unpooling2d.cover_all
-        self._use_integer_scale_forward = unpooling2d._use_integer_scale_forward
+        self._use_int_scale_forward = unpooling2d._use_int_scale_forward
 
     def _integer_scale_forward(self, gy):
         xp = backend.get_array_module(gy)
@@ -102,7 +102,7 @@ class Unpooling2DGrad(function_node.FunctionNode):
         return gx,
 
     def forward(self, gy):
-        if self._use_integer_scale_forward:
+        if self._use_int_scale_forward:
             return self._integer_scale_forward(gy[0])
         if isinstance(gy[0], cuda.ndarray):
             gcol = conv.im2col_gpu(

--- a/chainer/functions/pooling/unpooling_2d.py
+++ b/chainer/functions/pooling/unpooling_2d.py
@@ -46,7 +46,8 @@ class Unpooling2D(pooling_2d.Pooling2D):
         xp = backend.get_array_module(x)
         b, c, h, w = x.shape
         bs, cs, hs, ws = x.strides
-        x = x[:, :, self.ph // 2:-self.ph // 2, self.pw // 2:-self.pw // 2]
+        if self.ph > 0 or self.pw > 0:
+            x = x[:, :, self.ph // 2:-self.ph // 2, self.pw // 2:-self.pw // 2]
         y = xp.lib.stride_tricks.as_strided(
             x,
             (b, c, h - self.ph, self.kh, w - self.pw, self.kw),

--- a/chainer/functions/pooling/unpooling_2d.py
+++ b/chainer/functions/pooling/unpooling_2d.py
@@ -46,7 +46,8 @@ class Unpooling2D(pooling_2d.Pooling2D):
         xp = backend.get_array_module(x)
         b, c, h, w = x.shape
         bs, cs, hs, ws = x.strides
-        y = xp.lib.stride_tricks.as_strided(x, (b, c, h, self.kh, w, self.kw), (bs, cs, hs, 0, ws, 0))
+        y = xp.lib.stride_tricks.as_strided(
+            x, (b, c, h, self.kh, w, self.kw), (bs, cs, hs, 0, ws, 0))
         y = y.reshape((b, c, self.kh * h, self.kw * w))
         return y,
 
@@ -59,9 +60,9 @@ class Unpooling2D(pooling_2d.Pooling2D):
             self.outw = conv.get_deconv_outsize(
                 w, self.kw, self.sx, self.pw, cover_all=self.cover_all)
         if (self.outh % h == 0 and self.outw % w == 0 and
-           self.outh // h == self.kh and self.outw // w == self.kw and
-           self.ph == 0 and self.pw == 0 and
-           self.sx == self.kh and self.sy == self.kw):
+            self.outh // h == self.kh and self.outw // w == self.kw and
+            self.ph == 0 and self.pw == 0 and
+                self.sx == self.kh and self.sy == self.kw):
             self._use_integer_scale_forward = True
             return self._integer_scale_forward(x[0])
         xp = backend.get_array_module(*x)

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_unpooling_2d.py
@@ -142,6 +142,117 @@ class TestUnpooling2D(unittest.TestCase):
             'never')
 
 
+@testing.parameterize(*testing.product_dict(
+    [
+        # we assume insize as (2, 1)
+        # standard output size which is estimated with get_deconv_outsize
+        # function
+        {'outsize': (4, 2), 'ksize': 2},
+    ],
+    [
+        {'dtype': numpy.float16},
+        {'dtype': numpy.float32},
+        {'dtype': numpy.float64},
+    ],
+))
+class TestIntegerScaleUnpooling2D(unittest.TestCase):
+
+    def setUp(self):
+        self.N = 2
+        self.n_channels = 3
+        inh, inw = 2, 1
+        self.x = numpy.arange(
+            self.N * self.n_channels * inh * inw,
+            dtype=self.dtype).reshape(self.N, self.n_channels, inh, inw)
+        numpy.random.shuffle(self.x)
+        self.x = 2 * self.x / self.x.size - 1
+
+        outh, outw = self.outsize or self.expected_outsize
+        self.gy = numpy.random.uniform(
+            -1, 1, (self.N, self.n_channels, outh, outw)).astype(self.dtype)
+        self.check_backward_options = {'atol': 1e-4, 'rtol': 1e-3}
+        self.check_double_backward_options = {}
+        if self.dtype == numpy.float16:
+            self.check_backward_options = {'atol': 2e-3, 'rtol': 2e-2}
+            self.check_double_backward_options = {'atol': 3e-3, 'rtol': 3e-2}
+        self.ggx = numpy.random.uniform(
+            -1, 1, self.x.shape).astype(self.dtype)
+
+    def check_forward(self, x_data):
+        x = chainer.Variable(x_data)
+        y = functions.unpooling_2d(x, self.ksize, outsize=self.outsize)
+        self.assertEqual(y.data.dtype, self.dtype)
+        y_data = cuda.to_cpu(y.data)
+
+        self.assertEqual(self.gy.shape, y_data.shape)
+        for i in six.moves.range(self.N):
+            for c in six.moves.range(self.n_channels):
+                outsize = self.outsize or self.expected_outsize
+                assert y_data.shape[2:] == outsize
+                if outsize == (4, 2):
+                    expect = numpy.array([
+                        [self.x[i, c, 0, 0], self.x[i, c, 0, 0]],
+                        [self.x[i, c, 0, 0], self.x[i, c, 0, 0]],
+                        [self.x[i, c, 1, 0], self.x[i, c, 1, 0]],
+                        [self.x[i, c, 1, 0], self.x[i, c, 1, 0]],
+                    ])
+                else:
+                    raise ValueError('Unsupported outsize: {}'.format(outsize))
+                testing.assert_allclose(expect, y_data[i, c])
+
+    def test_forward_cpu(self):
+        self.check_forward(self.x)
+
+    @attr.gpu
+    def test_forward_gpu(self):
+        self.check_forward(cuda.to_gpu(self.x))
+
+    def check_backward(self, x_data, y_grad):
+        def f(x):
+            return functions.unpooling_2d(x, self.ksize, outsize=self.outsize)
+        gradient_check.check_backward(
+            f, x_data, y_grad, dtype=numpy.float64,
+            **self.check_backward_options)
+
+    def test_backward_cpu(self):
+        self.check_backward(self.x, self.gy)
+
+    @attr.gpu
+    def test_backward_gpu(self):
+        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+
+    def check_double_backward(self, x_data, y_grad, x_grad_grad,
+                              use_cudnn='always'):
+        def f(x):
+            return functions.unpooling_2d(x, self.ksize, outsize=self.outsize)
+        with chainer.using_config('use_cudnn', use_cudnn):
+            gradient_check.check_double_backward(
+                f, x_data, y_grad, x_grad_grad, dtype=numpy.float64,
+                **self.check_double_backward_options)
+
+    def test_double_backward_cpu(self):
+        self.check_double_backward(
+            self.x, self.gy, self.ggx, 'never')
+
+    @attr.gpu
+    def test_double_backward_gpu(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx))
+
+    @attr.gpu
+    def test_double_backward_gpu_non_contiguous(self):
+        self.check_double_backward(
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.x)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.gy)),
+            cuda.cupy.asfortranarray(cuda.to_gpu(self.ggx)))
+
+    @attr.gpu
+    def test_double_backward_gpu_no_cudnn(self):
+        self.check_double_backward(
+            cuda.to_gpu(self.x), cuda.to_gpu(self.gy), cuda.to_gpu(self.ggx),
+            'never')
+
+
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'h': [5],


### PR DESCRIPTION
I added a code path for faster unpooling when the output shape is an integer multiple of the input shape. This happens e.g. when upsampling the previous result of 2x2 max pooling, which is a common use case. This PR speeds up the forward pass about 1.7-3.2 times for this case.

MWE:
With batch and channel size 1, this PR makes the unpooling 1.7 times faster:
```
# Prepare input data
In [1]: import numpy as np; import cupy; import chainer.functions as F; x = cupy.arange(1, 128*64+1).reshape((1, 1, 64, 128)).astype(np.float32)

# Without this PR (master branch)
In [2]: %timeit F.unpooling_2d(x, 2, outsize=(x.shape[2]*2, x.shape[3]*2))
178 µs ± 18.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

# With this PR
In [3]: %timeit F.unpooling_2d(x, 2, outsize=(x.shape[2]*2, x.shape[3]*2))
99.2 µs ± 93.2 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

With larger batch and channel size, this PR makes the unpooling 3.2 times faster:
```
# Prepare input data
In [1]: import numpy as np; import cupy; import chainer.functions as F; x = cupy.arange(1, 128*32*128*64+1).reshape((128, 32, 64, 128)).astype(np.float32)

# Without this PR (master branch)
In [2]: %timeit F.unpooling_2d(x, 2, outsize=(x.shape[2]*2, x.shape[3]*2))
20.1 ms ± 1.82 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

# With this PR
In [3]: %timeit F.unpooling_2d(x, 2, outsize=(x.shape[2]*2, x.shape[3]*2))
6.17 ms ± 17.8 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```