### PR TITLE
Support default dtype in sentiment example's recursive minibatch version

### DIFF
--- a/examples/sentiment/train_recursive_minibatch.py
+++ b/examples/sentiment/train_recursive_minibatch.py
@@ -136,8 +136,8 @@ class ThinStackRecursiveNet(chainer.Chain):
         count = 0
         correct = 0
 
-        stack = self.xp.zeros(
-            (batch, maxlen * 2, self.n_units), self.xp.float32)
+        dtype = chainer.get_dtype()
+        stack = self.xp.zeros((batch, maxlen * 2, self.n_units), dtype)
         for i, (word, label) in enumerate(zip(sequences, leaf_labels)):
             batch = word.shape[0]
             es = self.leaf(word)


### PR DESCRIPTION
Rel #6168.

This PR fixes the sentiment example's recursive minibatch version, `train_recursive_minibatch.py`, to support the default dtype feature so that it works in FP16 mode.
