### PR TITLE
Remove backslashes to continue lines of link targets

### DIFF
--- a/chainer/functions/activation/lstm.py
+++ b/chainer/functions/activation/lstm.py
@@ -318,7 +318,7 @@ def lstm(c_prev, x):
         ``c`` is the updated cell state. ``h`` indicates the outgoing signal.
 
     See the original paper proposing LSTM with forget gates:
-    `Long Short-Term Memory in Recurrent Neural Networks \
+    `Long Short-Term Memory in Recurrent Neural Networks
     <http://www.felixgers.de/papers/phd.pdf>`_.
 
     .. seealso::

--- a/chainer/functions/activation/slstm.py
+++ b/chainer/functions/activation/slstm.py
@@ -378,7 +378,7 @@ def slstm(c_prev1, c_prev2, x1, x2):
         tuple: Two :class:`~chainer.Variable` objects ``c`` and ``h``. ``c`` is
         the cell state. ``h`` indicates the outgoing signal.
 
-    See detail in paper: `Long Short-Term Memory Over Tree Structures \
+    See detail in paper: `Long Short-Term Memory Over Tree Structures
     <https://arxiv.org/abs/1503.04881>`_.
 
     .. admonition:: Example

--- a/chainer/functions/activation/tree_lstm.py
+++ b/chainer/functions/activation/tree_lstm.py
@@ -242,10 +242,10 @@ def tree_lstm(*inputs):
         tuple: Two :class:`~chainer.Variable` objects ``c`` and ``h``. ``c`` is
         the updated cell state. ``h`` indicates the outgoing signal.
 
-    See the papers for details: `Improved Semantic Representations From \
-    Tree-Structured Long Short-Term Memory Networks \
+    See the papers for details: `Improved Semantic Representations From
+    Tree-Structured Long Short-Term Memory Networks
     <https://www.aclweb.org/anthology/P15-1150>`_ and
-    `A Fast Unified Model for Parsing and Sentence Understanding \
+    `A Fast Unified Model for Parsing and Sentence Understanding
     <https://arxiv.org/pdf/1603.06021.pdf>`_.
 
     Tai et al.'s N-Ary TreeLSTM is little extended in

--- a/chainer/functions/array/spatial_transformer_grid.py
+++ b/chainer/functions/array/spatial_transformer_grid.py
@@ -116,7 +116,7 @@ def spatial_transformer_grid(theta, output_shape, **kwargs):
     """2D Spatial Transformer grid.
 
     This function generates coordinates of the points sampled from an image
-    to perform warping described in `Spatial Transformer Networks \
+    to perform warping described in `Spatial Transformer Networks
     <https://arxiv.org/abs/1506.02025>`_.
 
     Given a coordinate in the warped image :math:`(x_i^t, y_i^t)`, the point

--- a/chainer/functions/array/spatial_transformer_sampler.py
+++ b/chainer/functions/array/spatial_transformer_sampler.py
@@ -274,7 +274,7 @@ def spatial_transformer_sampler(x, grid, **kwargs):
     - :math:`h_O` and :math:`w_O` are the height and width of the output
       image.
 
-    See detail in the following paper: `Spatial Transformer Networks \
+    See detail in the following paper: `Spatial Transformer Networks
     <https://arxiv.org/abs/1506.02025>`_.
 
     .. note::

--- a/chainer/functions/connection/deformable_convolution_2d_sampler.py
+++ b/chainer/functions/connection/deformable_convolution_2d_sampler.py
@@ -64,9 +64,9 @@ def deformable_convolution_2d_sampler(x, offset, W, b=None, stride=1, pad=0):
     locations in the standard convolution. It enables free form deformation of
     the sampling grid.
 
-    See `Jifeng Dai, Haozhi Qi, Yuwen Xiong, Yi Li, Guodong Zhang, Han Hu, \
-        Yichen Wei. Deformable Convolutional Networks\
-        <https://arxiv.org/abs/1703.06211>`_
+    See `Jifeng Dai, Haozhi Qi, Yuwen Xiong, Yi Li, Guodong Zhang, Han Hu,
+    Yichen Wei. Deformable Convolutional Networks
+    <https://arxiv.org/abs/1703.06211>`_
 
     If the bias vector is given, then it is added to all spatial locations of
     the output of convolution.

--- a/chainer/functions/connection/depthwise_convolution_2d.py
+++ b/chainer/functions/connection/depthwise_convolution_2d.py
@@ -51,8 +51,8 @@ def depthwise_convolution_2d(x, W, b=None, stride=1, pad=0):
     If the bias vector is given, then it is added to all spatial locations of
     the output of convolution.
 
-    See: `L. Sifre. Rigid-motion scattering for image classification\
-          <https://www.di.ens.fr/data/publications/papers/phd_sifre.pdf>`_
+    See: `L. Sifre. Rigid-motion scattering for image classification
+    <https://www.di.ens.fr/data/publications/papers/phd_sifre.pdf>`_
 
     .. seealso:: :class:`~chainer.links.DepthwiseConvolution2D`
 

--- a/chainer/functions/connection/shift.py
+++ b/chainer/functions/connection/shift.py
@@ -117,7 +117,7 @@ class Shift(function_node.FunctionNode):
 def shift(x, ksize=3, dilate=1):
     """Shift function.
 
