### PR TITLE
Use `pytest.mark.xfail` instead of `unittest.expectedFailure`

### DIFF
--- a/tests/chainer_tests/dataset_tests/test_convert.py
+++ b/tests/chainer_tests/dataset_tests/test_convert.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 
 import numpy
+import pytest
 
 from chainer import backend
 from chainer.backends import cuda
@@ -146,7 +147,7 @@ class TestConcatExamples(ConverterTestBase, unittest.TestCase):
 class _XFailConcatWithAsyncTransfer(object):
 
     @attr.chainerx
-    @unittest.expectedFailure
+    @pytest.mark.xfail(strict=True)
     def test_concat_arrays_to_chainerx(self, *args, **kwargs):
         (
             super(_XFailConcatWithAsyncTransfer, self)
@@ -154,7 +155,7 @@ class _XFailConcatWithAsyncTransfer(object):
         )
 
     @attr.chainerx
-    @unittest.expectedFailure
+    @pytest.mark.xfail(strict=True)
     def test_concat_tuples_to_chainerx(self, *args, **kwargs):
         (
             super(_XFailConcatWithAsyncTransfer, self)
@@ -162,7 +163,7 @@ class _XFailConcatWithAsyncTransfer(object):
         )
 
     @attr.chainerx
-    @unittest.expectedFailure
+    @pytest.mark.xfail(strict=True)
     def test_concat_dicts_to_chainerx(self, *args, **kwargs):
         (
             super(_XFailConcatWithAsyncTransfer, self)

--- a/tests/chainer_tests/test_backprop.py
+++ b/tests/chainer_tests/test_backprop.py
@@ -2,6 +2,7 @@ import unittest
 
 import mock
 import numpy as np
+import pytest
 
 import chainer
 from chainer.backends import cuda
@@ -62,14 +63,14 @@ class TestBackward(unittest.TestCase):
 
     # TODO(kataoka): Variable.backward with ChainerX backend unexpectedly
     # behaves like retain_grad=True
-    @unittest.expectedFailure
+    @pytest.mark.xfail(strict=True)
     @attr.chainerx
     def test_multiple_output_1arg_chainerx(self):
         self.check_multiple_output_1arg(chainerx)
 
     # TODO(kataoka): Variable.backward with ChainerX backend unexpectedly
     # behaves like retain_grad=True
-    @unittest.expectedFailure
+    @pytest.mark.xfail(strict=True)
     @attr.chainerx
     def test_multiple_output_2args_chainerx(self):
         self.check_multiple_output_2args(chainerx)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -417,7 +417,7 @@ class TestVariable(unittest.TestCase):
 
     # TODO(kataoka): Variable.backward with ChainerX backend unexpectedly
     # behaves like retain_grad=True
-    @unittest.expectedFailure
+    @pytest.mark.xfail(strict=True)
     @attr.chainerx
     def test_backward_chainerx(self):
         ret = self.create_linear_chain(2, chainerx)


### PR DESCRIPTION
It seems `unittest.expectedFailure` does not work with `pytest --pdb`.