### PR TITLE
Add nearest mode to resize_images

### DIFF
--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -171,11 +171,40 @@ def interpolate_grad_bilinear_gpu(gy, v, u, vw, uw, H, W):
     return gx.reshape((B, C, H, W))
 
 
+def compute_indices_and_weights(out_size, in_size, mode, align_corners, xp):
+    out_H, out_W = out_size
+    H, W = in_size
+    if mode == 'bilinear':
+        if align_corners:
+            v = xp.arange(out_H, dtype=numpy.float) * (H - 1) / (out_H - 1)
+            u = xp.arange(out_W, dtype=numpy.float) * (W - 1) / (out_W - 1)
+        else:
+            v = (xp.arange(out_H, dtype=numpy.float) + 0.5) * H / out_H - 0.5
+            v = xp.maximum(v, 0)
+            u = (xp.arange(out_W, dtype=numpy.float) + 0.5) * W / out_W - 0.5
+            u = xp.maximum(u, 0)
+        vw, v = xp.modf(v)
+        uw, u = xp.modf(u)
+    elif mode == 'nearest':
+        y_scale = H / out_H
+        x_scale = W / out_W
+
+        v = xp.minimum(xp.floor(
+            xp.arange(out_H, dtype=numpy.float) * y_scale), H - 1)
+        u = xp.minimum(xp.floor(
+            xp.arange(out_W, dtype=numpy.float) * x_scale), W - 1)
+        vw = xp.zeros_like(v)
+        uw = xp.zeros_like(u)
+    return v, u, vw, uw
+
+
 class ResizeImages(function_node.FunctionNode):
 
-    def __init__(self, output_shape, align_corners):
+    def __init__(self, output_shape, mode, align_corners):
         self.out_H = output_shape[0]
         self.out_W = output_shape[1]
+        assert mode in ['bilinear', 'nearest']
+        self.mode = mode
         self.align_corners = align_corners
 
     def check_type_forward(self, in_types):
@@ -191,20 +220,9 @@ class ResizeImages(function_node.FunctionNode):
         x, = inputs
         xp = backend.get_array_module(x)
 
-        _, C, H, W = x.shape
-        out_H, out_W = self.out_H, self.out_W
-
-        # Compute indices and weights.
-        if self.align_corners:
-            v = xp.arange(out_H, dtype=numpy.float) * (H - 1) / (out_H - 1)
-            u = xp.arange(out_W, dtype=numpy.float) * (W - 1) / (out_W - 1)
-        else:
-            v = (xp.arange(out_H, dtype=numpy.float) + 0.5) * H / out_H - 0.5
-            v = xp.maximum(v, 0)
-            u = (xp.arange(out_W, dtype=numpy.float) + 0.5) * W / out_W - 0.5
-            u = xp.maximum(u, 0)
-        vw, v = xp.modf(v)
-        uw, u = xp.modf(u)
+        v, u, vw, uw = compute_indices_and_weights(
+            (self.out_H, self.out_W), x.shape[2:],
+            self.mode, self.align_corners, xp)
         v = v.astype(numpy.intp)
         u = u.astype(numpy.intp)
         vw = vw.astype(x.dtype)
@@ -225,15 +243,18 @@ class ResizeImages(function_node.FunctionNode):
     def backward(self, indexes, grad_outputs):
         return ResizeImagesGrad(
             self.inputs[0].shape,
-            (self.out_H, self.out_W), self.align_corners).apply(grad_outputs)
+            (self.out_H, self.out_W),
+            self.mode, self.align_corners).apply(grad_outputs)
 
 
 class ResizeImagesGrad(function_node.FunctionNode):
 
-    def __init__(self, input_shape, output_shape, align_corners):
+    def __init__(self, input_shape, output_shape, mode, align_corners):
         self.out_H = output_shape[0]
         self.out_W = output_shape[1]
         self.input_shape = input_shape
+        assert mode in ['bilinear', 'nearest']
+        self.mode = mode
         self.align_corners = align_corners
 
     def check_type_forward(self, in_types):
@@ -250,19 +271,10 @@ class ResizeImagesGrad(function_node.FunctionNode):
         xp = backend.get_array_module(gy)
 
         _, C, H, W = self.input_shape
-        out_H, out_W = self.out_H, self.out_W
 
-        # Compute indices and weights.
-        if self.align_corners:
-            v = xp.arange(out_H, dtype=numpy.float) * (H - 1) / (out_H - 1)
-            u = xp.arange(out_W, dtype=numpy.float) * (W - 1) / (out_W - 1)
-        else:
-            v = (xp.arange(out_H) + 0.5) * H / out_H - 0.5
-            v = xp.maximum(v, 0)
-            u = (xp.arange(out_W) + 0.5) * W / out_W - 0.5
-            u = xp.maximum(u, 0)
-        vw, v = xp.modf(v)
-        uw, u = xp.modf(u)
+        v, u, vw, uw = compute_indices_and_weights(
+            (self.out_H, self.out_W), (H, W),
+            self.mode, self.align_corners, xp)
         v = v.astype(numpy.intp)
         u = u.astype(numpy.intp)
         vw = vw.astype(gy.dtype)