-    See: `Shift: A Zero FLOP, Zero Parameter Alternative to Spatial \
+    See: `Shift: A Zero FLOP, Zero Parameter Alternative to Spatial
     Convolutions <https://arxiv.org/abs/1711.08141>`_
 
     Args:

--- a/chainer/functions/loss/black_out.py
+++ b/chainer/functions/loss/black_out.py
@@ -59,8 +59,8 @@ def black_out(x, t, W, samples, reduce='mean'):
             array whose shape is :math:`(N,)` .
             If it is ``'mean'``, it holds a scalar.
 
-    See: `BlackOut: Speeding up Recurrent Neural Network Language Models With \
-         Very Large Vocabularies <https://arxiv.org/abs/1511.06909>`_
+    See: `BlackOut: Speeding up Recurrent Neural Network Language Models With
+    Very Large Vocabularies <https://arxiv.org/abs/1511.06909>`_
 
     .. seealso:: :class:`~chainer.links.BlackOut`.
 

--- a/chainer/functions/loss/ctc.py
+++ b/chainer/functions/loss/ctc.py
@@ -385,15 +385,15 @@ def connectionist_temporal_classification(
     .. note::
        This function supports (batch, sequence, 1-dimensional input)-data.
 
-    .. [Graves2006] Alex Graves, Santiago Fernandez,\
-    Faustino Gomez, Jurgen Schmidhuber,\
-    `Connectionist Temporal Classification: Labelling Unsegmented\
-    Sequence Data with Recurrent Neural Networks\
-    <ftp://ftp.idsia.ch/pub/juergen/icml2006.pdf>`_
+    .. [Graves2006] Alex Graves, Santiago Fernandez,
+       Faustino Gomez, Jurgen Schmidhuber,
+       `Connectionist Temporal Classification: Labelling Unsegmented
+       Sequence Data with Recurrent Neural Networks
+       <ftp://ftp.idsia.ch/pub/juergen/icml2006.pdf>`_
 
-    .. [Graves2012] Alex Graves,\
-    `Supervised Sequence Labelling with Recurrent Neural Networks\
-    <https://www.cs.toronto.edu/~graves/preprint.pdf>`_
+    .. [Graves2012] Alex Graves,
+       `Supervised Sequence Labelling with Recurrent Neural Networks
+       <https://www.cs.toronto.edu/~graves/preprint.pdf>`_
 
     """
     if not isinstance(x, collections_abc.Sequence):

--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -394,8 +394,8 @@ return_samples=False)
             whose shape is same as one of (hence both of) input variables.
             If it is ``'sum'``, the output variable holds a scalar value.
 
-    See: `Distributed Representations of Words and Phrases and their\
-         Compositionality <https://arxiv.org/abs/1310.4546>`_
+    See: `Distributed Representations of Words and Phrases and their
+    Compositionality <https://arxiv.org/abs/1310.4546>`_
 
     .. seealso:: :class:`~chainer.links.NegativeSampling`.
 

--- a/chainer/functions/loss/triplet.py
+++ b/chainer/functions/loss/triplet.py
@@ -124,8 +124,8 @@ def triplet(anchor, positive, negative, margin=0.2, reduce='mean'):
             If it is ``'mean'``, the output variable holds a scalar value.
 
     .. note::
-        This cost can be used to train triplet networks. See `Learning \
-        Fine-grained Image Similarity with Deep Ranking \
+        This cost can be used to train triplet networks. See `Learning
+        Fine-grained Image Similarity with Deep Ranking
         <https://arxiv.org/abs/1404.4661>`_ for details.
 
     .. admonition:: Example

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -166,7 +166,7 @@ def dropout(x, ratio=.5, **kwargs):
             input. The mask will become ``None`` when ``chainer.config.train``
             is set to ``False``.
 
-    See the paper by G. Hinton: `Improving neural networks by preventing \
+    See the paper by G. Hinton: `Improving neural networks by preventing
     co-adaptation of feature detectors <https://arxiv.org/abs/1207.0580>`_.
 
     .. admonition:: Example

--- a/chainer/functions/noise/gumbel_softmax.py
+++ b/chainer/functions/noise/gumbel_softmax.py
@@ -16,7 +16,7 @@ def gumbel_softmax(log_pi, tau=0.1, axis=1):
     :math:`g_i` s are samples drawn from
     Gumbel distribution :math:`Gumbel(0, 1)`
 
-    See `Categorical Reparameterization with Gumbel-Softmax \
+    See `Categorical Reparameterization with Gumbel-Softmax
     <https://arxiv.org/abs/1611.01144>`_.
 
     Args:

--- a/chainer/functions/noise/zoneout.py
+++ b/chainer/functions/noise/zoneout.py
@@ -58,7 +58,7 @@ def zoneout(h, x, ratio=.5, **kwargs):
     Returns:
         ~chainer.Variable: Output variable.
 
-    See the paper: `Zoneout: Regularizing RNNs by Randomly Preserving Hidden \
+    See the paper: `Zoneout: Regularizing RNNs by Randomly Preserving Hidden
     Activations <https://arxiv.org/abs/1606.01305>`_.
 
     """

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -779,8 +779,8 @@ running_var=None, decay=0.9, axis=None)
             option, numbers in the tuple must be being sorted in ascending
             order. For example, (0, 2) is OK, but (2, 0) is not.
 
