### PR TITLE
DataParallel with custom train-loop

### DIFF
--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -62,3 +62,5 @@ from chainer.links.normalization.decorrelated_batch_normalization import Decorre
 from chainer.links.normalization.group_normalization import GroupNormalization  # NOQA
 from chainer.links.normalization.layer_normalization import LayerNormalization  # NOQA
 from chainer.links.theano.theano_function import TheanoFunction  # NOQA
+from chainer.links.model.data_parallel import DataParallel  #NOQA
+

--- a/chainer/links/__init__.py
+++ b/chainer/links/__init__.py
@@ -62,5 +62,4 @@ from chainer.links.normalization.decorrelated_batch_normalization import Decorre
 from chainer.links.normalization.group_normalization import GroupNormalization  # NOQA
 from chainer.links.normalization.layer_normalization import LayerNormalization  # NOQA
 from chainer.links.theano.theano_function import TheanoFunction  # NOQA
-from chainer.links.model.data_parallel import DataParallel  #NOQA
-
+from chainer.links.model.data_parallel import DataParallel  # NOQA

--- a/chainer/links/model/data_parallel.py
+++ b/chainer/links/model/data_parallel.py
@@ -2,8 +2,8 @@ import chainer.variable
 import chainer.link
 
 
-def _apply_scatter(inputs: chainer.variable.Variable, target_devices: list,
-                   dim: int = 0):
+def _apply_scatter(inputs, target_devices,
+                   dim=0):
     """
     Scatters inputs to target devices; Slicing will be done against a given
     dimension
@@ -93,7 +93,7 @@ def _apply_gather(target_device, dim, *outputs):
     return chainer.functions.concat(outputs, dim)
 
 
-def _scatter(inputs, target_devices: list, dim):
+def _scatter(inputs, target_devices, dim):
     """
     Scatters all inputs across given target_devices
 
@@ -205,7 +205,7 @@ class DataParallel(chainer.link.Chain):
     training by splitting the batches
     """
 
-    def __init__(self, module: chainer.link.Chain, devices: list,
+    def __init__(self, module, devices,
                  batch_dim=0):
         """
         Args
@@ -284,7 +284,7 @@ class DataParallel(chainer.link.Chain):
         return self.modules[0].params(include_uninit)
 
     @staticmethod
-    def _scatter(inputs, kwargs, target_devices: list, dim=0):
+    def _scatter(inputs, kwargs, target_devices, dim=0):
         """
         Scatters all inputs (args and kwargs) to target devices and splits
         along given dimension

--- a/chainer/links/model/data_parallel.py
+++ b/chainer/links/model/data_parallel.py
@@ -262,7 +262,7 @@ class DataParallel(chainer.link.Chain):
         predictions = []
         for _args, _kwargs, _module in zip(scattered_args, scattered_kwargs,
                                            self.modules):
-            predictions.append(_module(*_args, *_kwargs))
+            predictions.append(_module(*_args, **_kwargs))
 
         predictions = self._gather(predictions, self.dim,
                                    self._output_device)

--- a/chainer/links/model/data_parallel.py
+++ b/chainer/links/model/data_parallel.py
@@ -344,9 +344,15 @@ class DataParallel(chainer.link.Chain):
         return _gather(predictions, target_device, dim)
 
     def zerograds(self):
+        """
+        Call zerograds on all scattered modules
+        """
         for module in self.modules:
             module.zerograds()
 
     def cleargrads(self):
+        """
+        call cleargrads on all scattered modules
+        """
         for module in self.modules:
             module.cleargrads()

--- a/chainer/links/model/data_parallel.py
+++ b/chainer/links/model/data_parallel.py
@@ -206,24 +206,23 @@ class DataParallel(chainer.link.Chain):
     """
     A Wrapper around a ~chainer.Chain instance to implement parallel
     training by splitting the batches
+
+    Args
+        module (~chainer.Chain):
+            the module to wrap (will be replicated on all devices)
+        devices (list of str or ~chainer.backend.Device):
+            a list containing the devices to use (either as strings or as
+            ~chainer.backend.Device). The first device will be used as
+            output device. Make sure, your labels are also on this device
+            for loss calculation!
+        batch_dim (int):
+            the index of the batchdimension (usually 0, but can become
+            e.g. 1 in NLP tasks)
     """
 
     def __init__(self, module, devices,
                  batch_dim=0):
-        """
-        Args
-            module (~chainer.Chain):
-                the module to wrap (will be replicated on all devices)
-            devices (list of str or ~chainer.backend.Device):
-                a list containing the devices to use (either as strings or as
-                ~chainer.backend.Device). The first device will be used as
-                output device. Make sure, your labels are also on this device
-                for loss calculation!
-            batch_dim (int):
-                the index of the batchdimension (usually 0, but can become
-                e.g. 1 in NLP tasks)
 
