### PR TITLE
Error when requesting a gpu higher than the available ones

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -211,7 +211,8 @@ class GpuDevice(_backend.Device):
         if not 0 <= device.id < num_gpus:
             raise ValueError(
                 'CUDA device ID must be lower '
-                'than max gpus:{} id: {}'.format(num_gpus, device.id))
+                'than max gpus: '
+                '(actual: {} > max: {})'.format(device.id, num_gpus))
 
         super(GpuDevice, self).__init__()
         self.device = device
@@ -280,7 +281,8 @@ def get_device_from_id(device_id):
         if not 0 <= device_id < num_gpus:
             raise ValueError(
                 'CUDA device ID must be lower '
-                'than max gpus:{} id: {} '.format(num_gpus, device_id))
+                'than max gpus: '
+                '(actual: {} > max: {})'.format(device_id, num_gpus))
         check_cuda_available()
         return Device(int(device_id))
     return DummyDevice
@@ -361,8 +363,9 @@ def _get_cuda_device(*args):
             num_gpus = cupy.cuda.runtime.getDeviceCount()
             if not 0 <= arg < num_gpus:
                 raise ValueError(
-                    'CUDA device ID must be in the range '
-                    'of max gpus:{} id: {}'.format(num_gpus, arg))
+                    'CUDA device ID must be lower '
+                    'than max gpus: '
+                    '(actual: {} > max: {})'.format(arg, num_gpus))
             return Device(arg)
         if isinstance(arg, ndarray):
             if arg.device is None:

--- a/tests/chainer_tests/backends_tests/test_cuda.py
+++ b/tests/chainer_tests/backends_tests/test_cuda.py
@@ -109,6 +109,16 @@ class TestCuda(unittest.TestCase):
         assert cuda.get_device_from_id(0) == cuda.Device(0)
 
     @attr.gpu
+    def test_get_device_from_id_invalid(self):
+        with self.assertRaises(ValueError):
+            cuda.get_device_from_id(99999)
+
+    @attr.gpu
+    def test_get_device_from_id_negative(self):
+        with self.assertRaises(ValueError):
+            cuda.get_device_from_id(-1)
+
+    @attr.gpu
     def test_get_device_from_array(self):
         arr = cuda.cupy.array([0])
         assert cuda.get_device_from_array(arr) == cuda.Device(0)
@@ -118,6 +128,12 @@ class TestCuda(unittest.TestCase):
         with testing.assert_warns(DeprecationWarning):
             device = cuda.get_device(0)
         assert device == cuda.Device(0)
+
+    @attr.gpu
+    def test_get_device_for_int_invalid(self):
+        with self.assertRaises(ValueError):
+            with testing.assert_warns(DeprecationWarning):
+                cuda.get_device(99999)
 
     @attr.gpu
     @unittest.skipUnless(_builtins_available,
@@ -533,10 +549,10 @@ class TestGpuDeviceFromArrayInvalidValue(unittest.TestCase):
 
 @testing.parameterize(*testing.product(
     {
-        'device_id': [0, 1, 99999, numpy.int32(1)],
+        'device_id': [0, 1, numpy.int32(1)],
     }))
 @attr.gpu
-class TestGpuDeviceFromDeviceId(unittest.TestCase):
+class TestGpuDeviceFromValidDeviceId(unittest.TestCase):
 
     def test_from_device_id(self):
         device = backend.GpuDevice.from_device_id(self.device_id)
@@ -548,7 +564,7 @@ class TestGpuDeviceFromDeviceId(unittest.TestCase):
 
 @testing.parameterize(*testing.product(
     {
-        'device_id': [None, -1, (), 0.0, numpy.float32(0)],
+        'device_id': [None, -1, (), 0.0, numpy.float32(0), 99999],
     }))
 @attr.gpu
 class TestGpuDeviceFromDeviceIdInvalid(unittest.TestCase):


### PR DESCRIPTION
This closes:#7309
Merge after #7552 
The main problem is that when using a device_id of '@cupy:id' a GPU object is created in chainer associated to the cupy device creation. However, neither chainer or cupy verify that the device_id is less than the number of available gpus when first creating the device handler object.

ChainerX does this check, but chainerx device handles are only created if the device name is other than numpy, cupy or intel64 (chainer/backend.py:157)