-    See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
-          Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_
+    See: `Batch Normalization: Accelerating Deep Network Training by Reducing
+    Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_
 
     .. seealso:: :class:`~chainer.links.BatchNormalization`
 

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -182,8 +182,8 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
         If it is desired to update the running statistics, call the function
         with `update_statistics=True` option.
 
-    See: `Batch Renormalization: Towards Reducing Minibatch Dependence in \
-          Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_
+    See: `Batch Renormalization: Towards Reducing Minibatch Dependence in
+    Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_
 
     .. seealso:: :class:`~chainer.links.BatchRenormalization`
 

--- a/chainer/functions/normalization/local_response_normalization.py
+++ b/chainer/functions/normalization/local_response_normalization.py
@@ -205,7 +205,7 @@ def local_response_normalization(x, n=5, k=2, alpha=1e-4, beta=.75):
     Returns:
         ~chainer.Variable: Output variable.
 
-    See: Section 3.3 of `ImageNet Classification with Deep Convolutional \\
+    See: Section 3.3 of `ImageNet Classification with Deep Convolutional
     Neural Networks <https://www.cs.toronto.edu/~fritz/absps/imagenet.pdf>`_
 
     """

--- a/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
+++ b/chainer/functions/pooling/spatial_pyramid_pooling_2d.py
@@ -29,8 +29,8 @@ def spatial_pyramid_pooling_2d(x, pyramid_height, pooling=None):
     :math:`b_h, b_w` are height and width of input variable ``x``,
     respectively. Note that index of pyramid level :math:`i` is zero-based.
 
-    See detail in paper: `Spatial Pyramid Pooling in Deep Convolutional \
-    Networks for Visual Recognition \
+    See detail in paper: `Spatial Pyramid Pooling in Deep Convolutional
+    Networks for Visual Recognition
     <https://arxiv.org/abs/1406.4729>`_.
 
     Args:

--- a/chainer/links/activation/prelu.py
+++ b/chainer/links/activation/prelu.py
@@ -11,8 +11,8 @@ class PReLU(link.Link):
         shape (tuple of ints): Shape of the parameter array.
         init (float): Initial parameter value.
 
-    See the paper for details: `Delving Deep into Rectifiers: Surpassing \
-    Human-Level Performance on ImageNet Classification \
+    See the paper for details: `Delving Deep into Rectifiers: Surpassing
+    Human-Level Performance on ImageNet Classification
     <https://arxiv.org/abs/1502.01852>`_.
 
     .. seealso:: :func:`chainer.functions.prelu`

--- a/chainer/links/activation/swish.py
+++ b/chainer/links/activation/swish.py
@@ -16,13 +16,14 @@ class Swish(link.Link):
         beta_init (float): Initial value of the parameter variable
             :math:`\\beta`.
 
-    See the paper for details: `Searching for Activation Functions \
+    See the paper for details: `Searching for Activation Functions
     <https://arxiv.org/abs/1710.05941>`_
 
     To try Swish instead of ReLU, replace ``F.ReLU`` with individual ``Swish``
     links registered to the model. For example, the model defined in the
-    `MNIST example <https://github.com/chainer/chainer/tree/master/examples/\
-    mnist/train_mnist.py>`_ can be rewritten as follows.
+    `MNIST example
+    <https://github.com/chainer/chainer/tree/master/examples/mnist/train_mnist.py>`_
+    can be rewritten as follows.
 
     ReLU version (original)::
 

--- a/chainer/links/connection/inceptionbn.py
+++ b/chainer/links/connection/inceptionbn.py
@@ -17,7 +17,7 @@ class InceptionBN(link.Chain):
     path is replaced by two consecutive 3x3 convolution applications, and the
     pooling method is configurable.
 
-    See: `Batch Normalization: Accelerating Deep Network Training by Reducing \
+    See: `Batch Normalization: Accelerating Deep Network Training by Reducing
     Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_.
 
     Args:

--- a/chainer/links/connection/tree_lstm.py
+++ b/chainer/links/connection/tree_lstm.py
@@ -47,8 +47,8 @@ class ChildSumTreeLSTM(link.Chain):
         W_h_f (chainer.links.Linear): Linear layer of connections between
             forget gate :math:`f` and the output of each child.
 
-    See the paper for details: `Improved Semantic Representations From \
-    Tree-Structured Long Short-Term Memory Networks \
+    See the paper for details: `Improved Semantic Representations From
+    Tree-Structured Long Short-Term Memory Networks
     <https://www.aclweb.org/anthology/P15-1150>`_.
 
     """
