### PR TITLE
Fix pointless comparison warning

### DIFF
--- a/chainerx_cc/chainerx/cuda/numeric.cuh
+++ b/chainerx_cc/chainerx/cuda/numeric.cuh
@@ -50,7 +50,7 @@ __device__ inline T Sign(T x) {
 
 template <>
 __device__ inline uint8_t Sign(uint8_t x) {
-    return x > 0;
+    return static_cast<uint8_t>(x > 0);
 }
 template <>
 __device__ inline cuda::Float16 Sign(cuda::Float16 x) {

--- a/chainerx_cc/chainerx/cuda/numeric.cuh
+++ b/chainerx_cc/chainerx/cuda/numeric.cuh
@@ -49,6 +49,10 @@ __device__ inline T Sign(T x) {
 }
 
 template <>
+__device__ inline uint8_t Sign(uint8_t x) {
+    return x > 0;
+}
+template <>
 __device__ inline cuda::Float16 Sign(cuda::Float16 x) {
     return IsNan(x) ? x : cuda::Float16{static_cast<int>(cuda::Float16{0} < x) - static_cast<int>(x < cuda::Float16{0})};
 }


### PR DESCRIPTION
Fixes a warning, `warning: pointless comparison of unsigned integer with zero`. This warning is by the way only raised for the `.cuh`.