### PR TITLE
Bugfix: `MultiNodeChainList` should not assume float32

### DIFF
--- a/chainermn/functions/point_to_point_communication.py
+++ b/chainermn/functions/point_to_point_communication.py
@@ -87,7 +87,7 @@ class Recv(chainer.Function):
         if inputs == ():
             dummy_var = tuple([xp.array([], dtype=xp.float32)])
         else:
-            dummy_var = tuple([xp.zeros(x.shape, dtype=xp.float32)
+            dummy_var = tuple([xp.zeros_like(x)
                                for x in inputs])
 
         return dummy_var


### PR DESCRIPTION
This PR improves float16 support for model parallelization.  The bug was found in #6575.