@@ -170,10 +170,10 @@ class NaryTreeLSTM(link.Chain):
             :math:`a`, input compound, equals to :math:`u` in
             the paper by Tai et al.
 
-    See the papers for details: `Improved Semantic Representations From \
-    Tree-Structured Long Short-Term Memory Networks \
+    See the papers for details: `Improved Semantic Representations From
+    Tree-Structured Long Short-Term Memory Networks
     <https://www.aclweb.org/anthology/P15-1150>`_, and
-    `A Fast Unified Model for Parsing and Sentence Understanding \
+    `A Fast Unified Model for Parsing and Sentence Understanding
     <https://arxiv.org/pdf/1603.06021.pdf>`_.
 
     Tai et al.'s N-Ary TreeLSTM is little extended in

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -72,8 +72,8 @@ class BatchNormalization(link.Link):
         may have a slightly different behavior on inference. To emulate the
         old behavior, pass ``initial_avg_var=0`` for training.
 
-    See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
-          Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_
+    See: `Batch Normalization: Accelerating Deep Network Training by Reducing
+    Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_
 
     .. seealso::
        :func:`~chainer.functions.batch_normalization`,

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -16,8 +16,8 @@ class BatchRenormalization(BatchNormalization):
     training and inference models generate the same outputs that depend on
     individual examples rather than the entire minibatch.
 
-    See: `Batch Renormalization: Towards Reducing Minibatch Dependence in \
-          Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_
+    See: `Batch Renormalization: Towards Reducing Minibatch Dependence in
+    Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_
 
     .. seealso::
        :func:`~chainer.functions.batch_renormalization`,

--- a/chainer/optimizer_hooks/gradient_lars.py
+++ b/chainer/optimizer_hooks/gradient_lars.py
@@ -6,12 +6,12 @@ class GradientLARS(object):
 
     """Optimizer/UpdateRule hook function for layer wise adaptive rate scaling.
 
-    See: `Large Batch Training of Convolutional Networks \
-          <https://arxiv.org/abs/1708.03888>`_.
+    See: `Large Batch Training of Convolutional Networks
+    <https://arxiv.org/abs/1708.03888>`_.
 
-    See: `Convergence Analysis of Gradient Descent Algorithms \
-          with Proportional Updates \
-          <https://arxiv.org/abs/1801.03137>`_.
+    See: `Convergence Analysis of Gradient Descent Algorithms
+    with Proportional Updates
+    <https://arxiv.org/abs/1801.03137>`_.
 
     This hook function scales all gradient arrays to fit to the weight norm.
 

