### PR TITLE
[backport] Document `CHAINERX_ENABLE_BLAS` environment variable

### DIFF
--- a/docs/source/chainerx/install/index.rst
+++ b/docs/source/chainerx/install/index.rst
@@ -20,6 +20,7 @@ Environment variable       Description
 ``CHAINER_BUILD_CHAINERX`` ``1`` to build the ``chainerx`` package along with ``chainer``. ``0`` to skip. Default is ``0``.
 ``CHAINERX_BUILD_CUDA``    ``1`` to build ``chainerx`` with CUDA support. ``0`` to skip. Default is ``0``.
 ``CUDNN_ROOT_DIR``         Path to your cuDNN installation. Required when ``CHAINERX_BUILD_CUDA=1``.
+``CHAINERX_ENABLE_BLAS``   ``1`` to make BLAS enabled. ``0`` to disabled. Default is ``1``.
 ========================== ================================================================================================
 
 Installing from source


### PR DESCRIPTION
Backport of #7098