### PR TITLE
Document `observe_value` and `observe_lr` trigger interval

### DIFF
--- a/chainer/training/extensions/value_observation.py
+++ b/chainer/training/extensions/value_observation.py
@@ -11,8 +11,8 @@ def observe_value(observation_key, target_func):
     Returns:
         The extension function.
 
-    This extension is triggered every 1 epoch by default.
-    To change this, specify ``trigger`` argument to
+    This extension is triggered each epoch by default.
+    To change this, use the ``trigger`` argument with the
     :meth:`Trainer.extend() <chainer.training.Trainer.extend>` method.
 
     """
@@ -34,8 +34,8 @@ def observe_lr(optimizer_name='main', observation_key='lr'):
     Returns:
         The extension function.
 
-    This extension is triggered every 1 epoch by default.
-    To change this, specify ``trigger`` argument to
+    This extension is triggered each epoch by default.
+    To change this, use the ``trigger`` argument with the
     :meth:`Trainer.extend() <chainer.training.Trainer.extend>` method.
 
     """

--- a/chainer/training/extensions/value_observation.py
+++ b/chainer/training/extensions/value_observation.py
@@ -10,6 +10,11 @@ def observe_value(observation_key, target_func):
             It must take one argument: :class:~chainer.training.Trainer object.
     Returns:
         The extension function.
+
+    This extension is triggered every 1 epoch by default.
+    To change this, specify ``trigger`` argument to
+    :meth:`Trainer.extend() <chainer.training.Trainer.extend>` method.
+
     """
     @extension.make_extension(
         trigger=(1, 'epoch'), priority=extension.PRIORITY_WRITER)
@@ -28,6 +33,11 @@ def observe_lr(optimizer_name='main', observation_key='lr'):
 
     Returns:
         The extension function.
+
+    This extension is triggered every 1 epoch by default.
+    To change this, specify ``trigger`` argument to
+    :meth:`Trainer.extend() <chainer.training.Trainer.extend>` method.
+
     """
     return observe_value(
         observation_key,


### PR DESCRIPTION
They're triggered at non-default interval of `(1, 'epoch')`, but it's not documented.