### PR TITLE
Support device specifiers in static graph example 

### DIFF
--- a/examples/static_graph_optimizations/cifar/train_cifar.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar.py
@@ -49,15 +49,14 @@ def main():
     args = parser.parse_args()
 
     device = chainer.get_device(args.device)
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     print('Device: {}'.format(device))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
-
-    if device.xp is chainerx:
-        sys.stderr.write('This example does not support ChainerX devices.\n')
-        sys.exit(1)
 
     device.use()
 
@@ -107,7 +106,7 @@ def main():
     # Dump a computational graph from 'loss' variable at the first iteration
     # The "main" refers to the target link of the "main" optimizer.
     # TODO(hvy): Support ChainerX
-    if not isinstance(device, chainer.backend.ChainerxDevice):
+    if device.xp is not chainerx:
         trainer.extend(extensions.DumpGraph('main/loss'))
 
     # Take a snapshot at each epoch

--- a/examples/static_graph_optimizations/cifar/train_cifar.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar.py
@@ -21,7 +21,7 @@ import models.VGG
 
 def main():
     parser = argparse.ArgumentParser(description='Chainer CIFAR example:')
-    parser.add_argument('--dataset', '-d', default='cifar10',
+    parser.add_argument('--dataset', default='cifar10',
                         help='The dataset to use: cifar10 or cifar100')
     parser.add_argument('--batchsize', '-b', type=int, default=64,
                         help='Number of images in each mini-batch')
@@ -29,20 +29,31 @@ def main():
                         help='Learning rate for SGD')
     parser.add_argument('--epoch', '-e', type=int, default=300,
                         help='Number of sweeps over the dataset to train')
-    parser.add_argument('--gpu', '-g', type=int, default=0,
-                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--device', '-d', type=str, default='0',
+                        help='Device specifier. Either ChainerX device '
+                        'specifier or an integer. If non-negative integer, '
+                        'CuPy arrays with specified device id are used. If '
+                        'negative integer, NumPy arrays are used')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
     parser.add_argument('--resume', '-r', default='',
                         help='Resume the training from snapshot')
     parser.add_argument('--early-stopping', type=str,
                         help='Metric to watch for early stopping')
+    group = parser.add_argument_group('deprecated arguments')
+    group.add_argument('--gpu', '-g', dest='device',
+                       type=int, nargs='?', const=0,
+                       help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
 
-    print('GPU: {}'.format(args.gpu))
+    device = chainer.get_device(args.device)
+
+    print('Device: {}'.format(device))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    device.use()
 
     # Set up a neural network to train.
     # Classifier reports softmax cross entropy loss and accuracy at every
@@ -58,10 +69,7 @@ def main():
     else:
         raise RuntimeError('Invalid dataset choice.')
     model = L.Classifier(models.VGG.VGG(class_labels))
-    if args.gpu >= 0:
-        # Make a specified GPU current
-        chainer.backends.cuda.get_device_from_id(args.gpu).use()
-        model.to_gpu()  # Copy the model to the GPU
+    model.to_device(device)
 
     optimizer = chainer.optimizers.MomentumSGD(args.learnrate)
     optimizer.setup(model)
@@ -80,11 +88,11 @@ def main():
 
     # Set up a trainer
     updater = training.updaters.StandardUpdater(
-        train_iter, optimizer, device=args.gpu)
+        train_iter, optimizer, device=device)
     trainer = training.Trainer(updater, stop_trigger, out=args.out)
 
     # Evaluate the model with the test dataset for each epoch
