### PR TITLE
Support `TabularDataset` in Iterator/Updater

### DIFF
--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -211,6 +211,11 @@ def concat_examples(batch, device=None, padding=None):
     if not batch:
         raise ValueError('batch is empty')
 
+    if isinstance(batch, tuple):
+        return tuple(to_device(device, b) for b in batch)
+    elif isinstance(batch, dict):
+        return {k: to_device(device, v) for k, v in batch.items()}
+
     first_elem = batch[0]
 
     if isinstance(first_elem, tuple):

--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -191,8 +191,8 @@ def concat_examples(batch, device=None, padding=None):
               [5, 6]]), 'label': array([0, 1, 2])}
 
     Args:
-        batch (list): A list of examples. This is typically given by a dataset
-            iterator.
+        batch (list or tuple or dict): A batch of examples.
+            This is typically given by a dataset iterator.
         device (device specifier): A device to which each array is sent.
             If it is omitted, all arrays are left in their original devices.
             See :meth:`~chainer.dataset.convert.to_device` for more details.
@@ -201,6 +201,7 @@ def concat_examples(batch, device=None, padding=None):
             minimum dimensionalities that can accommodate all arrays is
             created, and elements outside of the examples are padded by this
             value.
+            If :obj:`batch` is a tuple or dict, this parameter is ignored.
 
     Returns:
         Array, a tuple of arrays, or a dictionary of arrays. The type depends

--- a/chainer/dataset/tabular/__init__.py
+++ b/chainer/dataset/tabular/__init__.py
@@ -2,3 +2,4 @@ from chainer.dataset.tabular import _as_mode  # NOQA
 from chainer.dataset.tabular import _concat  # NOQA
 from chainer.dataset.tabular import _join  # NOQA
 from chainer.dataset.tabular import _slice  # NOQA
+from chainer.dataset.tabular import _with_converter  # NOQA

--- a/chainer/dataset/tabular/_as_mode.py
+++ b/chainer/dataset/tabular/_as_mode.py
@@ -20,6 +20,9 @@ class _AsTuple(tabular_dataset.TabularDataset):
     def get_examples(self, indices, key_indices):
         return self._dataset.get_examples(indices, key_indices)
 
+    def convert(self, data):
+        return self._dataset.convert(data)
+
 
 class _AsDict(tabular_dataset.TabularDataset):
 
@@ -39,3 +42,6 @@ class _AsDict(tabular_dataset.TabularDataset):
 
     def get_examples(self, indices, key_indices):
         return self._dataset.get_examples(indices, key_indices)
+
+    def convert(self, data):
+        return self._dataset.convert(data)

--- a/chainer/dataset/tabular/_concat.py
+++ b/chainer/dataset/tabular/_concat.py
@@ -108,3 +108,6 @@ class _Concat(tabular_dataset.TabularDataset):
                     [examples[dataset_index][col_index][p]
                      for dataset_index, p in example_indices]
                     for col_index in six.moves.range(n_cols))
+
+    def convert(self, data):
+        return self._datasets[0].convert(data)

--- a/chainer/dataset/tabular/_join.py
+++ b/chainer/dataset/tabular/_join.py
@@ -55,3 +55,6 @@ class _Join(tabular_dataset.TabularDataset):
             key_offset += len(dataset.keys)
 
         return tuple(examples[key_index] for key_index in key_indices)
+
+    def convert(self, data):
+        return self._datasets[0].convert(data)

--- a/chainer/dataset/tabular/_slice.py
+++ b/chainer/dataset/tabular/_slice.py
@@ -40,6 +40,9 @@ class _Slice(tabular_dataset.TabularDataset):
         key_indices = _merge_key_indices(self._key_indices, key_indices)
         return self._dataset.get_examples(indices, key_indices)
 
+    def convert(self, data):
+        return self._dataset.convert(data)
+
 
 class _SliceHelper(object):
 

--- a/chainer/dataset/tabular/_with_converter.py
+++ b/chainer/dataset/tabular/_with_converter.py
@@ -21,5 +21,5 @@ class _WithConverter(tabular_dataset.TabularDataset):
     def get_examples(self, indices, key_indices):
         return self._dataset.get_examples(indices, key_indices)
 
