### PR TITLE
Add a test to reproduce the bcast deadlock problem

### DIFF
--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -952,4 +952,3 @@ def test_deprecation_single():
 
     with chainer.testing.assert_warns(DeprecationWarning):
         chainermn.create_communicator('single_node')
-

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -12,6 +12,7 @@ import chainer.testing
 import chainer.testing.attr
 import chainermn
 from chainermn.communicators import _communication_utility
+from chainermn.communicators import _memory_utility
 from chainermn.communicators.flat_communicator \
     import FlatCommunicator
 from chainermn.communicators.hierarchical_communicator \
@@ -27,6 +28,7 @@ from chainermn.communicators.single_node_communicator \
 from chainermn.communicators.two_dimensional_communicator \
     import TwoDimensionalCommunicator
 from chainermn import nccl
+import cupy
 
 
 class ExampleModel(chainer.Chain):
@@ -822,6 +824,48 @@ class TestDifferentDtype(unittest.TestCase):
         self.teardown()
 
 
+
+
+
+class TestBcastDeadlock(unittest.TestCase):
+    def setup(self, gpu):
+        if gpu:
+            self.communicator = chainermn.create_communicator('flat')
+            self.device = self.communicator.intra_rank
+            chainer.cuda.get_device_from_id(self.device).use()
+        else:
+            self.device = -1
+
+        if self.communicator.size < 2:
+            pytest.skip('This test is for at least two processes')
+
+    def teardown(self):
+        pass
+
+    @chainer.testing.attr.gpu
+    def test_bcast_gpu_large_buffer_deadlock(self):
+        """This is a regression test of Open MPI's issue
+        https://github.com/open-mpi/ompi/issues/3972
+        """
+        self.setup(True)
+        buf_size = 10000
+        mpi_comm = self.communicator.mpi_comm
+
+        if self.communicator.rank == 0:
+            array = cupy.arange(buf_size, dtype=np.float32)
+        else:
+            array = cupy.empty(buf_size, dtype=np.float32)
+
+        ptr = _memory_utility.array_to_buffer_object(array)
+
+        # This Bcast() cause deadlock if the underlying MPI has the bug.
+        mpi_comm.Bcast(ptr, root=0)
+        mpi_comm.barrier()
+        assert True
+
+        self.teardown()
+
+
 class TestNonContiguousArray(unittest.TestCase):
 
     def setup(self, gpu):
@@ -952,3 +996,4 @@ def test_deprecation_single():
 
     with chainer.testing.assert_warns(DeprecationWarning):
         chainermn.create_communicator('single_node')
+

--- a/tests/chainermn_tests/communicator_tests/test_mpi.py
+++ b/tests/chainermn_tests/communicator_tests/test_mpi.py
@@ -40,13 +40,14 @@ class _TimeoutThread(threading.Thread):
                 m = re.search(r'ompi:version:full:(\S+)', out)
                 version = m.group(1)
 
-                msg = "\n\n***** ERROR:" \
+                msg = "\n\n***** ERROR: " \
                       "It looks like you are using " \
-                      "Open MPI version {}." \
-                      "It is known that the following Open MPI versions " \
-                      "have a bug that cause MPI_Bcast() deadlock when " \
-                      "GPUDirect is used: " \
-                      "3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.1.1, 3.1.2\n"
+                      "Open MPI version {}.\n" \
+                      "***** It is known that the following Open MPI " \
+                      "versions have a bug \n" \
+                      "***** that cause MPI_Bcast() deadlock " \
+                      "when GPUDirect is used: \n" \
+                      "***** 3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.1.1, 3.1.2\n"
                 if self.rank == 1:
                     # Rank 1 prints the error message,
                     # Rank 0 may finish Bcast() immediately without deadlock,

--- a/tests/chainermn_tests/communicator_tests/test_mpi.py
+++ b/tests/chainermn_tests/communicator_tests/test_mpi.py
@@ -75,7 +75,7 @@ class TestBcastDeadlock(unittest.TestCase):
 
         self.queue = queue.Queue(maxsize=1)
 
-    def teardown(self):
+    def tearDown(self):
         pass
 
     @chainer.testing.attr.gpu
@@ -101,5 +101,3 @@ class TestBcastDeadlock(unittest.TestCase):
         mpi_comm.barrier()
         self.queue.put(True)
         assert True