-    trainer.extend(extensions.Evaluator(test_iter, model, device=args.gpu))
+    trainer.extend(extensions.Evaluator(test_iter, model, device=device))
 
     # Reduce the learning rate by half every 25 epochs.
     trainer.extend(extensions.ExponentialShift('lr', 0.5),
@@ -92,7 +100,9 @@ def main():
 
     # Dump a computational graph from 'loss' variable at the first iteration
     # The "main" refers to the target link of the "main" optimizer.
-    trainer.extend(extensions.DumpGraph('main/loss'))
+    # TODO(hvy): Support ChainerX
+    if not isinstance(device, chainer.backend.ChainerxDevice):
+        trainer.extend(extensions.DumpGraph('main/loss'))
 
     # Take a snapshot at each epoch
     trainer.extend(extensions.snapshot(), trigger=(args.epoch, 'epoch'))

--- a/examples/static_graph_optimizations/cifar/train_cifar.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar.py
@@ -6,12 +6,14 @@ the code is mostly unchanged except for the addition of the
 `@static_graph` decorator to the model chain's `__call__()` method.
 """
 import argparse
+import sys
 
 import chainer
 import chainer.links as L
 from chainer import training
 from chainer.training import extensions
 from chainer.training import triggers
+import chainerx
 
 from chainer.datasets import get_cifar10
 from chainer.datasets import get_cifar100
@@ -52,6 +54,10 @@ def main():
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     device.use()
 

--- a/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
@@ -54,15 +54,14 @@ def main():
     args = parser.parse_args()
 
     device = chainer.get_device(args.device)
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     print('Device: {}'.format(device))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
-
-    if device.xp is chainerx:
-        sys.stderr.write('This example does not support ChainerX devices.\n')
-        sys.exit(1)
 
     device.use()
 

--- a/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
@@ -26,7 +26,7 @@ import models.VGG
 
 def main():
     parser = argparse.ArgumentParser(description='Chainer CIFAR example:')
-    parser.add_argument('--dataset', '-d', default='cifar10',
+    parser.add_argument('--dataset', default='cifar10',
                         help='The dataset to use: cifar10 or cifar100')
     parser.add_argument('--batchsize', '-b', type=int, default=64,
                         help='Number of images in each mini-batch')
@@ -34,20 +34,31 @@ def main():
                         help='Learning rate for SGD')
     parser.add_argument('--epoch', '-e', type=int, default=300,
                         help='Number of sweeps over the dataset to train')
-    parser.add_argument('--gpu', '-g', type=int, default=0,
-                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--device', '-d', type=str, default='0',
+                        help='Device specifier. Either ChainerX device '
+                        'specifier or an integer. If non-negative integer, '
+                        'CuPy arrays with specified device id are used. If '
+                        'negative integer, NumPy arrays are used')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
     parser.add_argument('--test', action='store_true',
                         help='Use tiny datasets for quick tests')
     parser.add_argument('--resume', '-r', default='',
                         help='Resume the training from snapshot')
+    group = parser.add_argument_group('deprecated arguments')
+    group.add_argument('--gpu', '-g', dest='device',
+                       type=int, nargs='?', const=0,
+                       help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
 
-    print('GPU: {}'.format(args.gpu))
+    device = chainer.get_device(args.device)
+
+    print('Device: {}'.format(device))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    device.use()
 
     # Set up a neural network to train.
     # Classifier reports softmax cross entropy loss and accuracy at every
@@ -71,10 +82,7 @@ def main():
     test_count = len(test)
 
     model = L.Classifier(models.VGG.VGG(class_labels))
-    if args.gpu >= 0:
-        # Make a specified GPU current
-        chainer.backends.cuda.get_device_from_id(args.gpu).use()
-        model.to_gpu()  # Copy the model to the GPU
+    model.to_device(device)
 
     optimizer = chainer.optimizers.MomentumSGD(args.learnrate)
     optimizer.setup(model)
@@ -94,9 +102,9 @@ def main():
             optimizer.lr *= 0.5
             print('Reducing learning rate to: {}'.format(optimizer.lr))
 
-        x_array, t_array = convert.concat_examples(batch, args.gpu)
+        x_array, t_array = convert.concat_examples(batch, device)
         x = chainer.Variable(x_array)
-        t = chainer.Variable(t_array)
+        t = chainer.Variable(t_array, requires_grad=False)
         optimizer.update(model, x, t)
         sum_loss += float(model.loss.array) * len(t)
         sum_accuracy += float(model.accuracy.array) * len(t)
@@ -112,9 +120,9 @@ def main():
             # It is good practice to turn off train mode during evaluation.
             with configuration.using_config('train', False):
                 for batch in test_iter:
-                    x_array, t_array = convert.concat_examples(batch, args.gpu)
+                    x_array, t_array = convert.concat_examples(batch, device)
                     x = chainer.Variable(x_array)
-                    t = chainer.Variable(t_array)
+                    t = chainer.Variable(t_array, requires_grad=False)
                     loss = model(x, t)
                     sum_loss += float(loss.array) * len(t)
                     sum_accuracy += float(model.accuracy.array) * len(t)

--- a/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
@@ -11,12 +11,14 @@ training loop that manually computes the loss of minibatches and
 applies an optimizer to update the model.
 """
 import argparse
+import sys
 
 import chainer
 from chainer import configuration
 from chainer.dataset import convert
 import chainer.links as L
 from chainer import serializers
+import chainerx
 
 from chainer.datasets import get_cifar10
 from chainer.datasets import get_cifar100
@@ -57,6 +59,10 @@ def main():
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     device.use()
 

--- a/examples/static_graph_optimizations/mnist/train_mnist.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist.py
@@ -108,16 +108,15 @@ def main():
     args = parser.parse_args()
 
     device = chainer.get_device(args.device)
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     print('Device: {}'.format(device))
     print('# unit: {}'.format(args.unit))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
-
-    if device.xp is chainerx:
-        sys.stderr.write('This example does not support ChainerX devices.\n')
-        sys.exit(1)
 
     device.use()
 

--- a/examples/static_graph_optimizations/mnist/train_mnist.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist.py
@@ -84,8 +84,11 @@ def main():
                         help='Number of sweeps over the dataset to train')
     parser.add_argument('--frequency', '-f', type=int, default=-1,
                         help='Frequency of taking a snapshot')
