### PR TITLE
Add fp16 test to `test_n_step_rnn`

### DIFF
--- a/tests/chainermn_tests/links_tests/test_n_step_rnn.py
+++ b/tests/chainermn_tests/links_tests/test_n_step_rnn.py
@@ -132,13 +132,11 @@ def check_heterogeneous_rnn(gpu, dtype):
         assert True
 
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('dtype', [np.float16, np.float32])
 def test_heterogeneous_rnn_cpu(dtype):
     check_heterogeneous_rnn(False, dtype)
 
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @chainer.testing.attr.gpu
 @pytest.mark.parametrize('dtype', [np.float16, np.float32])
 def test_heterogeneous_rnn_gpu(dtype):

--- a/tests/chainermn_tests/links_tests/test_n_step_rnn.py
+++ b/tests/chainermn_tests/links_tests/test_n_step_rnn.py
@@ -91,14 +91,12 @@ def check_homogeneous_rnn(gpu, dtype):
         assert True
 
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('dtype', [np.float16, np.float32])
 def test_homogeneous_rnn_cpu(dtype):
     check_homogeneous_rnn(False, dtype)
 
 
 @chainer.testing.attr.gpu
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 @pytest.mark.parametrize('dtype', [np.float16, np.float32])
 def test_homogeneous_rnn_gpu(dtype):
     check_homogeneous_rnn(True, dtype)

--- a/tests/chainermn_tests/links_tests/test_n_step_rnn.py
+++ b/tests/chainermn_tests/links_tests/test_n_step_rnn.py
@@ -1,11 +1,10 @@
-import unittest
-
 import chainer
 import chainer.backends
 from chainer.backends.cuda import cupy
 import chainer.functions as F
 import chainer.links as L
 import chainer.testing
+import chainer.testing.attr
 import chainermn
 import numpy as np
 import pytest
@@ -40,102 +39,109 @@ class Model(chainer.Chain):
         return err
 
 
-@chainer.testing.parameterize(*chainer.testing.product({
-    'dtype': [np.float16, np.float32],
-}))
-class TestNStepRNN(unittest.TestCase):
+def setup_communicator(gpu):
+    if gpu:
+        communicator = chainermn.create_communicator('flat')
+        chainer.backends.cuda.get_device_from_id(
+            communicator.intra_rank).use()
+    else:
+        communicator = chainermn.create_communicator('naive')
 
