### PR TITLE
Warn NaN in FP16 mode in wavenet example

### DIFF
--- a/examples/wavenet/train.py
+++ b/examples/wavenet/train.py
@@ -1,6 +1,9 @@
 import argparse
 import os
 import pathlib
+import warnings
+
+import numpy
 
 import chainer
 from chainer.training import extensions
@@ -60,6 +63,10 @@ group.add_argument('--gpu', '-g', dest='device',
                    type=int, nargs='?', const=0,
                    help='GPU ID (negative value indicates CPU)')
 args = parser.parse_args()
+
+if chainer.get_dtype() == numpy.float16:
+    warnings.warn(
+        'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
 device = chainer.get_device(args.device)
 


### PR DESCRIPTION
Related to #6168.

This PR fixes the wavenet example to warn possible NaN in FP16 mode.