### PR TITLE
Change 0 to 0.0 for python2

### DIFF
--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -357,7 +357,7 @@ def check_allreduce_grad_empty_half(communicator, model):
         chainer.testing.assert_allclose(model.b.W.grad,
                                         (base + 1) * np.ones((4, 3)))
 
-        v = 0
+        v = 0.0
         for i in range(communicator.size):
             if i % 2 == 0:
                 v += i + 2


### PR DESCRIPTION
This PR fixes #7370 .

The bug happens because Python has different arithmetic calculation behavior in version 2 and 3.

```
        # test_communicator.py:360
        v = 0.0
        for i in range(communicator.size):
            if i % 2 == 0:
                v += i + 2
        v /= communicator.size
```
The variable `v` is `[1 1 1 1]` in Python2 and `[1.0 1.0 1.0 1.0]`  in Python3, because Python3's division implicitly converts integer values to float.
Thus, to pass the test in Python2, the initial value of `v` must be `0.0`, instead of `1`.

