### PR TITLE
Fix float16 and TensorCore related issue in ChainerX

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_conv.h
+++ b/chainerx_cc/chainerx/cuda/cuda_conv.h
@@ -3,9 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
-#include <tuple>
 
 #include <cudnn.h>
 #include <nonstd/optional.hpp>
@@ -119,15 +119,12 @@ private:
         std::size_t operator()(const AlgoCacheKey& key) const;
     };
 
-    using FwdAlgoCacheMap = std::unordered_map<AlgoCacheKey,
-                                               std::tuple<cudnnConvolutionFwdAlgo_t, size_t, cudnnMathType_t>,
-                                               AlgoCacheKeyHash>;
-    using BwdDataAlgoCacheMap = std::unordered_map<AlgoCacheKey,
-                                                   std::tuple<cudnnConvolutionBwdDataAlgo_t, size_t, cudnnMathType_t>,
-                                                   AlgoCacheKeyHash>;
-    using BwdFilterAlgoCacheMap = std::unordered_map<AlgoCacheKey,
-                                                     std::tuple<cudnnConvolutionBwdFilterAlgo_t, size_t, cudnnMathType_t>,
-                                                     AlgoCacheKeyHash>;
+    using FwdAlgoCacheMap =
+            std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionFwdAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
+    using BwdDataAlgoCacheMap =
+            std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionBwdDataAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
+    using BwdFilterAlgoCacheMap =
+            std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionBwdFilterAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
 
     friend class CudaConvTest;  // for unit-tests
 

--- a/chainerx_cc/chainerx/cuda/cuda_conv.h
+++ b/chainerx_cc/chainerx/cuda/cuda_conv.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <utility>
+#include <tuple>
 
 #include <cudnn.h>
 #include <nonstd/optional.hpp>
@@ -118,9 +119,15 @@ private:
         std::size_t operator()(const AlgoCacheKey& key) const;
     };
 
-    using FwdAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionFwdAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
-    using BwdDataAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionBwdDataAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
-    using BwdFilterAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionBwdFilterAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
+    using FwdAlgoCacheMap = std::unordered_map<AlgoCacheKey,
+                                               std::tuple<cudnnConvolutionFwdAlgo_t, size_t, cudnnMathType_t>,
+                                               AlgoCacheKeyHash>;
+    using BwdDataAlgoCacheMap = std::unordered_map<AlgoCacheKey,
+                                                   std::tuple<cudnnConvolutionBwdDataAlgo_t, size_t, cudnnMathType_t>,
+                                                   AlgoCacheKeyHash>;
+    using BwdFilterAlgoCacheMap = std::unordered_map<AlgoCacheKey,
+                                                     std::tuple<cudnnConvolutionBwdFilterAlgo_t, size_t, cudnnMathType_t>,
+                                                     AlgoCacheKeyHash>;
 
     friend class CudaConvTest;  // for unit-tests
 

--- a/chainerx_cc/chainerx/cuda/cuda_conv.h
+++ b/chainerx_cc/chainerx/cuda/cuda_conv.h
@@ -59,7 +59,7 @@ public:
 private:
     void AddBias(CudnnHandle& handle, const CudnnTensorDescriptor& y_desc, const Array& y, const Array& b);
 
-    std::pair<cudnnConvolutionFwdAlgo_t, size_t> FindConvolutionForwardAlgorithm(
+    std::tuple<cudnnConvolutionFwdAlgo_t, size_t, cudnnMathType_t> FindConvolutionForwardAlgorithm(
             CudnnHandle& handle,
             const CudnnTensorDescriptor& x_desc,
             const Array& x,
@@ -71,7 +71,7 @@ private:
             size_t max_workspace_size,
             const StackVector<int64_t, kMaxNdim>& pad,
             const StackVector<int64_t, kMaxNdim>& stride);
-    std::pair<cudnnConvolutionBwdDataAlgo_t, size_t> FindConvolutionBackwardDataAlgorithm(
+    std::tuple<cudnnConvolutionBwdDataAlgo_t, size_t, cudnnMathType_t> FindConvolutionBackwardDataAlgorithm(
             CudnnHandle& handle,
             const CudnnFilterDescriptor& filter_desc,
             const Array& w,
@@ -83,7 +83,7 @@ private:
             size_t max_workspace_size,
             const StackVector<int64_t, kMaxNdim>& pad,
             const StackVector<int64_t, kMaxNdim>& stride);
-    std::pair<cudnnConvolutionBwdFilterAlgo_t, size_t> FindConvolutionBackwardFilterAlgorithm(
+    std::tuple<cudnnConvolutionBwdFilterAlgo_t, size_t, cudnnMathType_t> FindConvolutionBackwardFilterAlgorithm(
             CudnnHandle& handle,
             const CudnnTensorDescriptor& x_desc,
             const Array& x,
@@ -118,9 +118,9 @@ private:
         std::size_t operator()(const AlgoCacheKey& key) const;
     };
 
-    using FwdAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::pair<cudnnConvolutionFwdAlgo_t, size_t>, AlgoCacheKeyHash>;
-    using BwdDataAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::pair<cudnnConvolutionBwdDataAlgo_t, size_t>, AlgoCacheKeyHash>;
-    using BwdFilterAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::pair<cudnnConvolutionBwdFilterAlgo_t, size_t>, AlgoCacheKeyHash>;
+    using FwdAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionFwdAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
+    using BwdDataAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionBwdDataAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
+    using BwdFilterAlgoCacheMap = std::unordered_map<AlgoCacheKey, std::tuple<cudnnConvolutionBwdFilterAlgo_t, size_t, cudnnMathType_t>, AlgoCacheKeyHash>;
 
     friend class CudaConvTest;  // for unit-tests
 


### PR DESCRIPTION
This PR aims to fix the issue below.
* "CUDNN_STATUS_BAD_PARAM" occurs when ChainerX and float16 are used in the imagenet example due to improper setting of cudnn convolution math type.