@@ -282,10 +294,10 @@ class ResizeImagesGrad(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         return ResizeImages(
-            (self.out_H, self.out_W), self.align_corners).apply(grad_outputs)
+            (self.out_H, self.out_W), self.mode, self.align_corners).apply(grad_outputs)
 
 
-def resize_images(x, output_shape, align_corners=True):
+def resize_images(x, output_shape, mode='bilinear', align_corners=True):
     """Resize images to the given shape.
 
     This function resizes 2D data to :obj:`output_shape`.
@@ -306,6 +318,7 @@ def resize_images(x, output_shape, align_corners=True):
         output_shape (tuple): This is a tuple of length 2 whose values are
             :obj:`(h_O, w_O)`. Note that the order of height and width is
             opposite of the one in OpenCV.
+        mode ({\'bilinear\', \'nearest\'}): Defines the sampling rule.
         align_corners (bool): When this value is :obj:`True`,
             the corners of the input are mapped to the corners of
             the output.
@@ -315,4 +328,4 @@ def resize_images(x, output_shape, align_corners=True):
             :math:`(n, c_I, h_O, w_O)`.
 
     """
-    return ResizeImages(output_shape, align_corners).apply((x,))[0]
+    return ResizeImages(output_shape, mode, align_corners).apply((x,))[0]

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -297,7 +297,8 @@ class ResizeImagesGrad(function_node.FunctionNode):
 
     def backward(self, indexes, grad_outputs):
         return ResizeImages(
-            (self.out_H, self.out_W), self.mode, self.align_corners).apply(grad_outputs)
+            (self.out_H, self.out_W),
+            self.mode, self.align_corners).apply(grad_outputs)
 
 
 def resize_images(x, output_shape, mode='bilinear', align_corners=True):

--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -176,19 +176,22 @@ def compute_indices_and_weights(out_size, in_size, mode, align_corners, xp):
     H, W = in_size
     if mode == 'bilinear':
         if align_corners:
-            v = xp.arange(out_H, dtype=numpy.float) * (H - 1) / (out_H - 1)
-            u = xp.arange(out_W, dtype=numpy.float) * (W - 1) / (out_W - 1)
+            y_scale = (H - 1) / (out_H - 1)
+            x_scale = (W - 1) / (out_W - 1)
+            v = xp.arange(out_H, dtype=numpy.float) * y_scale
+            u = xp.arange(out_W, dtype=numpy.float) * x_scale
         else:
-            v = (xp.arange(out_H, dtype=numpy.float) + 0.5) * H / out_H - 0.5
+            y_scale = H / out_H
+            x_scale = W / out_W
+            v = (xp.arange(out_H, dtype=numpy.float) + 0.5) * y_scale - 0.5
             v = xp.maximum(v, 0)
-            u = (xp.arange(out_W, dtype=numpy.float) + 0.5) * W / out_W - 0.5
+            u = (xp.arange(out_W, dtype=numpy.float) + 0.5) * x_scale - 0.5
             u = xp.maximum(u, 0)
         vw, v = xp.modf(v)
         uw, u = xp.modf(u)
     elif mode == 'nearest':
         y_scale = H / out_H
         x_scale = W / out_W
-
         v = xp.minimum(xp.floor(
             xp.arange(out_H, dtype=numpy.float) * y_scale), H - 1)
         u = xp.minimum(xp.floor(

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -148,7 +148,7 @@ class TestResizeImagesForwardUpScale(testing.FunctionTestCase):
         return y,
 
 
-class TestResizeImagesForwardMultiLines(unittest.TestCase):
+class TestResizeImagesForwardMultiLinesAlignCorners(unittest.TestCase):
 
     in_shape = (1, 1, 987, 123)
     output_shape = (1, 1, 765, 345)

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -11,6 +11,7 @@ from chainer.testing import attr
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
+    'mode': ['bilinear', 'nearest'],
     'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
@@ -46,13 +47,14 @@ class TestResizeImagesForwardIdentity(testing.FunctionTestCase):
         x, = inputs
         output_shape = self.in_shape[2:]
         y = functions.resize_images(
-            x, output_shape, align_corners=self.align_corners)
+            x, output_shape, self.mode, align_corners=self.align_corners)
         return y,
 
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 2, 4, 4)],
     'output_shape': [(2, 2, 2, 2)],
+    'mode': ['bilinear', 'nearest'],
     'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
@@ -94,7 +96,8 @@ class TestResizeImagesForwardDownScale(testing.FunctionTestCase):
     def forward(self, inputs, device):
         x, = inputs
         output_shape = self.output_shape[2:]
-        y = functions.resize_images(x, output_shape, self.align_corners)
+        y = functions.resize_images(
+            x, output_shape, self.mode, self.align_corners)
         return y,
 
 
