### PR TITLE
Warn NaN in FP16 mode in vae example

### DIFF
--- a/examples/vae/train_vae.py
+++ b/examples/vae/train_vae.py
@@ -3,6 +3,7 @@
 """
 import argparse
 import os
+import warnings
 
 import numpy as np
 
@@ -53,6 +54,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == np.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     device.use()


### PR DESCRIPTION
Related to #6168.

This PR fixes the vae example to warn possible NaN in FP16 mode.