### PR TITLE
Explicit check of chainerx arrays on fallback functions

### DIFF
--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -62,8 +62,8 @@ def _from_chx(array, check_backprop=True):
     # Objects with other types are kept intact.
     # Returns a pair: (xp, cupy device or dummy context, numpy/cupy.ndarray).
     if not isinstance(array, chainerx.ndarray):
-        if (isinstance(array, numpy.ndarray) or
-                cupy and isinstance(array, cupy.ndarray)):
+        if (isinstance(array, numpy.ndarray)
+                or (cupy and isinstance(array, cupy.ndarray))):
             raise TypeError(
                 'ChainerX function fallback using NumPy/CuPy arrays '
                 'is not supported.')

--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -62,10 +62,10 @@ def _from_chx(array, check_backprop=True):
     # Objects with other types are kept intact.
     # Returns a pair: (xp, cupy device or dummy context, numpy/cupy.ndarray).
     if not isinstance(array, chainerx.ndarray):
-        if isinstance(array, numpy.ndarray):
-            return numpy, _dummy_context, array
-        if cupy and isinstance(array, cupy.ndarray):
-            return cupy, _dummy_context, array
+        if isinstance(array, numpy.ndarray) or cupy and isinstance(array, cupy.ndarray):
+            raise TypeError(
+                'ChainerX function fallback using NumPy/CuPy arrays '
+                'is not supported.')
         # _from_chx is also called for slice and tuple objects
         # Used to index a chx array
         return None, _dummy_context, array

--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -62,7 +62,7 @@ def _from_chx(array, check_backprop=True):
     # Objects with other types are kept intact.
     # Returns a pair: (xp, cupy device or dummy context, numpy/cupy.ndarray).
     if not isinstance(array, chainerx.ndarray):
-        if (isinstance(array, numpy.ndarray) or 
+        if (isinstance(array, numpy.ndarray) or
                 cupy and isinstance(array, cupy.ndarray)):
             raise TypeError(
                 'ChainerX function fallback using NumPy/CuPy arrays '

--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -62,7 +62,9 @@ def _from_chx(array, check_backprop=True):
     # Objects with other types are kept intact.
     # Returns a pair: (xp, cupy device or dummy context, numpy/cupy.ndarray).
     if not isinstance(array, chainerx.ndarray):
-        return None, _dummy_context, array
+        raise RuntimeError(
+            'ChainerX function fallback using NumPy/CuPy is not '
+            'supported for datatypes other than ChainerX.ndarray.')
     if check_backprop and array.is_backprop_required():
         raise RuntimeError(
             'ChainerX function fallback using NumPy/CuPy is not '

--- a/chainerx/_fallback_workarounds.py
+++ b/chainerx/_fallback_workarounds.py
@@ -62,7 +62,8 @@ def _from_chx(array, check_backprop=True):
     # Objects with other types are kept intact.
     # Returns a pair: (xp, cupy device or dummy context, numpy/cupy.ndarray).
     if not isinstance(array, chainerx.ndarray):
-        if isinstance(array, numpy.ndarray) or cupy and isinstance(array, cupy.ndarray):
+        if (isinstance(array, numpy.ndarray) or 
+                cupy and isinstance(array, cupy.ndarray)):
             raise TypeError(
                 'ChainerX function fallback using NumPy/CuPy arrays '
                 'is not supported.')


### PR DESCRIPTION
We don't allow numpy or cupy arrays to reach fallback functions on chainer x, and we also forbid advanced indexing of chainerx arrays using numpy or cupy arrays.

The behavior is according to the following code:
```
x = chx.array([[0., 1., 2.], [3., 4., 5.]],dtype=chx.float32,device='cuda:0')
xnp = np.array([[0., 1., 2.], [3., 4., 5.]])
x_i = (chx.array([1],device='cuda:0'),)
x_inp = np.array([1])
x_icp = cp.array([1])
x_tup = ([1],)
print(chx.fix(x)) #ALLOWED
print(chx.fix(xnp)) #TYPE ERROR
print('CX ',x[x_i]) #ALLOWED
print('NP ',x[x_inp])#TYPE ERROR
print('CP ',x[x_icp])#TYPE ERROR
print('TU ',x[x_tup])#ALLOWED
```