### PR TITLE
Change Deformable Convolution 2D docs to match arguments

### DIFF
--- a/chainer/links/connection/deformable_convolution_2d.py
+++ b/chainer/links/connection/deformable_convolution_2d.py
@@ -20,8 +20,7 @@ class DeformableConvolution2D(link.Chain):
         in_channels (int): Number of channels of input arrays. If ``None``,
             parameter initialization will be deferred until the first forward
             data pass at which time the size will be determined.
-        channel_multiplier (int): Channel multiplier number. Number of output
-            arrays equal ``in_channels * channel_multiplier``.
+        out_channels (int): Number of channels of output arrays.
         ksize (int or pair of ints): Size of filters (a.k.a. kernels).
             ``ksize=k`` and ``ksize=(k, k)`` are equivalent.
         stride (int or pair of ints): Stride of filter applications.


### PR DESCRIPTION
I think that it looks `Args` in comment is old one.
I fixed it.