### PR TITLE
Fix recomputation of `L.BatchRenormalization` 

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -233,6 +233,7 @@ else:
     raise TypeError('incorrect dtype name in CHAINER_DTYPE: "{}". '
                     'Only float16/32/64 are allowed.'.format(_chainer_dtype))
 global_config.in_recomputing = False
+global_config._will_recompute = False
 
 
 def is_debug():

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -29,6 +29,7 @@ class GlobalConfig(object):
     cudnn_fast_batch_normalization = None  # type: bool
     dtype = None  # type: numpy.dtype
     in_recomputing = None  # type: bool
+    _will_recompute = None  # type: bool
 
     """The plain object that represents the global configuration of Chainer."""
 

--- a/chainer/functions/util/forget.py
+++ b/chainer/functions/util/forget.py
@@ -36,7 +36,8 @@ class Forget(function_node.FunctionNode):
 
     def forward(self, inputs):
         self.retain_inputs(tuple(range(len(inputs))))
-        with function.no_backprop_mode():
+        with function.no_backprop_mode(),\
+                chainer.using_config('_will_recompute', True):
             xs = [variable.Variable(x) for x in inputs]
             outs = _call_func(self.func, xs)
         return tuple(out.data for out in outs)

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -72,7 +72,7 @@ class BatchRenormalization(BatchNormalization):
                 avg_mean = self._prev_avg_mean
                 avg_var = self._prev_avg_var
                 update_statistics = False
-            else:
+            elif chainer.config._will_recompute:
                 self._prev_avg_mean = avg_mean.copy()
                 self._prev_avg_var = avg_var.copy()
 

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -69,7 +69,12 @@ class BatchRenormalization(BatchNormalization):
                 # called.
                 if finetune:
                     self.N -= 1  # Revert the count
+                avg_mean = self._prev_avg_mean
+                avg_var = self._prev_avg_var
                 update_statistics = False
+            else:
+                self._prev_avg_mean = avg_mean.copy()
+                self._prev_avg_var = avg_var.copy()
 
             ret = batch_renormalization.batch_renormalization(
                 x, gamma, beta, self.rmax, self.dmax,

--- a/chainer/links/normalization/batch_renormalization.py
+++ b/chainer/links/normalization/batch_renormalization.py
@@ -62,19 +62,19 @@ class BatchRenormalization(BatchNormalization):
 
             avg_mean = self.avg_mean
             avg_var = self.avg_var
+            update_statistics = True
 
             if chainer.config.in_recomputing:
                 # Do not update statistics when extra forward computation is
                 # called.
                 if finetune:
                     self.N -= 1  # Revert the count
-                avg_mean = self.xp.zeros_like(self.avg_mean)
-                avg_var = self.xp.zeros_like(self.avg_var)
+                update_statistics = False
 
             ret = batch_renormalization.batch_renormalization(
                 x, gamma, beta, self.rmax, self.dmax,
                 self.eps, avg_mean, avg_var, decay,
-                update_statistics=True)
+                update_statistics=update_statistics)
         else:
             # Use running average statistics or fine-tuned statistics.
             mean = self.avg_mean


### PR DESCRIPTION
Fix #7255.

The PR adds a private flag for forward of `F.forget`, in order to avoid consuming additional memory unless `F.forget` requires it.