### PR TITLE
Clear outputs in `FunctionNode.unchain`

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -868,11 +868,15 @@ Use apply() method instead.\
 
     def unchain(self):
         """Purges in/out nodes and this function node itself from the graph."""
+        if self._is_chainerx_fallback_mode:
+            raise NotImplementedError(
+                'Unchaining is not yet supported in ChainerX fallback mode.')
         for y in self.outputs:
             y_ref = y()
             if y_ref is not None:
                 y_ref.unchain()
         self.inputs = None
+        self.outputs = None
 
     def add_hook(self, hook, name=None):
         """Registers a function hook.


### PR DESCRIPTION
From the documentation, I expect `outputs` to be cleared as well (even though they're weak refs).

Additionally I put an error message for ChainerX fallback function nodes.