-    parser.add_argument('--gpu', '-g', type=int, default=-1,
-                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--device', '-d', type=str, default='-1',
+                        help='Device specifier. Either ChainerX device '
+                        'specifier or an integer. If non-negative integer, '
+                        'CuPy arrays with specified device id are used. If '
+                        'negative integer, NumPy arrays are used')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
     parser.add_argument('--model', '-m', default='MLP',
@@ -96,13 +99,21 @@ def main():
                         help='Number of units')
     parser.add_argument('--noplot', dest='plot', action='store_false',
                         help='Disable PlotReport extension')
+    group = parser.add_argument_group('deprecated arguments')
+    group.add_argument('--gpu', '-g', dest='device',
+                       type=int, nargs='?', const=0,
+                       help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
 
-    print('GPU: {}'.format(args.gpu))
+    device = chainer.get_device(args.device)
+
+    print('Device: {}'.format(device))
     print('# unit: {}'.format(args.unit))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    device.use()
 
     # Set up a neural network to train
     # Classifier reports softmax cross entropy loss and accuracy at every
@@ -111,10 +122,8 @@ def main():
         model = L.Classifier(MLP(args.unit, 10))
     elif args.model == 'MLPSideEffect':
         model = L.Classifier(MLPSideEffect(args.unit, 10))
-    if args.gpu >= 0:
-        # Make a specified GPU current
-        chainer.cuda.get_device_from_id(args.gpu).use()
-        model.to_gpu()  # Copy the model to the GPU
+
+    model.to_device(device)
 
     # Setup an optimizer
     optimizer = chainer.optimizers.Adam()
@@ -129,11 +138,11 @@ def main():
 
     # Set up a trainer
     updater = training.updaters.StandardUpdater(
-        train_iter, optimizer, device=args.gpu)
+        train_iter, optimizer, device=device)
     trainer = training.Trainer(updater, (args.epoch, 'epoch'), out=args.out)
 
     # Evaluate the model with the test dataset for each epoch
-    trainer.extend(extensions.Evaluator(test_iter, model, device=args.gpu))
+    trainer.extend(extensions.Evaluator(test_iter, model, device=device))
 
     # Dump a computational graph from 'loss' variable at the first iteration
     # The "main" refers to the target link of the "main" optimizer.

--- a/examples/static_graph_optimizations/mnist/train_mnist.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist.py
@@ -8,6 +8,7 @@ the code is mostly unchanged except for the addition of the
 from __future__ import print_function
 
 import argparse
