### PR TITLE
Make `EXEPECT_ARRAY_*` macros able to used outside ChainerX

### DIFF
--- a/chainerx_cc/chainerx/testing/array_check.h
+++ b/chainerx_cc/chainerx/testing/array_check.h
@@ -128,7 +128,8 @@ void ExpectDataEqual(T expected, const Array& actual) {
 #define GET_MACRO(_1, _2, _3, _4, _5, NAME, ...) NAME
 #define EXPECT_ARRAY_ALL_CLOSE2(a, b) EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, 1e-5, 1e-8, false)
 #define EXPECT_ARRAY_ALL_CLOSE3(a, b, rtol) EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, rtol, 1e-8, false)
-#define EXPECT_ARRAY_ALL_CLOSE4(a, b, rtol, atol) EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, rtol, atol, false)
+#define EXPECT_ARRAY_ALL_CLOSE4(a, b, rtol, atol) \
+    EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, rtol, atol, false)
 #define EXPECT_ARRAY_ALL_CLOSE5(a, b, rtol, atol, equal_nan) \
     EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, rtol, atol, equal_nan)
 #define EXPECT_ARRAY_ALL_CLOSE(...)                                                                                            \
@@ -136,6 +137,7 @@ void ExpectDataEqual(T expected, const Array& actual) {
     (__VA_ARGS__)
 
 // Expects that the arrays a and b have distint array bodies.
-#define EXPECT_ARRAY_HAVE_DISTINCT_ARRAY_NODES(a, b) EXPECT_PRED_FORMAT2(::chainerx::testing::testing_internal::HaveDistinctArrayNodes, a, b)
+#define EXPECT_ARRAY_HAVE_DISTINCT_ARRAY_NODES(a, b) \
+    EXPECT_PRED_FORMAT2(::chainerx::testing::testing_internal::HaveDistinctArrayNodes, a, b)
 
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/testing/array_check.h
+++ b/chainerx_cc/chainerx/testing/array_check.h
@@ -120,22 +120,22 @@ void ExpectDataEqual(T expected, const Array& actual) {
 }  // namespace testing
 
 // Expects that given arrays have same elements and that they belong to the same device.
-#define EXPECT_ARRAY_EQ(a, b) EXPECT_PRED_FORMAT2(testing::testing_internal::IsEqual, a, b)
+#define EXPECT_ARRAY_EQ(a, b) EXPECT_PRED_FORMAT2(::chainerx::testing::testing_internal::IsEqual, a, b)
 
 // Expects that the given arrays have elements that are all close to each other and that they belong to the same device.
 //
 // GET_MACRO is used to "overload" EXPECT_ARRAY_ALL_CLOSE with optional arguments.
 #define GET_MACRO(_1, _2, _3, _4, _5, NAME, ...) NAME
-#define EXPECT_ARRAY_ALL_CLOSE2(a, b) EXPECT_PRED_FORMAT5(testing::testing_internal::IsAllClose, a, b, 1e-5, 1e-8, false)
-#define EXPECT_ARRAY_ALL_CLOSE3(a, b, rtol) EXPECT_PRED_FORMAT5(testing::testing_internal::IsAllClose, a, b, rtol, 1e-8, false)
-#define EXPECT_ARRAY_ALL_CLOSE4(a, b, rtol, atol) EXPECT_PRED_FORMAT5(testing::testing_internal::IsAllClose, a, b, rtol, atol, false)
+#define EXPECT_ARRAY_ALL_CLOSE2(a, b) EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, 1e-5, 1e-8, false)
+#define EXPECT_ARRAY_ALL_CLOSE3(a, b, rtol) EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, rtol, 1e-8, false)
+#define EXPECT_ARRAY_ALL_CLOSE4(a, b, rtol, atol) EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, rtol, atol, false)
 #define EXPECT_ARRAY_ALL_CLOSE5(a, b, rtol, atol, equal_nan) \
-    EXPECT_PRED_FORMAT5(testing::testing_internal::IsAllClose, a, b, rtol, atol, equal_nan)
+    EXPECT_PRED_FORMAT5(::chainerx::testing::testing_internal::IsAllClose, a, b, rtol, atol, equal_nan)
 #define EXPECT_ARRAY_ALL_CLOSE(...)                                                                                            \
     GET_MACRO(__VA_ARGS__, EXPECT_ARRAY_ALL_CLOSE5, EXPECT_ARRAY_ALL_CLOSE4, EXPECT_ARRAY_ALL_CLOSE3, EXPECT_ARRAY_ALL_CLOSE2) \
     (__VA_ARGS__)
 
 // Expects that the arrays a and b have distint array bodies.
-#define EXPECT_ARRAY_HAVE_DISTINCT_ARRAY_NODES(a, b) EXPECT_PRED_FORMAT2(testing::testing_internal::HaveDistinctArrayNodes, a, b)
+#define EXPECT_ARRAY_HAVE_DISTINCT_ARRAY_NODES(a, b) EXPECT_PRED_FORMAT2(::chainerx::testing::testing_internal::HaveDistinctArrayNodes, a, b)
 
 }  // namespace chainerx


### PR DESCRIPTION
Since the namespace is incomplete when it's used outside it causes compilation error