### PR TITLE
Fix build with clang

### DIFF
--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -664,7 +664,7 @@ Array Flip(const Array& m, const OptionalAxes& axes) {
     int64_t offset = 0;
     for (auto axis : real_axes) {
         // last element of that dimension.
-        offset += std::max(shape[axis] - 1, 0L) * strides[axis];
+        offset += std::max(shape[axis] - 1, 0LL) * strides[axis];
         if (shape[axis] != 0) {
             strides[axis] = -strides[axis];
         }

--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -664,7 +664,7 @@ Array Flip(const Array& m, const OptionalAxes& axes) {
     int64_t offset = 0;
     for (auto axis : real_axes) {
         // last element of that dimension.
-        offset += std::max(shape[axis] - 1, 0LL) * strides[axis];
+        offset += std::max<int64_t>(shape[axis] - 1, 0) * strides[axis];
         if (shape[axis] != 0) {
             strides[axis] = -strides[axis];
         }


### PR DESCRIPTION
https://github.com/chainer/chainer/pull/7065/files#diff-1a0097987b5e6a8fe06006b09904a09fR767 caused the error:
```
  /private/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/pip-req-build-ntqn56g1/chainerx_cc/chainerx/routines/manipulation.cc:667:19: error: no matching function for call to 'max'
          offset += std::max(shape[axis] - 1, 0L) * strides[axis];
                    ^~~~~~~~
  /Applications/Xcode-9.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:2717:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long long' vs. 'long')
  max(const _Tp& __a, const _Tp& __b)
  ^
  /Applications/Xcode-9.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:2727:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'long long'
  max(initializer_list<_Tp> __t, _Compare __comp)
  ^
  /Applications/Xcode-9.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:2709:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
  max(const _Tp& __a, const _Tp& __b, _Compare __comp)
  ^
  /Applications/Xcode-9.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:2735:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
  max(initializer_list<_Tp> __t)
  ^
  1 error generated.
```
https://travis-ci.org/chainer/chainer/jobs/531075063#L2273-L2288