### PR TITLE
Fix DtypeError in `chainerx.square`

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/misc.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/misc.cu
@@ -23,7 +23,7 @@ namespace {
 
 CHAINERX_CUDA_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(SqrtKernel, { out = cuda::Sqrt(x); });
 
-CHAINERX_CUDA_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(SquareKernel, { out = x * x; });
+CHAINERX_CUDA_REGISTER_ELTWISE_DTYPE_UNARY_KERNEL(SquareKernel, { out = x * x; }, VisitNumericDtype);
 
 CHAINERX_CUDA_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(FabsKernel, { out = cuda::Fabs(x); });
 

--- a/chainerx_cc/chainerx/native/native_device/misc.cc
+++ b/chainerx_cc/chainerx/native/native_device/misc.cc
@@ -19,7 +19,7 @@ namespace {
 
 CHAINERX_NATIVE_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(SqrtKernel, { out = chainerx::Sqrt(x); });
 
-CHAINERX_NATIVE_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(SquareKernel, { out = x * x; });
+CHAINERX_NATIVE_REGISTER_ELTWISE_DTYPE_UNARY_KERNEL(SquareKernel, { out = x * x; }, VisitNumericDtype);
 
 CHAINERX_NATIVE_REGISTER_ELTWISE_FLOAT_UNARY_KERNEL(FabsKernel, { out = chainerx::Fabs(x); });
 

--- a/chainerx_cc/chainerx/routines/misc.cc
+++ b/chainerx_cc/chainerx/routines/misc.cc
@@ -139,6 +139,9 @@ Array Sqrt(const Array& x) {
 }
 
 Array Square(const Array& x) {
+    if (x.dtype() == Dtype::kBool) {
+        throw DtypeError{"Square operation don't support Boolean type"};
+    }
     Array out = EmptyLike(x, x.device());
 
     {

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_misc.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_misc.py
@@ -46,14 +46,16 @@ class TestSqrt(math_utils.UnaryMathTestBase, op_utils.NumpyOpTest):
     # Special shapes
     chainer.testing.product({
         'shape': [(), (0,), (1,), (2, 0, 3), (1, 1, 1), (2, 3)],
-        'in_dtypes,out_dtype': math_utils.in_out_float_dtypes_math_functions,
-        'input': [-2, 0, 2],
+        'in_dtypes,out_dtype': dtype_utils.make_same_in_out_dtypes(
+            1, chainerx.testing.numeric_dtypes),
+        'input': ['random'],
         'contiguous': [None, 'C'],
     })
     # Special values
     + chainer.testing.product({
         'shape': [(2, 3)],
-        'in_dtypes,out_dtype': math_utils.in_out_float_dtypes_math_functions,
+        'in_dtypes,out_dtype': dtype_utils.make_same_in_out_dtypes(
+            1, chainerx.testing.float_dtypes),
         'input': [float('inf'), -float('inf'), float('nan')],
         'skip_backward_test': [True],
         'skip_double_backward_test': [True],
@@ -63,6 +65,14 @@ class TestSquare(math_utils.UnaryMathTestBase, op_utils.NumpyOpTest):
 
     def func(self, xp, a):
         return xp.square(a)
+
+
+@pytest.mark.parametrize_device(['native:0', 'cuda:0'])
+def test_square_invalid_dtypes(device):
+    shape = (3, 2)
+    bool_array = chainerx.array(array_utils.uniform(shape, 'bool_'))
+    with pytest.raises(chainerx.DtypeError):
+        chainerx.square(bool_array)
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])


### PR DESCRIPTION
Fix #7320.
Depends on #7298.

```
chainerx::Square(bool array) -> throws DtypeError
chainerx::Square(intX array) -> returns intX array
chainerx::Square(floatX array) -> returns floatX array
```