### PR TITLE
[WIP] Support NHWC tensor layout

### DIFF
--- a/chainer/configuration.py
+++ b/chainer/configuration.py
@@ -30,6 +30,7 @@ class GlobalConfig(object):
     dtype = None  # type: numpy.dtype
     in_recomputing = None  # type: bool
     _will_recompute = None  # type: bool
+    tensor_layout = 'NCHW'  # type: str
 
     """The plain object that represents the global configuration of Chainer."""
 

--- a/chainer/functions/__init__.py
+++ b/chainer/functions/__init__.py
@@ -62,6 +62,8 @@ from chainer.functions.array.stack import stack  # NOQA
 from chainer.functions.array.swapaxes import swapaxes  # NOQA
 from chainer.functions.array.tile import tile  # NOQA
 from chainer.functions.array.transpose import transpose  # NOQA
+from chainer.functions.array.transpose import transpose_to_NHWC  # NOQA
+from chainer.functions.array.transpose import transpose_to_NCHW  # NOQA
 from chainer.functions.array.transpose_sequence import transpose_sequence  # NOQA
 from chainer.functions.array.vstack import vstack  # NOQA
 from chainer.functions.array.where import where  # NOQA

--- a/chainer/functions/activation/relu.py
+++ b/chainer/functions/activation/relu.py
@@ -23,6 +23,7 @@ class ReLU(function_node.FunctionNode):
     """Rectified Linear Unit."""
 
     _use_cudnn = False
+    _supports_nhwc_tensor_layout = True
 
     def check_type_forward(self, in_types):
         type_check._argname(in_types, ('x',))

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -7,6 +7,8 @@ from chainer.utils import type_check
 class Transpose(function_node.FunctionNode):
     """Permute the dimensions of an array."""
 
+    _supports_nhwc_tensor_layout = True
+
     def __init__(self, axes=None):
         self.axes = axes
 

