### PR TITLE
Fix a bug that root is ignored in  scatter_dataset and bcast

### DIFF
--- a/chainermn/communicators/_communication_utility.py
+++ b/chainermn/communicators/_communication_utility.py
@@ -149,7 +149,8 @@ def chunked_bcast_obj(obj, mpi_comm, max_buf_len=256 * 1024 * 1024,
     if (total_bytes % max_buf_len) > 0:
         total_chunk_num += 1
 
-    data = mpi_comm.bcast((total_chunk_num, max_buf_len, total_bytes))
+    data = mpi_comm.bcast((total_chunk_num, max_buf_len, total_bytes),
+                          root=root)
     assert data is not None
     (total_chunk_num, max_buf_len, total_bytes) = data
 
@@ -167,7 +168,7 @@ def chunked_bcast_obj(obj, mpi_comm, max_buf_len=256 * 1024 * 1024,
         if mpi_comm.rank != root:
             pickled_bytes[b:e] = buf
 
-    if mpi_comm.rank > root:
+    if mpi_comm.rank != root:
         obj = pickle.loads(pickled_bytes)
 
     return obj

--- a/chainermn/datasets/scatter_dataset.py
+++ b/chainermn/datasets/scatter_dataset.py
@@ -12,7 +12,8 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False,
                     seed=None, max_buf_len=256 * 1024 * 1024):
     """Scatter the given dataset to the workers in the communicator.
 
-    The dataset of worker 0 (i.e., the worker whose ``comm.rank`` is 0) is
+    The dataset of worker ``root``
+    (i.e., the worker whose ``comm.rank`` is ``root``) is
     scattered to all workers. The given dataset of other workers are ignored.
     The dataset is split to sub datasets of almost equal sizes and scattered
     to workers. To create a sub dataset, ``chainer.datasets.SubDataset`` is
@@ -45,10 +46,10 @@ def scatter_dataset(dataset, comm, root=0, shuffle=False,
             n_total_samples)
 
     data = None
-    if comm.rank == 0:
+    if comm.rank == root:
         data = (dataset, order)
 
-    data = comm.bcast_obj(data, max_buf_len=max_buf_len, root=0)
+    data = comm.bcast_obj(data, max_buf_len=max_buf_len, root=root)
     assert data is not None
     (dataset, order) = data
 

--- a/tests/chainermn_tests/datasets_tests/test_dataset.py
+++ b/tests/chainermn_tests/datasets_tests/test_dataset.py
@@ -18,6 +18,8 @@ class TestDataset(unittest.TestCase):
         self.communicator = NaiveCommunicator(self.mpi_comm)
 
     def check_scatter_dataset(self, original_dataset, shuffle=False, root=0):
+        if self.communicator.rank != root:
+            original_dataset = None
         my_dataset = chainermn.scatter_dataset(
             original_dataset, self.communicator,
             shuffle=shuffle, root=root)


### PR DESCRIPTION
This PR fixes a critical bug, which is related to `scatter_dataset` and `bcast` routines.

`scatter_dataset()` has a parameter called `root`. It is expected that `root` is passed to the underlying MPI collective routines, in particular `Bcast()`. However, the routines are actually hard-coded so the `root` is always rank 0 and the `root` parameter is ignored. The test did not detect the bug.

The PR fixes the bug in two steps. 
First, the test is fixed. The problem in `check_scatter_dataset`  was that all ranks have the same data when the test begins, so if the `root` argument is ignored, rank 0 performed `bcast` and all process obtained the data so the test succeeded.

Second, the code is fixed.
