### PR TITLE
Use CHAINER_READTHEDOCS instead of READTHEDOCS

### DIFF
--- a/chainerx_build_helper.py
+++ b/chainerx_build_helper.py
@@ -45,8 +45,8 @@ class CMakeBuild(build_ext.build_ext):
         elif self.debug:
             # Being built with `python setup.py build --debug`
             build_type = 'Debug'
-        elif os.getenv('CHAINER_READTHEDOCS', None) == 'True':
-            # on ReadTheDocs
+        elif os.getenv('CHAINER_READTHEDOCS', None) == '1':
+            # Being built on ReadTheDocs; see comments in `setup.py`
             build_type = 'Debug'
         else:
             # default

--- a/chainerx_build_helper.py
+++ b/chainerx_build_helper.py
@@ -45,7 +45,7 @@ class CMakeBuild(build_ext.build_ext):
         elif self.debug:
             # Being built with `python setup.py build --debug`
             build_type = 'Debug'
-        elif os.getenv('READTHEDOCS', None) == 'True':
+        elif os.getenv('CHAINER_READTHEDOCS', None) == 'True':
             # on ReadTheDocs
             build_type = 'Debug'
         else:

--- a/setup.py
+++ b/setup.py
@@ -186,12 +186,13 @@ setup_kwargs = dict(
 
 build_chainerx = 0 != int(os.getenv('CHAINER_BUILD_CHAINERX', '0'))
 
-# `CHAINER_READTHEDOCS` is set to `True` in the project configuration
-# of ReadTheDocs. It should be used instead of `READTHEDOCS` environment
-# variable during the installation process of Chainer package. This allows
-# projects that depend on Chainer package to build their docs on RTD without
-# building ChainerX.
-if os.getenv('CHAINER_READTHEDOCS', None) == 'True':
+# `CHAINER_READTHEDOCS` is set to `1` in the project configuration of
+# ReadTheDocs. It should be used instead of `READTHEDOCS` environment
+# variable (which is set to `True`) during the installation process of
+# Chainer package.
+# This allows projects that depend on Chainer package to build their docs
+# on RTD without building ChainerX.
+if os.getenv('CHAINER_READTHEDOCS', None) == '1':
     os.environ['MAKEFLAGS'] = '-j2'
     build_chainerx = True
 

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,13 @@ setup_kwargs = dict(
 
 
 build_chainerx = 0 != int(os.getenv('CHAINER_BUILD_CHAINERX', '0'))
-if os.getenv('READTHEDOCS', None) == 'True':
+
+# `CHAINER_READTHEDOCS` is set to `True` in the project configuration
+# of ReadTheDocs. It should be used instead of `READTHEDOCS` environment
+# variable during the installation process of Chainer package. This allows
+# projects that depend on Chainer package to build their docs on RTD without
+# building ChainerX.
+if os.getenv('CHAINER_READTHEDOCS', None) == 'True':
     os.environ['MAKEFLAGS'] = '-j2'
     build_chainerx = True
 


### PR DESCRIPTION
I set `CHAINER_READTHEDOCS=1` in RTD configuration (only Chainer maintainers can access this page): https://readthedocs.org/dashboard/chainer/environmentvariables/
Note: it seems environment variables cannot be controlled via `readthedocs.yml`.