-
-        self.teardown()

--- a/tests/chainermn_tests/communicator_tests/test_mpi.py
+++ b/tests/chainermn_tests/communicator_tests/test_mpi.py
@@ -1,10 +1,14 @@
 import os
-import queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 import re
 import signal
 from subprocess import CalledProcessError
 from subprocess import PIPE
 from subprocess import Popen
+import sys
 import threading
 import unittest
 
@@ -48,7 +52,8 @@ class _TimeoutThread(threading.Thread):
                     # Rank 0 may finish Bcast() immediately without deadlock,
                     # depending on the timing,
                     # because rank 0 is the root of Bcast().
-                    print(msg.format(version), flush=True)
+                    print(msg.format(version))
+                    sys.stdout.flush()
 
                 os.kill(os.getpid(), signal.SIGKILL)
             except CalledProcessError:

--- a/tests/chainermn_tests/communicator_tests/test_mpi.py
+++ b/tests/chainermn_tests/communicator_tests/test_mpi.py
@@ -1,0 +1,99 @@
+import os
+import queue
+import re
+import signal
+import threading
+import unittest
+
+import numpy as np
+import pytest
+
+import chainer.testing
+import chainer.testing.attr
+import chainermn
+from chainermn.communicators import _memory_utility
+import cupy
+
+class _TimeoutThread(threading.Thread):
+    def __init__(self, queue, rank):
+        super(_TimeoutThread, self).__init__()
+        self.queue = queue
+        self.rank = rank
+
+    def run(self):
+        try:
+            self.queue.get(timeout=60)
+        except queue.Empty:
+            # Show error message and information of the problem
+            from subprocess import Popen, PIPE, CalledProcessError
+            try:
+                p = Popen(['ompi_info', '--all', '--parsable'], stdout=PIPE)
+                out, err = p.communicate()
+                if type(out) == bytes:
+                    out = out.decode('utf-8')
+                m = re.search(r'ompi:version:full:(\S+)', out)
+                version = m.group(1)
+
+                msg = "\n\n***** ERROR:" \
+                      "It looks like you are using " \
+                      "Open MPI version {}." \
+                      "It is known that the following Open MPI versions " \
+                      "have a bug that cause MPI_Bcast() deadlock when " \
+                      "GPUDirect is used: " \
+                      "3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.1.1, 3.1.2\n"
+                if self.rank == 1:
+                    # Rank 1 prints the error message,
+                    # Rank 0 may finish Bcast() immediately without deadlock,
+                    # depending on the timing,
+                    # because rank 0 is the root of Bcast().
+                    print(msg.format(version), flush=True)
+
+                os.kill(os.getpid(), signal.SIGKILL)
+            except CalledProcessError:
+                pass
+
+
+class TestBcastDeadlock(unittest.TestCase):
+    def setup(self, gpu):
+        if gpu:
+            self.communicator = chainermn.create_communicator('flat')
+            self.device = self.communicator.intra_rank
+            chainer.cuda.get_device_from_id(self.device).use()
+        else:
+            self.device = -1
+
+        if self.communicator.size < 2:
+            pytest.skip('This test is for at least two processes')
+
+        self.queue = queue.Queue(maxsize=1)
+
+    def teardown(self):
+        pass
+
+    @chainer.testing.attr.gpu
+    def test_bcast_gpu_large_buffer_deadlock(self):
+        """This is a regression test of Open MPI's issue
+        https://github.com/open-mpi/ompi/issues/3972
+        """
+        self.setup(True)
+        buf_size = 10000
+        mpi_comm = self.communicator.mpi_comm
+
+        if self.communicator.rank == 0:
+            array = cupy.arange(buf_size, dtype=np.float32)
+        else:
+            array = cupy.empty(buf_size, dtype=np.float32)
+
+        ptr = _memory_utility.array_to_buffer_object(array)
+
+        # This Bcast() cause deadlock if the underlying MPI has the bug.
+        th = _TimeoutThread(self.queue, self.communicator.rank)
+        th.start()
+        mpi_comm.Bcast(ptr, root=0)
+        mpi_comm.barrier()
+        self.queue.put(True)
+        assert True
+
+        self.teardown()
+
+

