### PR TITLE
Add `chainer.as_array` for consistency with `chainer.as_variable`

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -68,8 +68,8 @@ from chainer.sequential import Sequential  # NOQA
 from chainer.serializer import AbstractSerializer  # NOQA
 from chainer.serializer import Deserializer  # NOQA
 from chainer.serializer import Serializer  # NOQA
-from chainer.variable import as_variable  # NOQA
 from chainer.variable import as_array  # NOQA
+from chainer.variable import as_variable  # NOQA
 from chainer.variable import Parameter  # NOQA
 from chainer.variable import Variable  # NOQA
 

--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -69,6 +69,7 @@ from chainer.serializer import AbstractSerializer  # NOQA
 from chainer.serializer import Deserializer  # NOQA
 from chainer.serializer import Serializer  # NOQA
 from chainer.variable import as_variable  # NOQA
+from chainer.variable import as_array  # NOQA
 from chainer.variable import Parameter  # NOQA
 from chainer.variable import Variable  # NOQA
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1914,7 +1914,6 @@ def as_variable(obj):
     return Variable(obj, requires_grad=requires_grad)
 
 
-# TODO(hvy): Make private, i.e. _as_array?
 def as_array(obj):
     """Returns the underlying array from a variable or an array.
 

--- a/docs/source/reference/variable.rst
+++ b/docs/source/reference/variable.rst
@@ -9,6 +9,7 @@ Variable classes and utilities
    :nosignatures:
 
    chainer.Variable
+   chainer.as_array
    chainer.as_variable
    chainer.Parameter
    chainer.variable.VariableNode


### PR DESCRIPTION
`chainer.as_variable` can be used to easily write code that accepts either `Variable` or `ndarray` as input. However, the opposite is not possible directly from `chainer`, but we must write `chainer.variable.as_array`. I think it's inconsistent that `chainer.variable.as_variable` and `chainer.as_variable` exist, but only `chainer.variable.as_array` and not `chainer.as_array`. I propose that we make the API consistent by exposing the method from `chainer`. What do you think?