### PR TITLE
add align_corners option to `resize_images`

### DIFF
--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -308,7 +308,8 @@ def resize_images(x, output_shape, align_corners=True):
             opposite of the one in OpenCV.
         align_corners (bool): When this value is :obj:`True`,
             the corners of the input are mapped to the corners of
-            the output.
+            the output. When :obj:`False`, the behavior is the same as
+            OpenCV.
 
     Returns:
         ~chainer.Variable: Resized image whose shape is \

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -148,7 +148,7 @@ class TestResizeImagesForwardUpScale(testing.FunctionTestCase):
         return y,
 
 
-class TestResizeImagesForwardMultiLines(unittest.TestCase):
+class TestResizeImagesForwardMultiLinesAlignCorners(unittest.TestCase):
 
     in_shape = (1, 1, 987, 123)
     output_shape = (1, 1, 765, 345)

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -11,6 +11,7 @@ from chainer.testing import attr
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
+    'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
     None,
@@ -44,13 +45,15 @@ class TestResizeImagesForwardIdentity(testing.FunctionTestCase):
     def forward(self, inputs, device):
         x, = inputs
         output_shape = self.in_shape[2:]
-        y = functions.resize_images(x, output_shape)
+        y = functions.resize_images(
+            x, output_shape, align_corners=self.align_corners)
         return y,
 
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 2, 4, 4)],
     'output_shape': [(2, 2, 2, 2)],
+    'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
     None,
@@ -91,13 +94,14 @@ class TestResizeImagesForwardDownScale(testing.FunctionTestCase):
     def forward(self, inputs, device):
         x, = inputs
         output_shape = self.output_shape[2:]
-        y = functions.resize_images(x, output_shape)
+        y = functions.resize_images(x, output_shape, self.align_corners)
         return y,
 
 
 @testing.parameterize(*testing.product({
     'in_shape': [(1, 1, 2, 2)],
-    'output_shape': [(1, 1, 3, 3)]
+    'output_shape': [(1, 1, 3, 3)],
+    'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
     None,
@@ -139,7 +143,8 @@ class TestResizeImagesForwardUpScale(testing.FunctionTestCase):
     def forward(self, inputs, device):
         x, = inputs
         output_shape = self.output_shape[2:]
-        y = functions.resize_images(x, output_shape)
+        y = functions.resize_images(
+            x, output_shape, align_corners=self.align_corners)
         return y,
 
 
@@ -171,7 +176,8 @@ class TestResizeImagesForwardMultiLines(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
-    'output_shape': [(10, 5), (3, 4)]
+    'output_shape': [(10, 5), (3, 4)],
+    'align_corners': [False, True],
 }))
 class TestResizeImagesBackward(unittest.TestCase):
 
@@ -186,7 +192,7 @@ class TestResizeImagesBackward(unittest.TestCase):
 
     def check_backward(self, x, output_shape, gy):
         def f(x):
-            return functions.resize_images(x, output_shape)
+            return functions.resize_images(x, output_shape, self.align_corners)
 
         gradient_check.check_backward(
             f, x, gy, dtype='d', atol=1e-2, rtol=1e-3, eps=1e-5)
@@ -201,7 +207,7 @@ class TestResizeImagesBackward(unittest.TestCase):
 
     def check_double_backward(self, x, output_shape, gy, ggx):
         def f(x):
-            return functions.resize_images(x, output_shape)
+            return functions.resize_images(x, output_shape, self.align_corners)
 
         gradient_check.check_double_backward(
             f, x, gy, ggx, atol=1e-2, rtol=1e-3)


### PR DESCRIPTION
I add a functionality to make `resize_images` consistent with OpenCV.
`align_corners=True`: current implementation
`align_corners=False`: consistent with OpenCV

```python
import numpy as np
import chainer.functions as F
import cv2

x = np.array([[1, 2, 0],
              [3, 4, 0],
              [0, 0, 0]], dtype=np.float32).reshape(1, 1, 3, 3)
y = F.resize_images(x, (6, 6)).data
print(y)
# [[[[1.         1.4000001  1.8        1.6        0.79999995 0.        ]
#    [1.8000001  2.2        2.6        2.24       1.1199999  0.        ]
#    [2.6000001  3.         3.4        2.88       1.4399999  0.        ]
#    [2.4        2.72       3.04       2.56       1.28       0.        ]
#    [1.1999999  1.36       1.52       1.28       0.6399999  0.        ]
#    [0.         0.         0.         0.         0.         0.        ]]]]
y = F.resize_images(x, (6, 6), align_corners=False).data
print(y)
# [[[[1.     1.25   1.75   1.5    0.5    0.    ]
#    [1.5    1.75   2.25   1.875  0.625  0.    ]
#    [2.5    2.75   3.25   2.625  0.875  0.    ]
#    [2.25   2.4375 2.8125 2.25   0.75   0.    ]
#    [0.75   0.8125 0.9375 0.75   0.25   0.    ]
#    [0.     0.     0.     0.     0.     0.    ]]]]

opencv_y = cv2.resize(x[0].transpose(1, 2, 0), (6, 6))
print(opencv_y)
# [[1.     1.25   1.75   1.5    0.5    0.    ]
#  [1.5    1.75   2.25   1.875  0.625  0.    ]
#  [2.5    2.75   3.25   2.625  0.875  0.    ]
#  [2.25   2.4375 2.8125 2.25   0.75   0.    ]
#  [0.75   0.8125 0.9375 0.75   0.25   0.    ]
#  [0.     0.     0.     0.     0.     0.    ]]

```