### PR TITLE
Warn NaN in FP16 mode in sentiment example

### DIFF
--- a/examples/sentiment/train_sentiment.py
+++ b/examples/sentiment/train_sentiment.py
@@ -10,6 +10,7 @@ This is Socher's simple recursive model, not RTNN:
 
 import argparse
 import collections
+import warnings
 
 import numpy as np
 
@@ -151,6 +152,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == np.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     n_epoch = args.epoch       # number of epochs
     n_units = args.unit        # number of units per layer


### PR DESCRIPTION
Related to #6168.

This PR fixes the sentiment example to warn possible NaN in FP16 mode.
(train_recursive_minibatch.py causes dtype mismatch in FP16 mode, so I will fix it later)