### PR TITLE
Exclude eps from `running_var` of `F.batch_renormalization`

### DIFF
--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -193,9 +193,6 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
         - ``F.batch_renormalization`` applies Bessel's correction to update the
           moving average of variances.
 
-        In order to reuse :func:`chainer.functions.fixed_batch_normalization`
-        on inference, ``running_var`` does not include ``eps``.
-
     See: `Batch Renormalization: Towards Reducing Minibatch Dependence in
     Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_
 

--- a/chainer/functions/normalization/batch_renormalization.py
+++ b/chainer/functions/normalization/batch_renormalization.py
@@ -76,8 +76,8 @@ class BatchRenormalizationFunction(function.Function):
         # batch renormalization
         axis = (0,) + tuple(range(head_ndim, x.ndim))
         mean = x.mean(axis=axis, dtype=gamma.dtype)
-        var = x.var(axis=axis, dtype=gamma.dtype) + self.eps
-        self.std = xp.sqrt(var, dtype=var.dtype)
+        var = x.var(axis=axis, dtype=gamma.dtype)
+        self.std = xp.sqrt(var + self.eps, dtype=var.dtype)
 
         running_sigma = xp.sqrt(self._running_var + self.eps,
                                 dtype=self._running_mean.dtype)
@@ -192,6 +192,9 @@ def batch_renormalization(x, gamma, beta, rmax, dmax, eps=2e-5,
           average of standard deviations :math:`\\sigma`.
         - ``F.batch_renormalization`` applies Bessel's correction to update the
           moving average of variances.
+
+        In order to reuse :func:`chainer.functions.fixed_batch_normalization`
+        on inference, ``running_var`` does not include ``eps``.
 
     See: `Batch Renormalization: Towards Reducing Minibatch Dependence in
     Batch-Normalized Models <https://arxiv.org/abs/1702.03275>`_

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_renormalization.py
@@ -45,7 +45,7 @@ def _naive_batch_renormalization(
         m = x.size // gamma.size
         adjust = m / max(m - 1., 1.)
         running_var *= decay
-        running_var += (var.array + dt(eps)) * dt((1. - decay) * adjust)
+        running_var += var.array * dt((1. - decay) * adjust)
 
     return y
 

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_renormalization.py
@@ -143,18 +143,16 @@ class TestPopulationStatistics(unittest.TestCase):
         unbiased_var = self.x.var(axis=0) * self.nx / (self.nx - 1)
         testing.assert_allclose(unbiased_var, self.link.avg_var)
 
+        y = chainer.Variable(y)
         with chainer.using_config('train', False):
-            y = chainer.Variable(y)
             self.link(y, finetune=True)
-            testing.assert_allclose(mean, self.link.avg_mean)
-            testing.assert_allclose(unbiased_var, self.link.avg_var)
+        testing.assert_allclose(mean, self.link.avg_mean)
+        testing.assert_allclose(unbiased_var, self.link.avg_var)
 
-    @condition.retry(3)
     def test_statistics_cpu(self):
         self.check_statistics(self.x, self.y)
 
     @attr.gpu
-    @condition.retry(3)
     def test_statistics_gpu(self):
         self.link.to_gpu()
         self.check_statistics(cuda.to_gpu(self.x), cuda.to_gpu(self.y))
@@ -178,12 +176,10 @@ class TestPopulationStatistics(unittest.TestCase):
         testing.assert_allclose(mean, self.link.avg_mean)
         testing.assert_allclose(unbiased_var, self.link.avg_var)
 
-    @condition.retry(3)
     def test_statistics2_cpu(self):
         self.check_statistics2(self.x, self.y)
 
     @attr.gpu
-    @condition.retry(3)
     def test_statistics2_gpu(self):
         self.link.to_gpu()
         self.check_statistics2(

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_renormalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_renormalization.py
@@ -117,7 +117,8 @@ class BatchRenormalizationTest(unittest.TestCase):
 
 
 @testing.parameterize(
-    {'nx': 10, 'ny': 10},
+    {'nx': 10, 'ny': 10, 'eps': 2e-5},
+    {'nx': 10, 'ny': 10, 'eps': 1e-1},
     # TODO(Kenta Oono)
     # Pass the case below (this test does not pass when nx != ny).
     # {'nx': 10, 'ny': 15}
@@ -127,7 +128,8 @@ class TestPopulationStatistics(unittest.TestCase):
     def setUp(self):
         self.decay = 0.9
         self.size = 3
-        self.link = links.BatchRenormalization(self.size, self.decay)
+        self.link = links.BatchRenormalization(
+            self.size, decay=self.decay, eps=self.eps)
         self.x = numpy.random.uniform(
             -1, 1, (self.nx, self.size)).astype(numpy.float32)
         self.y = numpy.random.uniform(


### PR DESCRIPTION
Fix #7506.

The statistics tests were unexpectedly passing because they didn't test with large `eps`.

Split from #7104.