-        """
         super(DataParallel, self).__init__()
 
         modules = [module.copy() for _ in devices]

--- a/chainer/links/model/data_parallel.py
+++ b/chainer/links/model/data_parallel.py
@@ -177,7 +177,10 @@ def _gather(outputs, target_device, dim=0):
             outputs (Any): the outputs to gather
 
         Returns
-            Any: the concatenated outputs (same type as outputs[0] before concat)
+            Any:
+                the concatenated outputs
+                (same type as outputs[0] before concat)
+
         """
         out = outputs[0]
         if isinstance(out, chainer.variable.Variable):
@@ -295,7 +298,8 @@ class DataParallel(chainer.link.Chain):
             kwargs (dict):
                 keyword arguments
             target_devices (list of str or ~chainer.backend.Device):
-                list of target device (either string or ~chainer.backend.Device)
+                list of target device
+                (either string or ~chainer.backend.Device)
             dim (int):
                 the dimension, which should be used for splitting the batch
 

--- a/chainer/links/model/data_parallel.py
+++ b/chainer/links/model/data_parallel.py
@@ -337,7 +337,7 @@ class DataParallel(chainer.link.Chain):
         """
         return _gather(predictions, target_device, dim)
 
-    def __getattr__(self, name):
+    def __getattribute__(self, name):
         """
         Forward every call to attributes to root module's attributes,
         if attribute is not present here.