--- a/chainer/optimizer_hooks/gradient_noise.py
+++ b/chainer/optimizer_hooks/gradient_noise.py
@@ -39,7 +39,7 @@ class GradientNoise(object):
             the default noise function is recommended to be either 0.01, 0.3
             or 1.0.
         noise_func (function): Noise generating function which by default
-            is given by `Adding Gradient Noise Improves Learning for Very Deep\
+            is given by `Adding Gradient Noise Improves Learning for Very Deep
             Networks <https://arxiv.org/pdf/1511.06807>`_.
 
     Attributes:

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -78,23 +78,23 @@ class AdamRule(optimizer.UpdateRule):
 
     """Update rule of Adam optimization algorithm.
 
-    See: `Adam: A Method for Stochastic Optimization \
-          <https://arxiv.org/abs/1412.6980v8>`_
+    See: `Adam: A Method for Stochastic Optimization
+    <https://arxiv.org/abs/1412.6980v8>`_
 
     Modified for proper weight decay.
 
-    See: `Fixing Weight Decay Regularization in Adam \
-          <https://openreview.net/forum?id=rk6qdGgCZ>`_
+    See: `Fixing Weight Decay Regularization in Adam
+    <https://openreview.net/forum?id=rk6qdGgCZ>`_
 
     With option to use AMSGrad variant of Adam.
 
-    See: `On the Convergence of Adam and Beyond \
-          <https://openreview.net/forum?id=ryQu7f-RZ>`_
+    See: `On the Convergence of Adam and Beyond
+    <https://openreview.net/forum?id=ryQu7f-RZ>`_
 
     With option to use AdaBound variant of Adam.
 
-    See: `Adaptive Gradient Methods with Dynamic Bound of Learning Rate \
-          <https://openreview.net/forum?id=Bkg3g2R9FX>`
+    See: `Adaptive Gradient Methods with Dynamic Bound of Learning Rate
+    <https://openreview.net/forum?id=Bkg3g2R9FX>`
 
     See :class:`~chainer.optimizers.Adam` for the default values
     of the hyperparameters.
@@ -340,8 +340,8 @@ class Adam(optimizer.GradientMethod):
 
     """Adam optimizer.
 
-    See: `Adam: A Method for Stochastic Optimization \
-          <https://arxiv.org/abs/1412.6980v8>`_
+    See: `Adam: A Method for Stochastic Optimization
+    <https://arxiv.org/abs/1412.6980v8>`_
 
     Modified for proper weight decay (also called
     :class:`~chainer.optimizers.AdamW`).
@@ -354,18 +354,18 @@ class Adam(optimizer.GradientMethod):
     ``weight_decay_rate = 0``, this implementation is identical to
     the standard Adam method.
 
-    See: `Fixing Weight Decay Regularization in Adam \
-          <https://openreview.net/forum?id=rk6qdGgCZ>`_
+    See: `Fixing Weight Decay Regularization in Adam
+    <https://openreview.net/forum?id=rk6qdGgCZ>`_
 
     A flag ``amsgrad`` to use the :class:`~chainer.optimizers.AMSGrad`
-    variant of Adam from
-    the paper: `On the Convergence of Adam and Beyond \
-               <https://openreview.net/forum?id=ryQu7f-RZ>`_
+    variant of Adam from the paper:
+    `On the Convergence of Adam and Beyond
+    <https://openreview.net/forum?id=ryQu7f-RZ>`_
 
     A flag ``adabound`` to use the :class:`~chainer.optimizers.AdaBound`
-    variant of Adam from
-    the paper: `Adaptive Gradient Methods with Dynamic Bound of Learning Rate \
-               <https://openreview.net/forum?id=Bkg3g2R9FX>`_
+    variant of Adam from the paper:
+    `Adaptive Gradient Methods with Dynamic Bound of Learning Rate
+    <https://openreview.net/forum?id=Bkg3g2R9FX>`_
 
     If both ``amsgrad`` and ``adabound`` are ``True``, the optimizer is
     equivalent to :class:`~chainer.optimizers.AMSBound` proposed in the
@@ -441,8 +441,8 @@ class AdamW(Adam):
 
     This class is a special case of :class:`~chainer.optimizers.Adam`.
 
-    See: `Fixing Weight Decay Regularization in Adam \
-          <https://openreview.net/forum?id=rk6qdGgCZ>`_
+    See: `Fixing Weight Decay Regularization in Adam
+    <https://openreview.net/forum?id=rk6qdGgCZ>`_
 
     Args:
         alpha (float): Coefficient of learning rate.
