### PR TITLE
Fix typo in wavenet example requirements

### DIFF
--- a/examples/wavenet/requirements.txt
+++ b/examples/wavenet/requirements.txt
@@ -1,5 +1,5 @@
 cupy
 chainer
 matplotlib
-qlibrosa
+librosa
 tqdm


### PR DESCRIPTION
It looks a typo in wavenet's `requirements.txt`