### PR TITLE
Avoid installing ChainerX when building docs of other projects on ReadTheDocs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,8 +186,8 @@ setup_kwargs = dict(
 
 
 build_chainerx = 0 != int(os.getenv('CHAINER_BUILD_CHAINERX', '0'))
-if os.getenv('READTHEDOCS', None) == 'True' \
-        and os.getenv('READTHEDOCS_PROJECT', None) == 'chainer':
+if (os.getenv('READTHEDOCS', None) == 'True'
+        and os.getenv('READTHEDOCS_PROJECT', None) == 'chainer'):
     os.environ['MAKEFLAGS'] = '-j2'
     build_chainerx = True
 

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,8 @@ setup_kwargs = dict(
 
 
 build_chainerx = 0 != int(os.getenv('CHAINER_BUILD_CHAINERX', '0'))
-if os.getenv('READTHEDOCS', None) == 'True':
+if os.getenv('READTHEDOCS', None) == 'True' \
+        and os.getenv('READTHEDOCS_PROJECT', None) == 'chainer':
     os.environ['MAKEFLAGS'] = '-j2'
     build_chainerx = True
 


### PR DESCRIPTION
install `chainerx` when `READTHEDOCS_PROJECT` name is `chainer`.
this PR stop installing `chainerx` in other projects depending chainer.