### PR TITLE
Add ChainerX build option to use cuDNN from CuPy installation 

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -19,6 +19,15 @@ option(CHAINERX_BUILD_EXAMPLES "Build examples" OFF)
 option(CHAINERX_WARNINGS_AS_ERRORS "Make all warnings of compilers into errors" ON)
 option(CHAINERX_ENABLE_THREAD_SANITIZER "Enable thread sanitizer." OFF)
 
+# CHAINERX_CUDNN_USE_CUPY
+if(DEFINED ENV{CHAINERX_CUDNN_USE_CUPY})
+    set(DEFAULT_CHAINERX_CUDNN_USE_CUPY $ENV{CHAINERX_CUDNN_USE_CUPY})
+else()
+    set(DEFAULT_CHAINERX_CUDNN_USE_CUPY OFF)
+endif()
+option(CHAINERX_CUDNN_USE_CUPY "Use existing CuPy installation for cuDNN headers and libraries" ${DEFAULT_CHAINERX_CUDNN_USE_CUPY})
+
+# CHAINERX_ENABLE_COVERAGE
 if(DEFINED ENV{CHAINERX_ENABLE_COVERAGE})
     set(DEFAULT_CHAINERX_ENABLE_COVERAGE $ENV{CHAINERX_ENABLE_COVERAGE})
 else()
@@ -26,6 +35,7 @@ else()
 endif()
 option(CHAINERX_ENABLE_COVERAGE "Enable test coverage with gcov" ${DEFAULT_CHAINERX_ENABLE_COVERAGE})
 
+# CHAINERX_BUILD_CUDA
 if(DEFINED ENV{CHAINERX_BUILD_CUDA})
     set(DEFAULT_CHAINERX_BUILD_CUDA $ENV{CHAINERX_BUILD_CUDA})
 else()
@@ -37,6 +47,7 @@ option(CHAINERX_BUILD_CUDA "Build CUDA backend (if CUDA is available)" ${DEFAULT
 # Supposed usage is to avoid slowness of PTX JIT compilation on development.
 set(CHAINERX_NVCC_GENERATE_CODE "$ENV{CHAINERX_NVCC_GENERATE_CODE}" CACHE STRING "nvcc --generate-code option")
 
+# CHAINERX_ENABLE_BLAS
 if(DEFINED ENV{CHAINERX_ENABLE_BLAS})
     set(DEFAULT_CHAINERX_ENABLE_BLAS $ENV{CHAINERX_ENABLE_BLAS})
 else()
@@ -67,6 +78,33 @@ if(${CHAINERX_BUILD_CUDA})
         # This is because cublas_device was deprecated in CUDA 9.2, but FindCUDA supported it in 3.12.2.
         set(CUDA_cublas_device_LIBRARY ${CUDA_LIBRARIES})
         add_definitions(-DCHAINERX_ENABLE_CUDA=1)
+
+        # If CHAINERX_CUDNN_USE_CUPY is set, retrieve cuDNN files from CuPy installation.
+        if(CHAINERX_CUDNN_USE_CUPY)
+            execute_process(
+                # This counts on sys.stdout.write to raise an error if None is given, resulting ret != 0.
+                COMMAND python -c "import sys, cupyx; info = cupyx.runtime.get_install_info(); sys.stdout.write(info.get_data_path('include'))"
+                OUTPUT_VARIABLE CUDNN_INCLUDE_DIR
+                RESULT_VARIABLE ret)
+            if(NOT ret EQUAL 0)
+                message(FATAL_ERROR "Failed to retrieve cuDNN include directory from CuPy installation.")
+            endif()
+            execute_process(
+                # The same as above about sys.stdout.write.
+                COMMAND python -c "import sys, cupyx; info = cupyx.runtime.get_install_info(); sys.stdout.write(info.get_data_path('lib'))"
+                OUTPUT_VARIABLE CUDNN_LIB_DIR
+                RESULT_VARIABLE ret)
+            if(NOT ret EQUAL 0)
+                message(FATAL_ERROR "Failed to retrieve cuDNN library directory from CuPy installation.")
+            endif()
+            # find_library() cannot find the library file 'libcudnn.so.<ver>' without a symlink 'libcudnn.so', which CuPy does not provide due to pip restriction.
+            # Here using glob to actively find the target file.
+            file(GLOB CUDNN_LIBRARY ${CUDNN_LIB_DIR}/libcudnn.so*)
+            if(NOT CUDNN_LIBRARY)
+                message(FATAL_ERROR "Could not find libcudnn shared library in ${CUDNN_LIB_DIR}.")
+            endif()
+        endif()
+
         find_package(CuDNN 7 REQUIRED)
         include_directories(${CUDNN_INCLUDE_DIRS})
         if(NOT CHAINERX_NVCC_GENERATE_CODE STREQUAL "")


### PR DESCRIPTION
Fixes #7408

Requires ~#7441~ and ~https://github.com/cupy/cupy/pull/2245~

If `CHAINERX_CUDNN_USE_CUPY` (either environment variable or cmake `-D` option) is set, cmake script tries to find installed cupy package and use `cudnn.h` and `libcudnn.so.<ver>` in its installation.