@@ -121,7 +124,7 @@ class TestResizeImagesForwardDownScale(testing.FunctionTestCase):
         'chainerx_device': ['native:0', 'cuda:0', 'cuda:1'],
     })
 )
-class TestResizeImagesForwardUpScale(testing.FunctionTestCase):
+class TestResizeImagesForwardUpScaleBilnear(testing.FunctionTestCase):
 
     def generate_inputs(self):
         x = numpy.zeros(self.in_shape, dtype=numpy.float32)
@@ -177,6 +180,7 @@ class TestResizeImagesForwardMultiLinesAlignCorners(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
     'output_shape': [(10, 5), (3, 4)],
+    'mode': ['bilinear', 'nearest'],
     'align_corners': [False, True],
 }))
 class TestResizeImagesBackward(unittest.TestCase):
@@ -192,7 +196,8 @@ class TestResizeImagesBackward(unittest.TestCase):
 
     def check_backward(self, x, output_shape, gy):
         def f(x):
-            return functions.resize_images(x, output_shape, self.align_corners)
+            return functions.resize_images(
+                x, output_shape, self.mode, self.align_corners)
 
         gradient_check.check_backward(
             f, x, gy, dtype='d', atol=1e-2, rtol=1e-3, eps=1e-5)
@@ -207,7 +212,8 @@ class TestResizeImagesBackward(unittest.TestCase):
 
     def check_double_backward(self, x, output_shape, gy, ggx):
         def f(x):
-            return functions.resize_images(x, output_shape, self.align_corners)
+            return functions.resize_images(
+                x, output_shape, self.mode, self.align_corners)
 
         gradient_check.check_double_backward(
             f, x, gy, ggx, atol=1e-2, rtol=1e-3)

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -11,6 +11,7 @@ from chainer.testing import attr
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
+    'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
     None,
@@ -44,13 +45,15 @@ class TestResizeImagesForwardIdentity(testing.FunctionTestCase):
     def forward(self, inputs, device):
         x, = inputs
         output_shape = self.in_shape[2:]
-        y = functions.resize_images(x, output_shape)
+        y = functions.resize_images(
+            x, output_shape, align_corners=self.align_corners)
         return y,
 
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 2, 4, 4)],
     'output_shape': [(2, 2, 2, 2)],
+    'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
     None,
@@ -91,13 +94,14 @@ class TestResizeImagesForwardDownScale(testing.FunctionTestCase):
     def forward(self, inputs, device):
         x, = inputs
         output_shape = self.output_shape[2:]
-        y = functions.resize_images(x, output_shape)
+        y = functions.resize_images(x, output_shape, self.align_corners)
         return y,
 
 
 @testing.parameterize(*testing.product({
     'in_shape': [(1, 1, 2, 2)],
-    'output_shape': [(1, 1, 3, 3)]
+    'output_shape': [(1, 1, 3, 3)],
+    'align_corners': [True, False],
 }))
 @testing.inject_backend_tests(
     None,
@@ -139,7 +143,8 @@ class TestResizeImagesForwardUpScale(testing.FunctionTestCase):
     def forward(self, inputs, device):
         x, = inputs
         output_shape = self.output_shape[2:]
-        y = functions.resize_images(x, output_shape)
+        y = functions.resize_images(
+            x, output_shape, align_corners=self.align_corners)
         return y,
 
 
@@ -171,7 +176,8 @@ class TestResizeImagesForwardMultiLines(unittest.TestCase):
 
 @testing.parameterize(*testing.product({
     'in_shape': [(2, 3, 8, 6), (2, 1, 4, 6)],
-    'output_shape': [(10, 5), (3, 4)]
+    'output_shape': [(10, 5), (3, 4)],
+    'align_corners': [False, True],
 }))
 class TestResizeImagesBackward(unittest.TestCase):
 
@@ -186,7 +192,7 @@ class TestResizeImagesBackward(unittest.TestCase):
 
     def check_backward(self, x, output_shape, gy):
         def f(x):
-            return functions.resize_images(x, output_shape)
+            return functions.resize_images(x, output_shape, self.align_corners)
 
         gradient_check.check_backward(
             f, x, gy, dtype='d', atol=1e-2, rtol=1e-3, eps=1e-5)
@@ -201,7 +207,7 @@ class TestResizeImagesBackward(unittest.TestCase):
 
     def check_double_backward(self, x, output_shape, gy, ggx):
         def f(x):
-            return functions.resize_images(x, output_shape)
+            return functions.resize_images(x, output_shape, self.align_corners)
 
         gradient_check.check_double_backward(
             f, x, gy, ggx, atol=1e-2, rtol=1e-3)


### PR DESCRIPTION
merge after https://github.com/chainer/chainer/pull/7429

Current implementation of `resize_images` only supports bilinear interpolation.
This PR adds `nearest` interpolation.