-    def setup(self, gpu):
+    if communicator.size < 2:
+        pytest.skip('This test is for multinode only')
+
+    rank_next = communicator.rank + 1
+    rank_prev = communicator.rank - 1
+
+    if rank_prev < 0:
+        rank_prev = None
+
+    if rank_next >= communicator.size:
+        rank_next = None
+
+    return communicator, rank_prev, rank_next
+
+
+def check_homogeneous_rnn(gpu, dtype):
+    communicator, rank_prev, rank_next = setup_communicator(gpu=gpu)
+
+    n, n_vocab, l = 100, 8, 10
+    # Number of model parameters are same among processes.
+    n_hid = 2
+    with chainer.using_config('dtype', dtype):
+        X = [np.random.randint(
+            0, n_vocab, size=np.random.randint(l // 2, l + 1),
+            dtype=np.int32)
+            for _ in range(n)]
+        Y = (np.random.rand(n) * 2).astype(dtype)
+        model = Model(
+            n_vocab, n_hid, communicator, rank_next,
+            rank_prev)
+
         if gpu:
-            self.communicator = chainermn.create_communicator('flat')
-            chainer.backends.cuda.get_device_from_id(
-                self.communicator.intra_rank).use()
-        else:
-            self.communicator = chainermn.create_communicator('naive')
+            model.to_device(cupy.cuda.Device())
+            X = [chainer.backends.cuda.to_gpu(x) for x in X]
+            Y = chainer.backends.cuda.to_gpu(Y)
 
-        if self.communicator.size < 2:
-            pytest.skip('This test is for multinode only')
+        for i in range(n):
+            err = model(X[i:i + 1], Y[i:i + 1])
+            err.backward()
 
-        self.rank_next = self.communicator.rank + 1
-        self.rank_prev = self.communicator.rank - 1
+        # Check if backprop finishes without deadlock.
+        assert True
 
-        if self.rank_prev < 0:
-            self.rank_prev = None
 
-        if self.rank_next >= self.communicator.size:
-            self.rank_next = None
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.mark.parametrize('dtype', [np.float16, np.float32])
+def test_homogeneous_rnn_cpu(dtype):
+    check_homogeneous_rnn(False, dtype)
 
-    def check_homogeneous_rnn(self, gpu):
-        self.setup(gpu)
 
+@chainer.testing.attr.gpu
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.mark.parametrize('dtype', [np.float16, np.float32])
+def test_homogeneous_rnn_gpu(dtype):
+    check_homogeneous_rnn(True, dtype)
+
+
+def check_heterogeneous_rnn(gpu, dtype):
+    communicator, rank_prev, rank_next = setup_communicator(gpu)
+
+    with chainer.using_config('dtype', dtype):
         n, n_vocab, l = 100, 8, 10
-        # Number of model parameters are same among processes.
-        n_hid = 2
-        with chainer.using_config('dtype', self.dtype):
-            X = [np.random.randint(
-                0, n_vocab, size=np.random.randint(l // 2, l + 1),
-                dtype=np.int32)
-                for _ in range(n)]
-            Y = (np.random.rand(n) * 2).astype(self.dtype)
-            model = Model(
-                n_vocab, n_hid, self.communicator, self.rank_next,
-                self.rank_prev)
+        # Number of model parameters are different among processes.
+        n_hid = (communicator.rank + 1) * 10
 
-            if gpu:
-                model.to_device(cupy.cuda.Device()
-                X = [chainer.backends.cuda.to_gpu(x) for x in X]
-                Y = chainer.backends.cuda.to_gpu(Y)
+        X = [np.random.randint(
+            0, n_vocab, size=np.random.randint(l // 2, l + 1),
+            dtype=np.int32)
+            for _ in range(n)]
+        Y = (np.random.rand(n) * 2).astype(dtype)
+        model = Model(
+            n_vocab, n_hid, communicator, rank_next,
+            rank_prev)
 
-            for i in range(n):
-                err = model(X[i:i + 1], Y[i:i + 1])
-                err.backward()
+        if gpu:
+            model.to_device(cupy.cuda.Device())
+            X = [chainer.backends.cuda.to_gpu(x) for x in X]
+            Y = chainer.backends.cuda.to_gpu(Y)
 
-            # Check if backprop finishes without deadlock.
-            self.assertTrue(True)
+        for i in range(n):
+            err = model(X[i:i + 1], Y[i:i + 1])
+            err.backward()
 
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    def test_homogeneous_rnn_cpu(self):
-        self.check_homogeneous_rnn(False)
+        # Check if backprop finishes without deadlock.
+        assert True
 
-    @chainer.testing.attr.gpu
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    def test_homogeneous_rnn_gpu(self):
-        self.check_homogeneous_rnn(True)
 
-    def check_heterogeneous_rnn(self, gpu):
-        self.setup(gpu)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.mark.parametrize('dtype', [np.float16, np.float32])
+def test_heterogeneous_rnn_cpu(dtype):
+    check_heterogeneous_rnn(False, dtype)
 
-        with chainer.using_config('dtype', self.dtype):
-            n, n_vocab, l = 100, 8, 10
-            # Number of model parameters are different among processes.
-            n_hid = (self.communicator.rank + 1) * 10
 
-            X = [np.random.randint(
-                0, n_vocab, size=np.random.randint(l // 2, l + 1),
-                dtype=np.int32)
-                for _ in range(n)]
-            Y = (np.random.rand(n) * 2).astype(self.dtype)
-            model = Model(
-                n_vocab, n_hid, self.communicator, self.rank_next,
-                self.rank_prev)
-
-            if gpu:
-                model.to_device(cupy.cuda.Device()
-                X = [chainer.backends.cuda.to_gpu(x) for x in X]
-                Y = chainer.backends.cuda.to_gpu(Y)
-
-            for i in range(n):
-                err = model(X[i:i + 1], Y[i:i + 1])
-                err.backward()
-
-            # Check if backprop finishes without deadlock.
-            self.assertTrue(True)
-
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    def test_heterogeneous_rnn_cpu(self):
-        self.check_heterogeneous_rnn(False)
-
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    @chainer.testing.attr.gpu
-    def test_heterogeneous_rnn_gpu(self):
-        self.check_heterogeneous_rnn(True)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@chainer.testing.attr.gpu
+@pytest.mark.parametrize('dtype', [np.float16, np.float32])
+def test_heterogeneous_rnn_gpu(dtype):
+    check_heterogeneous_rnn(True, dtype)


### PR DESCRIPTION
This commit adds the fp16 tests to the n_step_rnn tests.
The chainer.testing is used to parameterize and switch between the
float16 and float32.

The old `chainer.cuda` is replaced with `chainer.backends.cuda`