### PR TITLE
`MultiprocessParallelUpdater` to support new devices

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -3,6 +3,7 @@ import warnings
 
 import six
 
+import chainer
 from chainer.backends import cuda
 from chainer.dataset import convert
 from chainer import reporter
@@ -35,20 +36,21 @@ class _Worker(multiprocessing.Process):
         self.comm = nccl.NcclCommunicator(self.n_devices, comm_id,
                                           self.proc_id)
 
-        self.model.to_gpu(self.device)
+        self.model.to_device(self.device)
         self.reporter = reporter.Reporter()
         self.reporter.add_observer('main', self.model)
         self.reporter.add_observers('main',
                                     self.model.namedlinks(skipself=True))
 
     def run(self):
-        dev = cuda.Device(self.device)
-        dev.use()
+        self.device.use()
+
         self.setup()
+
         while True:
             job, data = self.pipe.recv()
             if job == 'finalize':
-                dev.synchronize()
+                self.device.device.synchronize()
                 break
             if job == 'update':
                 # For reducing memory
@@ -178,11 +180,12 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             raise ValueError(
                 'devices argument should be either dict, list or tuple,'
                 ' but {} was given.'.format(type(devices)))
+
         if devices is None or any(device is None for device in devices):
-            raise ValueError('must specify GPU devices')
+            raise ValueError('GPU devices must be specified.')
 
         self._master = optimizer.target
-        self._devices = devices
+        self._devices = [chainer.get_device(device) for device in devices]
         self._mpu_iterators = iterators
         self._initialized = False
 
@@ -211,19 +214,19 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             self._workers.append(worker)
             self._pipes.append(pipe)
 
-        with cuda.Device(self._devices[0]):
-            self._master.to_gpu(self._devices[0])
+        with chainer.using_device(self._devices[0]):
+            self._master.to_device(self._devices[0])
             if len(self._devices) > 1:
                 comm_id = nccl.get_unique_id()
                 self._send_message(('set comm_id', comm_id))
-                self.comm = nccl.NcclCommunicator(len(self._devices),
-                                                  comm_id, 0)
+                self.comm = nccl.NcclCommunicator(
+                    len(self._devices), comm_id, 0)
 
     def update_core(self):
         self.setup_workers()
 
         self._send_message(('update', None))
-        with cuda.Device(self._devices[0]):
+        with chainer.using_device(self._devices[0]):
             # For reducing memory
             self._master.cleargrads()
 

--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/child_reporter.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/child_reporter.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
                 numpy.int32(0)) for i in range(100)]
 
     batch_size = 5
-    devices = tuple([int(x) for x in sys.argv[1].split(',')])
+    devices = tuple([chainer.get_device(d) for d in sys.argv[1].split(',')])
     iters = [chainer.iterators.SerialIterator(i, batch_size) for i in
              chainer.datasets.split_dataset_n_random(
                  dataset, len(devices))]

--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/cuda_init.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/cuda_init.py
@@ -11,7 +11,7 @@ def test():
                 numpy.int32(0)) for i in range(100)]
 
     batch_size = 5
-    devices = (0,)
+    devices = (chainer.get_device('@cupy:0'),)
     iters = [chainer.iterators.SerialIterator(i, batch_size) for i in
              chainer.datasets.split_dataset_n_random(
                  dataset, len(devices))]

--- a/tests/chainer_tests/training_tests/updaters_tests/snippets/raw_array.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/snippets/raw_array.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy
 
 import chainer
@@ -41,7 +43,7 @@ def test():
                 numpy.int32(0)) for i in range(100)]
 
     batch_size = 5
-    devices = (0,)
+    devices = tuple([chainer.get_device(d) for d in sys.argv[1].split(',')])
     iters = [chainer.iterators.SerialIterator(i, batch_size) for i in
              chainer.datasets.split_dataset_n_random(
                  dataset, len(devices))]

--- a/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
@@ -153,9 +153,11 @@ class TestRawArray(unittest.TestCase):
 
 class TestChildReporter(unittest.TestCase):
 
