### PR TITLE
[backport] Make too slow initializers' tests faster

### DIFF
--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -124,14 +124,14 @@ class NormalBase(unittest.TestCase):
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
     def test_initializer_statistics_slow_cpu(self):
-        self.check_initializer_statistics(numpy, 100000)
+        self.check_initializer_statistics(numpy, 10000)
 
     @attr.slow
     @attr.gpu
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
     def test_initializer_statistics_slow_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 100000)
+        self.check_initializer_statistics(cuda.cupy, 10000)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/initializer_tests/test_orthogonal.py
+++ b/tests/chainer_tests/initializer_tests/test_orthogonal.py
@@ -131,14 +131,14 @@ class OrthogonalBase(unittest.TestCase):
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
     def test_initializer_statistics_slow_cpu(self):
-        self.check_initializer_statistics(numpy, 100000)
+        self.check_initializer_statistics(numpy, 10000)
 
     @attr.slow
     @attr.gpu
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
     def test_initializer_statistics_slow_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 100000)
+        self.check_initializer_statistics(cuda.cupy, 10000)
 
 
 class TestEmpty(unittest.TestCase):

--- a/tests/chainer_tests/initializer_tests/test_uniform.py
+++ b/tests/chainer_tests/initializer_tests/test_uniform.py
@@ -128,14 +128,14 @@ class TestUniform(unittest.TestCase):
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
     def test_initializer_statistics_slow_cpu(self):
-        self.check_initializer_statistics(numpy, 100000)
+        self.check_initializer_statistics(numpy, 10000)
 
     @attr.slow
     @attr.gpu
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
     def test_initializer_statistics_slow_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 100000)
+        self.check_initializer_statistics(cuda.cupy, 10000)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Backport of #6792