### PR TITLE
Include `cuda_fp16.h` instead of `cuda_fp16.hpp`

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/dot.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/dot.cu
@@ -5,8 +5,8 @@
 #include <type_traits>
 
 #include <cublas_v2.h>
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
-#include <cuda_fp16.hpp>
 
 #include "chainerx/array.h"
 #include "chainerx/axes.h"

--- a/chainerx_cc/chainerx/cuda/float16.cuh
+++ b/chainerx_cc/chainerx/cuda/float16.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cuda_fp16.hpp>
+#include <cuda_fp16.h>
 
 #include "chainerx/float16.h"
 #include "chainerx/scalar.h"


### PR DESCRIPTION
`cuda_fp16.hpp` seems to assume `cuda_fp16.h` is included beforehand.
On the other hand `cuda_fp16.h` includes `cuda_fp16.hpp` at the end of it.

Thus it's only necessary to include `cuda_fp16.h`.

Found in #7407.