### PR TITLE
`get_device` returns `CpuDevice` for `cuda.DummyDevice`

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -126,6 +126,9 @@ def get_device(device_spec):
     if chainerx.is_available() and isinstance(device_spec, chainerx.Device):
         return _chainerx.ChainerxDevice(device_spec)
 
+    if device_spec is cuda.DummyDevice:
+        return _cpu.CpuDevice()
+
     if cuda.available and isinstance(device_spec, cuda.Device):
         return cuda.GpuDevice(device_spec)
 

--- a/tests/chainer_tests/test_backend.py
+++ b/tests/chainer_tests/test_backend.py
@@ -258,6 +258,9 @@ class TestDeviceSpec(unittest.TestCase):
     def test_str_intel64(self):
         self.check_device_spec_intel64('@intel64')
 
+    def test_cuda_dummy_device(self):
+        self.check_device_spec_numpy(cuda.DummyDevice)
+
     def test_str_chainerx_invalid(self):
         self.check_invalid('native:foo')
         self.check_invalid('')


### PR DESCRIPTION
Before this PR, it returned a seemingly invalid device:

```
>>> chainer.get_device(chainer.backends.cuda.DummyDevice)
<GpuDevice (cupy):-1>
```