### PR TITLE
Add missing doc entry for `CommunicatorBase.allgather`

### DIFF
--- a/docs/source/chainermn/reference/index.rst
+++ b/docs/source/chainermn/reference/index.rst
@@ -12,7 +12,7 @@ Communicators
     :members: rank, intra_rank, inter_rank, inter_size, size,
               alltoall, split, send, recv, bcast, gather, allreduce,
               send_obj, recv_obj, bcast_obj, gather_obj,
-              allreduce_obj, bcast_data, allreduce_grad
+              allreduce_obj, bcast_data, allreduce_grad, allgather
 
 
 Optimizers and Evaluators


### PR DESCRIPTION
I found that the method exists but the doc is missing.