### PR TITLE
Warn NaN in FP16 mode in static_graph_optimizations/cifar example

### DIFF
--- a/examples/static_graph_optimizations/cifar/train_cifar.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar.py
@@ -7,6 +7,9 @@ the code is mostly unchanged except for the addition of the
 """
 import argparse
 import sys
+import warnings
+
+import numpy
 
 import chainer
 import chainer.links as L
@@ -47,6 +50,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == numpy.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     if device.xp is chainerx:

--- a/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
@@ -12,6 +12,9 @@ applies an optimizer to update the model.
 """
 import argparse
 import sys
+import warnings
+
+import numpy
 
 import chainer
 from chainer import configuration
@@ -52,6 +55,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == numpy.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     if device.xp is chainerx:


### PR DESCRIPTION
Related to #6168.

This PR fixes the static_graph_optimizations/cifar example to warn possible NaN in FP16 mode.