### PR TITLE
Allow turning off the static subgraph optimizations using a config

### DIFF
--- a/chainer/__init__.py
+++ b/chainer/__init__.py
@@ -219,6 +219,7 @@ global_config.use_cudnn = os.environ.get('CHAINER_USE_CUDNN', 'auto')
 global_config.use_cudnn_tensor_core = 'auto'
 global_config.autotune = False
 global_config.schedule_func = None
+global_config.use_static_graph = True
 global_config.use_ideep = os.environ.get('CHAINER_USE_IDEEP', 'never')
 global_config.lazy_grad_sum = bool(int(
     os.environ.get('CHAINER_LAZY_GRAD_SUM', '0')))

--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -29,6 +29,7 @@ class GlobalConfig(object):
     cudnn_fast_batch_normalization = None  # type: bool
     dtype = None  # type: numpy.dtype
     in_recomputing = None  # type: bool
+    use_static_graph = None  # type: bool
     _will_recompute = None  # type: bool
 
     """The plain object that represents the global configuration of Chainer."""

--- a/chainer/graph_optimizations/static_graph.py
+++ b/chainer/graph_optimizations/static_graph.py
@@ -1273,6 +1273,12 @@ def static_graph(*args, **kwargs):
 
     def wrap(func):
         def wrapped_func(*inner_args, **inner_kwargs):
+            # The static subgraph optimization feature can be turned off using
+            # a configuration, in which case this decorator merely calls the
+            # wrapped function without introducing any side effects.
+            if not chainer.config.use_static_graph:
+                return func(*inner_args, **inner_kwargs)
+
             if verbosity_level >= 2:
                 print('Calling static chain...')
 

--- a/chainer/graph_optimizations/static_graph_utilities.py
+++ b/chainer/graph_optimizations/static_graph_utilities.py
@@ -168,6 +168,8 @@ def static_code(*dec_args, **dec_kwargs):
             # If trace mode is on, add to schedule.
             schedule_function = chainer.config.schedule_func
             if schedule_function is not None:
+                assert chainer.config.use_static_graph
+
                 # Note: 'ret = func(*args, **kwargs)' is called inside
                 # the following method.
                 ret = schedule_function.append_function(func, args, kwargs,

--- a/docs/source/reference/configuration.rst
+++ b/docs/source/reference/configuration.rst
@@ -76,7 +76,7 @@ Configuration Keys
    give a warning when executed. For functions that can take a seed argument, such as
    :func:`~chainer.datasets.split_dataset_random`, setting the seed should be done when the function is called and will not
    be flagged by this setting.
-   
+
    Note that this feature is provided as best-effort. It cannot assure that every nondeterministic function can be detected.  For example, SSE computations in CPU mode may cause non-deterministic behavior that would not raise a warning.
 
    Also, determinisitic outputs may still result, even if this flag produces a non-deterministic warning. For example, reduction on 1-dim axis should always be deterministic, but it may raise a warning.
@@ -163,6 +163,11 @@ Configuration Keys
    You can use this flag when implementing your own Link to avoid updating the internal states during recomputation done by :func:`chainer.functions.forget`.
    See the documentation of :func:`chainer.functions.forget` for details.
 
+* ``use_static_graph`` (default: ``True``)
+   Flag to configure whether or not to use the static subgraph optimization feature.
+   Where the static subgraph graph optimization decorator is used, we generally assume that that the feature should be used and the default value is thus ``True``.
+   However, if you would want to run the same code without the feature, you can simply set the flag to ``False`` instead of removing the decorators.
+   This is useful when for instance running your model with ChainerX, since ChainerX is not supported by the static subgraph optimization feature.
 
 User-defined Keys
 -----------------

--- a/docs/source/reference/configuration.rst
+++ b/docs/source/reference/configuration.rst
@@ -165,7 +165,7 @@ Configuration Keys
 
 * ``use_static_graph`` (default: ``True``)
    Flag to configure whether or not to use the static subgraph optimization feature.
-   Where the static subgraph graph optimization decorator is used, we generally assume that that the feature should be used and the default value is thus ``True``.
+   Where the static subgraph optimization decorator is used, we generally assume that the feature should be used and the default value is thus ``True``.
    However, if you would want to run the same code without the feature, you can simply set the flag to ``False`` instead of removing the decorators.
    This is useful when for instance running your model with ChainerX, since ChainerX is not supported by the static subgraph optimization feature.
 

--- a/docs/source/reference/static_graph.rst
+++ b/docs/source/reference/static_graph.rst
@@ -123,6 +123,13 @@ you wish (by debugging the ``forward()`` method of :class:`~chainer.static_graph
 in :mod:`~chainer.static_graph`).
 
 
+Disabling the static subgraph optimization
+------------------------------------------
+
+It is possible to turn off the static subgraph optimization feature by setting the ``chainer.config.use_static_graph`` to ``False``.
+If set to ``False``, the :func:`chainer.static_graph` decorator will simply call the wrapped function without any further side effects.
+
+
 Limitations and future work
 ---------------------------
 
@@ -139,6 +146,8 @@ Limitations and future work
 - Model export: In the case where the complete computation graph for the model is static, it should be possible in principle to export the static schedule in a format that can be run on other platforms and languages. One of the other original motivations for this feature was to support exporting static Chainer models to run on C/C++ and/or optimize the static schedule execution code in Cython/C/C++. However, it seems that ONNX is now fulfilling this purpose and there is a separate ONNX exporter already in development for Chainer. Perhaps these two features can be merged at some point in the future.
 
 - Double-backward support: This feature was designed to support double-backward (gradient of gradient) but it has not been tested.
+
+- ChainerX is not supported. If you have code written using this feature but would like to run the model with ChainerX, please set the ``chainer.config.use_static_graph`` configuration to ``False``. The code should then work without any additional changes.
 
 Examples
 --------

--- a/tests/chainer_tests/graph_optimization_tests/test_static_graph_models.py
+++ b/tests/chainer_tests/graph_optimization_tests/test_static_graph_models.py
@@ -76,6 +76,7 @@ class MLP(chainer.Chain):
 @testing.parameterize(*testing.product({
     'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'W_dtype': [numpy.float32],
+    'use_static_graph': [True, False],
 }))
 class TestSimpleChain(unittest.TestCase):
 
@@ -105,7 +106,9 @@ class TestSimpleChain(unittest.TestCase):
 
     def check_forward(self, x):
         y_dyn = self.chain.dynamic_call(x)
-        with chainer.using_config('enable_backprop', False):
+
+        with chainer.using_config('use_static_graph', self.use_static_graph), \
+                chainer.using_config('enable_backprop', False):
             y_static = self.chain.static_call(x)
             y_static = self.chain.static_call(x)
             y_static = self.chain.static_call(x)

--- a/tests/chainer_tests/graph_optimization_tests/test_static_graph_models.py
+++ b/tests/chainer_tests/graph_optimization_tests/test_static_graph_models.py
@@ -105,13 +105,19 @@ class TestSimpleChain(unittest.TestCase):
                                       self.x_dtype)
 
     def check_forward(self, x):
-        y_dyn = self.chain.dynamic_call(x)
+        chain = self.chain
+        y_dyn = chain.dynamic_call(x)
+        use_static_graph = self.use_static_graph
 
-        with chainer.using_config('use_static_graph', self.use_static_graph), \
+        with chainer.using_config('use_static_graph', use_static_graph), \
                 chainer.using_config('enable_backprop', False):
-            y_static = self.chain.static_call(x)
-            y_static = self.chain.static_call(x)
-            y_static = self.chain.static_call(x)
+            y_static = chain.static_call(x)
+            y_static = chain.static_call(x)
+            y_static = chain.static_call(x)
+
+        assert use_static_graph == hasattr(chain, 'schedule_manager')
+        assert use_static_graph == hasattr(chain, 'static_schedule')
+
         chainer.testing.assert_allclose(y_dyn.data, y_static.data)
 
     def test_forward_cpu(self):


### PR DESCRIPTION
Part of https://github.com/chainer/chainer/issues/7220.

Introduces a configuration flag `use_static_graph`, which is `True` by default and in which case does not introduce any new behavior to existing code. However, when set to `False`, the static graph decorators simply become "NOOP"s and the code will run as if there were no decorators there.

This is convenient to quickly turn off the static subgraph optimization feature with little change to the code. ChainerX is for instance not supported by the static subgraph optimization and this flag would then be useful.