### PR TITLE
Warn NaN in FP16 mode in reinforcement learning examples

### DIFF
--- a/examples/reinforcement_learning/ddpg_pendulum.py
+++ b/examples/reinforcement_learning/ddpg_pendulum.py
@@ -8,6 +8,7 @@ import argparse
 import collections
 import copy
 import random
+import warnings
 
 import gym
 import numpy as np
@@ -161,6 +162,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == np.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     device.use()

--- a/examples/reinforcement_learning/dqn_cartpole.py
+++ b/examples/reinforcement_learning/dqn_cartpole.py
@@ -9,6 +9,7 @@ import argparse
 import collections
 import copy
 import random
+import warnings
 
 import gym
 import numpy as np
@@ -116,6 +117,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == np.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     device.use()


### PR DESCRIPTION
Related to #6168.

This PR fixes the reinforcement learning examples to warn possible NaN in FP16 mode.
