### PR TITLE
[backport] Fix initialization of `L.Linear` when called with `n_batch_axes`

### DIFF
--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -150,6 +150,6 @@ class Linear(link.Link):
 
         """
         if self.W.array is None:
-            in_size = utils.size_of_shape(x.shape[1:])
+            in_size = utils.size_of_shape(x.shape[n_batch_axes:])
             self._initialize_params(in_size)
         return linear.linear(x, self.W, self.b, n_batch_axes=n_batch_axes)

--- a/tests/chainer_tests/links_tests/connection_tests/test_linear.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_linear.py
@@ -165,6 +165,17 @@ class TestEmptyBatchInitialize(unittest.TestCase):
         assert y.shape == (0, 4)
 
 
+class TestNBatchAxesInitialize(unittest.TestCase):
+
+    def setUp(self):
+        self.link = links.Linear(4)
+        self.x = numpy.random.uniform(-1, 1, (2, 5, 3)).astype(numpy.float32)
+
+    def test_init_n_batch_axes(self):
+        y = self.link(chainer.Variable(self.x), n_batch_axes=2)
+        assert y.shape == (2, 5, 4)
+
+
 class TestInvalidLinear(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Backport of #7167