### PR TITLE
Avoid transferring from a native device to another in `Array::ToNative()`

### DIFF
--- a/chainerx_cc/chainerx/array.cc
+++ b/chainerx_cc/chainerx/array.cc
@@ -359,8 +359,8 @@ Array Array::ToDevice(Device& dst_device) const {
 }
 
 Array Array::ToNative() const {
-    Context& context = device().backend().context();
-    Device& native_device = context.GetNativeBackend().GetDevice(0);
+    Backend& backend = device().backend();
+    Device& native_device = backend.IsNative() ? device() : backend.context().GetNativeBackend().GetDevice(0);
     return ToDevice(native_device);
 }
 

--- a/chainerx_cc/chainerx/array_test.cc
+++ b/chainerx_cc/chainerx/array_test.cc
@@ -1054,37 +1054,6 @@ TEST_P(ArrayTest, AsTypeDoubleBackward) {
             {a_eps, go_eps});
 }
 
-TEST_P(ArrayTest, ToNative) {
-    using T = float;
-    Array a = (*testing::BuildArray({2, 3}).WithLinearData<T>().WithPadding(1)).RequireGrad();
-
-    Array b = a.ToNative();
-    EXPECT_EQ("native:0", b.device().name());
-    EXPECT_EQ(&a.device().backend().context(), &b.device().backend().context());
-    EXPECT_NE(internal::GetArrayBody(a), internal::GetArrayBody(b));
-
-    EXPECT_EQ(a.dtype(), b.dtype());
-    EXPECT_EQ(a.shape(), b.shape());
-    EXPECT_ARRAY_EQ(a.ToNative(), b.ToNative());
-
-    if (a.device().name() == "native:0") {
-        // Between the same device
-        EXPECT_EQ(&a.device(), &b.device());
-        EXPECT_EQ(a.data().get(), b.data().get());
-        EXPECT_EQ(a.strides(), b.strides());
-    } else {
-        // Between different devices
-        EXPECT_NE(&a.data(), &b.data());
-        EXPECT_TRUE(b.IsContiguous());
-    }
-
-    // Graph
-    ASSERT_TRUE(!a.GetGrad().has_value());
-    Backward(b);
-    ASSERT_TRUE(a.GetGrad().has_value());
-    EXPECT_EQ(&a.device(), &a.GetGrad()->device());
-}
-
 TEST_P(ArrayTest, MultipleGraphsRequireGradDefault) {
     Array a = testing::BuildArray({1}).WithData<float>({2.0f});
 
@@ -1214,6 +1183,67 @@ INSTANTIATE_TEST_CASE_P(
                 std::string{"cuda"},
 #endif  // CHAINERX_ENABLE_CUDA
                 std::string{"native"}));
