### PR TITLE
Fix robots.txt to allow indexing root

### DIFF
--- a/docs/source/_static/robots.txt
+++ b/docs/source/_static/robots.txt
@@ -1,4 +1,5 @@
 User-Agent: *
+Allow: /
 Allow: /en/stable/
 Allow: /en/latest/
-Disallow: /
+Disallow: /en/


### PR DESCRIPTION
ReadTheDocs returns 302 instead of 301 for the root, so it may be indexed by search engine.

```
$ curl --head https://docs.chainer.org/
HTTP/2 302
...
```

We should allow indexing it.