@@ -354,9 +354,9 @@ class DataParallel(chainer.link.Chain):
                 attribute not present here and not found in root-module
         """
         if hasattr(self, name):
-            return super(DataParallel, self).__getattr__(name)
+            return super(DataParallel, self).__getattribute__(name)
 
-        return self.modules[0].__getattr__(name)
+        return getattr(self.modules[0], name)
 
     def zerograds(self):
         for module in self.modules:

--- a/chainer/links/model/data_parallel.py
+++ b/chainer/links/model/data_parallel.py
@@ -1,0 +1,367 @@
+import chainer.variable
+import chainer.link
+
+
+def _apply_scatter(inputs: chainer.variable.Variable, target_devices: list,
+                   dim: int = 0):
+    """
+    Scatters inputs to target devices; Slicing will be done against a given
+    dimension
+
+    Args:
+        inputs (~chainer.Variable): the input variable to scatter
+        target_devices (list of str or ~chainer.backend.Device):
+            the target devices to scatter to
+        dim (int): the dimension to use for slicing
+    Returns
+        list of ~chainer.Variable: list of variable slices on correct devices
+
+    """
+
+    def _slice_inputs(input_var, dim, num_dims, start, end, target_device):
+        """
+        Slices the input variable along a given dimension from start to end
+        and pushes it to correct device
+
+        Args:
+            input_var (~chainer.Variable): the variable to slice
+            dim (int): the dimension to slice along
+            num_dims (int): the dimensionality of ``input_var``
+            start (int): the start value for slicing (included)
+            end (int) : the end value for slicing (excluded)
+            target_device (str or ~chainer.backend.Device):
+                the device to push to
+        Returns
+            ~chainer.Variable: the slice of the variable
+
+        """
+        slc = [slice(None)] * num_dims
+        slc[dim] = slice(start, end)
+        sliced_var = input_var[slc]
+        sliced_var.to_device(target_device)
+        output_shape = list(input_var.shape)
+        output_shape[dim] = -1
+        return sliced_var.reshape(output_shape)
+
+    # create empty sliced input list
+    scattered_inputs = []
+
+    # calculate constant only once
+    num_devices = len(target_devices)
+    samples_per_device = inputs.shape[dim] // num_devices
+    num_dims = len(inputs.shape)
+
+    # iterate over number of devices and slice accordingly
+    # (exclude last device)
+    # iterating until the minimum of num_devices and inputs.shape[dim] -1
+    # ensures that if the batchsize is too small to be scattered across all
+    # devices, we will only scatter across as many devices as possible
+    for i in range(min(num_devices, inputs.shape[dim]) - 1):
+        start, end = i * samples_per_device, i + 1 * samples_per_device
+        scattered_inputs.append(_slice_inputs(inputs, dim,
+                                              num_dims, start, end,
+                                              target_devices[i]))
+
+    # all remaining samples (not yet sliced) are appended now
+    # (all samples used; will be pushed to last device later)
+    scattered_inputs.append(_slice_inputs(
+        inputs, dim, len(inputs.shape, ),
+        (num_devices - 1) * samples_per_device,
+        inputs.shape[dim], target_devices[-1]))
+
+    return scattered_inputs
+
+
+def _apply_gather(target_device, dim, *outputs):
+    """
+    Gathers all outputs from model replicas, pushes them to target_device
+    and concatenates them along the given dimension
+
+    Args:
+         target_device (str or ~chainer.backend.Device):
+            the target device to copy all outputs to
+         dim (int): the dimension to use for concatenation
+         outputs (list of ~chainer.Variable): the outputs obtained from model
+         replicas
+
+    Returns
+        ~chainer.Variable: the concatenated outputs
+    """
+    for _output in outputs:
+        _output.to_device(target_device)
+
+    return chainer.functions.concat(outputs, dim)
+
+
+def _scatter(inputs, target_devices: list, dim):
+    """
+    Scatters all inputs across given target_devices
+
+    Args
+        inputs (Any): the inputs to scatter across the devices
+        target_devices (list of ~chainer.Variable): devices to scatter to
+        dim (int): dimension to use for slicing
+
+    Returns
+
+    Any: iterable or mapping of scattered inputs (same type as inputs)
+
+    """
+
+    def _scatter_map(inputs):
+        """
+        Scatters all inputs across given target_devices. Supports arbitrary
+        iterables and mappings (dicts)
+
+        Args
+            inputs (Any): The inputs to scatter
+
+        Returns
+            list of ~chainer.Variable: list of scattered inputs
+
+        """
+
+        # directly apply the scattering on variable
+        if isinstance(inputs, chainer.variable.Variable):
+            return _apply_scatter(inputs, target_devices, dim)
+
+        # map _scatter_map recursively to all samples in tuple
+        if isinstance(inputs, tuple) and len(inputs) > 0:
+            return list(zip(*map(_scatter_map, inputs)))
+
+        # map _scatter_map recursively to all samples in list
+        if isinstance(inputs, list) and len(inputs) > 0:
+            return list(map(list, zip(*map(_scatter_map,
+                                           inputs))))
+
+        # map _scatter_map recursively to all samples in dict
+        if isinstance(inputs, dict) and len(inputs) > 0:
+            return list(map(type(inputs), zip(*map(_scatter_map,
+                                                   inputs.items()))))
+
+        # try to convert inputs to chainer variable first and afterwards apply
+        # __scatter_map again
+        return _scatter_map(chainer.as_variable(inputs))
+
+    # After scatter_map is called, a scatter_map cell will exist. This cell
+    # has a reference to the actual function scatter_map, which has references
+    # to a closure that has a reference to the scatter_map cell (because the
+    # fn is recursive). To avoid this reference cycle, we set the function to
+    # None, clearing the cell
+    try:
+        return _scatter_map(inputs)
+    finally:
+        _scatter_map = None
+
+
+def _gather(outputs, target_device, dim=0):
+    """
+    Gathers tensors from different devices onto a single device
+
+    Args
+        outputs (Any): the outputs obtained from model replicas
+        target_device (str or ~chainer.backend.Device):
+            the target device to copy all outputs to
+        dim (int): the dimension to use for concatenation
+
+    """
+
+    def gather_map(outputs):
+        """
+        Recursively gathers outputs from different devices
+
+        Args
+            outputs (Any): the outputs to gather
+
+        Returns
+            Any: the concatenated outputs (same type as outputs[0] before concat)
+        """
+        out = outputs[0]
+        if isinstance(out, chainer.variable.Variable):
+            return _apply_gather(target_device, dim, *outputs)
+        if out is None:
+            return None
+        if isinstance(out, dict):
+            if not all((len(out) == len(d) for d in outputs)):
+                raise ValueError('All dicts must have the same number of keys')
+            return type(out)(((k, gather_map([d[k] for d in outputs]))
+                              for k in out))
+        return type(out)(map(gather_map, zip(*outputs)))
+
+    # Recursive function calls like this create reference cycles.
+    # Setting the function to None clears the refcycle.
+    try:
+        return gather_map(outputs)
+    finally:
+        gather_map = None
+
+
+class DataParallel(chainer.link.Chain):
+    """
+    A Wrapper around a ~chainer.Chain instance to implement parallel
+    training by splitting the batches
+    """
+
+    def __init__(self, module: chainer.link.Chain, devices: list,
+                 batch_dim=0):
+        """
+        Args
+            module (~chainer.Chain):
+                the module to wrap (will be replicated on all devices)
+            devices (list of str or ~chainer.backend.Device):
+                a list containing the devices to use (either as strings or as
+                ~chainer.backend.Device). The first device will be used as
+                output device. Make sure, your labels are also on this device
+                for loss calculation!
+            batch_dim (int):
+                the index of the batchdimension (usually 0, but can become
+                e.g. 1 in NLP tasks)
+
+        """
+        super(DataParallel, self).__init__()
+
+        modules = [module.copy() for _ in devices]
+
+        for _module, _device in zip(modules, devices):
+            _module.to_device(_device)
+
+        with self.init_scope():
+            self.modules = chainer.link.ChainList(*modules)
+
+        self.devices = devices
+
+        self._output_device = devices[0]
+        assert self._output_device in self.devices
+        self._output_device_idx = self.devices.index(self._output_device)
+        self.dim = batch_dim
+
+    def forward(self, *args, **kwargs):
+        """
+        Scatters the inputs (both positional and keyword arguments) across
+        all devices, feeds them through model replicas and re-builds
+        batches on output device
+
+        Args
+            args (tuple):
+                positional arguments of arbitrary number and type
+            kwargs (dict):
+                keyword arguments of arbitrary number and type
+        Returns
+            Any:
+                predictions (concatenation of all predictions obtained from
+                model replicas)
+
+        """
+        scattered_args, scattered_kwargs = self._scatter(args, kwargs,
+                                                         self.devices,
+                                                         self.dim)
+
+        predictions = []
+        for _args, _kwargs, _module in zip(scattered_args, scattered_kwargs,
+                                           self.modules):
+            predictions.append(_module(*_args, *_kwargs))
+
+        predictions = self._gather(predictions, self.dim,
+                                   self._output_device)
+
+        return predictions
+
+    def params(self, include_uninit=True):
+        """
+        Only the parameters of the module on the first device will actually
+        be updated, all the other parameters will be replicated by the
+        optimizer after an update
+        Parameters
+        ----------
+        include_uninit : bool
+        Returns
+        -------
+        a generator holding the root-modules parameters
+        """
+        return self.modules[0].params(include_uninit)
+
+    @staticmethod
+    def _scatter(inputs, kwargs, target_devices: list, dim=0):
+        """
+        Scatters all inputs (args and kwargs) to target devices and splits
+        along given dimension
+
+        Args
+            inputs (list or tuple):
+                positional arguments
+            kwargs (dict):
+                keyword arguments
+            target_devices (list of str or ~chainer.backend.Device):
+                list of target device (either string or ~chainer.backend.Device)
+            dim (int):
+                the dimension, which should be used for splitting the batch
+
+        Returns
+            tuple: scattered positional arguments
+            tuple: scattered keyword arguments
+
+        """
+
+        # scatter inputs if given
+        inputs = _scatter(inputs, target_devices, dim) if inputs else []
+        # scatter kwargs if given
+        kwargs = _scatter(kwargs, target_devices, dim) if kwargs else []
+
+        # extend lengths by empty tuples if necessary
+        if len(inputs) < len(kwargs):
+            inputs.extend([() for _ in range(len(kwargs) - len(inputs))])
+        elif len(kwargs) < len(inputs):
+            kwargs.extend([{} for _ in range(len(inputs) - len(kwargs))])
+
+        inputs = tuple(inputs)
+        kwargs = tuple(kwargs)
+
+        return inputs, kwargs
+
+    @staticmethod
+    def _gather(predictions, dim, target_device):
+        """
+        Re-Builds batches on the target device
+
+        Args:
+            predictions (list):
+                list containing the predictions from all replicated models
+            dim (int):
+                dimension to use for concatenating single predictions
+            target_device (str or ~chainer.backend.Device):
+                the device, the re-built batch should lie on
+
+        Returns
+            Any: the rebuild batch (lying on target_device)
+
+        """
+        return _gather(predictions, target_device, dim)
+
+    def __getattr__(self, name):
+        """
+        Forward every call to attributes to root module's attributes,
+        if attribute is not present here.
+
+        Args
+            name (str):
+                the attribute name
+
+        Returns
+            Any: the returned attribute
+
+        Raises
+            AttributeError:
+                attribute not present here and not found in root-module
+        """
+        if hasattr(self, name):
+            return super(DataParallel, self).__getattr__(name)
+
+        return self.modules[0].__getattr__(name)
+
+    def zerograds(self):
+        for module in self.modules:
+            module.zerograds()
+
+    def cleargrads(self):
+        for module in self.modules:
+            module.cleargrads()

--- a/chainer/optimizer_hooks/__init__.py
+++ b/chainer/optimizer_hooks/__init__.py
@@ -4,3 +4,5 @@ from chainer.optimizer_hooks.gradient_lars import GradientLARS  # NOQA
 from chainer.optimizer_hooks.gradient_noise import GradientNoise  # NOQA
 from chainer.optimizer_hooks.lasso import Lasso  # NOQA
 from chainer.optimizer_hooks.weight_decay import WeightDecay  # NOQA
+from chainer.optimizer_hooks.data_parallel import DataParallelOptimizerCumulateGradientsHook  # NOQA
+from chainer.optimizer_hooks.data_parallel import DataParallelOptimizerUpdateModelParameters  # NOQA

--- a/chainer/optimizer_hooks/data_parallel.py
+++ b/chainer/optimizer_hooks/data_parallel.py
@@ -23,7 +23,7 @@ class DataParallelOptimizerCumulateGradientsHook(object):
                 summed across the replications
 
         """