-    def check_with_devices(self, *devices):
+    def check_with_devices(self, n_devices):
+        devices_str = ','.join([
+            '@cupy:{}'.format(device_id) for device_id in range(n_devices)])
         ret, stdoutdata, stderrdata = _run_test_snippet(
-            'child_reporter.py', ','.join(devices))
+            'child_reporter.py', devices_str)
         assert ret == 0, (
             '[stdout]:{!r}\n'
             '[stderr]:{!r}'.format(stdoutdata, stderrdata))
@@ -164,13 +166,13 @@ class TestChildReporter(unittest.TestCase):
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
     def test_single_device(self):
-        self.check_with_devices('@cupy:0')
+        self.check_with_devices(1)
 
     @attr.multi_gpu(2)
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
     def test_multi_device(self):
-        self.check_with_devices('@cupy:0', '@cupy:1')
+        self.check_with_devices(2)
 
 
 class TestCUDAContext(unittest.TestCase):

--- a/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
@@ -51,9 +51,6 @@ class SimpleNet(chainer.Chain):
 }))
 class TestGatherScatter(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
     @attr.gpu
     def test_gather_scatter_grads(self):
         cupy = cuda.cupy
@@ -143,9 +140,6 @@ def _run_test_snippet(name, *args):
 
 class TestRawArray(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
     @attr.gpu
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
@@ -192,9 +186,6 @@ class TestCUDAContext(unittest.TestCase):
 
 
 class TestDevicesByDeviceIds(unittest.TestCase):
-
-    def setUp(self):
-        pass
 
     @attr.gpu
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),

--- a/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
+++ b/tests/chainer_tests/training_tests/updaters_tests/test_multiprocess_parallel_updater.py
@@ -150,7 +150,8 @@ class TestRawArray(unittest.TestCase):
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
     def test_update_uses_raw_array(self):
-        ret, stdoutdata, stderrdata = _run_test_snippet('raw_array.py')
+        ret, stdoutdata, stderrdata = _run_test_snippet(
+            'raw_array.py', '@cupy:0')
         assert ret == 0, (
             '[stdout]:{!r}\n'
             '[stderr]:{!r}'.format(stdoutdata, stderrdata))
@@ -158,10 +159,9 @@ class TestRawArray(unittest.TestCase):
 
 class TestChildReporter(unittest.TestCase):
 
-    def check_with_gpus(self, n_devices):
-        device_ids_str = ','.join([str(n) for n in range(n_devices)])
+    def check_with_devices(self, *devices):
         ret, stdoutdata, stderrdata = _run_test_snippet(
-            'child_reporter.py', device_ids_str)
+            'child_reporter.py', ','.join(devices))
         assert ret == 0, (
             '[stdout]:{!r}\n'
             '[stderr]:{!r}'.format(stdoutdata, stderrdata))
@@ -170,13 +170,13 @@ class TestChildReporter(unittest.TestCase):
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
     def test_single_device(self):
-        self.check_with_gpus(1)
+        self.check_with_devices('@cupy:0')
 
     @attr.multi_gpu(2)
     @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
                          'MultiprocessParallelUpdater is not available.')
     def test_multi_device(self):
-        self.check_with_gpus(2)
+        self.check_with_devices('@cupy:0', '@cupy:1')
 
 
 class TestCUDAContext(unittest.TestCase):
@@ -186,6 +186,23 @@ class TestCUDAContext(unittest.TestCase):
                          'MultiprocessParallelUpdater is not available.')
     def test_cuda_init(self):
         ret, stdoutdata, stderrdata = _run_test_snippet('cuda_init.py')
+        assert ret == 0, (
+            '[stdout]:{!r}\n'
+            '[stderr]:{!r}'.format(stdoutdata, stderrdata))
+
+
+class TestDevicesByDeviceIds(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @attr.gpu
+    @unittest.skipUnless(mpu.MultiprocessParallelUpdater.available(),
+                         'MultiprocessParallelUpdater is not available.')
+    def test_devices_by_device_ids_array(self):
+        # Test passing devices to MultiprocessParallelUpdater by their ids.
+        ret, stdoutdata, stderrdata = _run_test_snippet(
+            'raw_array.py', '0')
         assert ret == 0, (
             '[stdout]:{!r}\n'
             '[stderr]:{!r}'.format(stdoutdata, stderrdata))


### PR DESCRIPTION
Support new chainer devices with `MultiProcessParallelUpdater`.

Required for https://github.com/chainer/chainer/pull/7164.