### PR TITLE
Support ChainerX in static subgraph optimization examples

### DIFF
--- a/examples/static_graph_optimizations/cifar/train_cifar.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar.py
@@ -55,13 +55,6 @@ def main():
             'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
-    if device.xp is chainerx:
-        warnings.warn(
-            'Static subgraph optimization does not support ChainerX and will'
-            ' be disabled.', UserWarning)
-        use_static_graph = False
-    else:
-        use_static_graph = True
 
     print('Device: {}'.format(device))
     print('# Minibatch-size: {}'.format(args.batchsize))
@@ -142,8 +135,14 @@ def main():
         chainer.serializers.load_npz(args.resume, trainer)
 
     # Run the training
-    with chainer.using_config('use_static_graph', use_static_graph):
+    if device.xp is not chainerx:
         trainer.run()
+    else:
+        warnings.warn(
+            'Static subgraph optimization does not support ChainerX and will'
+            ' be disabled.', UserWarning)
+        with chainer.using_config('use_static_graph', False):
+            trainer.run()
 
 
 if __name__ == '__main__':

--- a/examples/static_graph_optimizations/cifar/train_cifar.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar.py
@@ -6,7 +6,6 @@ the code is mostly unchanged except for the addition of the
 `@static_graph` decorator to the model chain's `__call__()` method.
 """
 import argparse
-import sys
 import warnings
 
 import numpy
@@ -57,8 +56,12 @@ def main():
 
     device = chainer.get_device(args.device)
     if device.xp is chainerx:
-        sys.stderr.write('This example does not support ChainerX devices.\n')
-        sys.exit(1)
+        warnings.warn(
+            'Static subgraph optimization does not support ChainerX and will'
+            ' be disabled.', UserWarning)
+        use_static_graph = False
+    else:
+        use_static_graph = True
 
     print('Device: {}'.format(device))
     print('# Minibatch-size: {}'.format(args.batchsize))
@@ -139,7 +142,8 @@ def main():
         chainer.serializers.load_npz(args.resume, trainer)
 
     # Run the training
-    trainer.run()
+    with chainer.using_config('use_static_graph', use_static_graph):
+        trainer.run()
 
 
 if __name__ == '__main__':

--- a/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
+++ b/examples/static_graph_optimizations/cifar/train_cifar_custom_loop.py
@@ -11,7 +11,6 @@ training loop that manually computes the loss of minibatches and
 applies an optimizer to update the model.
 """
 import argparse
-import sys
 import warnings
 
 import numpy
@@ -62,8 +61,12 @@ def main():
 
     device = chainer.get_device(args.device)
     if device.xp is chainerx:
-        sys.stderr.write('This example does not support ChainerX devices.\n')
-        sys.exit(1)
+        warnings.warn(
+            'Static subgraph optimization does not support ChainerX and will'
+            ' be disabled.', UserWarning)
+        use_static_graph = False
+    else:
+        use_static_graph = True
 
     print('Device: {}'.format(device))
     print('# Minibatch-size: {}'.format(args.batchsize))
@@ -107,44 +110,46 @@ def main():
     sum_accuracy = 0
     sum_loss = 0
 
-    while train_iter.epoch < args.epoch:
-        batch = train_iter.next()
-        # Reduce learning rate by 0.5 every 25 epochs.
-        if train_iter.epoch % 25 == 0 and train_iter.is_new_epoch:
-            optimizer.lr *= 0.5
-            print('Reducing learning rate to: {}'.format(optimizer.lr))
+    with chainer.using_config('use_static_graph', use_static_graph):
+        while train_iter.epoch < args.epoch:
+            batch = train_iter.next()
+            # Reduce learning rate by 0.5 every 25 epochs.
+            if train_iter.epoch % 25 == 0 and train_iter.is_new_epoch:
+                optimizer.lr *= 0.5
+                print('Reducing learning rate to: {}'.format(optimizer.lr))
 