-        if isinstance(optimizer.target, chainer.links.model.DataParallel):
+        if isinstance(optimizer.target, chainer.links.DataParallel):
             for module in optimizer.target.modules[1:]:
                 optimizer.target.modules[0].addgrads(module)
 
@@ -48,6 +48,6 @@ class DataParallelOptimizerUpdateModelParameters(object):
                 updated across the replications
 
         """
-        if isinstance(optimizer.target, chainer.links.model.DataParallel):
+        if isinstance(optimizer.target, chainer.links.DataParallel):
             for module in optimizer.target.modules[1:]:
                 module.copyparams(optimizer.target.modules[0])

--- a/chainer/optimizer_hooks/data_parallel.py
+++ b/chainer/optimizer_hooks/data_parallel.py
@@ -12,7 +12,7 @@ class DataParallelOptimizerCumulateGradientsHook(object):
     call_for_each_param = False
     timing = 'pre'
 
-    def __call__(self, optimizer: chainer.Optimizer):
+    def __call__(self, optimizer):
         """
         Summing up all parameters if the target is an instance of
         ~chainer.links.model.DataParallel
@@ -38,7 +38,7 @@ class DataParallelOptimizerUpdateModelParameters(object):
     call_for_each_param = False
     timing = "post"
 
-    def __call__(self, optimizer: chainer.Optimizer):
+    def __call__(self, optimizer):
         """
         Copying all parameters across the model replicas after optimizer update
 

--- a/chainer/optimizer_hooks/data_parallel.py
+++ b/chainer/optimizer_hooks/data_parallel.py
@@ -1,0 +1,53 @@
+import chainer
+import chainer.links.model
+
+
+class DataParallelOptimizerCumulateGradientsHook(object):
+    """
+    A hook which sums up all replication's gradients in a
+    DataParallel-Scenario
+    """
+
+    name = "DataParallelCumulateGradients"
+    call_for_each_param = False
+    timing = 'pre'
+
+    def __call__(self, optimizer: chainer.Optimizer):
+        """
+        Summing up all parameters if the target is an instance of
+        ~chainer.links.model.DataParallel
+
+        Args
+            optimizer (~chainer.Optimizer):
+                the optimizer holding the target, whose gradients should be
+                summed across the replications
+
+        """
+        if isinstance(optimizer.target, chainer.links.model.DataParallel):
+            for module in optimizer.target.modules[1:]:
+                optimizer.target.modules[0].addgrads(module)
+
+
+class DataParallelOptimizerUpdateModelParameters(object):
+    """
+    A hook to replicate all parameters from the root model, to all
+    model-replicas after the optimizer step
+    """
+
+    name = "DataParallelUpdateModelParams"
+    call_for_each_param = False
+    timing = "post"
+
+    def __call__(self, optimizer: chainer.Optimizer):
+        """
+        Copying all parameters across the model replicas after optimizer update
+
+        Args
+            optimizer (~chainer.Optimizer):
+                the optimizer holding the target, whose parameters should be
+                updated across the replications
+
+        """
+        if isinstance(optimizer.target, chainer.links.model.DataParallel):
+            for module in optimizer.target.modules[1:]:
+                module.copyparams(optimizer.target.modules[0])

--- a/chainer/optimizers/__init__.py
+++ b/chainer/optimizers/__init__.py
@@ -14,3 +14,4 @@ from chainer.optimizers.rmsprop import RMSprop  # NOQA
 from chainer.optimizers.rmsprop_graves import RMSpropGraves  # NOQA
 from chainer.optimizers.sgd import SGD  # NOQA
 from chainer.optimizers.smorms3 import SMORMS3  # NOQA
+from chainer.optimizers.data_parallel import DataParallelOptimizer  # NOQA

--- a/chainer/optimizers/data_parallel.py
+++ b/chainer/optimizers/data_parallel.py
@@ -13,21 +13,21 @@ class DataParallelOptimizer(optimizer.Optimizer):
     pre-update hook)
     """
 
