### PR TITLE
Add `Sequence` support for `shape` arguments

### DIFF
--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -37,7 +37,7 @@ def generate_array(initializer, shape, xp, dtype=None, device=None):
     Args:
         initializer: A callable object that takes :ref:`ndarray` and edits its
             value.
-        shape (tuple): Shape of a return array.
+        shape (int or tuple of int or None): Shape of a return array.
         xp (module): :mod:`cupy`, :mod:`numpy`, or :mod:`chainerx`.
         dtype: Dtype specifier. If omitted, ``initializer.dtype`` is used.
         device: Target device specifier. If omitted, the current device is

--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -37,7 +37,7 @@ def generate_array(initializer, shape, xp, dtype=None, device=None):
     Args:
         initializer: A callable object that takes :ref:`ndarray` and edits its
             value.
-        shape (int or tuple of int): Shape of a return array.
+        shape (tuple): Shape of a return array.
         xp (module): :mod:`cupy`, :mod:`numpy`, or :mod:`chainerx`.
         dtype: Dtype specifier. If omitted, ``initializer.dtype`` is used.
         device: Target device specifier. If omitted, the current device is

--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -37,7 +37,7 @@ def generate_array(initializer, shape, xp, dtype=None, device=None):
     Args:
         initializer: A callable object that takes :ref:`ndarray` and edits its
             value.
-        shape (int or tuple of int or None): Shape of a return array.
+        shape (int or tuple of int): Shape of a return array.
         xp (module): :mod:`cupy`, :mod:`numpy`, or :mod:`chainerx`.
         dtype: Dtype specifier. If omitted, ``initializer.dtype`` is used.
         device: Target device specifier. If omitted, the current device is

--- a/chainerx/__init__.pyi
+++ b/chainerx/__init__.pyi
@@ -298,7 +298,7 @@ class ndarray:
 
     def __init__(
             self,
-            shape: tp.Tuple[int, ...],
+            shape: tp.Union[int, tp.Sequence[int]],
             dtype: tp.Any,
             device: tp.Optional[Device]=None) -> None: ...
 
@@ -420,10 +420,7 @@ class ndarray:
             backprop_id: tp.Optional[BackpropId]=None) -> ndarray: ...
 
     @tp.overload
-    def reshape(self, arg0: tp.Tuple[int, ...]) -> ndarray: ...
-
-    @tp.overload
-    def reshape(self, arg0: tp.List[int]) -> ndarray: ...
+    def reshape(self, arg0: tp.Union[int, tp.Sequence[int]]) -> ndarray: ...
 
     @tp.overload
     def reshape(self, *args: tp.Any) -> ndarray: ...
@@ -809,7 +806,7 @@ def negative(x: ndarray) -> ndarray: ...
 def not_equal(x1: ndarray, x2: ndarray) -> ndarray: ...
 
 
