### PR TITLE
Fix capitalization of `F.relu` in doc

### DIFF
--- a/chainer/links/activation/swish.py
+++ b/chainer/links/activation/swish.py
@@ -19,7 +19,7 @@ class Swish(link.Link):
     See the paper for details: `Searching for Activation Functions
     <https://arxiv.org/abs/1710.05941>`_
 
-    To try Swish instead of ReLU, replace ``F.ReLU`` with individual ``Swish``
+    To try Swish instead of ReLU, replace ``F.relu`` with individual ``Swish``
     links registered to the model. For example, the model defined in the
     `MNIST example
     <https://github.com/chainer/chainer/tree/master/examples/mnist/train_mnist.py>`_


### PR DESCRIPTION
I also checked outputs of the following:
```zsh
git grep 'functions\.[A-Z]'
git grep 'F\.[A-Z]'
git grep 'links\.[a-z]' | grep -v import | grep -v 'links\.model'
git grep 'L\.[a-z]'
```