-    def __init__(self, optimizer):
+    def __init__(self, optim):
         """
 
         Args
-            optimizer (~chainer.Optimizer):
+            optim (~chainer.Optimizer):
                 the optimizer to wrap
 
         """
-        if isinstance(optimizer, optimizer.Optimizer):
-            self._optimizer = optimizer
+        if isinstance(optim, optimizer.Optimizer):
+            self._optimizer = optim
 
         else:
             raise RuntimeError("Invalid optimizer class given: Expected "
                                "instance of chainer.Optimizer, but got %s"
-                               % optimizer.__class__.__name__)
+                               % optim.__class__.__name__)
 
     @classmethod
     def from_optimizer_class(cls, optim_cls, *args, **kwargs):

--- a/chainer/optimizers/data_parallel.py
+++ b/chainer/optimizers/data_parallel.py
@@ -1,8 +1,8 @@
-import chainer
+from chainer import optimizer
 import chainer.optimizer_hooks
 
 
-class DataParallelOptimizer(chainer.Optimizer):
+class DataParallelOptimizer(optimizer.Optimizer):
     """
     An Optimizer-Wrapper to enable DataParallel. Basically this forwards
     all functions to the interal optimizer, but registers the additional
@@ -21,7 +21,7 @@ class DataParallelOptimizer(chainer.Optimizer):
                 the optimizer to wrap
 
         """
