### PR TITLE
Use external $MAKEFLAGS instead if set in Travis CI script

### DIFF
--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -124,9 +124,11 @@ step_chainer_install_from_sdist() {
 
     # Install from sdist
     local envs=(
-        MAKEFLAGS=-j"$DEFAULT_JOBS"
         CHAINERX_BUILD_TYPE=Debug
     )
+    if [ -z "$MAKEFLAGS" ] ; then
+        envs+=(MAKEFLAGS=-j"$DEFAULT_JOBS")
+    fi
 
     if [[ $SKIP_CHAINERX != 1 ]]; then
         envs+=(CHAINER_BUILD_CHAINERX=1)

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,8 @@ setup_kwargs = dict(
 
 build_chainerx = 0 != int(os.getenv('CHAINER_BUILD_CHAINERX', '0'))
 if os.getenv('READTHEDOCS', None) == 'True':
-    os.environ['MAKEFLAGS'] = '-j2'
+    if 'MAKEFLAGS' not in os.environ:
+        os.environ['MAKEFLAGS'] = '-j2'
     build_chainerx = True
 
 chainerx_build_helper.config_setup_kwargs(setup_kwargs, build_chainerx)

--- a/setup.py
+++ b/setup.py
@@ -187,8 +187,7 @@ setup_kwargs = dict(
 
 build_chainerx = 0 != int(os.getenv('CHAINER_BUILD_CHAINERX', '0'))
 if os.getenv('READTHEDOCS', None) == 'True':
-    if 'MAKEFLAGS' not in os.environ:
-        os.environ['MAKEFLAGS'] = '-j2'
+    os.environ['MAKEFLAGS'] = '-j2'
     build_chainerx = True
 
 chainerx_build_helper.config_setup_kwargs(setup_kwargs, build_chainerx)


### PR DESCRIPTION
Is there any reason why these are overwritten to `-j2` ?