--- a/tests/chainermn_tests/communicator_tests/test_mpi.py
+++ b/tests/chainermn_tests/communicator_tests/test_mpi.py
@@ -12,7 +12,6 @@ import chainer.testing
 import chainer.testing.attr
 import chainermn
 from chainermn.communicators import _memory_utility
-import cupy
 
 class _TimeoutThread(threading.Thread):
     def __init__(self, queue, rank):
@@ -80,9 +79,11 @@ class TestBcastDeadlock(unittest.TestCase):
         mpi_comm = self.communicator.mpi_comm
 
         if self.communicator.rank == 0:
-            array = cupy.arange(buf_size, dtype=np.float32)
+            array = np.arange(buf_size, dtype=np.float32)
         else:
-            array = cupy.empty(buf_size, dtype=np.float32)
+            array = np.empty(buf_size, dtype=np.float32)
+
+        array = chainer.cuda.to_gpu(array, device=self.device)
 
         ptr = _memory_utility.array_to_buffer_object(array)
 

--- a/tests/chainermn_tests/communicator_tests/test_mpi.py
+++ b/tests/chainermn_tests/communicator_tests/test_mpi.py
@@ -2,6 +2,9 @@ import os
 import queue
 import re
 import signal
+from subprocess import CalledProcessError
+from subprocess import PIPE
+from subprocess import Popen
 import threading
 import unittest
 
@@ -12,6 +15,7 @@ import chainer.testing
 import chainer.testing.attr
 import chainermn
 from chainermn.communicators import _memory_utility
+
 
 class _TimeoutThread(threading.Thread):
     def __init__(self, queue, rank):
@@ -24,7 +28,6 @@ class _TimeoutThread(threading.Thread):
             self.queue.get(timeout=60)
         except queue.Empty:
             # Show error message and information of the problem
-            from subprocess import Popen, PIPE, CalledProcessError
             try:
                 p = Popen(['ompi_info', '--all', '--parsable'], stdout=PIPE)
                 out, err = p.communicate()
@@ -71,9 +74,7 @@ class TestBcastDeadlock(unittest.TestCase):
 
     @chainer.testing.attr.gpu
     def test_bcast_gpu_large_buffer_deadlock(self):
-        """This is a regression test of Open MPI's issue
-        https://github.com/open-mpi/ompi/issues/3972
-        """
+        """Regression test of Open MPI's issue #3972"""
         self.setup(True)
         buf_size = 10000
         mpi_comm = self.communicator.mpi_comm
@@ -96,5 +97,3 @@ class TestBcastDeadlock(unittest.TestCase):
         assert True
 
         self.teardown()
-
-

--- a/tests/chainermn_tests/communicator_tests/test_mpi.py
+++ b/tests/chainermn_tests/communicator_tests/test_mpi.py
@@ -40,19 +40,21 @@ class _TimeoutThread(threading.Thread):
                 m = re.search(r'ompi:version:full:(\S+)', out)
                 version = m.group(1)
 
-                msg = "\n\n***** ERROR: " \
-                      "It looks like you are using " \
-                      "Open MPI version {}.\n" \
-                      "***** It is known that the following Open MPI " \
-                      "versions have a bug \n" \
+                msg = "\n\n" \
+                      "***** ERROR: bcast test deadlocked. " \
+                      "One of the processes " \
+                      "***** crashed or you encountered a known bug of " \
+                      "Open MPI." \
+                      "***** The following Open MPI versions have a bug \n" \
                       "***** that cause MPI_Bcast() deadlock " \
                       "when GPUDirect is used: \n" \
-                      "***** 3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.1.1, 3.1.2\n"
+                      "***** 3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.1.1, 3.1.2\n" \
+                      "***** Your Open MPI version: {}\n".format(version)
                 if self.rank == 1:
-                    # Rank 1 prints the error message,
-                    # Rank 0 may finish Bcast() immediately without deadlock,
-                    # depending on the timing,
-                    # because rank 0 is the root of Bcast().
+                    # Rank 1 prints the error message.
+                    # This is because rank 0 is the root of Bcast(), and it
+                    # may finish Bcast() immediately
+                    # without deadlock, depending on the timing.
                     print(msg.format(version))
                     sys.stdout.flush()
 


### PR DESCRIPTION
This PR fixes #7093 by adding a test to reproduce deadlock in mpi4py's Bcast function.