-        if isinstance(optimizer, chainer.optimizer.Optimizer):
+        if isinstance(optimizer, optimizer.Optimizer):
             self._optimizer = optimizer
 
         else:
@@ -47,7 +47,7 @@ class DataParallelOptimizer(chainer.Optimizer):
 
         """
         if optim_cls is not None and issubclass(optim_cls,
-                                                chainer.Optimizer):
+                                                optimizer.Optimizer):
             _optim = optim_cls(*args, **kwargs)
         else:
             raise RuntimeError("Invalid optimizer class given: Expected "

--- a/chainer/optimizers/data_parallel.py
+++ b/chainer/optimizers/data_parallel.py
@@ -68,10 +68,12 @@ class DataParallelOptimizer(optimizer.Optimizer):
         self._optimizer.setup(link)
 
         self._optimizer.add_hook(
-            chainer.optimizer_hooks.DataParallelOptimizerCumulateGradientsHook()
+            chainer.optimizer_hooks.DataParallelOptimizerCumulateGradientsHook(
+            )
         )
         self._optimizer.add_hook(
-            chainer.optimizer_hooks.DataParallelOptimizerUpdateModelParameters()
+            chainer.optimizer_hooks.DataParallelOptimizerUpdateModelParameters(
+            )
         )
 
     # forward all functions and attributes to internal optimizer via properties

--- a/chainer/optimizers/data_parallel.py
+++ b/chainer/optimizers/data_parallel.py
@@ -1,0 +1,148 @@
+import chainer
+import chainer.optimizer_hooks
+
+
+class DataParallelOptimizer(chainer.Optimizer):
+    """
+    An Optimizer-Wrapper to enable DataParallel. Basically this forwards
+    all functions to the interal optimizer, but registers the additional
+    hooks needed for DataParallel (namely
+    ~chainer.optimizer_hooks.ParallelOptimizerUpdateModelParameters as a
+    post-update hook and
+    ~chainer.optimizer_hooks.ParallelOptimizerCumulateGradientsHook as a
+    pre-update hook)
+    """
+
+    def __init__(self, optimizer):
+        """
+
+        Args
+            optimizer (~chainer.Optimizer):
+                the optimizer to wrap
+
+        """
+        if isinstance(optimizer, chainer.optimizer.Optimizer):
+            self._optimizer = optimizer
+
+        else:
+            raise RuntimeError("Invalid optimizer class given: Expected "
+                               "instance of chainer.Optimizer, but got %s"
+                               % optimizer.__class__.__name__)
+
+    @classmethod
+    def from_optimizer_class(cls, optim_cls, *args, **kwargs):
+        """
+        Classmethod to create an instance given only the optimizer class and
+        initialization arguments
+
+        Args
+            optim_cls (subclass of ~chainer.Optimizer):
+                the optimizer to use internally
+            args (tuple):
+                arbitrary positional arguments (will be used for
+                initialization of internally used optimizer)
+            kwargs (dict):
+                arbitrary keyword arguments (will be used for initialization
+                of internally used optimizer)
+
+        """
+        if optim_cls is not None and issubclass(optim_cls,
+                                                chainer.Optimizer):
+            _optim = optim_cls(*args, **kwargs)
+        else:
+            raise RuntimeError("Invalid optimizer class given: Expected "
+                               "Subclass of chainer.Optimizer, but got %s"
+                               % optim_cls.__name__)
+        return cls(_optim)
+
+    def setup(self, link):
+        """
+        Calls the setup method of the internal optimizer and registers the
+        necessary grads for data-parallel behavior
+
+        Args
+            link (~chainer.links.models.DataParallel):
+                the target, whose parameters should be updated
+
+        """
+        self._optimizer.setup(link)
+
+        self._optimizer.add_hook(
+            chainer.optimizer_hooks.DataParallelOptimizerCumulateGradientsHook()
+        )
+        self._optimizer.add_hook(
+            chainer.optimizer_hooks.DataParallelOptimizerUpdateModelParameters()
+        )
+
+    # forward all functions and attributes to internal optimizer via properties
+    @property
+    def target(self):
+        return self._optimizer.target
+
+    @property
+    def epoch(self):
+        return self._optimizer.epoch
+
+    @property
+    def _pre_update_hooks(self):
+        return self._optimizer._pre_update_hooks
+
+    @property
+    def _loss_scale(self):
+        return self._optimizer._loss_scale
+
+    @property
+    def _loss_scale_max(self):
+        return self._optimizer._loss_scale_max
+
+    @property
+    def _loss_scaling_is_dynamic(self):
+        return self._optimizer._loss_scaling_is_dynamic
+
+    @property
+    def use_auto_new_epoch(self):
+        return self._optimizer.use_auto_new_epoch
+
+    @property
+    def update(self):
+        return self._optimizer.update
+
+    @property
+    def new_epoch(self):
+        return self._optimizer.new_epoch
+
+    @property
+    def add_hook(self):
+        return self._optimizer.add_hook
+
+    @property
+    def remove_hook(self):
+        return self._optimizer.remove_hook
+
+    @property
+    def call_hooks(self):
+        return self._optimizer.call_hooks
+
+    @property
+    def serialize(self):
+        return self._optimizer.serialize
+
+    @property
+    def loss_scaling(self):
+        return self._optimizer.loss_scaling
+
+    @property
+    def set_loss_scale(self):
+        return self._optimizer.set_loss_scale
+
+    @property
+    def check_nan_in_grads(self):
+        return self._optimizer.check_nan_in_grads
+
+    @property
+    def is_safe_to_update(self):
+        return self._optimizer.is_safe_to_update
+
+    @property
+    def update_loss_scale(self):
+        return self._optimizer.update_loss_scale

--- a/chainer/optimizers/data_parallel.py
+++ b/chainer/optimizers/data_parallel.py
@@ -11,16 +11,14 @@ class DataParallelOptimizer(optimizer.Optimizer):
     post-update hook and
     ~chainer.optimizer_hooks.ParallelOptimizerCumulateGradientsHook as a
     pre-update hook)
+
+    Args
+        optim (~chainer.Optimizer):
+            the optimizer to wrap
     """
 
     def __init__(self, optim):
