### PR TITLE
Check device instance using `xp` when possible

### DIFF
--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -37,9 +37,10 @@ class ChainerxDevice(_backend.Device):
     def from_fallback_device(device):
         # TODO(niboshi): Write unit test
         assert isinstance(device, _backend.Device)
-        if isinstance(device, _cpu.CpuDevice):
+        assert not isinstance(device, intel64.Intel64Device)
+        if device.xp is numpy:
             return ChainerxDevice(chainerx.get_device('native', 0))
-        if isinstance(device, cuda.GpuDevice):
+        if device.xp is cuda.cupy:
             return ChainerxDevice(
                 chainerx.get_device('cuda', device.device.id))
         raise RuntimeError(

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -37,10 +37,9 @@ class ChainerxDevice(_backend.Device):
     def from_fallback_device(device):
         # TODO(niboshi): Write unit test
         assert isinstance(device, _backend.Device)
-        assert not isinstance(device, intel64.Intel64Device)
-        if device.xp is numpy:
+        if isinstance(device, _cpu.CpuDevice):
             return ChainerxDevice(chainerx.get_device('native', 0))
-        if device.xp is cuda.cupy:
+        if isinstance(device, cuda.GpuDevice):
             return ChainerxDevice(
                 chainerx.get_device('cuda', device.device.id))
         raise RuntimeError(

--- a/chainer/device_resident.py
+++ b/chainer/device_resident.py
@@ -139,7 +139,7 @@ without any copy.
     def from_chx(self):
         """Converts parameter variables and persistent values from ChainerX \
 to NumPy/CuPy devices without any copy."""
-        if isinstance(self._device, backend.ChainerxDevice):
+        if self._device.xp is chainerx:
             self._device = self._device.fallback_device
 
         self.device_resident_accept(_FromChxVisitor())

--- a/chainer/training/updaters/standard_updater.py
+++ b/chainer/training/updaters/standard_updater.py
@@ -80,7 +80,7 @@ class StandardUpdater(_updater.Updater):
 
         if device is not None:
             for optimizer in six.itervalues(self._optimizers):
-                if isinstance(device, cuda.GpuDevice):
+                if device.xp is cuda.cupy:
                     # Do not transfer between different cupy devices.
                     # TODO(niboshi): Reconsider this behavior
                     optimizer.target.to_gpu(device.device.id)

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1812,7 +1812,7 @@ class Parameter(Variable):
         else:
             device = self._initial_device
 
-        if isinstance(device, backend.ChainerxDevice):
+        if device.xp is chainerx:
             backend_name = device.device.backend.name
             if backend_name == 'native':
                 self._initial_device = backend.CpuDevice()

--- a/examples/imagenet/train_imagenet.py
+++ b/examples/imagenet/train_imagenet.py
@@ -152,7 +152,7 @@ def main():
     if args.dali:
         if not dali_util._dali_available:
             raise RuntimeError('DALI seems not available on your system.')
-        if not isinstance(device, chainer.backend.cuda.GpuDevice):
+        if device.xp is not chainer.backend.cuda.cupy:
             raise RuntimeError('Using DALI requires GPU device. Please '
                                'specify it with --device option.')
         num_threads = args.loaderjob


### PR DESCRIPTION
Should be slightly faster, easier to read. 

Note that `CpuDevice` and `Intel64Device` cannot be distinguished so those occurrences are left unchanged..