--- a/chainer/functions/array/transpose.py
+++ b/chainer/functions/array/transpose.py
@@ -73,3 +73,13 @@ def transpose(x, axes=None):
 
     """
     return Transpose(axes).apply((x,))[0]
+
+
+def transpose_to_NHWC(x, axes=None):
+    """Change tensor layout from NCHW to NHWC"""
+    return Transpose((0, 2, 3, 1)).apply((x,))[0]
+
+
+def transpose_to_NCHW(x, axes=None):
+    """Change tensor layout from NHWC to NCHW"""
+    return Transpose((0, 3, 1, 2)).apply((x,))[0]

--- a/chainer/functions/connection/convolution_2d.py
+++ b/chainer/functions/connection/convolution_2d.py
@@ -36,6 +36,7 @@ def _matmul(a, b):
 class Convolution2DFunction(function_node.FunctionNode):
 
     _use_ideep = False
+    _supports_nhwc_tensor_layout = True
 
     def __init__(self, stride=1, pad=0, cover_all=False, **kwargs):
         dilate, groups, tensor_layout = argument.parse_kwargs(
@@ -191,7 +192,12 @@ class Convolution2DFunction(function_node.FunctionNode):
             # cuDNN implementation
             return self._forward_cudnn(x, W, b, y)
 
-        elif self.groups > 1:
+        if self.tensor_layout == 'NHWC':
+            msg = ('NHWC tensor layout is available with {} only when cuDNN is'
+                   ' used.'.format(self.label))
+            raise RuntimeError(msg)
+
+        if self.groups > 1:
             return self._forward_grouped_convolution(x, W, b)
 
         else:

--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -27,6 +27,7 @@ class Deconvolution2DFunction(function_node.FunctionNode):
 
     cover_all = None
     _use_ideep = False
+    _supports_nhwc_tensor_layout = True
 
     def __init__(self, stride=1, pad=0, outsize=None, **kwargs):
         dilate, groups, tensor_layout = argument.parse_kwargs(
@@ -205,7 +206,12 @@ class Deconvolution2DFunction(function_node.FunctionNode):
             # cuDNN implementation
             return self._forward_cudnn(x, W, b)
 
-        elif self.groups > 1:
+        if self.tensor_layout == 'NHWC':
+            msg = ('NHWC tensor layout is available with {} only when cuDNN is'
+                   ' used.'.format(self.label))
+            raise RuntimeError(msg)
+
+        if self.groups > 1:
             return self._forward_grouped_convolution(x, W, b)
 
         else:

--- a/chainer/functions/math/basic_math.py
+++ b/chainer/functions/math/basic_math.py
@@ -152,6 +152,8 @@ def absolute(self):
 
 class Add(function_node.FunctionNode):
 
+    _supports_nhwc_tensor_layout = True
+
     @property
     def label(self):
         return '_ + _'

--- a/chainer/links/normalization/batch_normalization.py
+++ b/chainer/links/normalization/batch_normalization.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy
 
 import chainer
@@ -310,6 +312,13 @@ class BatchNormalization(link.Link):
 
         if self.tensor_layout is None:
             self.tensor_layout = configuration.config.tensor_layout
+
+        if self.tensor_layout == 'NHWC':
+            if x.dtype != numpy.float16 or gamma.dtype != numpy.float32:
+                warnings.warn(
+                    'NHWC tensor layout should not be used unless an'
+                    ' environment variable CHAINER_DTYPE is set to mixed16.',
+                    UserWarning)
 
         if configuration.config.train:
             if finetune:

--- a/chainer/utils/__init__.py
+++ b/chainer/utils/__init__.py
@@ -21,6 +21,9 @@ from chainer.utils.nondeterministic import nondeterministic  # NOQA
 from chainer.utils.sparse import CooMatrix  # NOQA
 from chainer.utils.sparse import get_order  # NOQA
 from chainer.utils.sparse import to_coo  # NOQA
+from chainer.utils.tensor_layout import get_cudnn_tensor_layout  # NOQA
+from chainer.utils.tensor_layout import nchw_shape  # NOQA
+from chainer.utils.tensor_layout import my_shape  # NOQA
 
 # The following alias has been moved to chainer/__init__.py in order to break
 # circular imports in Python 2.

--- a/chainer/utils/tensor_layout.py
+++ b/chainer/utils/tensor_layout.py
@@ -1,0 +1,22 @@
+from chainer.backends import cuda
+
+
+def nchw_shape(my_shape, my_layout):
+    if my_layout == 'NHWC':
+        return (my_shape[0], my_shape[3], my_shape[1], my_shape[2])
+    else:
+        return my_shape
+
+
+def my_shape(nchw_shape, my_layout):
+    if my_layout == 'NHWC':
+        return (nchw_shape[0], nchw_shape[2], nchw_shape[3], nchw_shape[1])
+    else:
+        return nchw_shape
+
+
+def get_cudnn_tensor_layout(layout=None):
+    if layout == 'NHWC':
+        return cuda.cuda.cudnn.CUDNN_TENSOR_NHWC
+    else:
+        return cuda.cuda.cudnn.CUDNN_TENSOR_NCHW


### PR DESCRIPTION
This PR aims to support **NHWC** tensor layout in convolution and batch normalization among others to improve performance when **mixed16** is set as default data type and TensorCore is used.

You can specify which parts of your model to apply **NHWC** tensor layout using ` with using_config('tensor_layout', 'NHWC') `.  The following is an example of application to RN50.

    def forward(self, x, t):
        h = self.bn1(self.conv1(x))
        h = F.max_pooling_2d(F.relu(h), 3, stride=2)
        with using_config('tensor_layout', 'NHWC'):
            h = F.transpose_to_NHWC(h)
            h = self.res2(h)
            h = self.res3(h)
            h = self.res4(h)
            h = self.res5(h)
            h = F.transpose_to_NCHW(h)
        h = F.average_pooling_2d(h, 7, stride=1)
        h = self.fc(h)
        loss = F.softmax_cross_entropy(h, t)
        chainer.report({'loss': loss, 'accuracy': F.accuracy(h, t)}, self)
        return loss

Tensor layout must be explicitly transposed to/from NHWC using ` transpose_to_NHWC/NCHW ` by users. I'm now considering how to do it automatically.

This is related to #5076.