-    def converter(self, data):
+    def convert(self, data):
         return self._converter(data)

--- a/chainer/dataset/tabular/_with_converter.py
+++ b/chainer/dataset/tabular/_with_converter.py
@@ -1,0 +1,25 @@
+from chainer.dataset.tabular import tabular_dataset
+
+
+class _WithConverter(tabular_dataset.TabularDataset):
+
+    def __init__(self, dataset, converter):
+        self._dataset = dataset
+        self._converter = converter
+
+    def __len__(self):
+        return len(self._dataset)
+
+    @property
+    def keys(self):
+        return self._dataset.keys
+
+    @property
+    def mode(self):
+        return self._dataset.mode
+
+    def get_examples(self, indices, key_indices):
+        return self._dataset.get_examples(indices, key_indices)
+
+    def converter(self, data):
+        return self._converter(data)

--- a/chainer/dataset/tabular/tabular_dataset.py
+++ b/chainer/dataset/tabular/tabular_dataset.py
@@ -142,6 +142,12 @@ class TabularDataset(dataset_mixin.DatasetMixin):
         elif self.mode is dict:
             return dict(six.moves.zip(self.keys, examples))
 
+    def convert(self, data):
+        if isinstance(data, tuple):
+            return tuple(_as_array(d) for d in data)
+        elif isinstance(data, dict):
+            return {k: _as_array(v) for k, v in data.items()}
+
     def as_tuple(self):
         """Return a view with tuple mode.
 
@@ -191,3 +197,12 @@ class TabularDataset(dataset_mixin.DatasetMixin):
             return example
         elif self.mode is dict:
             return dict(six.moves.zip(self.keys, example))
+
+
+def _as_array(data):
+    if isinstance(data, chainer.get_array_types()):
+        return data
+    else:
+        device = chainer.backend.get_device_from_array(data[0])
+        with chainer.using_device(device):
+            return device.xp.stack(data)

--- a/chainer/dataset/tabular/tabular_dataset.py
+++ b/chainer/dataset/tabular/tabular_dataset.py
@@ -190,6 +190,10 @@ class TabularDataset(dataset_mixin.DatasetMixin):
         """
         return chainer.dataset.tabular._join._Join(self, *datasets)
 
+    def with_converter(self, converter):
+        return chainer.dataset.tabular._with_converter._WithConverter(
+            self, converter)
+
     def get_example(self, i):
         example = self.get_examples([i], None)
         example = tuple(col[0] for col in example)

--- a/chainer/dataset/tabular/tabular_dataset.py
+++ b/chainer/dataset/tabular/tabular_dataset.py
@@ -143,6 +143,20 @@ class TabularDataset(dataset_mixin.DatasetMixin):
             return dict(six.moves.zip(self.keys, examples))
 
     def convert(self, data):
+        """Convert fetched data.
+
+        This method takes data fetched by :meth:`fetch` and
+        pre-process them before passing them to models.
+        The default behaviour is converting each column into an ndarray.
+        This behaviour can be overloaded by :meth:`with_converter`.
+
+        Args:
+            data (tuple or dict): Data from :meth:`fetch`.
+
+        Returns:
+            A tuple or dict.
+            Each value is an ndarray.
+        """
         if isinstance(data, tuple):
             return tuple(_as_array(d) for d in data)
         elif isinstance(data, dict):
@@ -191,6 +205,17 @@ class TabularDataset(dataset_mixin.DatasetMixin):
         return chainer.dataset.tabular._join._Join(self, *datasets)
 
     def with_converter(self, converter):
+        """Overload the behaviour of :meth:`convert`.
+
+        This method overloads :meth:`convert`.
+
+        Args:
+            converter (callable): A new converter.
+
+        Returns:
+            A dataset with the new converter.
+        """
+
         return chainer.dataset.tabular._with_converter._WithConverter(
             self, converter)
 

--- a/chainer/iterators/_tabular_helper.py
+++ b/chainer/iterators/_tabular_helper.py
@@ -1,6 +1,13 @@
 import six
 
 