-        """
 
-        Args
-            optim (~chainer.Optimizer):
-                the optimizer to wrap
-
-        """
         if isinstance(optim, optimizer.Optimizer):
             self._optimizer = optim
 

--- a/tests/chainer_tests/links_tests/model_tests/test_data_parallel.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_data_parallel.py
@@ -1,0 +1,64 @@
+import unittest
+import chainer
+from chainer import testing
+import chainer.link
+import chainer.links
+import chainer.functions
+
+
+class TestDataParallel(unittest.TestCase):
+
+    def setUp(self) -> None:
+
+        # creating a really simple model to test dataparallel behavior
+        class SimpleModel(chainer.link.Chain):
+            def __init__(self):
+                super(SimpleModel, self).__init__()
+
+                with self.init_scope():
+                    self.dense_1 = chainer.links.Linear(3, 32)
+                    self.dense_2 = chainer.links.Linear(32, 2)
+
+            def forward(self, x):
+                return self.dense_2(chainer.functions.relu(self.dense_1(x)))
+
+        self.model = chainer.links.DataParallel(SimpleModel(),
+                                                devices=["@numpy", "@numpy"])
+
+    # test with keyword arguments
+    def test_keyword_arguments_different_batchsize(self):
+        import numpy as np
+
+        # test batchsize smaller than, equal to and greater than number devices
+        for batchsize in [1, 2, 3]:
+            with self.subTest(batchsize=batchsize):
+                input_kwargs = {
+                    "x": np.random.rand(batchsize, 3).astype(np.float32)
+                }
+
+                pred = self.model(**input_kwargs)
+                self.assertTupleEqual(pred.shape,
+                                      (batchsize, 2))
+                self.assertEqual(chainer.get_device(pred.device),
+                                 chainer.get_device("@numpy"))
+
+    # test with positional arguments
+    def test_positional_arguments(self):
+        import numpy as np
+
+        # test batchsize smaller than, equal to and greater than number devices
+        for batchsize in [1, 2, 3]:
+            with self.subTest(batchsize=batchsize):
+                input_args = [
+                    np.random.rand(batchsize, 3).astype(np.float32)
+                ]
+
+                pred = self.model(*input_args)
+                self.assertTupleEqual(pred.shape,
+                                      (batchsize, 2))
+
+                self.assertEqual(chainer.get_device(pred.device),
+                                 chainer.get_device("@numpy"))
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/model_tests/test_data_parallel.py
+++ b/tests/chainer_tests/links_tests/model_tests/test_data_parallel.py
@@ -8,7 +8,7 @@ import chainer.functions
 
 class TestDataParallel(unittest.TestCase):
 
-    def setUp(self) -> None:
+    def setUp(self):
 
         # creating a really simple model to test dataparallel behavior
         class SimpleModel(chainer.link.Chain):

