### PR TITLE
Add observation_aggregator

### DIFF
--- a/chainermn/extensions/__init__.py
+++ b/chainermn/extensions/__init__.py
@@ -1,3 +1,4 @@
 from chainermn.extensions.allreduce_persistent import AllreducePersistent  # NOQA
 from chainermn.extensions.checkpoint import create_multi_node_checkpointer  # NOQA
 from chainermn.extensions.multi_node_evaluator import create_multi_node_evaluator  # NOQA
+from chainermn.extensions.observation_aggregator import observation_aggregator  # NOQA

--- a/chainermn/extensions/__init__.py
+++ b/chainermn/extensions/__init__.py
@@ -1,4 +1,5 @@
 from chainermn.extensions.allreduce_persistent import AllreducePersistent  # NOQA
 from chainermn.extensions.checkpoint import create_multi_node_checkpointer  # NOQA
 from chainermn.extensions.multi_node_evaluator import create_multi_node_evaluator  # NOQA
-from chainermn.extensions.observation_aggregator import observation_aggregator  # NOQA
+from chainermn.extensions.observation_aggregator import ObservationAggregator  # NOQA
+from chainermn.extensions.multi_node_early_stopping_trigger import MultiNodeEarlyStoppingTrigger  # NOQA

--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -4,10 +4,6 @@ from chainer.training.triggers import EarlyStoppingTrigger
 from chainermn.extensions import ObservationAggregator
 
 
