### PR TITLE
Warn NaN in FP16 mode in word2vec example

### DIFF
--- a/examples/wavenet/train.py
+++ b/examples/wavenet/train.py
@@ -1,6 +1,9 @@
 import argparse
 import os
 import pathlib
+import warnings
+
+import numpy
 
 import chainer
 from chainer.training import extensions
@@ -60,6 +63,10 @@ group.add_argument('--gpu', '-g', dest='device',
                    type=int, nargs='?', const=0,
                    help='GPU ID (negative value indicates CPU)')
 args = parser.parse_args()
+
+if chainer.get_dtype() == numpy.float16:
+    warnings.warn(
+        'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
 device = chainer.get_device(args.device)
 

--- a/examples/word2vec/train_word2vec.py
+++ b/examples/word2vec/train_word2vec.py
@@ -7,6 +7,7 @@ import argparse
 import collections
 import os
 import six
+import warnings
 
 import numpy as np
 
@@ -187,6 +188,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == np.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
     device.use()


### PR DESCRIPTION
Related to #6168.

This PR fixes the word2vec example to warn possible NaN in FP16 mode.