### PR TITLE
Warn NaN in FP16 mode in static_graph_optimizations/mnist example

### DIFF
--- a/examples/static_graph_optimizations/mnist/train_mnist.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist.py
@@ -9,6 +9,9 @@ from __future__ import print_function
 
 import argparse
 import sys
+import warnings
+
+import numpy
 
 import chainer
 import chainer.functions as F
@@ -107,6 +110,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == numpy.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     if device.xp is chainerx:

--- a/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
@@ -14,6 +14,9 @@ from __future__ import print_function
 
 import argparse
 import sys
+import warnings
+
+import numpy
 
 import chainer
 from chainer import configuration
@@ -49,6 +52,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == numpy.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     if device.xp is chainerx:


### PR DESCRIPTION
Related to #6168.

This PR fixes the static_graph_optimizations/mnist example to warn possible NaN in FP16 mode.