### PR TITLE
Avoid using `cuda.DummyDevice` and `cuda.get_device_from_array`

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -30,8 +30,9 @@ def _contains_nan(x):
 
     """
     if x.dtype.kind in ('f', 'c'):
-        with cuda.get_device_from_array(x):
-            return get_array_module(x).isnan(x).any()
+        device = get_device_from_array(x)
+        with chainer.using_device(device):
+            return device.xp.isnan(x).any()
     else:
         return False
 

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -4,6 +4,7 @@ import weakref
 
 import six
 
+import chainer
 from chainer import backend
 from chainer.backends import cuda
 from chainer import configuration
@@ -199,7 +200,8 @@ class FunctionAdapter(function_node.FunctionNode):
             grad_out_data = backend.from_chx(grad_out_data)
 
         # Call Function.backward
-        with cuda.get_device_from_array(*(in_data + grad_out_data)):
+        with chainer.using_device(
+                backend.get_device_from_array(*(in_data + grad_out_data))):
             if is_chainerx_fallback_mode:
                 # Enable attribute fallback
                 with function_node._chainerx_attribute_fallback(

--- a/chainer/functions/normalization/group_normalization.py
+++ b/chainer/functions/normalization/group_normalization.py
@@ -89,7 +89,7 @@ class GroupNormalization(function_node.FunctionNode):
         cudnn_shape = (1, batch_size * groups, -1, 1)
         x = x.reshape(cudnn_shape)
 
-        with cuda.get_device_from_array(x):
+        with x.device:
             dummy_beta = xp.zeros(batch_size * groups, dtype=x.dtype)
             self.dummy_gamma = xp.ones_like(dummy_beta)
         x_hat, self.mean, self.inv_std = \

--- a/chainer/gradient_check.py
+++ b/chainer/gradient_check.py
@@ -33,10 +33,9 @@ def _copy_arrays(xs):
 
 
 def _ones_like(arr):
-    device = cuda.get_device_from_array(arr)
-    xp = backend.get_array_module(arr)
-    with device:
-        return xp.ones_like(arr)
+    device = backend.get_device_from_array(arr)
+    with chainer.using_device(device):
+        return device.xp.ones_like(arr)
 
 
 def _make_outputs_props_in_error_message(outputs, grad_outputs):

--- a/chainer/optimizer_hooks/gradient_clipping.py
+++ b/chainer/optimizer_hooks/gradient_clipping.py
@@ -1,7 +1,9 @@
 import collections
 
+import numpy
 import six
 
+import chainer
 from chainer import backend
 from chainer import cuda
 
@@ -51,12 +53,13 @@ class GradientClipping(object):
 
     def __call__(self, opt):
         sqnorm = _sum_sqnorm([p.grad for p in opt.target.params(False)])
-        with cuda.get_device_from_array(sqnorm) as dev:
-            norm = backend.get_array_module(sqnorm).sqrt(sqnorm)
+        device = backend.get_device_from_array(sqnorm)
+        with chainer.using_device(device):
+            norm = device.xp.sqrt(sqnorm)
             rate = self.threshold / norm
             # When no clipping is needed, skip the clipping on CPU and
             # multiply 1.0 on the device otherwise.
-            if int(dev) == -1:
+            if device.xp is numpy:
                 if rate >= 1:
                     return
             else:

--- a/chainer/optimizer_hooks/gradient_hard_clipping.py
+++ b/chainer/optimizer_hooks/gradient_hard_clipping.py
@@ -1,5 +1,4 @@
-from chainer import backend
-from chainer import cuda
+import chainer
 
 
 class GradientHardClipping(object):
@@ -46,6 +45,6 @@ class GradientHardClipping(object):
         grad = param.grad
         if grad is None:
             return
-        xp = backend.get_array_module(grad)
-        with cuda.get_device_from_array(grad):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             xp.clip(grad, self.lower_bound, self.upper_bound, out=grad)

--- a/chainer/optimizer_hooks/gradient_lars.py
+++ b/chainer/optimizer_hooks/gradient_lars.py
@@ -1,4 +1,4 @@
-from chainer import backend
+import chainer
 from chainer import cuda
 
 
@@ -85,22 +85,22 @@ class GradientLARS(object):
         if p is None or g is None:
             return
 
-        xp = backend.get_array_module(p)
-
-        # weight norm
-        p_norm = xp.linalg.norm(p)
-        # grad norm
-        g_norm = xp.linalg.norm(g)
-        local_rate = p_norm / (self.eps + g_norm + self.weight_decay * p_norm)
-        rate = xp.where(p_norm > self.threshold, local_rate, 1.0)
-        with cuda.get_device_from_array(p) as dev:
-            if int(dev) == -1:
-                g += self.weight_decay * p
-                g *= rate
-            else:
+        with chainer.using_device(param.device):
+            xp = param.device.xp
+            # weight norm
+            p_norm = xp.linalg.norm(p)
+            # grad norm
+            g_norm = xp.linalg.norm(g)
+            local_rate = (p_norm
+                          / (self.eps + g_norm + self.weight_decay * p_norm))
+            rate = xp.where(p_norm > self.threshold, local_rate, 1.0)
+            if xp is cuda.cupy:
                 kernel = cuda.elementwise(
                     'T p, T rate, T weight_decay',
                     'T g',
                     'g += weight_decay * p; g *= rate;',
                     'lars')
                 kernel(p, rate, self.weight_decay, g)
+            else:
+                g += self.weight_decay * p
+                g *= rate

--- a/chainer/optimizer_hooks/weight_decay.py
+++ b/chainer/optimizer_hooks/weight_decay.py
@@ -1,3 +1,4 @@
+import chainer
 from chainer import cuda
 
 
@@ -40,10 +41,10 @@ class WeightDecay(object):
         p, g = param.data, param.grad
         if p is None or g is None:
             return
-        with cuda.get_device_from_array(p) as dev:
-            if int(dev) == -1:
-                g += self.rate * p
-            else:
+        with chainer.using_device(param.device):
+            if param.device.xp is cuda.cupy:
                 kernel = cuda.elementwise(
                     'T p, T decay', 'T g', 'g += decay * p', 'weight_decay')
                 kernel(p, self.rate, g)
+            else:
+                g += self.rate * p

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import types
@@ -49,8 +49,8 @@ class AdaDeltaRule(optimizer.UpdateRule):
             self.hyperparam.eps = eps
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             self.state['msg'] = xp.zeros_like(param.data)
             self.state['msdx'] = xp.zeros_like(param.data)
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import types
@@ -48,9 +48,8 @@ class AdaGradRule(optimizer.UpdateRule):
             self.hyperparam.eps = eps
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
-            self.state['h'] = xp.zeros_like(param.data)
+        with chainer.using_device(param.device):
+            self.state['h'] = param.device.xp.zeros_like(param.data)
 
     def update_core_cpu(self, param):
         grad = param.grad

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy
 
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import optimizer
@@ -155,8 +155,8 @@ class AdamRule(optimizer.UpdateRule):
             self.initial_alpha = self.hyperparam.alpha
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             self.state['m'] = xp.zeros_like(param.data)
             self.state['v'] = xp.zeros_like(param.data)
             if self.hyperparam.amsgrad:

--- a/chainer/optimizers/corrected_momentum_sgd.py
+++ b/chainer/optimizers/corrected_momentum_sgd.py
@@ -1,4 +1,4 @@
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import optimizer
@@ -46,9 +46,8 @@ class CorrectedMomentumSGDRule(optimizer.UpdateRule):
             self.hyperparam.momentum = momentum
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
-            self.state['v'] = xp.zeros_like(param.data)
+        with chainer.using_device(param.device):
+            self.state['v'] = param.device.xp.zeros_like(param.data)
 
         # For iDeep
         if isinstance(param.data, intel64.mdarray):

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -1,4 +1,4 @@
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer.backends import intel64
 from chainer import optimizer
@@ -47,8 +47,8 @@ class MomentumSGDRule(optimizer.UpdateRule):
             self.hyperparam.momentum = momentum
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             self.state['v'] = xp.zeros_like(param.data)
 
         # For iDeep

--- a/chainer/optimizers/msvag.py
+++ b/chainer/optimizers/msvag.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import numpy
 
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import types
@@ -72,8 +72,8 @@ class MSVAGRule(optimizer.UpdateRule):
         self.beta_power = self.hyperparam.beta
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             self.state['m'] = xp.zeros_like(param.data)
             self.state['v'] = xp.zeros_like(param.data)
 

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -1,4 +1,4 @@
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import types
@@ -46,8 +46,8 @@ class NesterovAGRule(optimizer.UpdateRule):
             self.hyperparam.momentum = momentum
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             self.state['v'] = xp.zeros_like(param.data)
 
     def update_core_cpu(self, param):

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import types
@@ -65,9 +65,8 @@ class RMSpropRule(optimizer.UpdateRule):
             self.hyperparam.eps_inside_sqrt = eps_inside_sqrt
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
-            self.state['ms'] = xp.zeros_like(param.data)
+        with chainer.using_device(param.device):
+            self.state['ms'] = param.device.xp.zeros_like(param.data)
 
     def update_core_cpu(self, param):
         grad = param.grad

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import types
@@ -61,8 +61,8 @@ class RMSpropGravesRule(optimizer.UpdateRule):
             self.hyperparam.eps = eps
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             self.state['n'] = xp.zeros_like(param.data)
             self.state['g'] = xp.zeros_like(param.data)
             self.state['delta'] = xp.zeros_like(param.data)

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer import backend
+import chainer
 from chainer.backends import cuda
 from chainer import optimizer
 from chainer import types
@@ -48,8 +48,8 @@ class SMORMS3Rule(optimizer.UpdateRule):
             self.hyperparam.eps = eps
 
     def init_state(self, param):
-        xp = backend.get_array_module(param.data)
-        with cuda.get_device_from_array(param.data):
+        with chainer.using_device(param.device):
+            xp = param.device.xp
             self.state['mem'] = xp.ones_like(param.data)
             self.state['g'] = xp.zeros_like(param.data)
             self.state['g2'] = xp.zeros_like(param.data)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -729,8 +729,9 @@ class Variable(object):
         stats_msg = 'mean={0:.8f}, std={1:.8f}'
 
         array = self.array
-        with cuda.get_device_from_array(array) as dev:
-            xp = numpy if int(dev) == -1 else cuda.cupy
+        device = self.device
+        with chainer.using_device(device):
+            xp = device.xp
 
             if array is None:
                 # `array` can be `None` if constructed without any arguments
@@ -1237,9 +1238,9 @@ class Variable(object):
             else:
                 gv._data[0].fill(0)
         else:
-            with cuda.get_device_from_array(arr) as dev:
+            with chainer.using_device(self.device):
+                xp = self.device.xp
                 if self._grad is None:
-                    xp = numpy if dev.id == -1 else cuda.cupy
                     self._grad = xp.zeros_like(arr)
                     self._grad_var = None
                 else:
@@ -1414,11 +1415,8 @@ class Variable(object):
                     ' If the size of this variable accidentally becomes one,'
                     ' set zero to grad.',
                     DeprecationWarning)
-            with cuda.get_device_from_array(self.array) as device:
-                if device is cuda.DummyDevice:
-                    self.grad = numpy.ones_like(self.array)
-                else:
-                    self.grad = cuda.cupy.ones_like(self.array)
+            with chainer.using_device(self.device):
+                self.grad = self.device.xp.ones_like(self.array)
             if loss_scale is not None:
                 self.grad *= loss_scale
 
@@ -1630,7 +1628,8 @@ def _backprop_to_all(outputs, retain_grad, loss_scale):
         else:
             hooks = base_hooks
 
-        with cuda.get_device_from_array(*(in_data + out_grad_array)):
+        with chainer.using_device(
+                backend.get_device_from_array(*(in_data + out_grad_array))):
             for hook in hooks:
                 hook.backward_preprocess(
                     func, tuple(in_data), tuple(out_grad_array))

--- a/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_lstm.py
@@ -3,6 +3,7 @@ import unittest
 import numpy
 
 import chainer
+from chainer import backend
 from chainer.backends import cuda
 from chainer import functions
 from chainer import links
@@ -47,7 +48,8 @@ class TestLSTM(unittest.TestCase):
         xp = self.link.xp
         x1 = chainer.Variable(x1_data) if self.input_variable else x1_data
         h1 = self.link(x1)
-        with cuda.get_device_from_array(x1_data):
+        device = backend.get_device_from_array(x1_data)
+        with chainer.using_device(device):
             c0 = chainer.Variable(xp.zeros((len(self.x1), self.out_size),
                                            dtype=self.x1.dtype))
             c1_expect, h1_expect = functions.lstm(c0, self.link.upward(x1))
@@ -60,7 +62,8 @@ class TestLSTM(unittest.TestCase):
         h1_in, h1_rest = functions.split_axis(
             self.link.h.data, [batch], axis=0)
         y2 = self.link(x2)
-        with cuda.get_device_from_array(x1):
+        device = backend.get_device_from_array(x1)
+        with chainer.using_device(device):
             c2_expect, y2_expect = \
                 functions.lstm(c1_expect,
                                self.link.upward(x2) + self.link.lateral(h1_in))
@@ -293,7 +296,8 @@ class TestStatelessLSTM(unittest.TestCase):
         xp = self.link.xp
         x = chainer.Variable(x_data) if self.input_variable else x_data
         c1, h1 = self.link(None, None, x)
-        with cuda.get_device_from_array(x_data):
+        device = backend.get_device_from_array(x_data)
+        with chainer.using_device(device):
             c0 = chainer.Variable(xp.zeros((len(self.x), self.out_size),
                                            dtype=self.x.dtype))
             c1_expect, h1_expect = functions.lstm(c0, self.link.upward(x))

--- a/tests/chainer_tests/links_tests/connection_tests/test_peephole.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_peephole.py
@@ -18,8 +18,9 @@ def _sigmoid(x):
 
 
 def _peephole(func, c, h, x):
-    xp = backend.get_array_module(x)
-    with cuda.get_device_from_array(x):
+    device = backend.get_device_from_array(x)
+    with chainer.using_device(device):
+        xp = device.xp
         lstm_in = x.dot(func.upward.W.data.T)
         lstm_in += h.dot(func.lateral.W.data.T)
         lstm_in = xp.reshape(lstm_in, (len(lstm_in),

--- a/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_tree_lstm.py
@@ -22,8 +22,9 @@ def _child_sum_tree_lstm(func, *inputs):
     cs = inputs[:len(inputs) // 2]
     hs = inputs[len(inputs) // 2:-1]
     x = inputs[-1]
-    xp = backend.get_array_module(x)
-    with cuda.get_device_from_array(x):
+    device = backend.get_device_from_array(x)
+    with chainer.using_device(device):
+        xp = device.xp
         W_x = func.W_x.W.data.T
         b_x = func.W_x.b.data
         W_h_aio = func.W_h_aio.W.data.T
@@ -62,8 +63,9 @@ def _nary_tree_lstm(func, *inputs):
     cs = inputs[:len(inputs) // 2]
     hs = inputs[len(inputs) // 2:-1]
     x = inputs[-1]
-    xp = backend.get_array_module(x)
-    with cuda.get_device_from_array(x):
+    device = backend.get_device_from_array(x)
+    with chainer.using_device(device):
+        xp = device.xp
         W_x = func.W_x.W.data.T
         b_x = func.W_x.b.data
         W_h_list = [getattr(func, 'W_h{}'.format(i)).W.data.T

--- a/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_zoneoutlstm.py
@@ -18,8 +18,9 @@ def _sigmoid(x):
 
 
 def _zoneoutlstm(func, c, h, x, c_creator, h_creator):
-    xp = backend.get_array_module(x)
-    with cuda.get_device_from_array(x):
+    device = backend.get_device_from_array(x)
+    with chainer.using_device(device):
+        xp = device.xp
         lstm_in = x.dot(func.upward.W.data.T)
         lstm_in += h.dot(func.lateral.W.data.T)
         lstm_in = xp.reshape(lstm_in, (len(lstm_in),


### PR DESCRIPTION
Now that Chainer has its own device abstraction, we should avoid using `DummyDevice` outside `backends.cuda` module.

Also replaces `cuda.get_device_from_array` with `backend.get_device_from_array`.
Some uses are left for respective reasons. (cupy-specific code, being handled in another PR (#6982), etc.)