+def apply(convert, data):
+    if isinstance(data, tuple):
+        return convert(*data)
+    elif isinstance(data, dict):
+        return convert(**data)
+
+
 def transpose(data):
     if isinstance(data[0], tuple):
         return tuple([d[i] for d in data]

--- a/chainer/iterators/_transpose.py
+++ b/chainer/iterators/_transpose.py
@@ -1,0 +1,9 @@
+import six
+
+
+def transpose(data):
+    if isinstance(data[0], tuple):
+        return tuple([d[i] for d in data]
+                     for i in six.moves.range(len(data[0])))
+    elif isinstance(data[0], dict):
+        return {k: [d[k] for d in data] for k in data[0].keys()}

--- a/chainer/iterators/_transpose.py
+++ b/chainer/iterators/_transpose.py
@@ -1,13 +1,6 @@
 import six
 
 
-def apply(convert, data):
-    if isinstance(data, tuple):
-        return convert(*data)
-    elif isinstance(data, dict):
-        return convert(**data)
-
-
 def transpose(data):
     if isinstance(data[0], tuple):
         return tuple([d[i] for d in data]

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -10,8 +10,10 @@ import warnings
 import numpy
 import six
 
+import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
+from chainer.iterators import _transpose
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -106,6 +108,8 @@ class MultiprocessIterator(iterator.Iterator):
                  order_sampler=None, dataset_timeout=30.0,
                  maxtasksperchild=None):
         self.dataset = dataset
+        self._is_tabular = isinstance(
+            self.dataset, chainer.dataset.TabularDataset)
         self.batch_size = batch_size
         self.repeat = repeat
         self.shuffle = shuffle
@@ -158,6 +162,9 @@ class MultiprocessIterator(iterator.Iterator):
         if batch is None:
             raise StopIteration
         else:
+            if self._is_tabular:
+                batch = self.dataset.convert(_transpose.transpose(batch))
+
             return batch
 
     next = __next__

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -13,7 +13,7 @@ import six
 import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
-from chainer.iterators import _tabular_helper
+from chainer.iterators import _transpose
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -420,9 +420,7 @@ class _PrefetchLoop(object):
             self._allocate_shared_memory()
 
             if self._is_tabular:
-                batch = _tabular_helper.apply(
-                    self.dataset.convert,
-                    _tabular_helper.transpose(batch))
+                batch = self.dataset.convert(_transpose.transpose(batch))
 
         return batch, self.prefetch_state
 
@@ -491,9 +489,7 @@ class _PrefetchLoop(object):
             batch = [_unpack(data, self.mem_bulk) for data in data_all]
 
             if self._is_tabular:
-                batch = _tabular_helper.apply(
-                    self.dataset.convert,
-                    _tabular_helper.transpose(batch))
+                batch = self.dataset.convert(_transpose.transpose(batch))
 
         self._comm.put(batch, self.prefetch_state, reset_count)
         return True

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -13,7 +13,7 @@ import six
 import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
-from chainer.iterators import _transpose
+from chainer.iterators import _tabular_helper
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -420,7 +420,9 @@ class _PrefetchLoop(object):
             self._allocate_shared_memory()
 
             if self._is_tabular:
-                batch = self.dataset.convert(_transpose.transpose(batch))
+                batch = _tabular_helper.apply(
+                    self.dataset.convert,
+                    _tabular_helper.transpose(batch))
 
         return batch, self.prefetch_state
 
@@ -489,7 +491,9 @@ class _PrefetchLoop(object):
             batch = [_unpack(data, self.mem_bulk) for data in data_all]
 
             if self._is_tabular:
-                batch = self.dataset.convert(_transpose.transpose(batch))
+                batch = _tabular_helper.apply(
+                    self.dataset.convert,
+                    _tabular_helper.transpose(batch))
 
         self._comm.put(batch, self.prefetch_state, reset_count)
         return True

--- a/chainer/iterators/multithread_iterator.py
+++ b/chainer/iterators/multithread_iterator.py
@@ -2,11 +2,11 @@ from __future__ import division
 from multiprocessing import pool
 
 import numpy
-import six
 
 import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
+from chainer.iterators import _transpose
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -172,14 +172,7 @@ class MultithreadIterator(iterator.Iterator):
             next.wait(0.5)  # To avoid interruption bug in Python2
 
         if self._is_tabular:
-            data = next.get()
-            if isinstance(data[0], tuple):
-                batch = tuple([d[i] for d in data]
-                              for i in six.moves.range(len(data[0])))
-            elif isinstance(data[0], dict):
-                batch = {k: [d[k] for d in data]
-                         for k in data[0].keys()}
-            return self.dataset.convert(batch)
+            return self.dataset.convert(_transpose.transpose(next.get()))
 
         batch = [data for data in next.get()]
         return batch

--- a/chainer/iterators/multithread_iterator.py
+++ b/chainer/iterators/multithread_iterator.py
@@ -6,7 +6,7 @@ import numpy
 import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
-from chainer.iterators import _transpose
+from chainer.iterators import _tabular_helper
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -147,7 +147,9 @@ class MultithreadIterator(iterator.Iterator):
 
     @staticmethod
     def _convert(convert, data):
-        return convert(_transpose.transpose(data.get()))
+        return _tabular_helper.apply(
+            convert,
+            _tabular_helper.transpose(data.get()))
 
     def _invoke_prefetch(self):
         assert self._next is None

--- a/chainer/iterators/multithread_iterator.py
+++ b/chainer/iterators/multithread_iterator.py
@@ -6,7 +6,7 @@ import numpy
 import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
-from chainer.iterators import _tabular_helper
+from chainer.iterators import _transpose
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -147,9 +147,7 @@ class MultithreadIterator(iterator.Iterator):
 
     @staticmethod
     def _convert(convert, data):
-        return _tabular_helper.apply(
-            convert,
-            _tabular_helper.transpose(data.get()))
+        return convert(_transpose.transpose(data.get()))
 
     def _invoke_prefetch(self):
         assert self._next is None

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -5,7 +5,6 @@ import numpy
 import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
-from chainer.iterators import _tabular_helper
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -79,9 +78,7 @@ class SerialIterator(iterator.Iterator):
             raise StopIteration
 
         if self._is_tabular:
-            return _tabular_helper.apply(
-                self.dataset.convert,
-                self.dataset.slice[indices].fetch())
+            return self.dataset.convert(self.dataset.slice[indices].fetch())
 
         batch = [self.dataset[index] for index in indices]
         return batch

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -5,6 +5,7 @@ import numpy
 import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
+from chainer.iterators import _tabular_helper
 from chainer.iterators.order_samplers import ShuffleOrderSampler
 
 
@@ -78,7 +79,9 @@ class SerialIterator(iterator.Iterator):
             raise StopIteration
 
         if self._is_tabular:
-            return self.dataset.convert(self.dataset.slice[indices].fetch())
+            return _tabular_helper.apply(
+                self.dataset.convert,
+                self.dataset.slice[indices].fetch())
 
         batch = [self.dataset[index] for index in indices]
         return batch

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import numpy
 
+import chainer
 from chainer.dataset import iterator
 from chainer.iterators import _statemachine
 from chainer.iterators.order_samplers import ShuffleOrderSampler
@@ -46,6 +47,8 @@ class SerialIterator(iterator.Iterator):
     def __init__(self, dataset, batch_size,
                  repeat=True, shuffle=None, order_sampler=None):
         self.dataset = dataset
+        self._is_tabular = isinstance(
+            self.dataset, chainer.dataset.TabularDataset)
         self.batch_size = batch_size
         self._repeat = repeat
         self._shuffle = shuffle
@@ -73,6 +76,9 @@ class SerialIterator(iterator.Iterator):
             len(self.dataset))
         if indices is None:
             raise StopIteration
