### PR TITLE
Add `is_array_supported` method on `backend.Device`

### DIFF
--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -106,7 +106,7 @@ class Device(object):
          """
         pass
 
-    def is_array_compatible(self, array):
+    def is_array_supported(self, array):
         """Returns if the specified array is compatible with the device.
         Args:
             array (:ref:`ndarray`): An array to be checked

--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -105,3 +105,14 @@ class Device(object):
         """Makes the device current in the current thread.
          """
         pass
+
+    def is_array_compatible(self, array):
+        """Returns if the specified array is compatible with the device.
+        Args:
+            array (:ref:`ndarray`): An array to be checked
+        Returns:
+            ``True`` if the array is compatible with the device. Otherwise
+            ``False`` is returned.
+        """
+        raise NotImplementedError(
+            'Device implementation must override this method.')

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -102,7 +102,7 @@ to the fallback device.
     def use(self):
         chainerx.set_default_device(self.device)
 
-    def is_array_compatible(self, array):
+    def is_array_supported(self, array):
         return (
             isinstance(array, chainerx.ndarray)
             and self.device == array.device)

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -102,6 +102,11 @@ to the fallback device.
     def use(self):
         chainerx.set_default_device(self.device)
 
+    def is_array_compatible(self, array):
+        return (
+            isinstance(array, chainerx.ndarray)
+            and self.device == array.device)
+
 
 def to_chx(array):
     """Converts an array or arrays to ChainerX.

--- a/chainer/backends/_cpu.py
+++ b/chainer/backends/_cpu.py
@@ -38,6 +38,9 @@ class CpuDevice(_backend.Device):
     def send_array(self, array):
         return _array_to_cpu(array)
 
+    def is_array_compatible(self, array):
+        return isinstance(array, numpy.ndarray)
+
 
 def _to_cpu(array):
     """Converts an array or arrays to NumPy."""

--- a/chainer/backends/_cpu.py
+++ b/chainer/backends/_cpu.py
@@ -38,7 +38,7 @@ class CpuDevice(_backend.Device):
     def send_array(self, array):
         return _array_to_cpu(array)
 
-    def is_array_compatible(self, array):
+    def is_array_supported(self, array):
         return isinstance(array, numpy.ndarray)
 
 

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -258,7 +258,7 @@ to the CUDA device ID.
     def use(self):
         self.device.use()
 
-    def is_array_compatible(self, array):
+    def is_array_supported(self, array):
         return isinstance(array, ndarray) and self.device == array.device
 
 

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -258,6 +258,9 @@ to the CUDA device ID.
     def use(self):
         self.device.use()
 
+    def is_array_compatible(self, array):
+        return isinstance(array, ndarray) and self.device == array.device
+
 
 # ------------------------------------------------------------------------------
 # Global states

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -71,7 +71,7 @@ class Intel64Device(_backend.Device):
             array = ideep.array(array, itype=ideep.wgt_array)
         return array
 
-    def is_array_compatible(self, array):
+    def is_array_supported(self, array):
         return isinstance(array, (numpy.ndarray, mdarray))
 
 

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -71,6 +71,9 @@ class Intel64Device(_backend.Device):
             array = ideep.array(array, itype=ideep.wgt_array)
         return array
 
+    def is_array_compatible(self, array):
+        return isinstance(array, (numpy.ndarray, mdarray))
+
 
 # ------------------------------------------------------------------------------
 # ideep configuration

--- a/tests/chainer_tests/backends_tests/test_chainerx.py
+++ b/tests/chainer_tests/backends_tests/test_chainerx.py
@@ -131,4 +131,33 @@ class TestFromToChainerx(unittest.TestCase):
         self.check_equal_memory_shared(arr, arr_converted)
 
 
+@chainer.testing.inject_backend_tests(
+    None,
+    [
+        # NumPy
+        {},
+        # CuPy
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+        # ChainerX
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+@attr.chainerx
+class TestIsArrayCompatible(unittest.TestCase):
+
+    def test_is_array_compatible(self, backend_config):
+        target = backend.ChainerxDevice(chainerx.get_device("native:0"))
+
+        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config.device
+
+        if (isinstance(device, backend.ChainerxDevice)
+                and device.device == chainerx.get_device('native:0')):
+            assert target.is_array_compatible(arr)
+        else:
+            assert not target.is_array_compatible(arr)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_tests/test_chainerx.py
+++ b/tests/chainer_tests/backends_tests/test_chainerx.py
@@ -152,7 +152,6 @@ class TestFromToChainerx(unittest.TestCase):
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
     ])
-@attr.chainerx
 class TestChainerxIsArraySupported(unittest.TestCase):
 
     def test_is_array_supported(self, backend_config1, backend_config2):

--- a/tests/chainer_tests/backends_tests/test_chainerx.py
+++ b/tests/chainer_tests/backends_tests/test_chainerx.py
@@ -131,7 +131,7 @@ class TestFromToChainerx(unittest.TestCase):
         self.check_equal_memory_shared(arr, arr_converted)
 
 
-@chainer.testing.inject_backend_tests(
+@chainer.testing.inject_backend_tests(  # backend_config2
     None,
     [
         # NumPy
@@ -144,20 +144,28 @@ class TestFromToChainerx(unittest.TestCase):
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
     ])
+@chainer.testing.inject_backend_tests(  # backend_config1
+    None,
+    [
+        # ChainerX
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
 @attr.chainerx
-class TestIsArrayCompatible(unittest.TestCase):
+class TestChainerxIsArraySupported(unittest.TestCase):
 
-    def test_is_array_compatible(self, backend_config):
-        target = backend.ChainerxDevice(chainerx.get_device("native:0"))
+    def test_is_array_supported(self, backend_config1, backend_config2):
+        target = backend_config1.device  # backend.ChainerxDevice
 
-        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
-        device = backend_config.device
+        arr = backend_config2.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config2.device
 
         if (isinstance(device, backend.ChainerxDevice)
-                and device.device == chainerx.get_device('native:0')):
-            assert target.is_array_compatible(arr)
+                and device.device == target.device):
+            assert target.is_array_supported(arr)
         else:
-            assert not target.is_array_compatible(arr)
+            assert not target.is_array_supported(arr)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_tests/test_cpu.py
+++ b/tests/chainer_tests/backends_tests/test_cpu.py
@@ -46,7 +46,7 @@ class TestCpuDeviceFromArrayInvalidValue(unittest.TestCase):
         assert device is None
 
 
-@testing.backend.inject_backend_tests(
+@testing.backend.inject_backend_tests(  # backend_config2
     None,
     [
         {},
@@ -54,18 +54,23 @@ class TestCpuDeviceFromArrayInvalidValue(unittest.TestCase):
         {'use_ideep': 'always'},
         {'use_chainerx': True, 'chainerx_device': 'native:0'},
     ])
-class TestIsArrayCompatible(unittest.TestCase):
+@testing.backend.inject_backend_tests(  # backend_config1
+    None,
+    [
+        {},
+    ])
+class TestCpuIsArraySupported(unittest.TestCase):
 
-    def test_is_array_compatible(self, backend_config):
-        target = backend.CpuDevice()
+    def test_is_array_supported(self, backend_config1, backend_config2):
+        target = backend_config1.device  # backend.CpuDevice
 
-        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
-        device = backend_config.device
+        arr = backend_config2.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config2.device
 
         if isinstance(device, backend.CpuDevice):
-            assert target.is_array_compatible(arr)
+            assert target.is_array_supported(arr)
         else:
-            assert not target.is_array_compatible(arr)
+            assert not target.is_array_supported(arr)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_tests/test_cpu.py
+++ b/tests/chainer_tests/backends_tests/test_cpu.py
@@ -46,4 +46,26 @@ class TestCpuDeviceFromArrayInvalidValue(unittest.TestCase):
         assert device is None
 
 
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_cuda': True},
+        {'use_ideep': 'always'},
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+    ])
+class TestIsArrayCompatible(unittest.TestCase):
+
+    def test_is_array_compatible(self, backend_config):
+        target = backend.CpuDevice()
+
+        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config.device
+
+        if isinstance(device, backend.CpuDevice):
+            assert target.is_array_compatible(arr)
+        else:
+            assert not target.is_array_compatible(arr)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_tests/test_cuda.py
+++ b/tests/chainer_tests/backends_tests/test_cuda.py
@@ -573,7 +573,7 @@ class TestGpuDeviceUse(unittest.TestCase):
             assert device.device == cuda.Device()
 
 
-@testing.backend.inject_backend_tests(
+@testing.backend.inject_backend_tests(  # backend_config2
     None,
     [
         {},
@@ -582,19 +582,26 @@ class TestGpuDeviceUse(unittest.TestCase):
         {'use_chainerx': True, 'chainerx_device': 'native:0'},
         {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
     ])
-class TestIsCompatibleArray(unittest.TestCase):
+@testing.backend.inject_backend_tests(  # backend_config1
+    None,
+    [
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+    ])
+@attr.gpu
+class TestGpuIsArraySupported(unittest.TestCase):
 
-    def test_is_array_compatible(self, backend_config):
-        target = backend.GpuDevice.from_device_id(0)
+    def test_is_array_supported(self, backend_config1, backend_config2):
+        target = backend_config1.device  # backend.GpuDevice
 
-        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
-        device = backend_config.device
+        arr = backend_config2.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config2.device
 
         if (isinstance(device, backend.GpuDevice)
-                and device.device == cuda.Device(0)):
-            assert target.is_array_compatible(arr)
+                and device.device == target.device):
+            assert target.is_array_supported(arr)
         else:
-            assert not target.is_array_compatible(arr)
+            assert not target.is_array_supported(arr)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_tests/test_cuda.py
+++ b/tests/chainer_tests/backends_tests/test_cuda.py
@@ -573,4 +573,28 @@ class TestGpuDeviceUse(unittest.TestCase):
             assert device.device == cuda.Device()
 
 
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+    ])
+class TestIsCompatibleArray(unittest.TestCase):
+
+    def test_is_array_compatible(self, backend_config):
+        target = backend.GpuDevice.from_device_id(0)
+
+        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config.device
+
+        if (isinstance(device, backend.GpuDevice)
+                and device.device == cuda.Device(0)):
+            assert target.is_array_compatible(arr)
+        else:
+            assert not target.is_array_compatible(arr)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_tests/test_cuda.py
+++ b/tests/chainer_tests/backends_tests/test_cuda.py
@@ -588,7 +588,6 @@ class TestGpuDeviceUse(unittest.TestCase):
         {'use_cuda': True, 'cuda_device': 0},
         {'use_cuda': True, 'cuda_device': 1},
     ])
-@attr.gpu
 class TestGpuIsArraySupported(unittest.TestCase):
 
     def test_is_array_supported(self, backend_config1, backend_config2):

--- a/tests/chainer_tests/backends_tests/test_intel64.py
+++ b/tests/chainer_tests/backends_tests/test_intel64.py
@@ -54,4 +54,26 @@ class TestIntel64DeviceFromArrayInvalidValue(unittest.TestCase):
         assert device is None
 
 
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_cuda': True},
+        {'use_ideep': 'always'},
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+    ])
+class TestIsArrayCompatible(unittest.TestCase):
+
+    def test_is_array_compatible(self, backend_config):
+        target = backend.Intel64Device()
+
+        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config.device
+
+        if isinstance(device, (backend.CpuDevice, backend.Intel64Device)):
+            assert target.is_array_compatible(arr)
+        else:
+            assert not target.is_array_compatible(arr)
+
+
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/backends_tests/test_intel64.py
+++ b/tests/chainer_tests/backends_tests/test_intel64.py
@@ -54,7 +54,7 @@ class TestIntel64DeviceFromArrayInvalidValue(unittest.TestCase):
         assert device is None
 
 
-@testing.backend.inject_backend_tests(
+@testing.backend.inject_backend_tests(  # backend_config2
     None,
     [
         {},
@@ -62,18 +62,23 @@ class TestIntel64DeviceFromArrayInvalidValue(unittest.TestCase):
         {'use_ideep': 'always'},
         {'use_chainerx': True, 'chainerx_device': 'native:0'},
     ])
-class TestIsArrayCompatible(unittest.TestCase):
+@testing.backend.inject_backend_tests(  # backend_config1
+    None,
+    [
+        {'use_ideep': 'always'},
+    ])
+class TestIntel64DeviceIsArraySupported(unittest.TestCase):
 
-    def test_is_array_compatible(self, backend_config):
-        target = backend.Intel64Device()
+    def test_is_array_supported(self, backend_config1, backend_config2):
+        target = backend_config1.device  # backend.Intel64Device
 
-        arr = backend_config.get_array(numpy.ndarray((2,), numpy.float32))
-        device = backend_config.device
+        arr = backend_config2.get_array(numpy.ndarray((2,), numpy.float32))
+        device = backend_config2.device
 
         if isinstance(device, (backend.CpuDevice, backend.Intel64Device)):
-            assert target.is_array_compatible(arr)
+            assert target.is_array_supported(arr)
         else:
-            assert not target.is_array_compatible(arr)
+            assert not target.is_array_supported(arr)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Add `is_array_supported` method on `backend.Device`. It is for `Variable` which checks if the specified value is reassignable to itself. This is split from #6072.