### PR TITLE
Warn NaN in FP16 mode in pix2pix example

### DIFF
--- a/examples/pix2pix/train_facade.py
+++ b/examples/pix2pix/train_facade.py
@@ -4,6 +4,9 @@ from __future__ import print_function
 
 import argparse
 import sys
+import warnings
+
+import numpy
 
 import chainer
 from chainer import training
@@ -49,6 +52,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == numpy.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     if device.xp is chainerx:


### PR DESCRIPTION
Rleated to #6168.

This PR fixes the pix2pix example to warn possible NaN in FP16 mode.