### PR TITLE
Support bool dtypes in `chainerx::{Max,Min}imum`

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/activation.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/activation.cu
@@ -41,10 +41,10 @@ public:
         const Array& x1_cast = x1.dtype() == x_dtype ? x1 : x1.AsType(x_dtype);
         const Array& neg_cast = neg.dtype() == out.dtype() ? neg : neg.AsType(out.dtype());
         CudaSetDeviceScope scope{device.index()};
-        VisitDtype(x_dtype, [&](auto x_pt) {
+        VisitNumericDtype(x_dtype, [&](auto x_pt) {
             using In = typename decltype(x_pt)::type;
             using InCudaType = cuda_internal::DataType<In>;
-            VisitDtype(out.dtype(), [&](auto pt) {
+            VisitNumericDtype(out.dtype(), [&](auto pt) {
                 using Out = typename decltype(pt)::type;
                 using OutCudaType = cuda_internal::DataType<Out>;
                 Elementwise<const In, const Out, Out>(
@@ -74,10 +74,10 @@ public:
         const Array& x1_cast = x1.dtype() == x_dtype ? x1 : x1.AsType(x_dtype);
         const Array& neg_cast = neg.dtype() == out.dtype() ? neg : neg.AsType(out.dtype());
         CudaSetDeviceScope scope{device.index()};
-        VisitDtype(x_dtype, [&](auto x_pt) {
+        VisitNumericDtype(x_dtype, [&](auto x_pt) {
             using In = typename decltype(x_pt)::type;
             using InCudaType = cuda_internal::DataType<In>;
-            VisitDtype(out.dtype(), [&](auto pt) {
+            VisitNumericDtype(out.dtype(), [&](auto pt) {
                 using Out = typename decltype(pt)::type;
                 using OutCudaType = cuda_internal::DataType<Out>;
                 Elementwise<const In, const Out, Out>(
@@ -109,9 +109,9 @@ public:
         const Array& pos_cast = pos.dtype() == out.dtype() ? pos : pos.AsType(out.dtype());
         const Array& neg_cast = neg.dtype() == out.dtype() ? neg : neg.AsType(out.dtype());
         CudaSetDeviceScope scope{device.index()};
-        VisitDtype(x_dtype, [&](auto x_pt) {
+        VisitNumericDtype(x_dtype, [&](auto x_pt) {
             using In = typename decltype(x_pt)::type;
-            VisitDtype(out.dtype(), [&](auto pt) {
+            VisitNumericDtype(out.dtype(), [&](auto pt) {
                 using Out = typename decltype(pt)::type;
                 Elementwise<const In, const In, const Out, const Out, Out>(
                         IfGreaterElseAAAAImpl<In, Out>{}, x1_cast, x2_cast, pos_cast, neg_cast, out);

--- a/chainerx_cc/chainerx/native/native_device/activation.cc
+++ b/chainerx_cc/chainerx/native/native_device/activation.cc
@@ -25,9 +25,9 @@ public:
         Dtype x_dtype = ResultType(x1, x2);
         const Array& x1_cast = x1.dtype() == x_dtype ? x1 : x1.AsType(x_dtype);
         const Array& neg_cast = neg.dtype() == out.dtype() ? neg : neg.AsType(out.dtype());
-        VisitDtype(x_dtype, [&](auto x_pt) {
+        VisitNumericDtype(x_dtype, [&](auto x_pt) {
             using In = typename decltype(x_pt)::type;
-            VisitDtype(out.dtype(), [&](auto pt) {
+            VisitNumericDtype(out.dtype(), [&](auto pt) {
                 using Out = typename decltype(pt)::type;
                 struct Impl {
                     void operator()(int64_t /*i*/, In x1, Out neg, Out& out) { out = x1 < x2 ? pos : neg; }
@@ -49,9 +49,9 @@ public:
         Dtype x_dtype = ResultType(x1, x2);
         const Array& x1_cast = x1.dtype() == x_dtype ? x1 : x1.AsType(x_dtype);
         const Array& neg_cast = neg.dtype() == out.dtype() ? neg : neg.AsType(out.dtype());
-        VisitDtype(x_dtype, [&](auto x_pt) {
+        VisitNumericDtype(x_dtype, [&](auto x_pt) {
             using In = typename decltype(x_pt)::type;
-            VisitDtype(out.dtype(), [&](auto pt) {
+            VisitNumericDtype(out.dtype(), [&](auto pt) {
                 using Out = typename decltype(pt)::type;
                 struct Impl {
                     void operator()(int64_t /*i*/, In x1, Out neg, Out& out) { out = x1 > x2 ? pos : neg; }
@@ -75,9 +75,9 @@ public:
         const Array& x2_cast = x2.dtype() == x_dtype ? x2 : x2.AsType(x_dtype);
         const Array& pos_cast = pos.dtype() == out.dtype() ? pos : pos.AsType(out.dtype());
         const Array& neg_cast = neg.dtype() == out.dtype() ? neg : neg.AsType(out.dtype());
-        VisitDtype(x_dtype, [&](auto x_pt) {
+        VisitNumericDtype(x_dtype, [&](auto x_pt) {
             using In = typename decltype(x_pt)::type;
-            VisitDtype(out.dtype(), [&](auto pt) {
+            VisitNumericDtype(out.dtype(), [&](auto pt) {
                 using Out = typename decltype(pt)::type;
                 struct Impl {
                     void operator()(int64_t /*i*/, In x1, In x2, Out pos, Out neg, Out& out) { out = x1 > x2 ? pos : neg; }

--- a/chainerx_cc/chainerx/routines/logic.cc
+++ b/chainerx_cc/chainerx/routines/logic.cc
@@ -54,7 +54,11 @@ Array LogicalNot(const Array& x) {
 
 Array LogicalAnd(const Array& x1, const Array& x2) { return LogicBinary<LogicalAndKernel>(x1, x2); }
 
+Array LogicalAnd(const Array& x1, Scalar x2) { return static_cast<bool>(x2) ? x1 : Zeros(x1.shape(), Dtype::kBool, x1.device()); }
+
 Array LogicalOr(const Array& x1, const Array& x2) { return LogicBinary<LogicalOrKernel>(x1, x2); }
+
+Array LogicalOr(const Array& x1, Scalar x2) { return static_cast<bool>(x2) ? Ones(x1.shape(), Dtype::kBool, x1.device()) : x1; }
 
 Array LogicalXor(const Array& x1, const Array& x2) { return LogicBinary<LogicalXorKernel>(x1, x2); }
 

--- a/chainerx_cc/chainerx/routines/logic.cc
+++ b/chainerx_cc/chainerx/routines/logic.cc
@@ -25,11 +25,19 @@ public:
     }
 };
 
+void CheckLogicDtypes(DtypeKind kind1, DtypeKind kind2) {
+    if ((kind1 == DtypeKind::kBool) != (kind2 == DtypeKind::kBool)) {
+        throw DtypeError{"Comparison of bool and non-bool dtypes is not supported."};
+    }
+}
+
+void CheckLogicDtypes(const Array& x1, const Array& x2) { return CheckLogicDtypes(GetKind(x1.dtype()), GetKind(x2.dtype())); }
+
+void CheckLogicDtypes(const Array& x1, Scalar x2) { return CheckLogicDtypes(GetKind(x1.dtype()), x2.kind()); }
+
 template <typename KernelType>
 Array LogicBinary(const Array& x1, const Array& x2) {
-    if ((x1.dtype() == Dtype::kBool) != (x2.dtype() == Dtype::kBool)) {
-        throw DtypeError{"Comparison of ", GetDtypeName(x1.dtype()), " and ", GetDtypeName(x2.dtype()), " is not supported."};
-    }
+    CheckLogicDtypes(x1, x2);
     return internal::BroadcastBinary(LogicBinaryImpl<KernelType>{}, x1, x2, Dtype::kBool);
 }
 
@@ -54,11 +62,17 @@ Array LogicalNot(const Array& x) {
 
 Array LogicalAnd(const Array& x1, const Array& x2) { return LogicBinary<LogicalAndKernel>(x1, x2); }
 
-Array LogicalAnd(const Array& x1, Scalar x2) { return static_cast<bool>(x2) ? x1 : Zeros(x1.shape(), Dtype::kBool, x1.device()); }
+Array LogicalAnd(const Array& x1, Scalar x2) {
+    CheckLogicDtypes(x1, x2);
+    return static_cast<bool>(x2) ? x1.AsType(Dtype::kBool) : Zeros(x1.shape(), Dtype::kBool, x1.device());
+}
 
 Array LogicalOr(const Array& x1, const Array& x2) { return LogicBinary<LogicalOrKernel>(x1, x2); }
 
-Array LogicalOr(const Array& x1, Scalar x2) { return static_cast<bool>(x2) ? Ones(x1.shape(), Dtype::kBool, x1.device()) : x1; }
+Array LogicalOr(const Array& x1, Scalar x2) {
+    CheckLogicDtypes(x1, x2);
+    return static_cast<bool>(x2) ? Ones(x1.shape(), Dtype::kBool, x1.device()) : x1.AsType(Dtype::kBool);
+}
 
 Array LogicalXor(const Array& x1, const Array& x2) { return LogicBinary<LogicalXorKernel>(x1, x2); }
 

--- a/chainerx_cc/chainerx/routines/logic.h
+++ b/chainerx_cc/chainerx/routines/logic.h
@@ -42,7 +42,13 @@ Array LogicalNot(const Array& x);
 
 Array LogicalAnd(const Array& x1, const Array& x2);
 
+// TODO(imanishi): Add python binding
+Array LogicalAnd(const Array& x1, Scalar x2);
+
 Array LogicalOr(const Array& x1, const Array& x2);
+
+// TODO(imanishi): Add python binding
+Array LogicalOr(const Array& x1, Scalar x2);
 
 Array LogicalXor(const Array& x1, const Array& x2);
 

--- a/chainerx_cc/chainerx/routines/math.cc
+++ b/chainerx_cc/chainerx/routines/math.cc
@@ -579,6 +579,9 @@ void MaximumImpl(const Array& x1, const Array& x2, const Array& out) { IfGreater
 }  // namespace
 
 Array Maximum(const Array& x1, Scalar x2) {
+    if (x1.dtype() == Dtype::kBool && x2.kind() == DtypeKind::kBool) {
+        return LogicalOr(x1, x2);
+    }
     // TODO(niboshi): IfLessElse redundantly casts x1 twice.
     return IfLessElse(x1, x2, x2, x1);  // x1 < x2 ? x2 : x1
 }
@@ -586,11 +589,17 @@ Array Maximum(const Array& x1, Scalar x2) {
 Array Maximum(Scalar x1, const Array& x2) { return Maximum(x2, x1); }
 
 Array Maximum(const Array& x1, const Array& x2) {
+    if (x1.dtype() == Dtype::kBool && x2.dtype() == Dtype::kBool) {
+        return LogicalOr(x1, x2);
+    }
     Dtype dtype = ResultType(x1, x2);
     return internal::BroadcastBinary(&MaximumImpl, x1, x2, dtype);  // x1 > x2 ? x1 : x2
 }
 
 Array Minimum(const Array& x1, Scalar x2) {
+    if (x1.dtype() == Dtype::kBool && x2.kind() == DtypeKind::kBool) {
+        return LogicalAnd(x1, x2);
+    }
     // TODO(niboshi): IfGreaterElse redundantly casts x1 twice.
     return IfGreaterElse(x1, x2, x2, x1);  // x1 > x2 ? x2 : x1
 }
@@ -598,6 +607,9 @@ Array Minimum(const Array& x1, Scalar x2) {
 Array Minimum(Scalar x1, const Array& x2) { return Minimum(x2, x1); }
 
 Array Minimum(const Array& x1, const Array& x2) {
+    if (x1.dtype() == Dtype::kBool && x2.dtype() == Dtype::kBool) {
+        return LogicalAnd(x1, x2);
+    }
     Dtype dtype = ResultType(x1, x2);
     return internal::BroadcastBinary(&MinimumImpl, x1, x2, dtype);  // x1 > x2 ? x2 : x1
 }

--- a/chainerx_cc/chainerx/routines/math.cc
+++ b/chainerx_cc/chainerx/routines/math.cc
@@ -471,7 +471,7 @@ namespace {
 
 void CheckComparisonDtypes(DtypeKind kind1, DtypeKind kind2) {
     if ((kind1 == DtypeKind::kBool) != (kind2 == DtypeKind::kBool)) {
-        throw DtypeError{"Comparison does not support Boolean and another mixed dtypes"};
+        throw DtypeError{"Comparison of bool and non-bool dtypes is not supported."};
     }
 }
 

--- a/tests/chainerx_tests/dtype_utils.py
+++ b/tests/chainerx_tests/dtype_utils.py
@@ -98,6 +98,47 @@ result_dtypes_three_arrays = _permutate_dtype_mapping([
 ])
 
 
+result_float_dtypes_array_scalar = [
+    (('float16',), float, 'float16'),
+    (('float32',), float, 'float32'),
+    (('float64',), float, 'float64'),
+    (('float16',), numpy.float64, 'float16'),
+    (('float64',), numpy.float16, 'float64'),
+]
+
+
+result_numeric_dtypes_array_scalar = [
+    # Float scalar.
+    (('int8',), float, 'float32'),
+    (('int16',), float, 'float32'),
+    (('int32',), float, 'float32'),
+    (('int64',), float, 'float32'),
+    (('uint8',), float, 'float32'),
+    (('int8',), numpy.float32, 'float32'),
+    (('int64',), numpy.float16, 'float32'),
+    (('uint8',), numpy.float64, 'float32'),
+    # Int scalar.
+    (('int8',), int, 'int8'),
+    (('int16',), int, 'int16'),
+    (('int32',), int, 'int32'),
+    (('int64',), int, 'int64'),
+    (('uint8',), int, 'uint8'),
+    (('float16',), int, 'float16'),
+    (('float32',), int, 'float32'),
+    (('float64',), int, 'float64'),
+    (('int16',), numpy.int16, 'int16'),
+    (('uint8',), numpy.int8, 'uint8'),
+    (('float64',), numpy.int8, 'float64'),
+    (('float16',), numpy.int64, 'float16'),
+] + result_float_dtypes_array_scalar
+
+
+result_comparable_dtypes_array_scalar = [
+    (('bool_',), bool, 'bool_'),
+    (('bool_',), numpy.bool_, 'bool_'),
+] + result_numeric_dtypes_array_scalar
+
+
 def cast_if_numpy_array(xp, array, chx_expected_dtype):
     """Casts NumPy result array to match the dtype of ChainerX's corresponding
     result.

--- a/tests/chainerx_tests/dtype_utils.py
+++ b/tests/chainerx_tests/dtype_utils.py
@@ -49,6 +49,12 @@ result_numeric_dtypes_two_arrays = _permutate_dtype_mapping([
 ])
 
 
+result_comparable_dtypes_two_arrays = [
+    # Bools.
+    (('bool_', 'bool_'), 'bool_'),
+] + result_numeric_dtypes_two_arrays
+
+
 result_dtypes_two_arrays = _permutate_dtype_mapping([
     # Bools.
     (('bool_', 'bool_'), 'bool_'),

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_logic.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_logic.py
@@ -11,9 +11,7 @@ from chainerx_tests import op_utils
 
 
 _expected_numeric_dtypes_comparison = [
-    (t1, t2)
-    for (t1, t2), _ in dtype_utils.result_dtypes_two_arrays
-    if all([numpy.dtype(t) != 'bool_' for t in (t1, t2)])
+    (t1, t2) for (t1, t2), _ in dtype_utils.result_numeric_dtypes_two_arrays
 ]
 
 
@@ -24,8 +22,8 @@ _expected_float_dtypes_comparison = [
 ]
 
 
-_expected_all_dtypes_comparison = _expected_numeric_dtypes_comparison + [
-    ('bool_', 'bool_'),
+_expected_all_dtypes_comparison = [
+    (t1, t2) for (t1, t2), _ in dtype_utils.result_comparable_dtypes_two_arrays
 ]
 
 

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -1313,21 +1313,24 @@ def test_sum_invalid(is_module, xp, shape, axis, keepdims, dtype):
     # Special shapes
     chainer.testing.product({
         'shape': [(), (0,), (1,), (2, 0, 3), (1, 1, 1), (2, 3)],
-        'in_dtypes,scalar_type,out_dtype': _in_out_dtypes_arithmetic_scalar,
+        'in_dtypes,scalar_type,out_dtype': (
+            dtype_utils.result_comparable_dtypes_array_scalar),
         'input': ['random'],
         'scalar_value': [1],
         'is_scalar_rhs': [False],
     })
     # Differentiable cases
     + chainer.testing.product({
-        'in_dtypes,scalar_type,out_dtype': _in_out_dtypes_arithmetic_scalar,
+        'in_dtypes,scalar_type,out_dtype': (
+            dtype_utils.result_comparable_dtypes_array_scalar),
         'input': [numpy.array([1, 3, 3, 4])],
         'scalar_value': [0, 2, 5],
         'is_scalar_rhs': [False, True],
     })
     # Non-differentiable cases
     + chainer.testing.product({
-        'in_dtypes,scalar_type,out_dtype': _in_out_dtypes_arithmetic_scalar,
+        'in_dtypes,scalar_type,out_dtype': (
+            dtype_utils.result_comparable_dtypes_array_scalar),
         'input': [numpy.array([1, 3, 3, 4])],
         'scalar_value': [1, 3, 4],
         'is_scalar_rhs': [False, True],
@@ -1337,7 +1340,7 @@ def test_sum_invalid(is_module, xp, shape, axis, keepdims, dtype):
     # Special float values
     + chainer.testing.product({
         'in_dtypes,scalar_type,out_dtype': (
-            _in_out_dtypes_float_arithmetic_scalar),
+            dtype_utils.result_float_dtypes_array_scalar),
         # TODO(imanishi): Add test for NaN.
         'input': [numpy.array([0, float('inf'), -float('inf')])],
         'scalar_value': [-1, 0, 1, float('inf'), -float('inf')],
@@ -1362,21 +1365,24 @@ class TestMinimumScalar(math_utils.MathScalarTestBase, op_utils.NumpyOpTest):
     # Special shapes
     chainer.testing.product({
         'shape': [(), (0,), (1,), (2, 0, 3), (1, 1, 1), (2, 3)],
-        'in_dtypes,scalar_type,out_dtype': _in_out_dtypes_arithmetic_scalar,
+        'in_dtypes,scalar_type,out_dtype': (
+            dtype_utils.result_comparable_dtypes_array_scalar),
         'input': ['random'],
         'scalar_value': [0, 1],
         'is_scalar_rhs': [False],
     })
     # Differentiable cases
     + chainer.testing.product({
-        'in_dtypes,scalar_type,out_dtype': _in_out_dtypes_arithmetic_scalar,
+        'in_dtypes,scalar_type,out_dtype': (
+            dtype_utils.result_comparable_dtypes_array_scalar),
         'input': [numpy.array([1, 3, 3, 4])],
         'scalar_value': [0, 2, 5],
         'is_scalar_rhs': [False, True],
     })
     # Non-differentiable cases
     + chainer.testing.product({
-        'in_dtypes,scalar_type,out_dtype': _in_out_dtypes_arithmetic_scalar,
+        'in_dtypes,scalar_type,out_dtype': (
+            dtype_utils.result_comparable_dtypes_array_scalar),
         'input': [numpy.array([1, 3, 3, 4])],
         'scalar_value': [1, 3, 4],
         'is_scalar_rhs': [False, True],
@@ -1386,7 +1392,7 @@ class TestMinimumScalar(math_utils.MathScalarTestBase, op_utils.NumpyOpTest):
     # Special float values
     + chainer.testing.product({
         'in_dtypes,scalar_type,out_dtype': (
-            _in_out_dtypes_float_arithmetic_scalar),
+            dtype_utils.result_float_dtypes_array_scalar),
         # TODO(imanishi): Add test for NaN.
         'input': [numpy.array([0, float('inf'), -float('inf')])],
         'scalar_value': [-1, 0, 1, float('inf'), -float('inf')],

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_math.py
@@ -2105,14 +2105,15 @@ def test_isfinite(xp, device, input, dtype):
         'in_shapes': math_utils.shapes_combination_binary,
         'in_dtypes,out_dtype': (
             dtype_utils.make_same_in_out_dtypes(
-                2, chainerx.testing.numeric_dtypes)),
+                2, chainerx.testing.all_dtypes)),
         'input_lhs': ['random'],
         'input_rhs': ['random'],
+        'is_module': [False],
     })
     # Dtype combinations
     + chainer.testing.product({
         'in_shapes': [((2, 3), (2, 3))],
-        'in_dtypes,out_dtype': _in_out_dtypes_arithmetic,
+        'in_dtypes,out_dtype': dtype_utils.result_comparable_dtypes_two_arrays,
         'input_lhs': ['random'],
         'input_rhs': ['random'],
         'is_module': [False],
@@ -2122,7 +2123,7 @@ def test_isfinite(xp, device, input, dtype):
         'in_shapes': [((2, 3), (2, 3))],
         'in_dtypes,out_dtype': (
             dtype_utils.make_same_in_out_dtypes(
-                2, chainerx.testing.numeric_dtypes)),
+                2, chainerx.testing.all_dtypes)),
         'input_lhs': ['random'],
         'input_rhs': ['random'],
         'is_module': [True, False],
@@ -2138,14 +2139,15 @@ class TestMaximum(math_utils.BinaryMathTestBase, op_utils.NumpyOpTest):
 
 
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
-@pytest.mark.parametrize('dtypes', _in_out_dtypes_arithmetic_invalid)
-def test_maximum_invalid_dtypes(device, dtypes):
-    (in_dtype1, in_dtype2), _ = dtypes
+@pytest.mark.parametrize('dtype', chainerx.testing.numeric_dtypes)
+def test_maximum_invalid_dtypes(device, dtype):
     shape = (3, 2)
-    a = chainerx.array(array_utils.uniform(shape, in_dtype1))
-    b = chainerx.array(array_utils.uniform(shape, in_dtype2))
+    bool_array = chainerx.array(array_utils.uniform(shape, 'bool_'))
+    numeric_array = chainerx.array(array_utils.uniform(shape, dtype))
     with pytest.raises(chainerx.DtypeError):
-        chainerx.maximum(a, b)
+        chainerx.maximum(bool_array, numeric_array)
+    with pytest.raises(chainerx.DtypeError):
+        chainerx.maximum(numeric_array, bool_array)
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
@@ -2160,12 +2162,23 @@ def test_maximum_invalid_dtypes(device, dtypes):
         'input_rhs': ['random'],
         'is_module': [False],
     })
+    # Dtype combinations
+    + chainer.testing.product({
+        'in_shapes': [((2, 3), (2, 3))],
+        'in_dtypes,out_dtype': dtype_utils.result_comparable_dtypes_two_arrays,
+        'input_lhs': ['random'],
+        'input_rhs': ['random'],
+        'is_module': [False],
+    })
     # is_module
     + chainer.testing.product({
         'in_shapes': [((2, 3), (2, 3))],
-        'in_dtypes,out_dtype': _in_out_dtypes_arithmetic,
+        'in_dtypes,out_dtype': (
+            dtype_utils.make_same_in_out_dtypes(
+                2, chainerx.testing.all_dtypes)),
         'input_lhs': ['random'],
         'input_rhs': ['random'],
+        'is_module': [True, False],
     })
     # TODO(aksub99): Add tests for inf and NaN.
 ))
@@ -2178,11 +2191,12 @@ class TestMinimum(math_utils.BinaryMathTestBase, op_utils.NumpyOpTest):
 
 
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
-@pytest.mark.parametrize('dtypes', _in_out_dtypes_arithmetic_invalid)
-def test_minimum_invalid_dtypes(device, dtypes):
-    (in_dtype1, in_dtype2), _ = dtypes
+@pytest.mark.parametrize('dtype', chainerx.testing.numeric_dtypes)
+def test_minimum_invalid_dtypes(device, dtype):
     shape = (3, 2)
-    a = chainerx.array(array_utils.uniform(shape, in_dtype1))
-    b = chainerx.array(array_utils.uniform(shape, in_dtype2))
+    bool_array = chainerx.array(array_utils.uniform(shape, 'bool_'))
+    numeric_array = chainerx.array(array_utils.uniform(shape, dtype))
     with pytest.raises(chainerx.DtypeError):
-        chainerx.minimum(a, b)
+        chainerx.minimum(bool_array, numeric_array)
+    with pytest.raises(chainerx.DtypeError):
+        chainerx.minimum(numeric_array, bool_array)


### PR DESCRIPTION
This PR makes `chainerx::Maximum` and `chainerx::Minimum` accept Boolean dtypes like as `chainerx::Greater` and `chainerx::Less` do.