-        x_array, t_array = convert.concat_examples(batch, device)
-        x = chainer.Variable(x_array)
-        t = chainer.Variable(t_array, requires_grad=False)
-        optimizer.update(model, x, t)
-        sum_loss += float(model.loss.array) * len(t)
-        sum_accuracy += float(model.accuracy.array) * len(t)
+            x_array, t_array = convert.concat_examples(batch, device)
+            x = chainer.Variable(x_array)
+            t = chainer.Variable(t_array, requires_grad=False)
+            optimizer.update(model, x, t)
+            sum_loss += float(model.loss.array) * len(t)
+            sum_accuracy += float(model.accuracy.array) * len(t)
 
-        if train_iter.is_new_epoch:
-            print('epoch: {}'.format(train_iter.epoch))
-            print('train mean loss: {}, accuracy: {}'.format(
-                sum_loss / train_count, sum_accuracy / train_count))
-            # evaluation
-            sum_accuracy = 0
-            sum_loss = 0
-            model.predictor.train = False
-            # It is good practice to turn off train mode during evaluation.
-            with configuration.using_config('train', False):
-                for batch in test_iter:
-                    x_array, t_array = convert.concat_examples(batch, device)
-                    x = chainer.Variable(x_array)
-                    t = chainer.Variable(t_array, requires_grad=False)
-                    loss = model(x, t)
-                    sum_loss += float(loss.array) * len(t)
-                    sum_accuracy += float(model.accuracy.array) * len(t)
+            if train_iter.is_new_epoch:
+                print('epoch: {}'.format(train_iter.epoch))
+                print('train mean loss: {}, accuracy: {}'.format(
+                    sum_loss / train_count, sum_accuracy / train_count))
+                # evaluation
+                sum_accuracy = 0
+                sum_loss = 0
+                model.predictor.train = False
+                # It is good practice to turn off train mode during evaluation.
+                with configuration.using_config('train', False):
+                    for batch in test_iter:
+                        x_array, t_array = convert.concat_examples(
+                            batch, device)
+                        x = chainer.Variable(x_array)
+                        t = chainer.Variable(t_array, requires_grad=False)
+                        loss = model(x, t)
+                        sum_loss += float(loss.array) * len(t)
+                        sum_accuracy += float(model.accuracy.array) * len(t)
 
-            test_iter.reset()
-            model.predictor.train = True
-            print('test mean  loss: {}, accuracy: {}'.format(
-                sum_loss / test_count, sum_accuracy / test_count))
-            sum_accuracy = 0
-            sum_loss = 0
+                test_iter.reset()
+                model.predictor.train = True
+                print('test mean  loss: {}, accuracy: {}'.format(
+                    sum_loss / test_count, sum_accuracy / test_count))
+                sum_accuracy = 0
+                sum_loss = 0
 
     # Save the model and the optimizer
     print('save the model')

--- a/examples/static_graph_optimizations/mnist/train_mnist.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist.py
@@ -115,13 +115,6 @@ def main():
             'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     device = chainer.get_device(args.device)
-    if device.xp is chainerx:
-        warnings.warn(
-            'Static subgraph optimization does not support ChainerX and will'
-            ' be disabled.', UserWarning)
-        use_static_graph = False
-    else:
-        use_static_graph = True
 
     print('Device: {}'.format(device))
     print('# unit: {}'.format(args.unit))
@@ -199,8 +192,14 @@ def main():
         chainer.serializers.load_npz(args.resume, trainer)
 
     # Run the training
-    with chainer.using_config('use_static_graph', use_static_graph):
+    if device.xp is not chainerx:
         trainer.run()
+    else:
+        warnings.warn(
+            'Static subgraph optimization does not support ChainerX and will'
+            ' be disabled.', UserWarning)
+        with chainer.using_config('use_static_graph', False):
+            trainer.run()
 
 
 if __name__ == '__main__':

--- a/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
@@ -27,6 +27,47 @@ import chainerx
 import train_mnist
 
 
