### PR TITLE
Fix rtol and atol to assert_allclose() of FP16 test

### DIFF
--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -363,7 +363,9 @@ def check_allreduce_grad_empty_half(communicator, model):
                 v += i + 2
         v /= communicator.size
         chainer.testing.assert_allclose(model.c.b.grad,
-                                        v * np.ones((5, )))
+                                        v * np.ones((5, )),
+                                        rtol=1e-3,
+                                        atol=1e-4)
 
 
 def check_send_recv(param, use_gpu):


### PR DESCRIPTION
When pytest runs on odd number of processes, such as 3 or 5, some tests using `float16` fail due to too strict `atol` and `rtol`. 

This PR fixes the issue by adding `rtol` and `atol` argument to `chainer.testing.assert_allclose()`. 

Note that precision of float16 is typically up to 3 or 4 digits.

```
tests/chainermn_tests/communicator_tests/test_communicator.py:521:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/chainermn_tests/communicator_tests/test_communicator.py:490: in check_collective_communication
    check_allreduce_grad_empty_half(communicator, model)
tests/chainermn_tests/communicator_tests/test_communicator.py:366: in check_allreduce_grad_empty_half
    v * np.ones((5, )))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = array([2.4003906, 2.4003906, 2.4003906, 2.4003906, 2.4003906],
      dtype=float32)
y = array([2.4, 2.4, 2.4, 2.4, 2.4]), atol = 1e-05, rtol = 0.0001
verbose = True
```
