### PR TITLE
Fix `cuda.DummyDevice` inheritance

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -147,7 +147,7 @@ def check_cuda_available():
         check_cuda_available._already_warned = True
 
 
-class DummyDeviceType(Device):
+class DummyDeviceType(object):
 
     """Dummy device class that does nothing with cupy.cuda.Device interface.
 

--- a/tests/chainer_tests/test_backend.py
+++ b/tests/chainer_tests/test_backend.py
@@ -279,6 +279,9 @@ class TestDeviceSpec(unittest.TestCase):
         # tuple is no longer supported from Chainer
         self.check_invalid(('native', 0))
 
+    def test_cuda_dummy_device_invalid(self):
+        self.check_invalid(cuda.DummyDevice)
+
     @unittest.skipIf(
         chainerx.is_available(), 'Only tested when ChainerX is not built')
     def test_chx_device_spec_without_chx_available(self):


### PR DESCRIPTION
Related: #7145:

>Before this PR, it returned a seemingly invalid device:
>
>```
>>>> chainer.get_device(chainer.backends.cuda.DummyDevice)
><GpuDevice (cupy):-1>
>```


`DummyDevice` is not a `cupy.cuda.Device`: this inheritance is not appropriate.