+def run_train_loop(
+        optimizer, train_iter, test_iter, train_count, test_count, epoch,
+        device):
+    model = optimizer.target
+
+    sum_accuracy = 0
+    sum_loss = 0
+    while train_iter.epoch < epoch:
+        batch = train_iter.next()
+        x_array, t_array = convert.concat_examples(batch, device)
+        x = chainer.Variable(x_array)
+        t = chainer.Variable(t_array, requires_grad=False)
+        optimizer.update(model, x, t)
+        sum_loss += float(model.loss.array) * len(t)
+        sum_accuracy += float(model.accuracy.array) * len(t)
+
+        if train_iter.is_new_epoch:
+            print('epoch: ', train_iter.epoch)
+            print('train mean loss: {}, accuracy: {}'.format(
+                sum_loss / train_count, sum_accuracy / train_count))
+            # evaluation
+            sum_accuracy = 0
+            sum_loss = 0
+            # It is good practice to turn off train mode during evaluation.
+            with configuration.using_config('train', False):
+                for batch in test_iter:
+                    x_array, t_array = convert.concat_examples(
+                        batch, device)
+                    x = chainer.Variable(x_array)
+                    t = chainer.Variable(t_array, requires_grad=False)
+                    loss = model(x, t)
+                    sum_loss += float(loss.array) * len(t)
+                    sum_accuracy += float(model.accuracy.array) * len(t)
+
+            test_iter.reset()
+            print('test mean  loss: {}, accuracy: {}'.format(
+                sum_loss / test_count, sum_accuracy / test_count))
+            sum_accuracy = 0
+            sum_loss = 0
+
+
 def main():
     parser = argparse.ArgumentParser(description='Chainer example: MNIST')
     parser.add_argument('--batchsize', '-b', type=int, default=100,
@@ -87,51 +128,18 @@ def main():
     test_iter = chainer.iterators.SerialIterator(
         test, args.batchsize, repeat=False, shuffle=False)
 
-    def run():
-        sum_accuracy = 0
-        sum_loss = 0
-
-        while train_iter.epoch < args.epoch:
-            batch = train_iter.next()
-            x_array, t_array = convert.concat_examples(batch, device)
-            x = chainer.Variable(x_array)
-            t = chainer.Variable(t_array, requires_grad=False)
-            optimizer.update(model, x, t)
-            sum_loss += float(model.loss.array) * len(t)
-            sum_accuracy += float(model.accuracy.array) * len(t)
-
-            if train_iter.is_new_epoch:
-                print('epoch: ', train_iter.epoch)
-                print('train mean loss: {}, accuracy: {}'.format(
-                    sum_loss / train_count, sum_accuracy / train_count))
-                # evaluation
-                sum_accuracy = 0
-                sum_loss = 0
-                # It is good practice to turn off train mode during evaluation.
-                with configuration.using_config('train', False):
-                    for batch in test_iter:
-                        x_array, t_array = convert.concat_examples(
-                            batch, device)
-                        x = chainer.Variable(x_array)
-                        t = chainer.Variable(t_array, requires_grad=False)
-                        loss = model(x, t)
-                        sum_loss += float(loss.array) * len(t)
-                        sum_accuracy += float(model.accuracy.array) * len(t)
-
-                test_iter.reset()
-                print('test mean  loss: {}, accuracy: {}'.format(
-                    sum_loss / test_count, sum_accuracy / test_count))
-                sum_accuracy = 0
-                sum_loss = 0
-
     if device.xp is not chainerx:
-        run()
+        run_train_loop(
+            optimizer, train_iter, test_iter, train_count, test_count,
+            args.epoch, device)
     else:
         warnings.warn(
             'Static subgraph optimization does not support ChainerX and will'
             ' be disabled.', UserWarning)
         with chainer.using_config('use_static_graph', False):
-            run()
+            run_train_loop(
+                optimizer, train_iter, test_iter, train_count, test_count,
+                args.epoch, device)
 
     # Save the model and the optimizer
     print('save the model')


### PR DESCRIPTION
Part of https://github.com/chainer/chainer/issues/7220.

The examples are "supported" by disabling the static subgraph optimization feature altogether.
However, the PTB example remains unsupported similar to the original PTB example as explained here https://github.com/chainer/chainer/issues/7220#issuecomment-496785612.