### PR TITLE
Improve type check in _values_to_dicts so it works with unicode of python 2 too

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -99,7 +99,7 @@ def parameterize(*params):
 
 
 def _values_to_dicts(names, values):
-    assert isinstance(names, str)
+    assert isinstance(names, six.string_types)
     assert isinstance(values, (tuple, list))
 
     def safe_zip(ns, vs):


### PR DESCRIPTION
Resolves #7315 