-def ones(shape: tp.Union[int, tp.Tuple[int, ...]],
+def ones(shape: tp.Union[int, tp.Sequence[int]],
          dtype: tp.Optional[tp.Any]=None,
          device: tp.Optional[Device]=None) -> ndarray: ...
 
@@ -817,16 +814,9 @@ def ones(shape: tp.Union[int, tp.Tuple[int, ...]],
 def ones_like(a: ndarray, device: tp.Optional[Device]=None) -> ndarray: ...
 
 
-@tp.overload
 def reshape(
         a: ndarray,
-        newshape: tp.Union[int, tp.Tuple[int, ...]]) -> ndarray: ...
-
-
-@tp.overload
-def reshape(
-        a: ndarray,
-        newshape: tp.Union[int, tp.List[int]]) -> ndarray: ...
+        newshape: tp.Union[int, tp.Sequence[int]]) -> ndarray: ...
 
 
 @tp.overload
@@ -906,7 +896,7 @@ def where(cond: ndarray, x: ndarray, y: ndarray) -> ndarray: ...
 
 
 def zeros(
-        shape: tp.Union[int, tp.Tuple[int, ...]],
+        shape: tp.Union[int, tp.Sequence[int]],
         dtype: tp.Optional[tp.Any]=None,
         device: tp.Optional[Device]=None) -> ndarray: ...
 
@@ -940,7 +930,7 @@ def fromfile(
 
 def fromfunction(
         function: tp.Callable[..., tp.Any],
-        shape: tp.Tuple[int, ...],
+        shape: tp.Union[int, tp.Sequence[int]],
         **kwargs: tp.Any) -> ndarray: ...
 
 

--- a/chainerx_cc/chainerx/python/array.cc
+++ b/chainerx_cc/chainerx/python/array.cc
@@ -159,7 +159,7 @@ ArrayBodyPtr MakeArray(py::handle object, const nonstd::optional<Dtype>& dtype, 
 void InitChainerxArray(pybind11::module& m) {
     py::class_<ArrayBody, ArrayBodyPtr> c{m, "ndarray", py::buffer_protocol()};
     // TODO(hvy): Support all arguments in the constructor of numpy.ndarray.
-    c.def(py::init([](const py::tuple& shape, py::handle dtype, py::handle device) {
+    c.def(py::init([](py::handle shape, py::handle dtype, py::handle device) {
               return MoveArrayBody(Empty(ToShape(shape), GetDtype(dtype), GetDevice(device)));
           }),
           py::arg("shape"),
@@ -175,7 +175,7 @@ void InitChainerxArray(pybind11::module& m) {
     // TODO(niboshi): Remove this once it will be possible to import cupy.ndarray using chx.array / chx.asarray.
     m.def("_fromrawpointer",
           [](intptr_t ptr,
-             const py::tuple& shape,
+             py::handle shape,
              py::handle dtype,
              const py::tuple& strides,
              py::handle device,
@@ -268,7 +268,7 @@ void InitChainerxArray(pybind11::module& m) {
           },
           py::arg("axes") = nullptr);
     c.def("transpose", [](const ArrayBodyPtr& self, py::args args) { return MoveArrayBody(Array{self}.Transpose(ToAxes(args))); });
-    c.def("reshape", [](const ArrayBodyPtr& self, py::tuple shape) { return MoveArrayBody(Array{self}.Reshape(ToShape(shape))); });
+    c.def("reshape", [](const ArrayBodyPtr& self, py::handle shape) { return MoveArrayBody(Array{self}.Reshape(ToShape(shape))); });
     c.def("reshape", [](const ArrayBodyPtr& self, const std::vector<int64_t>& shape) {
         return MoveArrayBody(Array{self}.Reshape({shape.begin(), shape.end()}));
     });

--- a/chainerx_cc/chainerx/python/array.cc
+++ b/chainerx_cc/chainerx/python/array.cc
@@ -174,13 +174,8 @@ void InitChainerxArray(pybind11::module& m) {
     // This is currently for internal use (from Chainer) to support CuPy.
     // TODO(niboshi): Remove this once it will be possible to import cupy.ndarray using chx.array / chx.asarray.
     m.def("_fromrawpointer",
-          [](intptr_t ptr,
-             py::handle shape,
-             py::handle dtype,
-             const py::tuple& strides,
-             py::handle device,
-             int64_t offset,
-             py::object base) -> ArrayBodyPtr {
+          [](intptr_t ptr, py::handle shape, py::handle dtype, const py::tuple& strides, py::handle device, int64_t offset, py::object base)
+                  -> ArrayBodyPtr {
               // TODO(niboshi): Expose `base` as `ndarray.base` attribute.
               void* c_ptr = reinterpret_cast<void*>(ptr);  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
               // Note that inc_ref() / dec_ref() is performed by the lambda capture.

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -118,14 +118,7 @@ void InitChainerxCreation(pybind11::module& m) {
           py::arg("device") = nullptr);
     m.def("empty",
           [](py::handle shape, py::handle dtype, py::handle device) {
-              if (py::isinstance<py::sequence>(shape)) {
-                  return MoveArrayBody(Empty(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype),
-                      GetDevice(device)));
-              } else if (py::isinstance<py::int_>(shape)) {
-                  int64_t dim = shape.cast<int64_t>();
-                  return MoveArrayBody(Empty(Shape{dim}, dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype),
-                      GetDevice(device)));
-              }
+              return MoveArrayBody(Empty(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
           py::arg("shape"),
           py::arg("dtype") = nullptr,

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -124,7 +124,7 @@ void InitChainerxCreation(pybind11::module& m) {
           py::arg("dtype") = nullptr,
           py::arg("device") = nullptr);
     m.def("full",
-          [](py::tuple shape, Scalar fill_value, py::handle dtype, py::handle device) {
+          [](py::handle shape, Scalar fill_value, py::handle dtype, py::handle device) {
               return MoveArrayBody(Full(ToShape(shape), fill_value, GetDtype(dtype), GetDevice(device)));
           },
           py::arg("shape"),
@@ -140,7 +140,7 @@ void InitChainerxCreation(pybind11::module& m) {
           py::arg("dtype"),
           py::arg("device") = nullptr);
     m.def("full",
-          [](py::tuple shape, Scalar fill_value, py::handle device) {
+          [](py::handle shape, Scalar fill_value, py::handle device) {
               return MoveArrayBody(Full(ToShape(shape), fill_value, GetDevice(device)));
           },
           py::arg("shape"),
@@ -152,7 +152,7 @@ void InitChainerxCreation(pybind11::module& m) {
           py::arg("fill_value"),
           py::arg("device") = nullptr);
     m.def("zeros",
-          [](py::tuple shape, py::handle dtype, py::handle device) {
+          [](py::handle shape, py::handle dtype, py::handle device) {
               return MoveArrayBody(Zeros(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
           py::arg("shape"),
@@ -166,7 +166,7 @@ void InitChainerxCreation(pybind11::module& m) {
           py::arg("dtype") = nullptr,
           py::arg("device") = nullptr);
     m.def("ones",
-          [](py::tuple shape, py::handle dtype, py::handle device) {
+          [](py::handle shape, py::handle dtype, py::handle device) {
               return MoveArrayBody(Ones(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
           py::arg("shape"),
@@ -431,7 +431,7 @@ void InitChainerxManipulation(pybind11::module& m) {
           py::arg("axis"),
           py::arg("start") = 0);
     m.def("reshape",
-          [](const ArrayBodyPtr& a, py::tuple newshape) { return MoveArrayBody(Reshape(Array{a}, ToShape(newshape))); },
+          [](const ArrayBodyPtr& a, py::handle newshape) { return MoveArrayBody(Reshape(Array{a}, ToShape(newshape))); },
           py::arg("a"),
           py::arg("newshape"));
     m.def("reshape",
@@ -468,7 +468,7 @@ void InitChainerxManipulation(pybind11::module& m) {
           py::arg("axis1"),
           py::arg("axis2"));
     m.def("broadcast_to",
-          [](const ArrayBodyPtr& array, py::tuple shape) { return MoveArrayBody(Array{array}.BroadcastTo(ToShape(shape))); },
+          [](const ArrayBodyPtr& array, py::handle shape) { return MoveArrayBody(Array{array}.BroadcastTo(ToShape(shape))); },
           py::arg("array"),
           py::arg("shape"));
     m.def("concatenate",

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -117,15 +117,15 @@ void InitChainerxCreation(pybind11::module& m) {
           py::arg("dtype") = nullptr,
           py::arg("device") = nullptr);
     m.def("empty",
-          [](py::tuple shape, py::handle dtype, py::handle device) {
-              return MoveArrayBody(Empty(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
-          },
-          py::arg("shape"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
-    m.def("empty",
-          [](py::int_ dim, py::handle dtype, py::handle device) {
-              return MoveArrayBody(Empty(Shape{dim}, dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
+          [](py::handle shape, py::handle dtype, py::handle device) {
+              if (py::isinstance<py::sequence>(shape)) {
+                  return MoveArrayBody(Empty(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype),
+                      GetDevice(device)));
+              } else if (py::isinstance<py::int_>(shape)) {
+                  int64_t dim = shape.cast<int64_t>();
+                  return MoveArrayBody(Empty(Shape{dim}, dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype),
+                      GetDevice(device)));
+              }
           },
           py::arg("shape"),
           py::arg("dtype") = nullptr,

--- a/chainerx_cc/chainerx/python/shape.cc
+++ b/chainerx_cc/chainerx/python/shape.cc
@@ -12,7 +12,7 @@ namespace python_internal {
 
 namespace py = pybind11;
 
-Shape ToShape(const py::tuple& tup) {
+Shape ToShape(const py::sequence& tup) {
     Shape shape{};
     std::transform(tup.begin(), tup.end(), std::back_inserter(shape), [](auto& item) { return py::cast<int64_t>(item); });
     return shape;

--- a/chainerx_cc/chainerx/python/shape.cc
+++ b/chainerx_cc/chainerx/python/shape.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace chainerx {
 namespace python {

--- a/chainerx_cc/chainerx/python/shape.cc
+++ b/chainerx_cc/chainerx/python/shape.cc
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "chainerx/shape.h"
+
 namespace chainerx {
 namespace python {
 namespace python_internal {
@@ -18,13 +20,13 @@ Shape ToShape(py::handle shape) {
         try {
             seq = py::cast<std::vector<int64_t>>(shape);
         } catch (const py::cast_error& e) {
-            throw py::type_error{std::string{"shape not understood: "} + py::cast<std::string>(py::repr(shape))};
+            throw py::type_error{"shape not understood: " + py::cast<std::string>(py::repr(shape))};
         }
         return Shape{seq};
     } else if (py::isinstance<py::int_>(shape)) {
         return Shape{shape.cast<int64_t>()};
     } else {
-        throw py::type_error{"only integer and sequence are valid shape"};
+        throw py::type_error{"expected sequence object or a single integer"};
     }
 }
 

--- a/chainerx_cc/chainerx/python/shape.cc
+++ b/chainerx_cc/chainerx/python/shape.cc
@@ -12,14 +12,17 @@ namespace python_internal {
 
 namespace py = pybind11;
 
-Shape ToShape(const py::handle& object) {
-    if (py::isinstance<py::sequence>(object)) {
-        Shape shape{};
-        py::sequence& seq = object;
-        std::transform(seq.begin(), seq.end(), std::back_inserter(shape), [](auto& item) { return py::cast<int64_t>(item); });
-        return shape;
-    } else if (py::isinstance<py::int_>(object)) {
-        return Shape{object.cast<int64_t>()};
+Shape ToShape(py::handle shape) {
+    if (py::isinstance<py::sequence>(shape)) {
+        std::vector<int64_t> seq{};
+        try {
+            seq = py::cast<std::vector<int64_t>>(shape);
+        } catch (const py::cast_error& e) {
+            throw py::type_error{std::string{"shape not understood: "} + py::cast<std::string>(py::repr(shape))};
+        }
+        return Shape{seq};
+    } else if (py::isinstance<py::int_>(shape)) {
+        return Shape{shape.cast<int64_t>()};
     } else {
         throw py::type_error{"only integer and sequence are valid shape"};
     }

--- a/chainerx_cc/chainerx/python/shape.cc
+++ b/chainerx_cc/chainerx/python/shape.cc
@@ -12,10 +12,17 @@ namespace python_internal {
 
 namespace py = pybind11;
 
-Shape ToShape(const py::sequence& tup) {
-    Shape shape{};
-    std::transform(tup.begin(), tup.end(), std::back_inserter(shape), [](auto& item) { return py::cast<int64_t>(item); });
-    return shape;
+Shape ToShape(const py::handle& object) {
+    if (py::isinstance<py::sequence>(object)) {
+        Shape shape{};
+        py::sequence& seq = object;
+        std::transform(seq.begin(), seq.end(), std::back_inserter(shape), [](auto& item) { return py::cast<int64_t>(item); });
+        return shape;
+    } else if (py::isinstance<py::int_>(object)) {
+        return Shape{object.cast<int64_t>()};
+    } else {
+        throw py::type_error{"only integer and sequence are valid shape"};
+    }
 }
 
 py::tuple ToTuple(const Shape& shape) {

--- a/chainerx_cc/chainerx/python/shape.cc
+++ b/chainerx_cc/chainerx/python/shape.cc
@@ -4,8 +4,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "chainerx/shape.h"
-
 namespace chainerx {
 namespace python {
 namespace python_internal {

--- a/chainerx_cc/chainerx/python/shape.h
+++ b/chainerx_cc/chainerx/python/shape.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "chainerx/shape.h"
 

--- a/chainerx_cc/chainerx/python/shape.h
+++ b/chainerx_cc/chainerx/python/shape.h
@@ -8,7 +8,7 @@ namespace chainerx {
 namespace python {
 namespace python_internal {
 
-Shape ToShape(const pybind11::tuple& tup);
+Shape ToShape(pybind11::handle shape);
 
 pybind11::tuple ToTuple(const Shape& shape);
 

--- a/chainerx_cc/chainerx/python/testing/device_buffer.cc
+++ b/chainerx_cc/chainerx/python/testing/device_buffer.cc
@@ -50,7 +50,7 @@ private:
 
 void InitChainerxDeviceBuffer(pybind11::module& m) {
     py::class_<PyDeviceBuffer> c{m, "_DeviceBuffer", py::buffer_protocol()};
-    c.def(py::init([](const py::list& list, const py::tuple& shape_tup, const py::handle& dtype_handle, const py::handle& device) {
+    c.def(py::init([](const py::list& list, py::handle shape_tup, const py::handle& dtype_handle, const py::handle& device) {
               Shape shape = python_internal::ToShape(shape_tup);
               int64_t total_size = shape.GetTotalSize();
               if (static_cast<size_t>(total_size) != list.size()) {

--- a/tests/chainerx_tests/conftest.py
+++ b/tests/chainerx_tests/conftest.py
@@ -123,7 +123,10 @@ _shapes = [
     (2, 0, 3),
 ]
 
-_shapes_as_tuple_or_int = _shapes + [0, 1, 5]
+_shapes_as_sequence_or_int = (
+    _shapes
+    + map(lambda t: list(t), _shapes)
+    + [0, 1, 5])
 
 
 @pytest.fixture(params=_shapes)
@@ -131,6 +134,6 @@ def shape(request):
     return request.param
 
 
-@pytest.fixture(params=_shapes_as_tuple_or_int)
-def shape_as_tuple_or_int(request):
+@pytest.fixture(params=_shapes_as_sequence_or_int)
+def shape_as_sequence_or_int(request):
     return request.param

--- a/tests/chainerx_tests/conftest.py
+++ b/tests/chainerx_tests/conftest.py
@@ -125,7 +125,7 @@ _shapes = [
 
 _shapes_as_sequence_or_int = (
     _shapes
-    + map(lambda t: list(t), _shapes)
+    + list(map(lambda t: list(t), _shapes))
     + [0, 1, 5])
 
 

--- a/tests/chainerx_tests/conftest.py
+++ b/tests/chainerx_tests/conftest.py
@@ -125,7 +125,7 @@ _shapes = [
 
 _shapes_as_sequence_or_int = (
     _shapes
-    + list(map(lambda t: list(t), _shapes))
+    + [[], [0]]  # shape as a list instead of tuple
     + [0, 1, 5])
 
 

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -466,13 +466,13 @@ def test_asanyarray_with_device(device):
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
 @chainerx.testing.parametrize_dtype_specifier(
     'dtype_spec', additional_args=(None, Unspecified))
-def test_empty(xp, shape_as_tuple_or_int, dtype_spec, device):
+def test_empty(xp, shape_as_sequence_or_int, dtype_spec, device):
     if xp is numpy and isinstance(dtype_spec, chainerx.dtype):
         dtype_spec = dtype_spec.name
     if dtype_spec is Unspecified:
-        a = xp.empty(shape_as_tuple_or_int)
+        a = xp.empty(shape_as_sequence_or_int)
     else:
-        a = xp.empty(shape_as_tuple_or_int, dtype_spec)
+        a = xp.empty(shape_as_sequence_or_int, dtype_spec)
     a.fill(0)
     if dtype_spec in (None, Unspecified):
         a = dtype_utils.cast_if_numpy_array(xp, a, 'float32')
@@ -513,13 +513,13 @@ def test_empty_like_with_device(device):
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
 @chainerx.testing.parametrize_dtype_specifier(
     'dtype_spec', additional_args=(None, Unspecified))
-def test_zeros(xp, shape_as_tuple_or_int, dtype_spec, device):
+def test_zeros(xp, shape_as_sequence_or_int, dtype_spec, device):
     if xp is numpy and isinstance(dtype_spec, chainerx.dtype):
         dtype_spec = dtype_spec.name
     if dtype_spec is Unspecified:
-        out = xp.zeros(shape_as_tuple_or_int)
+        out = xp.zeros(shape_as_sequence_or_int)
     else:
-        out = xp.zeros(shape_as_tuple_or_int, dtype_spec)
+        out = xp.zeros(shape_as_sequence_or_int, dtype_spec)
     if dtype_spec in (None, Unspecified):
         out = dtype_utils.cast_if_numpy_array(xp, out, 'float32')
     return out
@@ -555,13 +555,13 @@ def test_zeros_like_with_device(device):
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
 @chainerx.testing.parametrize_dtype_specifier(
     'dtype_spec', additional_args=(None, Unspecified))
-def test_ones(xp, shape_as_tuple_or_int, dtype_spec, device):
+def test_ones(xp, shape_as_sequence_or_int, dtype_spec, device):
     if xp is numpy and isinstance(dtype_spec, chainerx.dtype):
         dtype_spec = dtype_spec.name
     if dtype_spec is Unspecified:
-        out = xp.ones(shape_as_tuple_or_int)
+        out = xp.ones(shape_as_sequence_or_int)
     else:
-        out = xp.ones(shape_as_tuple_or_int, dtype_spec)
+        out = xp.ones(shape_as_sequence_or_int, dtype_spec)
     if dtype_spec in (None, Unspecified):
         out = dtype_utils.cast_if_numpy_array(xp, out, 'float32')
     return out
@@ -597,8 +597,8 @@ def test_ones_like_with_device(shape, device):
 @pytest.mark.parametrize(
     'value', [True, False, -2, 0, 1, 2, 2.3, float('inf'), float('nan')])
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
-def test_full(xp, shape_as_tuple_or_int, value, device):
-    out = xp.full(shape_as_tuple_or_int, value)
+def test_full(xp, shape_as_sequence_or_int, value, device):
+    out = xp.full(shape_as_sequence_or_int, value)
     return dtype_utils.cast_if_numpy_array(xp, out, _get_default_dtype(value))
 
 
@@ -1153,8 +1153,9 @@ def test_fromstring(xp, count, sep, dtype_spec, device):
 
 @chainerx.testing.numpy_chainerx_array_equal()
 @pytest.mark.parametrize('device', ['native:0', 'cuda:0'])
+@pytest.mark.parametrize('shape', [(2, 2), [2, 2]])
 @chainerx.testing.parametrize_dtype_specifier('dtype_spec')
-def test_fromfunction(xp, dtype_spec, device):
+def test_fromfunction(xp, shape, dtype_spec, device):
     if xp is numpy and isinstance(dtype_spec, chainerx.dtype):
         dtype_spec = dtype_spec.name
 
@@ -1162,7 +1163,7 @@ def test_fromfunction(xp, dtype_spec, device):
         return i * j + addend
 
     # addend should be passed as a keyword argument to function.
-    return xp.fromfunction(function, (2, 2), dtype=dtype_spec, addend=2)
+    return xp.fromfunction(function, shape, dtype=dtype_spec, addend=2)
 
 
 @chainerx.testing.numpy_chainerx_array_equal()

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -394,6 +394,9 @@ class TestBroadcastTo(op_utils.NumpyOpTest):
     ((3,), (2,)),
     ((3,), (3, 2)),
     ((1, 3), (3, 2)),
+    ((3,), [2]),
+    ((3,), [3, 2]),
+    ((1, 3), [3, 2]),
 ])
 def test_broadcast_to_invalid(xp, src_shape, dst_shape):
     a = xp.ones(src_shape, 'float32')

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -394,9 +394,7 @@ class TestBroadcastTo(op_utils.NumpyOpTest):
     ((3,), (2,)),
     ((3,), (3, 2)),
     ((1, 3), (3, 2)),
-    ((3,), [2]),
-    ((3,), [3, 2]),
-    ((1, 3), [3, 2]),
+    ((3,), [2]),  # shape as a list instead of tuple
 ])
 def test_broadcast_to_invalid(xp, src_shape, dst_shape):
     a = xp.ones(src_shape, 'float32')


### PR DESCRIPTION
- Add `Sequence[int]` support for `shape` arguments in ChainerX functions, which only accept `int` and `Tuple[int]` at the moment.
- Fix tests to check if `shape` is a list of integers

Fixes #7427.

## Note
I added `#include <pybind11/stl.h>` to `chainerx_cc/chainerx/python/shape.h` to avoid the following compilation error. It maybe related to pybind/pybind11#1055.

<details><summary>error message</summary>
<p>

```
    ...
    [ 98%] Building CXX object chainerx/python/CMakeFiles/_core.so.dir/shape.o
    [100%] Linking CXX shared module /home/user/chainer/chainerx/_core.so
    /home/user/chainer/build/temp.linux-x86_64-3.6/pybind11/include/pybind11/stl.h:179:49: error: type ‘struct type_caster’ violates one definition rule [-Werror=odr]
     template <typename Type, typename Alloc> struct type_caster<std::vector<Type, Alloc>>
                                                     ^
    /home/user/chainer/build/temp.linux-x86_64-3.6/pybind11/include/pybind11/cast.h:866:56: note: a type with different bases is defined in another translation unit
     template <typename type, typename SFINAE = void> class type_caster : public type_caster_base<type> { };
                                                            ^
    lto1: all warnings being treated as errors
    lto-wrapper: fatal error: /usr/bin/c++ returned 1 exit status
    compilation terminated.
    /usr/bin/ld: error: lto-wrapper failed
    collect2: error: ld returned 1 exit status
    chainerx/python/CMakeFiles/_core.so.dir/build.make:387: recipe for target '/home/user/chainer/chainerx/_core.so' failed
    make[3]: *** [/home/user/chainer/chainerx/_core.so] Error 1
    CMakeFiles/Makefile2:614: recipe for target 'chainerx/python/CMakeFiles/_core.so.dir/all' failed
    make[2]: *** [chainerx/python/CMakeFiles/_core.so.dir/all] Error 2
    CMakeFiles/Makefile2:626: recipe for target 'chainerx/python/CMakeFiles/_core.so.dir/rule' failed
    make[1]: *** [chainerx/python/CMakeFiles/_core.so.dir/rule] Error 2
    Makefile:281: recipe for target '_core.so' failed
    make: *** [_core.so] Error 2
    /home/user/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'long_description_content_type'
      warnings.warn(msg)
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/user/chainer/setup.py", line 197, in <module>
        setup(**setup_kwargs)
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
        return distutils.core.setup(**attrs)
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/site-packages/setuptools/command/develop.py", line 36, in run
        self.install_for_development()
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/site-packages/setuptools/command/develop.py", line 136, in install_for_development
        self.run_command('build_ext')
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/home/user/chainer/chainerx_build_helper.py", line 37, in run
        self.build_extension(ext)
      File "/home/user/chainer/chainerx_build_helper.py", line 88, in build_extension
        ['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
      File "/home/user/.pyenv/versions/3.6.5/lib/python3.6/subprocess.py", line 291, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['cmake', '--build', '.', '--config', 'Release', '--', '_core.so']' returned non-zero exit status 2.
```

</p>
</details>
