### PR TITLE
Support mixed indices in `TabularDataset.slice`

### DIFF
--- a/chainer/dataset/tabular/_slice.py
+++ b/chainer/dataset/tabular/_slice.py
@@ -81,13 +81,14 @@ def _as_indices(indices, len_):
     else:
         checked_indices = []
         for index in indices:
+            index = int(index)
             if index < 0:
                 index += len_
             if index < 0 or len_ <= index:
                 raise IndexError(
                     'index {} is out of bounds for dataset with size {}'
                     .format(index, len_))
-            checked_indices.append(int(index))
+            checked_indices.append(index)
         return checked_indices
 
 

--- a/chainer/dataset/tabular/_slice.py
+++ b/chainer/dataset/tabular/_slice.py
@@ -73,31 +73,22 @@ def _as_indices(indices, len_):
     if isinstance(indices, slice) or len(indices) == 0:
         return indices
 
-    if isinstance(indices[0], (bool, np.bool_)):
+    if all(isinstance(index, (bool, np.bool_)) for index in indices):
         if not len(indices) == len_:
             raise ValueError('The number of booleans is '
                              'different from the length of dataset')
-        new_indices = []
-        for i, index in enumerate(indices):
-            if not isinstance(index, (bool, np.bool_)):
-                raise ValueError('{} is not a boolean'.format(index))
-            elif index:
-                new_indices.append(i)
-        return new_indices
-    elif isinstance(indices[0], numbers.Integral):
-        new_indices = []
+        return [i for i, index in enumerate(indices) if index]
+    else:
+        checked_indices = []
         for index in indices:
-            if isinstance(index, numbers.Integral):
-                if index < 0:
-                    index += len_
-                if index < 0 or len_ <= index:
-                    raise IndexError(
-                        'index {} is out of bounds ''for dataset with size {}'
-                        .format(index, len_))
-            else:
-                raise ValueError('{} is not an integer'.format(index))
-            new_indices.append(index)
-        return new_indices
+            if index < 0:
+                index += len_
+            if index < 0 or len_ <= index:
+                raise IndexError(
+                    'index {} is out of bounds for dataset with size {}'
+                    .format(index, len_))
+            checked_indices.append(int(index))
+        return checked_indices
 
 
 def _as_key_indices(keys, key_names):

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_slice.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_slice.py
@@ -78,6 +78,7 @@ def _filter_params(params):
         {'indices': [i in {1, 3} for i in range(10)], 'expected_len': 2},
         {'indices': [True] * 11, 'index_exception': ValueError},
         {'indices': slice(3, None, -2), 'expected_len': 2},
+        {'indices': [False, 3, 9, 5, True], 'expected_len': 5},
         {'indices': [], 'expected_len': 0},
     ],
     testing.product({


### PR DESCRIPTION
`numpy.ndarray` supports mixture of ints and bools as slice indices. This PR adds same functionality to `TabularDataset.slice`.