### PR TITLE
Support `None` arguments in `chainerx.clip` and `chainerx.ndarray.clip`

### DIFF
--- a/chainerx/math/misc.py
+++ b/chainerx/math/misc.py
@@ -30,10 +30,13 @@ def clip(a, a_min, a_max):
     .. seealso:: :func:`numpy.clip`
 
     """
-    if a_min is None:
-        a_min = a.min()
+    if a_min is None and a_max is None:
+        raise ValueError('Must set either a_min or a_max.')
 
-    if a_max is None:
-        a_max = a.max()
+    if a_min is not None:
+        a = chainerx.maximum(a, a_min)
 
-    return -chainerx.maximum(-chainerx.maximum(a, a_min), -a_max)
+    if a_max is not None:
+        a = chainerx.minimum(a, a_max)
+
+    return a

--- a/chainerx/math/misc.py
+++ b/chainerx/math/misc.py
@@ -30,4 +30,10 @@ def clip(a, a_min, a_max):
     .. seealso:: :func:`numpy.clip`
 
     """
+    if a_min is None:
+        a_min = a.min()
+
+    if a_max is None:
+        a_max = a.max()
+
     return -chainerx.maximum(-chainerx.maximum(a, a_min), -a_max)


### PR DESCRIPTION
A temporary fix (until https://github.com/chainer/chainer/pull/7285 is merged) that allows `chainerx.clip` and `chainerx.ndarray.clip` to take `None` interval arguments.