+import sys
 
 import chainer
 import chainer.functions as F
@@ -16,6 +17,7 @@ from chainer import static_code
 from chainer import static_graph
 from chainer import training
 from chainer.training import extensions
+import chainerx
 
 
 # Network definition
@@ -112,6 +114,10 @@ def main():
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     device.use()
 

--- a/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
@@ -51,16 +51,15 @@ def main():
     args = parser.parse_args()
 
     device = chainer.get_device(args.device)
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     print('Device: {}'.format(device))
     print('# unit: {}'.format(args.unit))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
-
-    if device.xp is chainerx:
-        sys.stderr.write('This example does not support ChainerX devices.\n')
-        sys.exit(1)
 
     device.use()
 

--- a/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
@@ -29,8 +29,11 @@ def main():
                         help='Number of images in each mini-batch')
     parser.add_argument('--epoch', '-e', type=int, default=20,
                         help='Number of sweeps over the dataset to train')
-    parser.add_argument('--gpu', '-g', type=int, default=-1,
-                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--device', '-d', type=str, default='-1',
+                        help='Device specifier. Either ChainerX device '
+                        'specifier or an integer. If non-negative integer, '
+                        'CuPy arrays with specified device id are used. If '
+                        'negative integer, NumPy arrays are used')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
     parser.add_argument('--model', '-m', default='MLP',
@@ -39,23 +42,28 @@ def main():
                         help='Resume the training from snapshot')
     parser.add_argument('--unit', '-u', type=int, default=1000,
                         help='Number of units')
+    group = parser.add_argument_group('deprecated arguments')
+    group.add_argument('--gpu', '-g', dest='device',
+                       type=int, nargs='?', const=0,
+                       help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
 
-    print('GPU: {}'.format(args.gpu))
+    device = chainer.get_device(args.device)
+
+    print('Device: {}'.format(device))
     print('# unit: {}'.format(args.unit))
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    device.use()
 
     # Set up a neural network to train
     if args.model == 'MLP':
         model = L.Classifier(train_mnist.MLP(args.unit, 10))
     elif args.model == 'MLPSideEffect':
         model = L.Classifier(train_mnist.MLPSideEffect(args.unit, 10))
-    if args.gpu >= 0:
-        # Make a speciied GPU current
-        chainer.cuda.get_device_from_id(args.gpu).use()
-        model.to_gpu()  # Copy the model to the GPU
+    model.to_device(device)
 
     # Setup an optimizer
     optimizer = chainer.optimizers.Adam()
@@ -76,9 +84,9 @@ def main():
 
     while train_iter.epoch < args.epoch:
         batch = train_iter.next()
-        x_array, t_array = convert.concat_examples(batch, args.gpu)
+        x_array, t_array = convert.concat_examples(batch, device)
         x = chainer.Variable(x_array)
-        t = chainer.Variable(t_array)
+        t = chainer.Variable(t_array, requires_grad=False)
         optimizer.update(model, x, t)
         sum_loss += float(model.loss.array) * len(t)
         sum_accuracy += float(model.accuracy.array) * len(t)
@@ -93,7 +101,7 @@ def main():
             # It is good practice to turn off train mode during evaluation.
             with configuration.using_config('train', False):
                 for batch in test_iter:
-                    x_array, t_array = convert.concat_examples(batch, args.gpu)
+                    x_array, t_array = convert.concat_examples(batch, device)
                     x = chainer.Variable(x_array)
                     t = chainer.Variable(t_array)
                     loss = model(x, t)

--- a/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
@@ -13,12 +13,14 @@ applies an optimizer to update the model.
 from __future__ import print_function
 
 import argparse
+import sys
 
 import chainer
 from chainer import configuration
 from chainer.dataset import convert
 import chainer.links as L
 from chainer import serializers
+import chainerx
 
 import train_mnist
 
@@ -55,6 +57,10 @@ def main():
     print('# Minibatch-size: {}'.format(args.batchsize))
     print('# epoch: {}'.format(args.epoch))
     print('')
+
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
 
     device.use()
 

--- a/examples/static_graph_optimizations/ptb/train_ptb_custom_loop.py
+++ b/examples/static_graph_optimizations/ptb/train_ptb_custom_loop.py
@@ -210,7 +210,6 @@ def main():
     args = parser.parse_args()
 
     device = chainer.get_device(args.device)
-
     if device.xp is chainerx:
         sys.stderr.write('This example does not support ChainerX devices.\n')
         sys.exit(1)

--- a/examples/static_graph_optimizations/ptb/train_ptb_custom_loop.py
+++ b/examples/static_graph_optimizations/ptb/train_ptb_custom_loop.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import argparse
 import numpy as np
 import random
+import sys
 
 import chainer
 from chainer import configuration
@@ -33,6 +34,7 @@ from chainer.functions.loss import softmax_cross_entropy
 import chainer.links as L
 from chainer import serializers
 from chainer import static_graph
+import chainerx
 
 
 # Definition of a recurrent net for language modeling
@@ -208,6 +210,11 @@ def main():
     args = parser.parse_args()
 
     device = chainer.get_device(args.device)
+
+    if device.xp is chainerx:
+        sys.stderr.write('This example does not support ChainerX devices.\n')
+        sys.exit(1)
+
     device.use()
 
     def evaluate(model, iter):

--- a/examples/static_graph_optimizations/ptb/train_ptb_custom_loop.py
+++ b/examples/static_graph_optimizations/ptb/train_ptb_custom_loop.py
@@ -185,8 +185,11 @@ def main():
                              '(= length of truncated BPTT)')
     parser.add_argument('--epoch', '-e', type=int, default=39,
                         help='Number of sweeps over the dataset to train')