+
+class ArrayToNativeTest : public ::testing::TestWithParam<::testing::tuple<std::string, int>> {
+protected:
+    void SetUp() override {
+        backend_name_ = std::get<0>(GetParam());
+        device_index_ = std::get<1>(GetParam());
+        device_session_.emplace(DeviceId{backend_name_, device_index_});
+    }
+
+    void TearDown() override { device_session_.reset(); }
+
+protected:
+    std::string backend_name_{};
+    int device_index_{};
+
+private:
+    nonstd::optional<testing::DeviceSession> device_session_;
+};
+
+TEST_P(ArrayToNativeTest, ToNative) {
+    using T = float;
+    Array a = (*testing::BuildArray({2, 3}).WithLinearData<T>().WithPadding(1)).RequireGrad();
+
+    Array b = a.ToNative();
+    EXPECT_EQ("native", b.device().backend().GetName());
+    EXPECT_EQ(&a.device().backend().context(), &b.device().backend().context());
+    EXPECT_NE(internal::GetArrayBody(a), internal::GetArrayBody(b));
+
+    EXPECT_EQ(a.dtype(), b.dtype());
+    EXPECT_EQ(a.shape(), b.shape());
+    EXPECT_ARRAY_EQ(a.ToNative(), b.ToNative());
+
+    if (backend_name_ == "native") {
+        // Native-to-native
+        EXPECT_EQ(device_index_, b.device().index());
+        EXPECT_EQ(&a.device(), &b.device());
+        EXPECT_EQ(a.data().get(), b.data().get());
+        EXPECT_EQ(a.strides(), b.strides());
+    } else {
+        // Otherwise
+        EXPECT_EQ(0, b.device().index());
+        EXPECT_NE(&a.data(), &b.data());
+        EXPECT_TRUE(b.IsContiguous());
+    }
+
+    // Graph
+    ASSERT_TRUE(!a.GetGrad().has_value());
+    Backward(b);
+    ASSERT_TRUE(a.GetGrad().has_value());
+    EXPECT_EQ(&a.device(), &a.GetGrad()->device());
+}
+
+INSTANTIATE_TEST_CASE_P(
+        ForEachDevice,
+        ArrayToNativeTest,
+        ::testing::Values(
+#ifdef CHAINERX_ENABLE_CUDA
+                std::make_tuple<std::string, int>("cuda", 0),
+#endif  // CHAINERX_ENABLE_CUDA
+                std::make_tuple<std::string, int>("native", 0),
+                std::make_tuple<std::string, int>("native", 1)));
 
 TEST(ArrayGradTest, SetGradFlagsIsGradRequired) {
     testing::ContextSession context_session{};

--- a/chainerx_cc/chainerx/backend.h
+++ b/chainerx_cc/chainerx/backend.h
@@ -47,6 +47,9 @@ public:
     // Throws out_of_range exception if index >= GetDeviceCount().
     Device& GetDevice(int index);
 
+    // Returns whether the backend is a native device.
+    virtual bool IsNative() const { return false; }
+
     // Queries if the backend supports data transfer between two devices.
     virtual bool SupportsTransfer(Device& src_device, Device& dst_device) = 0;
 

--- a/chainerx_cc/chainerx/cuda/cuda_backend.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_backend.cc
@@ -48,12 +48,11 @@ std::unique_ptr<Device> CudaBackend::CreateDevice(int index) {
 bool CudaBackend::SupportsTransfer(Device& src_device, Device& dst_device) {
     Backend& src_backend = src_device.backend();
     Backend& dst_backend = dst_device.backend();
-    // TODO(niboshi): Make clearner interface to check whether a backend is native, like dst_backend.is_native()
     if (&src_backend == this) {
-        return &dst_backend == this || nullptr != dynamic_cast<native::NativeBackend*>(&dst_backend);
+        return &dst_backend == this || dst_backend.IsNative();
     }
     if (&dst_backend == this) {
-        return &src_backend == this || nullptr != dynamic_cast<native::NativeBackend*>(&src_backend);
+        return &src_backend == this || src_backend.IsNative();
     }
     return false;
 }

--- a/chainerx_cc/chainerx/cuda/cuda_backend_test.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_backend_test.cc
@@ -78,6 +78,11 @@ TEST(CudaBackendTest, GetDeviceCount) {
     EXPECT_EQ(count, CudaBackend(ctx).GetDeviceCount());
 }
 
+TEST(NativeBackendTest, IsNative) {
+    Context ctx;
+    EXPECT_FALSE(CudaBackend{ctx}.IsNative());
+}
+
 TEST(CudaBackendTest, GetDeviceCountGetNameThreadSafe) {
     Context ctx;
     CudaBackend backend{ctx};

--- a/chainerx_cc/chainerx/native/native_backend.h
+++ b/chainerx_cc/chainerx/native/native_backend.h
@@ -35,6 +35,8 @@ public:
 
     int GetDeviceCount() const override;
 
+    bool IsNative() const override { return true; }
+
     bool SupportsTransfer(Device& src_device, Device& dst_device) override;
 
     static KernelRegistry& GetGlobalKernelRegistry() {

--- a/chainerx_cc/chainerx/native/native_backend_test.cc
+++ b/chainerx_cc/chainerx/native/native_backend_test.cc
@@ -45,6 +45,11 @@ TEST(NativeBackendTest, GetDeviceCount) {
     EXPECT_EQ(4, NativeBackend{ctx}.GetDeviceCount());
 }
 
+TEST(NativeBackendTest, IsNative) {
+    Context ctx;
+    EXPECT_TRUE(NativeBackend{ctx}.IsNative());
+}
+
 TEST(NativeBackendTest, GetDeviceCountGetNameThreadSafe) {
     static constexpr size_t kThreadCount = 2;
 


### PR DESCRIPTION
Split from #7393.

Also added `Backend::IsNative()`.