--- a/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
+++ b/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
@@ -9,7 +9,7 @@ import chainer.optimizers
 
 class TestDataParallel(unittest.TestCase):
 
-    def setUp(self) -> None:
+    def setUp(self):
 
         # creating a really simple model to test dataparallel behavior
         class SimpleModel(chainer.link.Chain):

--- a/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
+++ b/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
@@ -38,7 +38,7 @@ class TestDataParallel(unittest.TestCase):
         input_tensor = np.random.rand(10, 3).astype(np.float32)
         label_tensor = np.random.rand(10, 2).astype(np.float)
 
-        model_copy = self.model.copy()
+        model_copy = self.model.copy(mode="copy")
 
         preds = self.model(input_tensor)
 

--- a/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
+++ b/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
@@ -1,0 +1,63 @@
+import unittest
+import chainer
+from chainer import testing
+import chainer.link
+import chainer.links
+import chainer.functions
+import chainer.optimizers
+
+
+class TestDataParallel(unittest.TestCase):
+
+    def setUp(self) -> None:
+
+        # creating a really simple model to test dataparallel behavior
+        class SimpleModel(chainer.link.Chain):
+            def __init__(self):
+                super(SimpleModel, self).__init__()
+
+                with self.init_scope():
+                    self.dense_1 = chainer.links.Linear(3, 32)
+                    self.dense_2 = chainer.links.Linear(32, 2)
+
+            def forward(self, x):
+                return self.dense_2(chainer.functions.relu(self.dense_1(x)))
+
+        self.model = chainer.links.DataParallel(SimpleModel(),
+                                                devices=["@numpy", "@numpy"])
+
+        self.optimizer = chainer.optimizers.DataParallelOptimizer.from_optimizer_class(
+            chainer.optimizers.Adam
+        )
+        self.optimizer.setup(self.model)
+
+    def test_update(self):
+        import numpy as np
+
+        input_tensor = np.random.rand(10, 3).astype(np.float32)
+        label_tensor = np.random.rand(10, 2).astype(np.float)
+
+        model_copy = self.model.copy()
+
+        preds = self.model(input_tensor)
+
+        loss = chainer.functions.sum(preds-label_tensor)
+
+        self.model.cleargrads()
+        loss.backward()
+        self.optimizer.update()
+
+        # check if param was updated
+        for orig_param, updated_param in zip(model_copy.params(),
+                                             self.model.params()):
+
+            self.assertFalse(np.array_equal(orig_param, updated_param))
+
+        # check if all grads were cleared
+        self.model.cleargrads()
+        for module in self.model.modules:
+            for updated_param in module.params():
+                self.assertIsNone(updated_param.grad_var)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
+++ b/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
@@ -52,7 +52,8 @@ class TestDataParallel(unittest.TestCase):
         for orig_param, updated_param in zip(model_copy.params(),
                                              self.model.params()):
 
-            self.assertFalse(np.array_equal(orig_param, updated_param))
+            self.assertFalse(np.array_equal(orig_param.array,
+                                            updated_param.array))
 
         # check if all grads were cleared
         self.model.cleargrads()

--- a/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
+++ b/tests/chainer_tests/optimizers_tests/test_data_parallel_optimizer.py
@@ -26,9 +26,10 @@ class TestDataParallel(unittest.TestCase):
         self.model = chainer.links.DataParallel(SimpleModel(),
                                                 devices=["@numpy", "@numpy"])
 
-        self.optimizer = chainer.optimizers.DataParallelOptimizer.from_optimizer_class(
-            chainer.optimizers.Adam
-        )
+        self.optimizer = \
+            chainer.optimizers.DataParallelOptimizer.from_optimizer_class(
+                chainer.optimizers.Adam
+            )
         self.optimizer.setup(self.model)
 
     def test_update(self):


### PR DESCRIPTION
This adds a `DataParallel` chain, optimizer hooks for gradient accumulation and parameter replication and an optimizer wrapper, which automatically registers this hooks.

I didn't really know, how to test this, so I came up with some functional tests.

The gathering and scattering somehow mimics the behavior of [pytorch](https://pytorch.org/docs/stable/nn.html#torch.nn.DataParallel). The whole code is inspired by the pytorch version and the [data-parallel example without a trainer](https://docs.chainer.org/en/stable/guides/gpu.html#data-parallel-computation-on-multiple-gpus-without-trainer).

I'm also not sure, whether the attribute forwarding inside the optimizer wrapper should be done by properties (which just works, but maybe missleads code completion in IDEs) or if we should explicitly write down the functions including all parameters (which would increase the effort to maintain this, if the API changes).

Closes #7264 

EDIT: I don't know, why `chainer.Optimizer` isn't found. This worked for me in my own implementation with chainer installed via pip... Will investigate this tomorrow