### PR TITLE
Improve device documentation

### DIFF
--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -33,6 +33,13 @@ _dummy_context = _DummyContext()
 # TODO(niboshi): Write more detailed description about interface/usage.
 class Device(object):
     """A base class of unified devices.
+
+    Chainer has the following concrete implementations:
+
+    - :class:`chainer.backend.CpuDevice`
+    - :class:`chainer.backend.GpuDevice`
+    - :class:`chainer.backend.Intel64Device`
+    - :class:`chainer.backend.ChainerxDevice`
     """
 
     @property

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -35,6 +35,12 @@ class ChainerxDevice(_backend.Device):
 
     @staticmethod
     def from_fallback_device(device):
+        """Returns a :class:`~chainer.backend.ChainerxDevice` corresponding \
+to the fallback device.
+
+        .. seealso::
+            :data:`~chainer.backend.ChainerxDevice.fallback_device`
+        """
         # TODO(niboshi): Write unit test
         assert isinstance(device, _backend.Device)
         if isinstance(device, _cpu.CpuDevice):
@@ -48,6 +54,17 @@ class ChainerxDevice(_backend.Device):
 
     @property
     def fallback_device(self):
+        """Fallback device.
+
+        A fallback device is either a :class:`~chainer.backend.CpuDevice` or
+        a :class:`~chainer.backend.GpuDevice` which shares the same physical
+        device with the original ChainerX device.
+
+        For example, the fallback device of ``native:0`` ChainerX device is
+        :class:`~chainer.backend.CpuDevice`. The fallback device of ``cuda:1``
+        ChainerX device is :class:`~chainer.backend.GpuDevice` with device ID
+        1.
+        """
         # TODO(niboshi): Write unit test
         backend_name = self.device.backend.name
         if backend_name == 'native':

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -213,6 +213,9 @@ class GpuDevice(_backend.Device):
 
     @staticmethod
     def from_device_id(device_id):
+        """Returns a :class:`~chainer.backend.GpuDevice` corresponding \
+to the CUDA device ID.
+        """
         check_cuda_available()
 
         if not (isinstance(device_id, _integer_types) and device_id >= 0):


### PR DESCRIPTION
- List concrete devices in `chainer.backend.Device` docstring.
- Document
  * `ChainerxDevice.fallback_device`
  * `ChainerxDevice.from_fallback_device`
  * `GpuDevice.from_device_id`
