### PR TITLE
[backport] Fix invalid escape sequences in ChainerX routine docstrings

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -1580,7 +1580,8 @@ Note:
 def _docs_normalization():
     _docs.set_doc(
         chainerx.batch_norm,
-        """batch_norm(x, gamma, beta, running_mean, running_var, eps=2e-5, decay=0.9, axis=None)
+        """batch_norm(x, gamma, beta, running_mean, running_var, eps=2e-5, \
+decay=0.9, axis=None)
 Batch normalization function.
 
 It takes the input array ``x`` and two parameter arrays ``gamma`` and
@@ -1613,7 +1614,7 @@ Note:
 
 See: `Batch Normalization: Accelerating Deep Network Training by Reducing\
       Internal Covariate Shift <https://arxiv.org/abs/1502.03167>`_
-""")  # NOQA
+""")
 
     _docs.set_doc(
         chainerx.fixed_batch_norm,


### PR DESCRIPTION
Backport of #7214