@@ -473,8 +473,8 @@ class AMSGrad(Adam):
 
     This class is a special case of :class:`~chainer.optimizers.Adam`.
 
-    See: `On the Convergence of Adam and Beyond \
-          <https://openreview.net/forum?id=ryQu7f-RZ>`_
+    See: `On the Convergence of Adam and Beyond
+    <https://openreview.net/forum?id=ryQu7f-RZ>`_
 
     Args:
         alpha (float): Coefficient of learning rate.
@@ -501,8 +501,8 @@ class AdaBound(Adam):
 
     This class is a special case of :class:`~chainer.optimizers.Adam`.
 
-    See: `Adaptive Gradient Methods with Dynamic Bound of Learning Rate \
-          <https://openreview.net/forum?id=Bkg3g2R9FX>`_
+    See: `Adaptive Gradient Methods with Dynamic Bound of Learning Rate
+    <https://openreview.net/forum?id=Bkg3g2R9FX>`_
 
     Args:
         alpha (float): Coefficient of learning rate.
@@ -533,8 +533,8 @@ class AMSBound(Adam):
 
     This class is a special case of :class:`~chainer.optimizers.Adam`.
 
-    See: `Adaptive Gradient Methods with Dynamic Bound of Learning Rate \
-          <https://openreview.net/forum?id=Bkg3g2R9FX>`_
+    See: `Adaptive Gradient Methods with Dynamic Bound of Learning Rate
+    <https://openreview.net/forum?id=Bkg3g2R9FX>`_
 
     Args:
         alpha (float): Coefficient of learning rate.

--- a/chainer/optimizers/corrected_momentum_sgd.py
+++ b/chainer/optimizers/corrected_momentum_sgd.py
@@ -88,7 +88,7 @@ class CorrectedMomentumSGD(optimizer.GradientMethod):
     """Momentum SGD optimizer.
 
     This implements momentum correction discussed in the third section of
-    `Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour \
+    `Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour
     <https://arxiv.org/abs/1706.02677>`_.
 
     :class:`~chainer.optimizers.MomentumSGD` implements the equation (10) of

--- a/chainer/optimizers/msvag.py
+++ b/chainer/optimizers/msvag.py
@@ -33,13 +33,13 @@ class MSVAGRule(optimizer.UpdateRule):
 
     """Update rule of the M-SVAG optimization algorithm.
 
-    See: `Dissecting Adam: The Sign, Magnitude and Variance of Stochastic \
-          Gradients <https://arxiv.org/abs/1705.07774>`_
+    See: `Dissecting Adam: The Sign, Magnitude and Variance of Stochastic
+    Gradients <https://arxiv.org/abs/1705.07774>`_
 
     Modified for proper weight decay.
 
-    See: `Fixing Weight Decay Regularization in Adam \
-          <https://openreview.net/forum?id=rk6qdGgCZ>`_
+    See: `Fixing Weight Decay Regularization in Adam
+    <https://openreview.net/forum?id=rk6qdGgCZ>`_
 
     See :class:`~chainer.optimizers.MSVAG` for the default values
     of the hyperparameters.
@@ -153,8 +153,8 @@ class MSVAG(optimizer.GradientMethod):
 
     """M-SVAG optimizer.
 
-    See: `Dissecting Adam: The Sign, Magnitude and Variance of Stochastic \
-          Gradients <https://arxiv.org/abs/1705.07774>`_
+    See: `Dissecting Adam: The Sign, Magnitude and Variance of Stochastic
+    Gradients <https://arxiv.org/abs/1705.07774>`_
 
     Modified for proper weight decay (also called AdamW).
     AdamW introduces the additional parameters ``eta``
@@ -162,8 +162,8 @@ class MSVAG(optimizer.GradientMethod):
     learning rate, and decouple the weight decay rate from ``alpha``,
     as shown in the below paper.
 
-    See: `Fixing Weight Decay Regularization in Adam \
-          <https://openreview.net/forum?id=rk6qdGgCZ>`_
+    See: `Fixing Weight Decay Regularization in Adam
+    <https://openreview.net/forum?id=rk6qdGgCZ>`_
 
     Args:
         lr (float): Learning rate.


### PR DESCRIPTION
Follow the example in ReST reference:
```
External hyperlinks, like `Python
<http://www.python.org/>`_.
```
http://docutils.sourceforge.net/docs/user/rst/quickref.html#external-hyperlink-targets