-def _random_suffix(n):
-    return ''.join([random.choice(string.ascii_letters) for i in range(n)])
-
-
 class MultiNodeEarlyStoppingTrigger(object):
     """__init__(\
         self, comm, check_trigger=(1, 'epoch'), monitor='main/loss', \
@@ -43,6 +39,8 @@ class MultiNodeEarlyStoppingTrigger(object):
         verbose (bool) : Enable verbose output.
             If verbose is true, you can get more information
         max_trigger: Upper bound of the number of training loops
+        suffix (str): Suffix added to the name of the monitored
+            metric after aggregation.
 
     .. note::
        ``patients`` is also available as an alias of ``patience`` for
@@ -51,10 +49,10 @@ class MultiNodeEarlyStoppingTrigger(object):
 
     def __init__(self, comm, check_trigger=(1, 'epoch'), monitor='main/loss',
                  patience=None, mode='auto', verbose=False,
-                 max_trigger=(100, 'epoch'), **kwargs):
+                 max_trigger=(100, 'epoch'), suffix='_aggregated', **kwargs):
 
         # `patients` as an alias of `patience`
-        monitor_aggregated = monitor + '-aggregated-' + _random_suffix(10)
+        monitor_aggregated = monitor + suffix
 
         self.actual_trigger = EarlyStoppingTrigger(check_trigger=check_trigger,
                                                    monitor=monitor_aggregated,

--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -1,0 +1,39 @@
+import random, string
+from chainer.training.triggers import EarlyStoppingTrigger
+from chainermn.extensions import ObservationAggregator
+
+
+def _random_suffix(n):
+    return ''.join(random.choices(string.ascii_letters, k=n))
+
+
+class MultiNodeEarlyStoppingTrigger(object):
+
+    def __init__(self, comm, check_trigger=(1, 'epoch'), monitor='main/loss',
+                 patience=None, mode='auto', verbose=False,
+                 max_trigger=(100, 'epoch'), **kwargs):
+
+        # `patients` as an alias of `patience`
+        monitor_aggregated = monitor + '-aggregated-' + _random_suffix(10)
+
+        self.actual_trigger = EarlyStoppingTrigger(check_trigger=check_trigger,
+                                              monitor=monitor_aggregated,
+                                              patience=patience,
+                                              mode=mode, verbose=verbose,
+                                              max_trigger=max_trigger,
+                                              **kwargs)
+        self.aggregator = ObservationAggregator(comm, monitor, monitor_aggregated,
+                                           check_trigger)
+
+    def __call__(self, trainer):
+        self.aggregator(trainer)
+        return self.actual_trigger(trainer)
+
+    def _stop_condition(self):
+        return self.actual_trigger._stop_condition()
+
+    def _init_summary(self):
+        return self.actual_trigger._init_summary()
+
+    def get_training_length(self):
+        return self.actual_trigger.get_training_length()

--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -1,5 +1,3 @@
-import random
-import string
 from chainer.training.triggers import EarlyStoppingTrigger
 from chainermn.extensions import ObservationAggregator
 

--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -1,4 +1,5 @@
-import random, string
+import random
+import string
 from chainer.training.triggers import EarlyStoppingTrigger
 from chainermn.extensions import ObservationAggregator
 
@@ -17,13 +18,14 @@ class MultiNodeEarlyStoppingTrigger(object):
         monitor_aggregated = monitor + '-aggregated-' + _random_suffix(10)
 
         self.actual_trigger = EarlyStoppingTrigger(check_trigger=check_trigger,
-                                              monitor=monitor_aggregated,
-                                              patience=patience,
-                                              mode=mode, verbose=verbose,
-                                              max_trigger=max_trigger,
-                                              **kwargs)
-        self.aggregator = ObservationAggregator(comm, monitor, monitor_aggregated,
-                                           check_trigger)
+                                                   monitor=monitor_aggregated,
+                                                   patience=patience,
+                                                   mode=mode, verbose=verbose,
+                                                   max_trigger=max_trigger,
+                                                   **kwargs)
+        self.aggregator = ObservationAggregator(comm, monitor,
+                                                monitor_aggregated,
+                                                check_trigger)
 
     def __call__(self, trainer):
         self.aggregator(trainer)

--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -9,6 +9,45 @@ def _random_suffix(n):
 
 
 class MultiNodeEarlyStoppingTrigger(object):
+    """__init__(\
+        self, comm, check_trigger=(1, 'epoch'), monitor='main/loss', \
+        patience=3, mode='auto', verbose=False, \
+        max_trigger=(100, 'epoch'))
+
+    Trigger for Early Stopping in Multiple Node Environments
+
+    It serves almost the same as
+    :class:`~chainer.training.triggers.EarlyStoppingTrigger`,
+    but it can correctly work in multiple node environments.
+
+    The difference between it and
+    :class:`~chainer.training.triggers.EarlyStoppingTrigger` is that,
+    in each check interval, it computes the mean of the accumulated
+    values *across all nodes*. In this way, all nodes will have the same
+    value to determine the timing at which the trigger fires so that
+    they will stop at the same time.
+
+    Args:
+        comm : ChainerMN communicator
+        check_trigger: Trigger that decides the comparison
+            interval between current best value and new value.
+            This must be a tuple in the form of ``<int>,
+            'epoch'`` or ``<int>, 'iteration'`` which is passed to
+            :class:`~chainer.training.triggers.IntervalTrigger`.
+        monitor (str) : The metric you want to monitor
+        patience (int) : Counts to let the trigger be patient.
+            The trigger will not fire until the condition is met
+            for successive ``patience`` checks.
+        mode (str) : ``'max'``, ``'min'``, or ``'auto'``.
+            It is used to determine how to compare the monitored values.
+        verbose (bool) : Enable verbose output.
+            If verbose is true, you can get more information
+        max_trigger: Upper bound of the number of training loops
+
+    .. note::
+       ``patients`` is also available as an alias of ``patience`` for
+       historical reason.
+    """
 
     def __init__(self, comm, check_trigger=(1, 'epoch'), monitor='main/loss',
                  patience=None, mode='auto', verbose=False,

--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -5,7 +5,7 @@ from chainermn.extensions import ObservationAggregator
 
 
 def _random_suffix(n):
-    return ''.join(random.choices(string.ascii_letters, k=n))
+    return ''.join([random.choice(string.ascii_letters) for i in range(n)])
 
 
 class MultiNodeEarlyStoppingTrigger(object):

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -1,4 +1,5 @@
-from chainer.training import extension
+from __future__ import division
+from chainer.training import extension, util
 
 
 def observation_aggregator(comm, original_key, aggregated_key=None,
@@ -42,3 +43,70 @@ def observation_aggregator(comm, original_key, aggregated_key=None,
         trainer.observation[aggregated_key] = value_summarized
 
     return _observation_aggregator
+
+
+class ObservationAggregator(extension.Extension):
+
+    """Trainer extension to aggregate an observation in the trainer.
+    Args:
+         comm: ChainerMN communicator
+         original_key (str): Key of the observation to be summarized.
+         aggregated_key (str): Name of the key after the summarization.
+         If not specified, it is set to `original_key` to overwrite it.
+         comm_trigger: Trigger that decides the timing to communicate
+         observation values for aggregation.
+         aggregator (function): Function to compute summarization from
+         individual values. It takes a list of lists of observed values.
+         Each list contains all the observed values since the last communication.
+    """
+
+    trigger = 1, 'iteration'
+    priority = extension.PRIORITY_EDITOR
+    name = None
+
+    def __init__(self, comm, original_key, aggregated_key=None,
+                 comm_trigger=(1, 'iteration'), aggregator=None):
+        self.comm = comm
+        self.original_key = original_key
+
+        if aggregated_key is None:
+            self.aggregated_key = original_key
+        else:
+            self.aggregated_key = aggregated_key
+
+        self.comm_trigger = util.get_trigger(comm_trigger)
+        self.observation_history = []
+
+        self.aggregator = aggregator or _average_2d
+
+    def compute_summary(self, trainer):
+        if self.original_key in trainer.observation:
+            value = trainer.observation[self.original_key]
+            self.observation_history.append(value)
+
+        if not self.comm_trigger(trainer):
+            return None
+
+        internal_summary = self.internal_aggregator(self.observation_history)
+        self.observation_history = []
+
+        internal_summary_gathered = self.comm.gather_obj(internal_summary)
+
+        if self.comm.rank == 0:
+            global_summary = self.global_aggregator(internal_summary_gathered)
+            self.comm.bcast_obj(global_summary)
+        else:
+            global_summary = self.comm.bcast_obj(None)
+
+        return global_summary
+
+    def __call__(self, trainer):
+        summary = self.compute_summary(trainer)
+
+        if summary is not None:
+            trainer.observation[self.aggregated_key] = summary
+
+
+def _average_2d(xs):
+    xs = sum(xs, [])
+    return sum(xs) / len(xs)

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -57,7 +57,8 @@ class ObservationAggregator(extension.Extension):
          observation values for aggregation.
          aggregator (function): Function to compute summarization from
          individual values. It takes a list of lists of observed values.
-         Each list contains all the observed values since the last communication.
+         Each list contains all the observed values since
+         the last communication.
     """
 
     trigger = 1, 'iteration'
