### PR TITLE
Avoid unload module call in PureNcclCommunicator

### DIFF
--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -182,13 +182,6 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             self.ensure_all_finite(gpu_buffer_a.array(n_elems, dtype=dtype))
 
 
-def _get_converting_kernel(src_dtype, dst_dtype, kernel_name):
-    return chainer.cuda.cupy.ElementwiseKernel(
-        '{} x'.format(src_dtype.name),
-        '{} y'.format(dst_dtype.name),
-        'y = x', kernel_name)
-
-
 def _get_param_data_dtype(param):
     return param.data.dtype
 

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -172,14 +172,10 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.nccl_comm.allReduce(gpu_buffer_a.ptr(),
                                  gpu_buffer_b.ptr(), n_elems,
                                  type_id, nccl.NCCL_SUM, stream.ptr)
-        div_by_size = chainer.cuda.cupy.ElementwiseKernel(
-            '{} x'.format(dtype.name),
-            '{} y'.format(dtype.name),
-            'y = x*(1.0/{})'.format(self.size), 'div_by_size')
-        div_by_size(
+        chainer.cuda.cupy.mul(
             gpu_buffer_b.array(n_elems, dtype=dtype),
-            gpu_buffer_a.array(n_elems, dtype=dtype),
-            stream=stream)
+            1.0 / self.size,
+            gpu_buffer_a.array(n_elems, dtype=dtype))
 
         if chainer.is_debug():
             stream.synchronize()

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -172,7 +172,7 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.nccl_comm.allReduce(gpu_buffer_a.ptr(),
                                  gpu_buffer_b.ptr(), n_elems,
                                  type_id, nccl.NCCL_SUM, stream.ptr)
-        chainer.cuda.cupy.mul(
+        chainer.cuda.cupy.multiply(
             gpu_buffer_b.array(n_elems, dtype=dtype),
             1.0 / self.size,
             gpu_buffer_a.array(n_elems, dtype=dtype))

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -245,7 +245,7 @@ def _batched_unpack_params(params_data, buffer, dtype):
 
 
 def _cupy_batched_pack_params():
-    return chainer.cuda.cupy.RawKernel(r'''
+    return chainer.cuda.raw(r'''
 #include <cupy/carray.cuh>
 #define NCCL_FLOAT16  6
 #define NCCL_FLOAT32  7
@@ -298,7 +298,7 @@ def _cupy_batched_pack_params():
 
 
 def _cupy_batched_unpack_params():
-    return chainer.cuda.cupy.RawKernel(r'''
+    return chainer.cuda.raw(r'''
 #include <cupy/carray.cuh>
 #define NCCL_FLOAT16  6
 #define NCCL_FLOAT32  7


### PR DESCRIPTION
This is performance improvement PR.
`chainer.cuda.cupy.ElementwiseKernel` creates a function module for each function call.
`cuModuleLoadData` and `cuModule Unload` functions are blocking API call.
