### PR TITLE
Allow `CUDNN_LIBNAME` to be specified by environment variable

### DIFF
--- a/chainerx_cc/cmake/FindCuDNN.cmake
+++ b/chainerx_cc/cmake/FindCuDNN.cmake
@@ -28,10 +28,19 @@ else()
     PATH_SUFFIXES cuda/include include)
 endif()
 
-if(DEFINED ENV{USE_STATIC_CUDNN})
+if(DEFINED ENV{CUDNN_LIB_DIR})
+  set(CUDNN_LIB_DIR $ENV{CUDNN_LIB_DIR})
+endif()
+
+if(DEFINED ENV{CUDNN_LIBNAME})
+  # libname from envvar
+  set(CUDNN_LIBNAME $ENV{CUDNN_LIBNAME})
+elseif(DEFINED ENV{USE_STATIC_CUDNN})
+  # Static library
   MESSAGE(STATUS "USE_STATIC_CUDNN detected. Linking against static CUDNN library")
   set(CUDNN_LIBNAME "libcudnn_static.a")
 else()
+  # Dynamic library
   set(CUDNN_LIBNAME "cudnn")
 endif()
 


### PR DESCRIPTION
Fixes #7244

This is a Chainer-side fix to support sharing cuDNN library with wheel-distributed CuPy, by manually specifying the paths of header and library files.

CuPy needs https://github.com/cupy/cupy/pull/2208 and https://github.com/cupy/cupy-release-tools/pull/35.