@@ -87,7 +88,8 @@ class ObservationAggregator(extension.Extension):
         if not self.comm_trigger(trainer):
             return None
 
-        observation_history_gathered = self.comm.gather_obj(self.observation_history)
+        observation_history_gathered = self.comm.gather_obj(
+            self.observation_history)
         self.observation_history = []
 
         if self.comm.rank == 0:

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -1,4 +1,3 @@
-import numpy as np
 from chainer.training import extension
 
 
@@ -22,7 +21,7 @@ def observation_aggregator(comm, original_key, aggregated_key=None,
 
     if aggregator is None:
         def _average(xs):
-            return sum(xs) / len(xs)
+            return sum(xs) / float(len(xs))
         aggregator = _average
 
     @extension.make_extension(

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -1,0 +1,43 @@
+import numpy as np
+from chainer.training import extension
+
+
+def observation_aggregator(comm, original_key, aggregated_key=None,
+                           aggregator=None):
+    """Returns an observation aggregator, which summarizes
+    (computing the average, etc) the observation `original_key` in the trainer.
+    It should be noted that, in each iteration, `original_key` must be reported
+    either in every training process, or no process at all.
+    Args:
+         comm: ChainerMN communicator
+         original_key (str): Key of the observation to be summarized.
+         aggregated_key (str): Name of the key after the summarization.
+         If not specified, it is set to `original_key` to overwrite it.
+         aggregator (function): Function to compute summarization from
+         individual values. If not specified, `numpy.average` is used.
+    """
+
+    if aggregated_key is None:
+        aggregated_key = original_key
+
+    if aggregator is None:
+        aggregator = np.average
+
+    @extension.make_extension(
+        trigger=(1, 'iteration'), priority=extension.PRIORITY_EDITOR)
+    def _observation_aggregator(trainer):
+        if original_key not in trainer.observation:
+            return
+        value = trainer.observation[original_key]
+        value_collected = comm.gather_obj(value)
+
+        if comm.rank == 0:
+            assert len(value_collected) == comm.size
+            value_summarized = aggregator(value_collected)
+            comm.bcast_obj(value_summarized)
+        else:
+            value_summarized = comm.bcast_obj(None)
+
+        trainer.observation[aggregated_key] = value_summarized
+
+    return _observation_aggregator

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -1,48 +1,6 @@
 from __future__ import division
 from chainer.training import extension, util
-
-
-def observation_aggregator(comm, original_key, aggregated_key=None,
-                           aggregator=None):
-    """Returns an observation aggregator, which summarizes
-    (computing the average, etc) the observation `original_key` in the trainer.
-    It should be noted that, in each iteration, `original_key` must be reported
-    either in every training process, or no process at all.
-    Args:
-         comm: ChainerMN communicator
-         original_key (str): Key of the observation to be summarized.
-         aggregated_key (str): Name of the key after the summarization.
-         If not specified, it is set to `original_key` to overwrite it.
-         aggregator (function): Function to compute summarization from
-         individual values. If not specified, the average function is used.
-    """
-
-    if aggregated_key is None:
-        aggregated_key = original_key
-
-    if aggregator is None:
-        def _average(xs):
-            return sum(xs) / float(len(xs))
-        aggregator = _average
-
-    @extension.make_extension(
-        trigger=(1, 'iteration'), priority=extension.PRIORITY_EDITOR)
-    def _observation_aggregator(trainer):
-        if original_key not in trainer.observation:
-            return
-        value = trainer.observation[original_key]
-        value_collected = comm.gather_obj(value)
-
-        if comm.rank == 0:
-            assert len(value_collected) == comm.size
-            value_summarized = aggregator(value_collected)
-            comm.bcast_obj(value_summarized)
-        else:
-            value_summarized = comm.bcast_obj(None)
-
-        trainer.observation[aggregated_key] = value_summarized
-
-    return _observation_aggregator
+from chainer import Variable
 
 
 class ObservationAggregator(extension.Extension):
@@ -51,6 +9,8 @@ class ObservationAggregator(extension.Extension):
     Args:
          comm: ChainerMN communicator
          original_key (str): Key of the observation to be summarized.
+         If the observation is a :class:`chainer.Variable`, its value
+         is automatically copied to CPU.
          aggregated_key (str): Name of the key after the summarization.
          If not specified, it is set to `original_key` to overwrite it.
          comm_trigger: Trigger that decides the timing to communicate
@@ -83,6 +43,8 @@ class ObservationAggregator(extension.Extension):
     def compute_summary(self, trainer):
         if self.original_key in trainer.observation:
             value = trainer.observation[self.original_key]
+            if isinstance(value, Variable):
+                value.to_cpu()
             self.observation_history.append(value)
 
         if not self.comm_trigger(trainer):

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -14,14 +14,16 @@ def observation_aggregator(comm, original_key, aggregated_key=None,
          aggregated_key (str): Name of the key after the summarization.
          If not specified, it is set to `original_key` to overwrite it.
          aggregator (function): Function to compute summarization from
-         individual values. If not specified, `numpy.average` is used.
+         individual values. If not specified, the average function is used.
     """
 
     if aggregated_key is None:
         aggregated_key = original_key
 
     if aggregator is None:
-        aggregator = np.average
+        def _average(xs):
+            return sum(xs) / len(xs)
+        aggregator = _average
 
     @extension.make_extension(
         trigger=(1, 'iteration'), priority=extension.PRIORITY_EDITOR)

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -87,13 +87,11 @@ class ObservationAggregator(extension.Extension):
         if not self.comm_trigger(trainer):
             return None
 
-        internal_summary = self.internal_aggregator(self.observation_history)
+        observation_history_gathered = self.comm.gather_obj(self.observation_history)
         self.observation_history = []
 
-        internal_summary_gathered = self.comm.gather_obj(internal_summary)
-
         if self.comm.rank == 0:
-            global_summary = self.global_aggregator(internal_summary_gathered)
+            global_summary = self.aggregator(observation_history_gathered)
             self.comm.bcast_obj(global_summary)
         else:
             global_summary = self.comm.bcast_obj(None)

--- a/tests/chainermn_tests/extensions_tests/test_multi_node_early_stopping_trigger.py
+++ b/tests/chainermn_tests/extensions_tests/test_multi_node_early_stopping_trigger.py
@@ -3,7 +3,6 @@ from __future__ import division
 import unittest
 
 import numpy
-import pytest
 
 import chainer
 from chainer import testing
@@ -30,17 +29,19 @@ class TestMultiNodeEarlyStoppingTrigger(unittest.TestCase):
     def test_early_stopping_trigger_with_accuracy(self):
         comm = self.communicator
         key = 'main/accuracy'
-        trigger = MultiNodeEarlyStoppingTrigger(monitor=key, patience=3,
+        trigger = MultiNodeEarlyStoppingTrigger(comm, monitor=key, patience=3,
                                                 check_trigger=(1, 'epoch'),
                                                 verbose=False)
         trigger = util.get_trigger(trigger)
 
-        accuracies = [0.5, 0.5, 0.5, 0.5, 0.6, 0.6, 0.7, 0.7, 0.6, 0.6, 0.4, 0.4, 0.3, 0.3, 0.2, 0.2]
+        accuracies = [0.5, 0.5, 0.5, 0.5, 0.6, 0.6, 0.7,
+                      0.7, 0.6, 0.6, 0.4, 0.4, 0.3, 0.3, 0.2, 0.2]
         accuracies = [x * (1 - comm.rank / comm.size) for x in accuracies]
         accuracies = numpy.asarray([
             chainer.Variable(numpy.asarray(acc, dtype=numpy.float32))
             for acc in accuracies])
 
-        expected = [False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True]
+        expected = [False, False, False, False, False, False,
+                    False, False, False, False, False, False,
+                    False, True, False, True]
         _test_trigger(self, trigger, key, accuracies, expected)
-

--- a/tests/chainermn_tests/extensions_tests/test_multi_node_early_stopping_trigger.py
+++ b/tests/chainermn_tests/extensions_tests/test_multi_node_early_stopping_trigger.py
@@ -1,0 +1,46 @@
+from __future__ import division
+
+import unittest
+
+import numpy
+import pytest
+
+import chainer
+from chainer import testing
+import chainermn
+from chainermn.extensions import MultiNodeEarlyStoppingTrigger
+from chainer.training import util
+
+
+def _test_trigger(self, trigger, key, accuracies, expected):
+    trainer = testing.training.get_trainer_with_mock_updater(
+        stop_trigger=None, iter_per_epoch=2)
+
+    for accuracy, expected in zip(accuracies, expected):
+        trainer.updater.update()
+        trainer.observation = {key: accuracy}
+        self.assertEqual(trigger(trainer), expected)
+
+
+class TestMultiNodeEarlyStoppingTrigger(unittest.TestCase):
+
+    def setUp(self):
+        self.communicator = chainermn.create_communicator('naive')
+
+    def test_early_stopping_trigger_with_accuracy(self):
+        comm = self.communicator
+        key = 'main/accuracy'
+        trigger = MultiNodeEarlyStoppingTrigger(monitor=key, patience=3,
+                                                check_trigger=(1, 'epoch'),
+                                                verbose=False)
+        trigger = util.get_trigger(trigger)
+
+        accuracies = [0.5, 0.5, 0.5, 0.5, 0.6, 0.6, 0.7, 0.7, 0.6, 0.6, 0.4, 0.4, 0.3, 0.3, 0.2, 0.2]
+        accuracies = [x * (1 - comm.rank / comm.size) for x in accuracies]
+        accuracies = numpy.asarray([
+            chainer.Variable(numpy.asarray(acc, dtype=numpy.float32))
+            for acc in accuracies])
+
+        expected = [False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True]
+        _test_trigger(self, trigger, key, accuracies, expected)
+

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -15,25 +15,47 @@ class DummyChain(chainer.Chain):
 
     def __init__(self):
         super(DummyChain, self).__init__()
+        with self.init_scope():
+            self.l = chainer.links.Linear(None, 1)
 
     def forward(self, x):
-        return chainer.Variable(x, grad=np.array([0]))
+        return chainer.functions.sum(self.l(x))
+#        xp = chainer.backend.get_array_module(x)
+#        print(xp)
+#        return chainer.Variable(x, grad=xp.array([0]))
 
 
+@chainer.testing.parameterize(*chainer.testing.product({
+    'use_cupy': [False, True],
+    'use_chainer_variable': [False, True],
+    'communicate_interval': [1, 2],
+}))
 class TestObservationAggregator(unittest.TestCase):
 
     def setUp(self):
-        self.communicator = chainermn.create_communicator('naive')
+        if self.use_cupy:
+            comm_name = 'pure_nccl'
+            import cupy
+            self.xp = cupy
+        else:
+            comm_name = 'naive'
+            self.xp = np
+        self.communicator = chainermn.create_communicator(comm_name)
 
-    def test_observation_aggregator1(self):
+        if self.use_cupy:
+            cupy.cuda.Device(self.communicator.intra_rank).use()
+
+    def test_observation_aggregator(self):
         model = DummyChain()
+        if self.use_cupy:
+            model.to_gpu()
         comm = self.communicator
 
         optimizer = chainermn.create_multi_node_optimizer(
             chainer.optimizers.Adam(), self.communicator)
         optimizer.setup(model)
 
-        train = np.random.rand(10, 1)
+        train = self.xp.random.rand(10, 1).astype(np.float32)
         train_iter = chainer.iterators.SerialIterator(train,
                                                       batch_size=1,
                                                       repeat=True,
@@ -46,59 +68,25 @@ class TestObservationAggregator(unittest.TestCase):
         @extension.make_extension(
             trigger=(1, 'iteration'), priority=extension.PRIORITY_WRITER)
         def rank_reporter(trainer):
-            trainer.observation['rank'] = comm.rank
+            tmp = self.xp.asarray(comm.rank, dtype=np.float32)
+            if self.use_chainer_variable:
+                tmp = chainer.Variable(tmp)
+            trainer.observation['rank'] = tmp
 
         @extension.make_extension(
-            trigger=(1, 'iteration'), priority=extension.PRIORITY_READER)
+            trigger=(self.communicate_interval, 'iteration'),
+            priority=extension.PRIORITY_READER)
         def aggregated_rank_checker(trainer):
             actual = trainer.observation['rank-aggregated']
+            if self.use_chainer_variable:
+                actual = actual.data
             expected = (comm.size - 1) / 2
-            chainer.testing.assert_allclose(actual,
-                                            expected)
+            chainer.testing.assert_allclose(actual, expected)
 
         trainer.extend(rank_reporter)
         trainer.extend(ObservationAggregator(
-            comm, 'rank', 'rank-aggregated', comm_trigger=(1, 'iteration')))
-        trainer.extend(aggregated_rank_checker)
-
-        trainer.run()
-
-    def test_observation_aggregator2(self):
-        model = DummyChain()
-        comm = self.communicator
-
-        optimizer = chainermn.create_multi_node_optimizer(
-            chainer.optimizers.Adam(), self.communicator)
-        optimizer.setup(model)
-
-        train = np.random.rand(10, 1)
-        train_iter = chainer.iterators.SerialIterator(train,
-                                                      batch_size=1,
-                                                      repeat=True,
-                                                      shuffle=True)
-
-        updater = chainer.training.StandardUpdater(train_iter, optimizer)
-
-        trainer = chainer.training.Trainer(updater, (1, 'epoch'))
-
-        @extension.make_extension(
-            trigger=(1, 'iteration'), priority=extension.PRIORITY_WRITER)
-        def rank_reporter(trainer):
-            trainer.observation['rank'] = comm.rank + \
-                trainer.updater.iteration % 2
-
-        @extension.make_extension(
-            trigger=(1, 'iteration'), priority=extension.PRIORITY_READER)
-        def aggregated_rank_checker(trainer):
-            if trainer.updater.iteration % 2 == 0:
-                actual = trainer.observation['rank-aggregated']
-                expected = (comm.size - 1) / 2 + 1 / 2
-                chainer.testing.assert_allclose(actual,
-                                                expected)
-
-        trainer.extend(rank_reporter)
-        trainer.extend(ObservationAggregator(
-            comm, 'rank', 'rank-aggregated', comm_trigger=(2, 'iteration')))
+            comm, 'rank', 'rank-aggregated',
+            comm_trigger=(self.communicate_interval, 'iteration')))
         trainer.extend(aggregated_rank_checker)
 
         trainer.run()

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -57,7 +57,8 @@ class TestObservationAggregator(unittest.TestCase):
                                             expected)
 
         trainer.extend(rank_reporter)
-        trainer.extend(ObservationAggregator(comm, 'rank', 'rank-aggregated', comm_trigger=(1, 'iteration')))
+        trainer.extend(ObservationAggregator(
+            comm, 'rank', 'rank-aggregated', comm_trigger=(1, 'iteration')))
         trainer.extend(aggregated_rank_checker)
 
         trainer.run()
@@ -83,7 +84,8 @@ class TestObservationAggregator(unittest.TestCase):
         @extension.make_extension(
             trigger=(1, 'iteration'), priority=extension.PRIORITY_WRITER)
         def rank_reporter(trainer):
-            trainer.observation['rank'] = comm.rank + trainer.updater.iteration % 2
+            trainer.observation['rank'] = comm.rank + \
+                trainer.updater.iteration % 2
 
         @extension.make_extension(
             trigger=(1, 'iteration'), priority=extension.PRIORITY_READER)
@@ -95,7 +97,8 @@ class TestObservationAggregator(unittest.TestCase):
                                                 expected)
 
         trainer.extend(rank_reporter)
-        trainer.extend(ObservationAggregator(comm, 'rank', 'rank-aggregated', comm_trigger=(2, 'iteration')))
+        trainer.extend(ObservationAggregator(
+            comm, 'rank', 'rank-aggregated', comm_trigger=(2, 'iteration')))
         trainer.extend(aggregated_rank_checker)
 
         trainer.run()

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -88,10 +88,11 @@ class TestObservationAggregator(unittest.TestCase):
         @extension.make_extension(
             trigger=(1, 'iteration'), priority=extension.PRIORITY_READER)
         def aggregated_rank_checker(trainer):
-            actual = trainer.observation['rank-aggregated']
-            expected = (comm.size - 1) / 2 + 1 / 2
-            chainer.testing.assert_allclose(actual,
-                                            expected)
+            if trainer.updater.iteration % 2 == 0:
+                actual = trainer.observation['rank-aggregated']
+                expected = (comm.size - 1) / 2 + 1 / 2
+                chainer.testing.assert_allclose(actual,
+                                                expected)
 
         trainer.extend(rank_reporter)
         trainer.extend(ObservationAggregator(comm, 'rank', 'rank-aggregated', comm_trigger=(2, 'iteration')))

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -25,7 +25,7 @@ class TestObservationAggregator(unittest.TestCase):
     def setUp(self):
         self.communicator = chainermn.create_communicator('naive')
 
-    def test_observation_aggregator(self):
+    def test_observation_aggregator1(self):
         model = DummyChain()
         comm = self.communicator
 
@@ -53,6 +53,43 @@ class TestObservationAggregator(unittest.TestCase):
         def aggregated_rank_checker(trainer):
             actual = trainer.observation['rank-aggregated']
             expected = (comm.size - 1) / 2
+            chainer.testing.assert_allclose(actual,
+                                            expected)
+
+        trainer.extend(rank_reporter)
+        trainer.extend(ObservationAggregator(comm, 'rank', 'rank-aggregated', comm_trigger=(1, 'iteration')))
+        trainer.extend(aggregated_rank_checker)
+
+        trainer.run()
+
+    def test_observation_aggregator2(self):
+        model = DummyChain()
+        comm = self.communicator
+
+        optimizer = chainermn.create_multi_node_optimizer(
+            chainer.optimizers.Adam(), self.communicator)
+        optimizer.setup(model)
+
+        train = np.random.rand(10, 1)
+        train_iter = chainer.iterators.SerialIterator(train,
+                                                      batch_size=1,
+                                                      repeat=True,
+                                                      shuffle=True)
+
+        updater = chainer.training.StandardUpdater(train_iter, optimizer)
+
+        trainer = chainer.training.Trainer(updater, (1, 'epoch'))
+
+        @extension.make_extension(
+            trigger=(1, 'iteration'), priority=extension.PRIORITY_WRITER)
+        def rank_reporter(trainer):
+            trainer.observation['rank'] = comm.rank + trainer.updater.iteration % 2
+
+        @extension.make_extension(
+            trigger=(1, 'iteration'), priority=extension.PRIORITY_READER)
+        def aggregated_rank_checker(trainer):
+            actual = trainer.observation['rank-aggregated']
+            expected = (comm.size - 1) / 2 + 1 / 2
             chainer.testing.assert_allclose(actual,
                                             expected)
 

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-import unittest
+import pytest
 
 import numpy as np
 
@@ -21,71 +21,77 @@ class DummyChain(chainer.Chain):
 
     def forward(self, x):
         return chainer.functions.sum(self.l(x))
-#        xp = chainer.backend.get_array_module(x)
-#        print(xp)
-#        return chainer.Variable(x, grad=xp.array([0]))
 
 
-@chainer.testing.parameterize(*chainer.testing.product({
-    'use_chainer_variable': [False, True],
-    'communicate_interval': [1, 2],
-}))
-class TestObservationAggregator(unittest.TestCase):
+@pytest.mark.parametrize('use_chainer_variable', [False, True])
+@pytest.mark.parametrize('communicate_interval', [1, 2])
+def test_observation_aggregator_cpu(use_chainer_variable,
+                                    communicate_interval):
+    communicator = chainermn.create_communicator('naive')
+    xp = np
+    run_test_observation_aggregator(communicator, xp,
+                                    use_chainer_variable,
+                                    communicate_interval,
+                                    use_cupy=False)
 
-    def test_observation_aggregator_cpu(self):
-        self.communicator = chainermn.create_communicator('naive')
-        self.xp = np
-        self.run_test_observation_aggregator(use_cupy=False)
 
-    @chainer.testing.attr.gpu
-    def test_observation_aggregator_gpu(self):
-        self.communicator = chainermn.create_communicator('pure_nccl')
-        self.xp = cuda.cupy
-        cuda.Device(self.communicator.intra_rank).use()
-        self.run_test_observation_aggregator(use_cupy=True)
+@pytest.mark.parametrize('use_chainer_variable', [False, True])
+@pytest.mark.parametrize('communicate_interval', [1, 2])
+@chainer.testing.attr.gpu
+def test_observation_aggregator_gpu(use_chainer_variable,
+                                    communicate_interval):
+    communicator = chainermn.create_communicator('pure_nccl')
+    xp = cuda.cupy
+    cuda.Device(communicator.intra_rank).use()
+    run_test_observation_aggregator(communicator, xp,
+                                    use_chainer_variable,
+                                    communicate_interval,
+                                    use_cupy=True)
 
-    def run_test_observation_aggregator(self, use_cupy):
-        model = DummyChain()
-        if use_cupy:
-            model.to_gpu()
-        comm = self.communicator
 
-        optimizer = chainermn.create_multi_node_optimizer(
-            chainer.optimizers.Adam(), self.communicator)
-        optimizer.setup(model)
+def run_test_observation_aggregator(comm, xp,
+                                    use_chainer_variable,
+                                    communicate_interval,
+                                    use_cupy):
+    model = DummyChain()
+    if use_cupy:
+        model.to_gpu()
+    optimizer = chainermn.create_multi_node_optimizer(
+        chainer.optimizers.Adam(), comm)
+    optimizer.setup(model)
 
-        train = self.xp.random.rand(10, 1).astype(np.float32)
-        train_iter = chainer.iterators.SerialIterator(train,
-                                                      batch_size=1,
-                                                      repeat=True,
-                                                      shuffle=True)
+    train = xp.random.rand(10, 1).astype(np.float32)
+    train_iter = chainer.iterators.SerialIterator(train,
+                                                  batch_size=1,
+                                                  repeat=True,
+                                                  shuffle=True)
 
-        updater = chainer.training.StandardUpdater(train_iter, optimizer)
+    updater = chainer.training.StandardUpdater(train_iter, optimizer)
 
-        trainer = chainer.training.Trainer(updater, (1, 'epoch'))
+    trainer = chainer.training.Trainer(updater, (1, 'epoch'))
 
-        @extension.make_extension(
-            trigger=(1, 'iteration'), priority=extension.PRIORITY_WRITER)
-        def rank_reporter(trainer):
-            tmp = self.xp.asarray(comm.rank, dtype=np.float32)
-            if self.use_chainer_variable:
-                tmp = chainer.Variable(tmp)
-            trainer.observation['rank'] = tmp
+    @extension.make_extension(
+        trigger=(1, 'iteration'), priority=extension.PRIORITY_WRITER)
+    def rank_reporter(trainer):
+        tmp = xp.asarray(comm.rank, dtype=np.float32)
+        if use_chainer_variable:
+            tmp = chainer.Variable(tmp)
+        trainer.observation['rank'] = tmp
 
-        @extension.make_extension(
-            trigger=(self.communicate_interval, 'iteration'),
-            priority=extension.PRIORITY_READER)
-        def aggregated_rank_checker(trainer):
-            actual = trainer.observation['rank-aggregated']
-            if self.use_chainer_variable:
-                actual = actual.data
-            expected = (comm.size - 1) / 2
-            chainer.testing.assert_allclose(actual, expected)
+    @extension.make_extension(
+        trigger=(communicate_interval, 'iteration'),
+        priority=extension.PRIORITY_READER)
+    def aggregated_rank_checker(trainer):
+        actual = trainer.observation['rank-aggregated']
+        if use_chainer_variable:
+            actual = actual.data
+        expected = (comm.size - 1) / 2
+        chainer.testing.assert_allclose(actual, expected)
 
-        trainer.extend(rank_reporter)
-        trainer.extend(ObservationAggregator(
-            comm, 'rank', 'rank-aggregated',
-            comm_trigger=(self.communicate_interval, 'iteration')))
-        trainer.extend(aggregated_rank_checker)
+    trainer.extend(rank_reporter)
+    trainer.extend(ObservationAggregator(
+        comm, 'rank', 'rank-aggregated',
+        comm_trigger=(communicate_interval, 'iteration')))
+    trainer.extend(aggregated_rank_checker)
 
-        trainer.run()
+    trainer.run()

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -50,7 +50,7 @@ class TestObservationAggregator(unittest.TestCase):
             trigger=(2, 'iteration'), priority=extension.PRIORITY_READER)
         def aggregated_rank_checker(trainer):
             actual = trainer.observation['rank-aggregated']
-            expected = (comm.size - 1) / 2
+            expected = (comm.size - 1) / 2.0
             chainer.testing.assert_allclose(actual,
                                             expected)
 

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -1,0 +1,61 @@
+import unittest
+
+import numpy as np
+
+import chainer
+import chainer.testing
+from chainer.training import extension
+import chainermn
+from chainermn.extensions.observation_aggregator import observation_aggregator
+
+
+class DummyChain(chainer.Chain):
+
+    def __init__(self):
+        super(DummyChain, self).__init__()
+
+    def forward(self, x):
+        return chainer.Variable(x, grad=np.array([0]))
+
+
+class TestObservationAggregator(unittest.TestCase):
+
+    def setUp(self):
+        self.communicator = chainermn.create_communicator('naive')
+
+    def test_observation_aggregator(self):
+        model = DummyChain()
+        comm = self.communicator
+
+        optimizer = chainermn.create_multi_node_optimizer(
+            chainer.optimizers.Adam(), self.communicator)
+        optimizer.setup(model)
+
+        train = np.random.rand(10, 1)
+        train_iter = chainer.iterators.SerialIterator(train,
+                                                      batch_size=1,
+                                                      repeat=True,
+                                                      shuffle=True)
+
+        updater = chainer.training.StandardUpdater(train_iter, optimizer)
+
+        trainer = chainer.training.Trainer(updater, (1, 'epoch'))
+
+        @extension.make_extension(
+            trigger=(2, 'iteration'), priority=extension.PRIORITY_WRITER)
+        def rank_reporter(trainer):
+            trainer.observation['rank'] = comm.rank
+
+        @extension.make_extension(
+            trigger=(2, 'iteration'), priority=extension.PRIORITY_READER)
+        def aggregated_rank_checker(trainer):
+            actual = trainer.observation['rank-aggregated']
+            expected = (comm.size - 1) / 2
+            chainer.testing.assert_allclose(actual,
+                                            expected)
+
+        trainer.extend(rank_reporter)
+        trainer.extend(observation_aggregator(comm, 'rank', 'rank-aggregated'))
+        trainer.extend(aggregated_rank_checker)
+
+        trainer.run()

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -94,7 +94,7 @@ class TestObservationAggregator(unittest.TestCase):
                                             expected)
 
         trainer.extend(rank_reporter)
-        trainer.extend(ObservationAggregator(comm, 'rank', 'rank-aggregated', comm_trigger=(1, 'iteration')))
+        trainer.extend(ObservationAggregator(comm, 'rank', 'rank-aggregated', comm_trigger=(2, 'iteration')))
         trainer.extend(aggregated_rank_checker)
 
         trainer.run()


### PR DESCRIPTION
This commit adds `chainermn.extensions.observation_aggregator` which summarizes a specific observation in the trainer over all processes.
This is the implementation of #6974.