-    parser.add_argument('--gpu', '-g', type=int, default=0,
-                        help='GPU ID (negative value indicates CPU)')
+    parser.add_argument('--device', '-d', type=str, default='0',
+                        help='Device specifier. Either ChainerX device '
+                        'specifier or an integer. If non-negative integer, '
+                        'CuPy arrays with specified device id are used. If '
+                        'negative integer, NumPy arrays are used')
     parser.add_argument('--gradclip', '-c', type=float, default=5,
                         help='Gradient norm threshold to clip')
     parser.add_argument('--out', '-o', default='result',
@@ -198,7 +201,14 @@ def main():
     parser.set_defaults(test=False)
     parser.add_argument('--unit', '-u', type=int, default=650,
                         help='Number of LSTM units in each layer')
+    group = parser.add_argument_group('deprecated arguments')
+    group.add_argument('--gpu', '-g', dest='device',
+                       type=int, nargs='?', const=0,
+                       help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    device = chainer.get_device(args.device)
+    device.use()
 
     def evaluate(model, iter):
         # Evaluation routine to be used for validation and test.
@@ -212,7 +222,7 @@ def main():
         with configuration.using_config('train', False):
             iter.reset()
             for batch in iter:
-                word, label = convert.concat_examples(batch, args.gpu)
+                word, label = convert.concat_examples(batch, device)
                 words.append(word)
                 labels.append(label)
                 data_count += 1
@@ -243,10 +253,7 @@ def main():
     # Prepare an RNNLM model
     model = RNNForLMUnrolled(n_vocab, args.unit)
     lossfun = softmax_cross_entropy.softmax_cross_entropy
-    if args.gpu >= 0:
-        # Make the specified GPU current
-        chainer.cuda.get_device_from_id(args.gpu).use()
-        model.to_gpu()
+    model.to_device(device)
 
     # Set up an optimizer
     optimizer = chainer.optimizers.SGD(lr=1.0)
@@ -268,7 +275,7 @@ def main():
             # Concatenate the word IDs to matrices and send them to the device
             # self.converter does this job
             # (it is chainer.dataset.concat_examples by default)
-            word, label = convert.concat_examples(batch, args.gpu)
+            word, label = convert.concat_examples(batch, device)
             words.append(word)
             labels.append(label)
             count += 1


### PR DESCRIPTION
Part of #6661.

All of the sub-examples of the static graph optimization example, specifying a ChainerX device fail and need separate fixes. For instance, this error is raised. https://github.com/chainer/chainer/blob/master/chainer/graph_optimizations/static_graph.py#L738