### PR TITLE
[backport] Improve `get_device` error message when ChainerX is not available

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -151,7 +151,16 @@ def get_device(device_spec):
                 if not colon:
                     return intel64.Intel64Device()
 
-        elif chainerx.is_available():
+        else:
+            # String device specifier without '@' prefix is assumed to be a
+            # ChainerX device.
+            if not chainerx.is_available():
+                raise RuntimeError(
+                    'Tried to parse ChainerX device specifier \'{}\', '
+                    'but ChainerX is not available. '
+                    'Note that device specifiers without \'@\' prefix are '
+                    'assumed to be ChainerX device '
+                    'specifiers.'.format(device_spec))
             return _chainerx.ChainerxDevice(chainerx.get_device(device_spec))
 
     raise ValueError('Invalid device specifier: {}'.format(device_spec))

--- a/tests/chainer_tests/test_backend.py
+++ b/tests/chainer_tests/test_backend.py
@@ -279,6 +279,14 @@ class TestDeviceSpec(unittest.TestCase):
         # tuple is no longer supported from Chainer
         self.check_invalid(('native', 0))
 
+    @unittest.skipIf(
+        chainerx.is_available(), 'Only tested when ChainerX is not built')
+    def test_chx_device_spec_without_chx_available(self):
+        # If chainerx is not available, get_device() with unprefixed string
+        # should mention ChainerX unavailability in the error message.
+        with pytest.raises(RuntimeError, match=r'.*ChainerX.*'):
+            chainer.get_device('foo')
+
 
 class TestDevice(unittest.TestCase):
 


### PR DESCRIPTION
Backport of #7401