### PR TITLE
Warn NaN in FP16 mode in sentiment example's recursive minibatch version

### DIFF
--- a/examples/sentiment/train_recursive_minibatch.py
+++ b/examples/sentiment/train_recursive_minibatch.py
@@ -136,8 +136,8 @@ class ThinStackRecursiveNet(chainer.Chain):
         count = 0
         correct = 0
 
-        stack = self.xp.zeros(
-            (batch, maxlen * 2, self.n_units), self.xp.float32)
+        dtype = chainer.get_dtype()
+        stack = self.xp.zeros((batch, maxlen * 2, self.n_units), dtype)
         for i, (word, label) in enumerate(zip(sequences, leaf_labels)):
             batch = word.shape[0]
             es = self.leaf(word)

--- a/examples/sentiment/train_recursive_minibatch.py
+++ b/examples/sentiment/train_recursive_minibatch.py
@@ -1,4 +1,5 @@
 import argparse
+import warnings
 
 import numpy
 
@@ -194,6 +195,10 @@ def main():
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
     args = parser.parse_args()
+
+    if chainer.get_dtype() == numpy.float16:
+        warnings.warn(
+            'This example may cause NaN in FP16 mode.', RuntimeWarning)
 
     vocab = {}
     max_size = None


### PR DESCRIPTION
Rel. #6168,  and following #7438.

This PR fixes the sentiment example's recursive minibatch version to warn possible NaN in FP16 mode.