+
+        if self._is_tabular:
+            return self.dataset.convert(self.dataset.slice[indices].fetch())
 
         batch = [self.dataset[index] for index in indices]
         return batch

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_as_mode.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_as_mode.py
@@ -20,6 +20,18 @@ class TestAsTuple(unittest.TestCase):
         self.assertEqual(view.mode, tuple)
 
 
+class TestAsTupleConvert(unittest.TestCase):
+
+    def test_as_tuple_convert(self):
+        def converter(data):
+            self.assertEqual(data, 'input')
+            return 'converted'
+
+        dataset = dummy_dataset.DummyDataset().with_converter(converter)
+        view = dataset.as_tuple()
+        self.assertEqual(view.convert('input'), 'converted')
+
+
 @testing.parameterize(
     {'mode': tuple},
     {'mode': dict},
@@ -33,6 +45,18 @@ class TestAsDict(unittest.TestCase):
         self.assertEqual(len(view), len(dataset))
         self.assertEqual(view.keys, dataset.keys)
         self.assertEqual(view.mode, dict)
+
+
+class TestAsDictConvert(unittest.TestCase):
+
+    def test_as_dict_convert(self):
+        def converter(data):
+            self.assertEqual(data, 'input')
+            return 'converted'
+
+        dataset = dummy_dataset.DummyDataset().with_converter(converter)
+        view = dataset.as_dict()
+        self.assertEqual(view.convert('input'), 'converted')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_concat.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_concat.py
@@ -92,4 +92,17 @@ class TestConcatInvalid(unittest.TestCase):
             dataset_a.concat(dataset_b)
 
 
+class TestConcatConvert(unittest.TestCase):
+
+    def test_concat_convert(self):
+        def converter(data):
+            self.assertEqual(data, 'input')
+            return 'converted'
+
+        dataset_a = dummy_dataset.DummyDataset().with_converter(converter)
+        dataset_b = dummy_dataset.DummyDataset()
+        view = dataset_a.concat(dataset_b)
+        self.assertEqual(view.convert('input'), 'converted')
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_join.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_join.py
@@ -84,4 +84,17 @@ class TestJoinInvalid(unittest.TestCase):
             dataset_a.join(dataset_b)
 
 
+class TestJoinConvert(unittest.TestCase):
+
+    def test_join_convert(self):
+        def converter(data):
+            self.assertEqual(data, 'input')
+            return 'converted'
+
+        dataset_a = dummy_dataset.DummyDataset().with_converter(converter)
+        dataset_b = dummy_dataset.DummyDataset(keys=('d', 'e'))
+        view = dataset_a.join(dataset_b)
+        self.assertEqual(view.convert('input'), 'converted')
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_slice.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_slice.py
@@ -134,6 +134,18 @@ class TestSlice(unittest.TestCase):
                 self.assertIsInstance(out, list)
 
 
+class TestSliceConvert(unittest.TestCase):
+
+    def test_slice_convert(self):
+        def converter(data):
+            self.assertEqual(data, 'input')
+            return 'converted'
+
+        dataset = dummy_dataset.DummyDataset().with_converter(converter)
+        view = dataset.slice[[3, 1], (1, 'a')]
+        self.assertEqual(view.convert('input'), 'converted')
+
+
 # Replace list of bool with ndarray of bool
 # since old numpy cannot handle list of bool.
 def _indices_for_numpy(indices):

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_tabular_dataset.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_tabular_dataset.py
@@ -35,6 +35,22 @@ class TestTabularDataset(unittest.TestCase):
             else:
                 self.assertIsInstance(out, list)
 
+    def test_convert(self):
+        dataset = dummy_dataset.DummyDataset(
+            mode=self.mode, return_array=self.return_array)
+        output = dataset.convert(dataset.fetch())
+
+        if self.mode is tuple:
+            expected = tuple(dataset.data)
+        elif self.mode is dict:
+            expected = dict(zip(('a', 'b', 'c'), dataset.data))
+        np.testing.assert_equal(output, expected)
+
+        if self.mode is dict:
+            output = output.values()
+        for out in output:
+            self.assertIsInstance(out, np.ndarray)
+
     def test_get_example(self):
         def callback(indices, key_indices):
             self.assertEqual(indices, [3])

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_with_converter.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_with_converter.py
@@ -1,9 +1,14 @@
 import unittest
 
+import chainer
 from chainer import testing
 from chainer_tests.dataset_tests.tabular_tests import dummy_dataset
 
 
+@testing.parameterize(
+    {'mode': tuple},
+    {'mode': dict},
+)
 class TestWithConverter(unittest.TestCase):
 
     def test_with_converter(self):
@@ -11,8 +16,13 @@ class TestWithConverter(unittest.TestCase):
             self.assertEqual(data, 'input')
             return 'converted'
 
-        dataset = dummy_dataset.DummyDataset().with_converter(converter)
-        self.assertEqual(dataset.convert('input'), 'converted')
+        dataset = dummy_dataset.DummyDataset(mode=self.mode)
+        view = dataset.with_converter(converter)
+        self.assertIsInstance(view, chainer.dataset.TabularDataset)
+        self.assertEqual(len(view), len(dataset))
+        self.assertEqual(view.keys, dataset.keys)
+        self.assertEqual(view.mode, dataset.mode)
+        self.assertEqual(view.convert('input'), 'converted')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/dataset_tests/tabular_tests/test_with_converter.py
+++ b/tests/chainer_tests/dataset_tests/tabular_tests/test_with_converter.py
@@ -1,0 +1,18 @@
+import unittest
+
+from chainer import testing
+from chainer_tests.dataset_tests.tabular_tests import dummy_dataset
+
+
+class TestWithConverter(unittest.TestCase):
+
+    def test_with_converter(self):
+        def converter(data):
+            self.assertEqual(data, 'input')
+            return 'converted'
+
+        dataset = dummy_dataset.DummyDataset().with_converter(converter)
+        self.assertEqual(dataset.convert('input'), 'converted')
+
+
+testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -847,7 +847,7 @@ class TestMultiprocessIteratorTabularDataset(unittest.TestCase):
             self.assertIsInstance(out, numpy.ndarray)
 
     def test_iterator_tabular_dataset_converter(self):
-        main_thread = threading.main_thread()
+        main_thread = threading.current_thread()
 
         def converter(a, b, c):
             if self.shared_mem is not None:

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -817,15 +817,22 @@ class TestMultiprocessIteratorStalledDatasetDetection(unittest.TestCase):
             for i in range((len(dataset) + batch_size - 1) // batch_size)]
 
 
-@testing.parameterize(
-    {'mode': tuple},
-    {'mode': dict},
-)
+@testing.parameterize(*testing.product({
+    'mode': [tuple, dict],
+    'n_prefetch': [1, 2],
+    'shared_mem': [None, 1000000],
+}))
 class TestMultiprocessIteratorTabularDataset(unittest.TestCase):
+
+    n_processes = 2
 
     def test_iterator_tabular_dataset(self):
         dataset = dummy_dataset.DummyDataset(mode=self.mode)
-        it = iterators.MultiprocessIterator(dataset, 2, shuffle=False)
+        it = iterators.MultiprocessIterator(
+            dataset, 2, shuffle=False,
+            n_processes=self.n_processes,
+            n_prefetch=self.n_prefetch,
+            shared_mem=self.shared_mem)
         output = it.next()
 
         if self.mode is tuple:

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -847,10 +847,11 @@ class TestMultiprocessIteratorTabularDataset(unittest.TestCase):
             self.assertIsInstance(out, numpy.ndarray)
 
     def test_iterator_tabular_dataset_converter(self):
+        main_thread = threading.main_thread()
+
         def converter(a, b, c):
             if self.shared_mem is not None:
-                self.assertNotEqual(
-                    threading.current_thread(), threading.main_thread())
+                self.assertNotEqual(threading.current_thread(), main_thread)
             return 'converted'
 
         dataset = dummy_dataset.DummyDataset(

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -846,5 +846,21 @@ class TestMultiprocessIteratorTabularDataset(unittest.TestCase):
         for out in output:
             self.assertIsInstance(out, numpy.ndarray)
 
+    def test_iterator_tabular_dataset_converter(self):
+        def converter(a, b, c):
+            if self.shared_mem is not None:
+                self.assertNotEqual(
+                    threading.current_thread(), threading.main_thread())
+            return 'converted'
+
+        dataset = dummy_dataset.DummyDataset(
+            mode=self.mode).with_converter(converter)
+        it = iterators.MultiprocessIterator(
+            dataset, 2, shuffle=False,
+            n_processes=self.n_processes,
+            n_prefetch=self.n_prefetch,
+            shared_mem=self.shared_mem)
+        self.assertEqual(it.next(), 'converted')
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import copy
+import threading
 import unittest
 
 import numpy
@@ -446,6 +447,18 @@ class TestMultithreadIteratorTabularDataset(unittest.TestCase):
             output = output.values()
         for out in output:
             self.assertIsInstance(out, numpy.ndarray)
+
+    def test_iterator_tabular_dataset_converter(self):
+        def converter(a, b, c):
+            self.assertNotEqual(
+                threading.current_thread(), threading.main_thread())
+            return 'converted'
+
+        dataset = dummy_dataset.DummyDataset(
+            mode=self.mode).with_converter(converter)
+        it = iterators.MultithreadIterator(
+            dataset, 2, shuffle=False, n_threads=self.n_threads)
+        self.assertEqual(it.next(), 'converted')
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
@@ -449,7 +449,7 @@ class TestMultithreadIteratorTabularDataset(unittest.TestCase):
             self.assertIsInstance(out, numpy.ndarray)
 
     def test_iterator_tabular_dataset_converter(self):
-        main_thread = threading.main_thread()
+        main_thread = threading.current_thread()
 
         def converter(a, b, c):
             self.assertNotEqual(threading.current_thread(), main_thread)

--- a/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
@@ -449,9 +449,10 @@ class TestMultithreadIteratorTabularDataset(unittest.TestCase):
             self.assertIsInstance(out, numpy.ndarray)
 
     def test_iterator_tabular_dataset_converter(self):
+        main_thread = threading.main_thread()
+
         def converter(a, b, c):
-            self.assertNotEqual(
-                threading.current_thread(), threading.main_thread())
+            self.assertNotEqual(threading.current_thread(), main_thread)
             return 'converted'
 
         dataset = dummy_dataset.DummyDataset(

--- a/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multithread_iterator.py
@@ -424,15 +424,16 @@ class TestMultithreadIteratorInvalidOrderSampler(unittest.TestCase):
             it.next()
 
 
-@testing.parameterize(
-    {'mode': tuple},
-    {'mode': dict},
-)
+@testing.parameterize(*testing.product({
+    'mode': [tuple, dict],
+    'n_threads': [1, 2],
+}))
 class TestMultithreadIteratorTabularDataset(unittest.TestCase):
 
     def test_iterator_tabular_dataset(self):
         dataset = dummy_dataset.DummyDataset(mode=self.mode)
-        it = iterators.MultithreadIterator(dataset, 2, shuffle=False)
+        it = iterators.MultithreadIterator(
+            dataset, 2, shuffle=False, n_threads=self.n_threads)
         output = it.next()
 
         if self.mode is tuple:

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -7,6 +7,8 @@ from chainer import iterators
 from chainer import serializer
 from chainer import testing
 
+from chainer_tests.dataset_tests.tabular_tests import dummy_dataset
+
 
 class DummySerializer(serializer.Serializer):
 
@@ -416,6 +418,29 @@ class TestSerialIteratorInvalidOrderSampler(unittest.TestCase):
             it = iterators.SerialIterator(
                 dataset, 6, order_sampler=InvalidOrderSampler())
             it.next()
+
+
+@testing.parameterize(
+    {'mode': tuple},
+    {'mode': dict},
+)
+class TestSerialIteratorTabularDataset(unittest.TestCase):
+
+    def test_iterator_tabular_dataset(self):
+        dataset = dummy_dataset.DummyDataset(mode=self.mode)
+        it = iterators.SerialIterator(dataset, 2, shuffle=False)
+        output = it.next()
+
+        if self.mode is tuple:
+            expected = tuple(dataset.data[:, [0, 1]])
+        elif self.mode is dict:
+            expected = dict(zip(('a', 'b', 'c'), dataset.data[:, [0, 1]]))
+        numpy.testing.assert_equal(output, expected)
+
+        if self.mode is dict:
+            output = output.values()
+        for out in output:
+            self.assertIsInstance(out, numpy.ndarray)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
merge after #7428 

```python
import numpy as np

import chainer
from chainer.dataset import tabular


dataset = tabular.from_data(
    ('img', np.arange(10)),
    ('roi', [np.random.uniform(size=(i + 1, 4)) for i in range(10)]),
)


def converter(imgs, rois):
    roi_indices = np.array([
        index for index, roi in enumerate(rois) for _ in roi])
    rois = np.array([ri for roi in rois for ri in roi])

    return imgs, rois, roi_indices


print(dataset.slice[:2].fetch())

it = chainer.iterators.SerialIterator(
    dataset.with_converter(converter), 2, shuffle=False)
print(it.next())
```