### PR TITLE
Use py::arg literal in ChainerX python binding

### DIFF
--- a/chainerx_cc/chainerx/python/array.cc
+++ b/chainerx_cc/chainerx/python/array.cc
@@ -56,7 +56,7 @@ using internal::MoveArrayBody;
 }  // namespace
 
 namespace py = pybind11;
-using namespace py::literals;
+using py::literals::operator""_a;
 
 ArrayBodyPtr MakeArrayFromNumpyArray(py::array array, Device& device) {
     Shape shape{array.shape(), array.shape() + array.ndim()};

--- a/chainerx_cc/chainerx/python/array.cc
+++ b/chainerx_cc/chainerx/python/array.cc
@@ -56,6 +56,7 @@ using internal::MoveArrayBody;
 }  // namespace
 
 namespace py = pybind11;
+using namespace py::literals;
 
 ArrayBodyPtr MakeArrayFromNumpyArray(py::array array, Device& device) {
     Shape shape{array.shape(), array.shape() + array.ndim()};
@@ -150,7 +151,7 @@ ArrayBodyPtr MakeArray(py::handle object, const nonstd::optional<Dtype>& dtype, 
     if (dtype.has_value()) {
         dtype_name = py::str{GetDtypeName(*dtype)};
     }
-    py::array np_array = array_func(object, py::arg("copy") = copy, py::arg("dtype") = dtype_name);
+    py::array np_array = array_func(object, "copy"_a = copy, "dtype"_a = dtype_name);
 
     // Convert NumPy array to ChainerX array
     return MakeArrayFromNumpyArray(np_array, device);
@@ -162,15 +163,15 @@ void InitChainerxArray(pybind11::module& m) {
     c.def(py::init([](py::handle shape, py::handle dtype, py::handle device) {
               return MoveArrayBody(Empty(ToShape(shape), GetDtype(dtype), GetDevice(device)));
           }),
-          py::arg("shape"),
-          py::arg("dtype"),
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "dtype"_a,
+          "device"_a = nullptr);
     c.def_property_readonly("__array_priority__", [](const ArrayBodyPtr & /*self*/) -> double { return 100.; });
     m.def("to_numpy",
           [m](const ArrayBodyPtr& array, bool copy) { return MakeNumpyArrayFromArray(m, array, copy); },
-          py::arg("array"),
-          py::arg("copy") = true);
-    m.def("_to_cupy", [m](py::handle array) { return MakeCupyArrayFromArray(m, array); }, py::arg("array"));
+          "array"_a,
+          "copy"_a = true);
+    m.def("_to_cupy", [m](py::handle array) { return MakeCupyArrayFromArray(m, array); }, "array"_a);
     // This is currently for internal use (from Chainer) to support CuPy.
     // TODO(niboshi): Remove this once it will be possible to import cupy.ndarray using chx.array / chx.asarray.
     m.def("_fromrawpointer",
@@ -224,17 +225,17 @@ void InitChainerxArray(pybind11::module& m) {
           [](const ArrayBodyPtr& self, bool copy) {
               return MoveArrayBody(Array{self}.AsGradStopped(copy ? CopyKind::kCopy : CopyKind::kView));
           },
-          py::arg("copy") = false);
+          "copy"_a = false);
     c.def("as_grad_stopped",
           [](const ArrayBodyPtr& self, const std::vector<BackpropId>& backprop_ids, bool copy) {
               return MoveArrayBody(Array{self}.AsGradStopped(backprop_ids, copy ? CopyKind::kCopy : CopyKind::kView));
           },
           py::arg().noconvert(),
-          py::arg("copy") = false);
+          "copy"_a = false);
     c.def("astype",
           [](const ArrayBodyPtr& self, py::handle dtype, bool copy) { return MoveArrayBody(Array{self}.AsType(GetDtype(dtype), copy)); },
-          py::arg("dtype"),
-          py::arg("copy") = true);
+          "dtype"_a,
+          "copy"_a = true);
     c.def("copy", [](const ArrayBodyPtr& self) { return MoveArrayBody(Array{self}.Copy()); });
     c.def("__getitem__", [](const ArrayBodyPtr& self, py::handle key) { return MoveArrayBody(Array{self}.At(MakeArrayIndices(key))); });
     c.def("take",
@@ -255,13 +256,13 @@ void InitChainerxArray(pybind11::module& m) {
               }
               throw py::type_error{"only integers, slices (`:`), sequence, numpy.ndarray and chainerx.newaxis (`None`) are valid indices"};
           },
-          py::arg("indices"),
-          py::arg("axis") = nullptr);
+          "indices"_a,
+          "axis"_a = nullptr);
     c.def("transpose",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axes) {
               return MoveArrayBody(Array{self}.Transpose(ToAxes(axes)));
           },
-          py::arg("axes") = nullptr);
+          "axes"_a = nullptr);
     c.def("transpose", [](const ArrayBodyPtr& self, py::args args) { return MoveArrayBody(Array{self}.Transpose(ToAxes(args))); });
     c.def("reshape", [](const ArrayBodyPtr& self, py::handle shape) { return MoveArrayBody(Array{self}.Reshape(ToShape(shape))); });
     c.def("reshape", [](const ArrayBodyPtr& self, const std::vector<int64_t>& shape) {
@@ -277,12 +278,12 @@ void InitChainerxArray(pybind11::module& m) {
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis) {
               return MoveArrayBody(Array{self}.Squeeze(ToAxes(axis)));
           },
-          py::arg("axis") = nullptr);
-    c.def("squeeze", [](const ArrayBodyPtr& self, int8_t axis) { return MoveArrayBody(Array{self}.Squeeze(Axes{axis})); }, py::arg("axis"));
+          "axis"_a = nullptr);
+    c.def("squeeze", [](const ArrayBodyPtr& self, int8_t axis) { return MoveArrayBody(Array{self}.Squeeze(Axes{axis})); }, "axis"_a);
     c.def("swapaxes",
           [](const ArrayBodyPtr& self, int8_t axis1, int8_t axis2) { return MoveArrayBody(Array{self}.Swapaxes(axis1, axis2)); },
-          py::arg("axis1"),
-          py::arg("axis2"));
+          "axis1"_a,
+          "axis2"_a);
     c.def("__eq__",
           [](const ArrayBodyPtr& self, const ArrayBodyPtr& rhs) { return MoveArrayBody(Array{self} == Array{rhs}); },
           py::is_operator());
@@ -435,104 +436,104 @@ void InitChainerxArray(pybind11::module& m) {
     c.def("__rxor__", [](const ArrayBodyPtr& self, Scalar lhs) { return MoveArrayBody(Array{self} ^ lhs); }, py::is_operator());
     c.def("sum",
           [](const ArrayBodyPtr& self, int8_t axis, bool keepdims) { return MoveArrayBody(Array{self}.Sum(Axes{axis}, keepdims)); },
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "axis"_a,
+          "keepdims"_a = false);
     c.def("sum",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Array{self}.Sum(ToAxes(axis), keepdims));
           },
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     c.def("max",
           [](const ArrayBodyPtr& self, int8_t axis, bool keepdims) { return MoveArrayBody(Array{self}.Max(Axes{axis}, keepdims)); },
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "axis"_a,
+          "keepdims"_a = false);
     c.def("max",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Array{self}.Max(ToAxes(axis), keepdims));
           },
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     c.def("min",
           [](const ArrayBodyPtr& self, int8_t axis, bool keepdims) { return MoveArrayBody(Array{self}.Min(Axes{axis}, keepdims)); },
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "axis"_a,
+          "keepdims"_a = false);
     c.def("min",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Array{self}.Min(ToAxes(axis), keepdims));
           },
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     c.def("mean",
           [](const ArrayBodyPtr& self, int8_t axis, bool keepdims) { return MoveArrayBody(Array{self}.Mean(Axes{axis}, keepdims)); },
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "axis"_a,
+          "keepdims"_a = false);
     c.def("mean",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Array{self}.Mean(ToAxes(axis), keepdims));
           },
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     c.def("var",
           [](const ArrayBodyPtr& self, int8_t axis, bool keepdims) { return MoveArrayBody(Array{self}.Var(Axes{axis}, keepdims)); },
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "axis"_a,
+          "keepdims"_a = false);
     c.def("var",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Array{self}.Var(ToAxes(axis), keepdims));
           },
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     c.def("all",
           [](const ArrayBodyPtr& self, int8_t axis, bool keepdims) { return MoveArrayBody(Array{self}.All(Axes{axis}, keepdims)); },
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "axis"_a,
+          "keepdims"_a = false);
     c.def("all",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Array{self}.All(ToAxes(axis), keepdims));
           },
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     c.def("any",
           [](const ArrayBodyPtr& self, int8_t axis, bool keepdims) { return MoveArrayBody(Array{self}.Any(Axes{axis}, keepdims)); },
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "axis"_a,
+          "keepdims"_a = false);
     c.def("any",
           [](const ArrayBodyPtr& self, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Array{self}.Any(ToAxes(axis), keepdims));
           },
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     c.def("argmax",
           [](const ArrayBodyPtr& self, const nonstd::optional<int8_t>& axis) { return MoveArrayBody(ArgMax(Array{self}, ToAxes(axis))); },
-          py::arg("axis") = nullptr);
+          "axis"_a = nullptr);
     c.def("argmin",
           [](const ArrayBodyPtr& self, const nonstd::optional<int8_t>& axis) { return MoveArrayBody(ArgMin(Array{self}, ToAxes(axis))); },
-          py::arg("axis") = nullptr);
-    c.def("dot", [](const ArrayBodyPtr& self, const ArrayBodyPtr& b) { return MoveArrayBody(Array{self}.Dot(Array{b})); }, py::arg("b"));
+          "axis"_a = nullptr);
+    c.def("dot", [](const ArrayBodyPtr& self, const ArrayBodyPtr& b) { return MoveArrayBody(Array{self}.Dot(Array{b})); }, "b"_a);
     c.def("fill",
           [](const ArrayBodyPtr& self, Scalar value) {
               Array{self}.Fill(value);
               return;
           },
-          py::arg("value"));
+          "value"_a);
 
     c.def("require_grad",
           [](const ArrayBodyPtr& self, const nonstd::optional<BackpropId>& backprop_id) {
               return MoveArrayBody(std::move(Array{self}.RequireGrad(backprop_id)));
           },
-          py::arg("backprop_id") = nullptr);
+          "backprop_id"_a = nullptr);
     c.def("is_grad_required",
           [](const ArrayBodyPtr& self, const nonstd::optional<BackpropId>& backprop_id) { return Array{self}.IsGradRequired(backprop_id); },
-          py::arg("backprop_id") = nullptr);
+          "backprop_id"_a = nullptr);
     c.def("is_backprop_required",
           [](const ArrayBodyPtr& self, const nonstd::optional<BackpropId>& backprop_id) {
               return Array{self}.IsBackpropRequired(backprop_id);
           },
-          py::arg("backprop_id") = nullptr);
+          "backprop_id"_a = nullptr);
     c.def("is_backprop_required",
           [](const ArrayBodyPtr& self, AnyGraph any_graph) { return Array{self}.IsBackpropRequired(any_graph); },
-          py::arg("backprop_id"));
+          "backprop_id"_a);
     c.def("get_grad",
           [](const ArrayBodyPtr& self, const nonstd::optional<BackpropId>& backprop_id) -> ConstArrayBodyPtr {
               const nonstd::optional<Array>& grad = Array{self}.GetGrad(backprop_id);
@@ -541,7 +542,7 @@ void InitChainerxArray(pybind11::module& m) {
               }
               return internal::GetArrayBody(*grad);
           },
-          py::arg("backprop_id") = nullptr);
+          "backprop_id"_a = nullptr);
     c.def("set_grad",
           [](const ArrayBodyPtr& self, const ArrayBodyPtr& grad, const nonstd::optional<BackpropId>& backprop_id) {
               Array array{self};
@@ -551,20 +552,20 @@ void InitChainerxArray(pybind11::module& m) {
                   array.ClearGrad(backprop_id);
               }
           },
-          py::arg("grad"),
-          py::arg("backprop_id") = nullptr);
+          "grad"_a,
+          "backprop_id"_a = nullptr);
     c.def("backward",
           [](const ArrayBodyPtr& self, const nonstd::optional<BackpropId>& backprop_id, bool enable_double_backprop) {
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
               Backward(Array{self}, backprop_id, double_backprop);
           },
-          py::arg("backprop_id") = nullptr,
-          py::arg("enable_double_backprop") = false);
+          "backprop_id"_a = nullptr,
+          "enable_double_backprop"_a = false);
     c.def("_debug_dump_computational_graph",
           [](const ArrayBodyPtr& self, const nonstd::optional<BackpropId>& backprop_id) {
               DebugDumpComputationalGraph(std::cout, Array{self}, backprop_id);
           },
-          py::arg("backprop_id") = nullptr);
+          "backprop_id"_a = nullptr);
     c.def_property(
             "grad",
             [](const ArrayBodyPtr& self) -> ConstArrayBodyPtr {
@@ -584,7 +585,7 @@ void InitChainerxArray(pybind11::module& m) {
             });
     c.def("cleargrad",
           [](const ArrayBodyPtr& self, const nonstd::optional<BackpropId>& backprop_id) { Array{self}.ClearGrad(backprop_id); },
-          py::arg("backprop_id") = nullptr);
+          "backprop_id"_a = nullptr);
     c.def_property_readonly(
             "device", [](const ArrayBodyPtr& self) -> Device& { return self->device(); }, py::return_value_policy::reference);
     c.def_property_readonly("dtype", [m](const ArrayBodyPtr& self) { return GetNumpyDtypeFromModule(m, self->dtype()); });

--- a/chainerx_cc/chainerx/python/backprop_mode.cc
+++ b/chainerx_cc/chainerx/python/backprop_mode.cc
@@ -21,7 +21,7 @@ namespace python_internal {
 namespace {
 
 namespace py = pybind11;  // standard convention
-using namespace py::literals;
+using py::literals::operator""_a;
 
 template <class BackpropModeScope>
 class PyBackpropModeScope {

--- a/chainerx_cc/chainerx/python/backprop_mode.cc
+++ b/chainerx_cc/chainerx/python/backprop_mode.cc
@@ -21,6 +21,7 @@ namespace python_internal {
 namespace {
 
 namespace py = pybind11;  // standard convention
+using namespace py::literals;
 
 template <class BackpropModeScope>
 class PyBackpropModeScope {
@@ -58,7 +59,7 @@ void InitChainerxBackpropModeScope(pybind11::module& m, const char* class_name, 
     m.def(function_name, [](const std::vector<BackpropId>& backprop_ids) { return PyBackpropModeScope<BackpropModeScope>{backprop_ids}; });
     m.def(function_name,
           [](py::object context) { return PyBackpropModeScope<BackpropModeScope>{GetContext(context)}; },
-          py::arg("context") = py::none());
+          "context"_a = py::none());
 }
 
 }  // namespace
@@ -67,10 +68,8 @@ void InitChainerxBackpropMode(pybind11::module& m) {
     InitChainerxBackpropModeScope<NoBackpropModeScope>(m, "NoBackpropMode", "no_backprop_mode");
     InitChainerxBackpropModeScope<ForceBackpropModeScope>(m, "ForceBackpropMode", "force_backprop_mode");
 
-    m.def("is_backprop_required", [](const BackpropId& backprop_id) { return IsBackpropRequired(backprop_id); }, py::arg("backprop_id"));
-    m.def("is_backprop_required",
-          [](py::handle context) { return IsBackpropRequired(GetContext(context)); },
-          py::arg("context") = py::none());
+    m.def("is_backprop_required", [](const BackpropId& backprop_id) { return IsBackpropRequired(backprop_id); }, "backprop_id"_a);
+    m.def("is_backprop_required", [](py::handle context) { return IsBackpropRequired(GetContext(context)); }, "context"_a = py::none());
 }
 
 }  // namespace python_internal

--- a/chainerx_cc/chainerx/python/backward.cc
+++ b/chainerx_cc/chainerx/python/backward.cc
@@ -19,7 +19,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
-using namespace py::literals;
+using py::literals::operator""_a;
 
 using ArrayBodyPtr = std::shared_ptr<internal::ArrayBody>;
 

--- a/chainerx_cc/chainerx/python/backward.cc
+++ b/chainerx_cc/chainerx/python/backward.cc
@@ -19,6 +19,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
+using namespace py::literals;
 
 using ArrayBodyPtr = std::shared_ptr<internal::ArrayBody>;
 
@@ -44,8 +45,8 @@ void InitChainerxBackward(pybind11::module& m) {
               Backward(array, backprop_id, double_backprop);
           },
           py::arg(),
-          py::arg("backprop_id") = nullptr,
-          py::arg("enable_double_backprop") = false);
+          "backprop_id"_a = nullptr,
+          "enable_double_backprop"_a = false);
 
     m.def("backward",
           [](const std::vector<ArrayBodyPtr>& outputs, const nonstd::optional<BackpropId>& backprop_id, bool enable_double_backprop) {
@@ -54,8 +55,8 @@ void InitChainerxBackward(pybind11::module& m) {
               Backward({arrays.begin(), arrays.end()}, backprop_id, double_backprop);
           },
           py::arg(),
-          py::arg("backprop_id") = nullptr,
-          py::arg("enable_double_backprop") = false);
+          "backprop_id"_a = nullptr,
+          "enable_double_backprop"_a = false);
 
     m.def("grad",
           [](const std::vector<ArrayBodyPtr>& outputs,
@@ -74,8 +75,8 @@ void InitChainerxBackward(pybind11::module& m) {
           },
           py::arg(),  // outputs
           py::arg(),  // inputs
-          py::arg("backprop_id") = nullptr,
-          py::arg("enable_double_backprop") = false);
+          "backprop_id"_a = nullptr,
+          "enable_double_backprop"_a = false);
 }
 
 }  // namespace python_internal

--- a/chainerx_cc/chainerx/python/chainer_interop.cc
+++ b/chainerx_cc/chainerx/python/chainer_interop.cc
@@ -25,7 +25,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
-using namespace py::literals;
+using py::literals::operator""_a;
 
 using ArrayBodyPtr = std::shared_ptr<internal::ArrayBody>;
 

--- a/chainerx_cc/chainerx/python/chainer_interop.cc
+++ b/chainerx_cc/chainerx/python/chainer_interop.cc
@@ -25,6 +25,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
+using namespace py::literals;
 
 using ArrayBodyPtr = std::shared_ptr<internal::ArrayBody>;
 
@@ -230,11 +231,11 @@ void InitChainerxChainerInterop(pybind11::module& m) {
               }
               bb.Finalize();
           },
-          py::arg("function_node"),
-          py::arg("inputs"),
-          py::arg("outputs"),
-          py::arg("input_indexes_to_retain"),
-          py::arg("output_indexes_to_retain"));
+          "function_node"_a,
+          "inputs"_a,
+          "outputs"_a,
+          "input_indexes_to_retain"_a,
+          "output_indexes_to_retain"_a);
 }
 
 }  // namespace python_internal

--- a/chainerx_cc/chainerx/python/check_backward.cc
+++ b/chainerx_cc/chainerx/python/check_backward.cc
@@ -17,6 +17,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
+using namespace py::literals;
 
 using ArrayBodyPtr = std::shared_ptr<internal::ArrayBody>;
 
@@ -59,13 +60,13 @@ void InitChainerxCheckBackward(pybind11::module& m) {
                       rtol,
                       backprop_id);
           },
-          py::arg("func"),
-          py::arg("inputs"),
-          py::arg("grad_outputs"),
-          py::arg("eps"),
-          py::arg("atol") = 1e-5,
-          py::arg("rtol") = 1e-4,
-          py::arg("backprop_id") = nullptr);
+          "func"_a,
+          "inputs"_a,
+          "grad_outputs"_a,
+          "eps"_a,
+          "atol"_a = 1e-5,
+          "rtol"_a = 1e-4,
+          "backprop_id"_a = nullptr);
 
     m.def("check_double_backward",
           [](py::object func,
@@ -88,14 +89,14 @@ void InitChainerxCheckBackward(pybind11::module& m) {
                       rtol,
                       backprop_id);
           },
-          py::arg("func"),
-          py::arg("inputs"),
-          py::arg("grad_outputs"),
-          py::arg("grad_grad_inputs"),
-          py::arg("eps"),
-          py::arg("atol") = 1e-5,
-          py::arg("rtol") = 1e-4,
-          py::arg("backprop_id") = nullptr);
+          "func"_a,
+          "inputs"_a,
+          "grad_outputs"_a,
+          "grad_grad_inputs"_a,
+          "eps"_a,
+          "atol"_a = 1e-5,
+          "rtol"_a = 1e-4,
+          "backprop_id"_a = nullptr);
 }
 
 }  // namespace python_internal

--- a/chainerx_cc/chainerx/python/check_backward.cc
+++ b/chainerx_cc/chainerx/python/check_backward.cc
@@ -17,7 +17,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
-using namespace py::literals;
+using py::literals::operator""_a;
 
 using ArrayBodyPtr = std::shared_ptr<internal::ArrayBody>;
 

--- a/chainerx_cc/chainerx/python/context.cc
+++ b/chainerx_cc/chainerx/python/context.cc
@@ -5,6 +5,8 @@
 #include <string>
 #include <utility>
 
+#include <pybind11/cast.h>
+
 #include "chainerx/backend.h"
 #include "chainerx/context.h"
 #include "chainerx/device.h"
@@ -17,6 +19,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;  // standard convention
+using namespace py::literals;
 
 Context& GetContext(py::handle handle) {
     if (handle.is_none()) {
@@ -59,19 +62,19 @@ void InitChainerxContext(pybind11::module& m) {
           py::return_value_policy::reference);
     c.def("make_backprop_id",
           [](Context& self, std::string backprop_name) { return self.MakeBackpropId(std::move(backprop_name)); },
-          py::arg("backprop_name"));
+          "backprop_name"_a);
     c.def("release_backprop_id",
           [](Context& self, const BackpropId& backprop_id) { return self.ReleaseBackpropId(backprop_id); },
-          py::arg("backprop_id"));
+          "backprop_id"_a);
     // For testing
     c.def("_check_valid_backprop_id",
           [](Context& self, const BackpropId& backprop_id) { return self.CheckValidBackpropId(backprop_id); },
-          py::arg("backprop_id"));
+          "backprop_id"_a);
 
     m.def("get_backend", &GetBackend, py::return_value_policy::reference);
     m.def("get_device",
           [](py::handle device) -> Device& { return GetDevice(device); },
-          py::arg("device") = nullptr,
+          "device"_a = nullptr,
           py::return_value_policy::reference);
     m.def("get_device",
           [](const std::string& backend_name, int index) -> Device& {

--- a/chainerx_cc/chainerx/python/context.cc
+++ b/chainerx_cc/chainerx/python/context.cc
@@ -19,7 +19,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;  // standard convention
-using namespace py::literals;
+using py::literals::operator""_a;
 
 Context& GetContext(py::handle handle) {
     if (handle.is_none()) {

--- a/chainerx_cc/chainerx/python/graph.cc
+++ b/chainerx_cc/chainerx/python/graph.cc
@@ -18,6 +18,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;  // standard convention
+using namespace py::literals;
 
 class PyBackpropScope {
 public:
@@ -68,8 +69,8 @@ void InitChainerxBackpropScope(pybind11::module& m) {
 
     m.def("backprop_scope",
           [](const std::string& backprop_name, py::handle context) { return PyBackpropScope(backprop_name, GetContext(context)); },
-          py::arg("backprop_name"),
-          py::arg("context") = py::none());
+          "backprop_name"_a,
+          "context"_a = py::none());
 }
 
 }  // namespace python_internal

--- a/chainerx_cc/chainerx/python/graph.cc
+++ b/chainerx_cc/chainerx/python/graph.cc
@@ -18,7 +18,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;  // standard convention
-using namespace py::literals;
+using py::literals::operator""_a;
 
 class PyBackpropScope {
 public:

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -53,7 +53,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
-using namespace py::literals;
+using py::literals::operator""_a;
 
 namespace {
 

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -53,6 +53,7 @@ namespace python {
 namespace python_internal {
 
 namespace py = pybind11;
+using namespace py::literals;
 
 namespace {
 
@@ -98,87 +99,87 @@ void InitChainerxCreation(pybind11::module& m) {
     // standard way (not depending on CuPy), but we might tentatively provide one which concretely depends on CuPy.
     m.def("array",
           [](py::handle object, py::handle dtype, bool copy, py::handle device) { return MakeArray(object, dtype, copy, device); },
-          py::arg("object"),
-          py::arg("dtype") = nullptr,
-          py::arg("copy") = true,
-          py::arg("device") = nullptr);
+          "object"_a,
+          "dtype"_a = nullptr,
+          "copy"_a = true,
+          "device"_a = nullptr);
     // TODO(niboshi): Rename `object` to `a` as per numpy.
     m.def("asarray",
           [](py::handle object, py::handle dtype, py::handle device) { return MakeArray(object, dtype, false, device); },
-          py::arg("object"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "object"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("ascontiguousarray",
           [](py::handle a, py::handle dtype, py::handle device) {
               Array arr{MakeArray(a, dtype, false, device)};
               return MoveArrayBody(AsContiguousArray(arr));
           },
-          py::arg("a"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "a"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("empty",
           [](py::handle shape, py::handle dtype, py::handle device) {
               return MoveArrayBody(Empty(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("full",
           [](py::handle shape, Scalar fill_value, py::handle dtype, py::handle device) {
               return MoveArrayBody(Full(ToShape(shape), fill_value, GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("fill_value"),
-          py::arg("dtype"),
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "fill_value"_a,
+          "dtype"_a,
+          "device"_a = nullptr);
     m.def("full",
           [](py::int_ dim, Scalar fill_value, py::handle dtype, py::handle device) {
               return MoveArrayBody(Full(Shape{dim}, fill_value, GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("fill_value"),
-          py::arg("dtype"),
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "fill_value"_a,
+          "dtype"_a,
+          "device"_a = nullptr);
     m.def("full",
           [](py::handle shape, Scalar fill_value, py::handle device) {
               return MoveArrayBody(Full(ToShape(shape), fill_value, GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("fill_value"),
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "fill_value"_a,
+          "device"_a = nullptr);
     m.def("full",
           [](py::int_ dim, Scalar fill_value, py::handle device) { return MoveArrayBody(Full(Shape{dim}, fill_value, GetDevice(device))); },
-          py::arg("shape"),
-          py::arg("fill_value"),
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "fill_value"_a,
+          "device"_a = nullptr);
     m.def("zeros",
           [](py::handle shape, py::handle dtype, py::handle device) {
               return MoveArrayBody(Zeros(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("zeros",
           [](py::int_ dim, py::handle dtype, py::handle device) {
               return MoveArrayBody(Zeros(Shape{dim}, dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("ones",
           [](py::handle shape, py::handle dtype, py::handle device) {
               return MoveArrayBody(Ones(ToShape(shape), dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("ones",
           [](py::int_ dim, py::handle dtype, py::handle device) {
               return MoveArrayBody(Ones(Shape{dim}, dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("shape"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("arange",
           [](Scalar start_or_stop,
              const nonstd::optional<Scalar>& maybe_stop,
@@ -198,45 +199,39 @@ void InitChainerxCreation(pybind11::module& m) {
               return dtype.is_none() ? MoveArrayBody(Arange(start, stop, step, GetDevice(device)))
                                      : MoveArrayBody(Arange(start, stop, step, GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("start"),
-          py::arg("stop") = nullptr,
-          py::arg("step") = nullptr,
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "start"_a,
+          "stop"_a = nullptr,
+          "step"_a = nullptr,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("empty_like",
           [](const ArrayBodyPtr& a, py::handle device) { return MoveArrayBody(EmptyLike(Array{a}, GetDevice(device))); },
-          py::arg("a"),
-          py::arg("device") = nullptr);
+          "a"_a,
+          "device"_a = nullptr);
     m.def("full_like",
           [](const ArrayBodyPtr& a, Scalar value, py::handle device) {
               return MoveArrayBody(FullLike(Array{a}, value, GetDevice(device)));
           },
-          py::arg("a"),
-          py::arg("fill_value"),
-          py::arg("device") = nullptr);
+          "a"_a,
+          "fill_value"_a,
+          "device"_a = nullptr);
     m.def("zeros_like",
           [](const ArrayBodyPtr& a, py::handle device) { return MoveArrayBody(ZerosLike(Array{a}, GetDevice(device))); },
-          py::arg("a"),
-          py::arg("device") = nullptr);
+          "a"_a,
+          "device"_a = nullptr);
     m.def("ones_like",
           [](const ArrayBodyPtr& a, py::handle device) { return MoveArrayBody(OnesLike(Array{a}, GetDevice(device))); },
-          py::arg("a"),
-          py::arg("device") = nullptr);
-    m.def("copy", [](const ArrayBodyPtr& a) { return MoveArrayBody(Copy(Array{a})); }, py::arg("a"));
-    m.def("frombuffer",
-          &MakeArrayFromBuffer,
-          py::arg("buffer"),
-          py::arg("dtype") = "float32",
-          py::arg("count") = -1,
-          py::arg("offset") = 0,
-          py::arg("device") = nullptr);
+          "a"_a,
+          "device"_a = nullptr);
+    m.def("copy", [](const ArrayBodyPtr& a) { return MoveArrayBody(Copy(Array{a})); }, "a"_a);
+    m.def("frombuffer", &MakeArrayFromBuffer, "buffer"_a, "dtype"_a = "float32", "count"_a = -1, "offset"_a = 0, "device"_a = nullptr);
     m.def("identity",
           [](int64_t n, py::handle dtype, py::handle device) {
               return MoveArrayBody(Identity(n, dtype.is_none() ? Dtype::kFloat32 : GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("n"),
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "n"_a,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
     m.def("eye",
           [](int64_t n, nonstd::optional<int64_t> m, int64_t k, py::handle dtype, py::handle device) {
               if (!m.has_value()) {
@@ -244,21 +239,21 @@ void InitChainerxCreation(pybind11::module& m) {
               }
               return MoveArrayBody(Eye(n, m.value(), k, GetDtype(dtype), GetDevice(device)));
           },
-          py::arg("N"),
-          py::arg("M") = nullptr,
-          py::arg("k") = 0,
-          py::arg("dtype") = "float64",
-          py::arg("device") = nullptr);
+          "N"_a,
+          "M"_a = nullptr,
+          "k"_a = 0,
+          "dtype"_a = "float64",
+          "device"_a = nullptr);
     m.def("diag",
           [](const ArrayBodyPtr& v, int64_t k, py::handle device) { return MoveArrayBody(Diag(Array{v}, k, GetDevice(device))); },
-          py::arg("v"),
-          py::arg("k") = 0,
-          py::arg("device") = nullptr);
+          "v"_a,
+          "k"_a = 0,
+          "device"_a = nullptr);
     m.def("diagflat",
           [](const ArrayBodyPtr& v, int64_t k, py::handle device) { return MoveArrayBody(Diagflat(Array{v}, k, GetDevice(device))); },
-          py::arg("v"),
-          py::arg("k") = 0,
-          py::arg("device") = nullptr);
+          "v"_a,
+          "k"_a = 0,
+          "device"_a = nullptr);
     m.def("linspace",
           [](Scalar start, Scalar stop, int64_t num, bool endpoint, py::handle dtype, py::handle device) {
               return MoveArrayBody(Linspace(
@@ -269,12 +264,12 @@ void InitChainerxCreation(pybind11::module& m) {
                       dtype.is_none() ? nonstd::optional<Dtype>{nonstd::nullopt} : nonstd::optional<Dtype>{GetDtype(dtype)},
                       GetDevice(device)));
           },
-          py::arg("start"),
-          py::arg("stop"),
-          py::arg("num") = 50,
-          py::arg("endpoint") = true,
-          py::arg("dtype") = nullptr,
-          py::arg("device") = nullptr);
+          "start"_a,
+          "stop"_a,
+          "num"_a = 50,
+          "endpoint"_a = true,
+          "dtype"_a = nullptr,
+          "device"_a = nullptr);
 }
 
 void InitChainerxIndexing(pybind11::module& m) {
@@ -297,108 +292,102 @@ void InitChainerxIndexing(pybind11::module& m) {
               }
               throw py::type_error{"only integers, slices (`:`), sequence, numpy.ndarray and chainerx.newaxis (`None`) are valid indices"};
           },
-          py::arg("a"),
-          py::arg("indices"),
-          py::arg("axis"));
+          "a"_a,
+          "indices"_a,
+          "axis"_a);
     m.def("where",
           [](const ArrayBodyPtr& condition, const ArrayBodyPtr& x, const ArrayBodyPtr& y) {
               return MoveArrayBody(Where(Array{condition}, Array{x}, Array{y}));
           },
-          py::arg("condition"),
-          py::arg("x"),
-          py::arg("y"));
+          "condition"_a,
+          "x"_a,
+          "y"_a);
     m.def("where",
           [](const ArrayBodyPtr& condition, const ArrayBodyPtr& x, Scalar y) {
               return MoveArrayBody(Where(Array{condition}, Array{x}, y));
           },
-          py::arg("condition"),
-          py::arg("x"),
-          py::arg("y"));
+          "condition"_a,
+          "x"_a,
+          "y"_a);
     m.def("where",
           [](const ArrayBodyPtr& condition, Scalar x, const ArrayBodyPtr& y) {
               return MoveArrayBody(Where(Array{condition}, x, Array{y}));
           },
-          py::arg("condition"),
-          py::arg("x"),
-          py::arg("y"));
+          "condition"_a,
+          "x"_a,
+          "y"_a);
     m.def("where",
           [](const ArrayBodyPtr& condition, Scalar x, Scalar y) { return MoveArrayBody(Where(Array{condition}, x, y)); },
-          py::arg("condition"),
-          py::arg("x"),
-          py::arg("y"));
+          "condition"_a,
+          "x"_a,
+          "y"_a);
 }
 
 void InitChainerxLinalg(pybind11::module& m) {
     // linalg routines
-    m.def("dot",
-          [](const ArrayBodyPtr& a, const ArrayBodyPtr& b) { return MoveArrayBody(Dot(Array{a}, Array{b})); },
-          py::arg("a"),
-          py::arg("b"));
+    m.def("dot", [](const ArrayBodyPtr& a, const ArrayBodyPtr& b) { return MoveArrayBody(Dot(Array{a}, Array{b})); }, "a"_a, "b"_a);
 }
 
 void InitChainerxLogic(pybind11::module& m) {
     // logic routines
     m.def("equal",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Equal(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
     m.def("not_equal",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(NotEqual(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
     m.def("greater",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Greater(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
     m.def("greater_equal",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(GreaterEqual(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("less",
-          [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Less(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
+    m.def("less", [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Less(Array{x1}, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("less_equal",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(LessEqual(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
     m.def("logical_and",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(LogicalAnd(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
     m.def("logical_or",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(LogicalOr(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("logical_not", [](const ArrayBodyPtr& x) { return MoveArrayBody(LogicalNot(Array{x})); }, py::arg("x"));
+          "x1"_a,
+          "x2"_a);
+    m.def("logical_not", [](const ArrayBodyPtr& x) { return MoveArrayBody(LogicalNot(Array{x})); }, "x"_a);
     m.def("logical_xor",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(LogicalXor(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
     m.def("all",
           [](const ArrayBodyPtr& a, int8_t axis, bool keepdims) { return MoveArrayBody(All(Array{a}, Axes{axis}, keepdims)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("all",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(All(Array{a}, ToAxes(axis), keepdims));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     m.def("any",
           [](const ArrayBodyPtr& a, int8_t axis, bool keepdims) { return MoveArrayBody(Any(Array{a}, Axes{axis}, keepdims)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("any",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Any(Array{a}, ToAxes(axis), keepdims));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
 }
 
 void InitChainerxManipulation(pybind11::module& m) {
@@ -407,39 +396,36 @@ void InitChainerxManipulation(pybind11::module& m) {
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axes) {
               return MoveArrayBody(Transpose(Array{a}, ToAxes(axes)));
           },
-          py::arg("a"),
-          py::arg("axes") = nullptr);
+          "a"_a,
+          "axes"_a = nullptr);
     m.def("transpose",
           [](const ArrayBodyPtr& a, int8_t axes) { return MoveArrayBody(Transpose(Array{a}, {axes})); },
-          py::arg("a"),
-          py::arg("axes") = nullptr);
+          "a"_a,
+          "axes"_a = nullptr);
     m.def("flip",
           [](const ArrayBodyPtr& m, const nonstd::optional<std::vector<int8_t>>& axes) {
               return MoveArrayBody(Flip(Array{m}, ToAxes(axes)));
           },
-          py::arg("m"),
-          py::arg("axes") = nullptr);
-    m.def("flip",
-          [](const ArrayBodyPtr& m, int8_t axes) { return MoveArrayBody(Flip(Array{m}, {axes})); },
-          py::arg("m"),
-          py::arg("axes") = nullptr);
-    m.def("fliplr", [](const ArrayBodyPtr& m) { return MoveArrayBody(Fliplr(Array{m})); }, py::arg("m"));
-    m.def("flipud", [](const ArrayBodyPtr& m) { return MoveArrayBody(Flipud(Array{m})); }, py::arg("m"));
+          "m"_a,
+          "axes"_a = nullptr);
+    m.def("flip", [](const ArrayBodyPtr& m, int8_t axes) { return MoveArrayBody(Flip(Array{m}, {axes})); }, "m"_a, "axes"_a = nullptr);
+    m.def("fliplr", [](const ArrayBodyPtr& m) { return MoveArrayBody(Fliplr(Array{m})); }, "m"_a);
+    m.def("flipud", [](const ArrayBodyPtr& m) { return MoveArrayBody(Flipud(Array{m})); }, "m"_a);
     m.def("rollaxis",
           [](const ArrayBodyPtr& a, int8_t axis, int8_t start) { return MoveArrayBody(RollAxis(Array{a}, axis, start)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("start") = 0);
+          "a"_a,
+          "axis"_a,
+          "start"_a = 0);
     m.def("reshape",
           [](const ArrayBodyPtr& a, py::handle newshape) { return MoveArrayBody(Reshape(Array{a}, ToShape(newshape))); },
-          py::arg("a"),
-          py::arg("newshape"));
+          "a"_a,
+          "newshape"_a);
     m.def("reshape",
           [](const ArrayBodyPtr& a, const std::vector<int64_t>& newshape) {
               return MoveArrayBody(Reshape(Array{a}, {newshape.begin(), newshape.end()}));
           },
-          py::arg("a"),
-          py::arg("newshape"));
+          "a"_a,
+          "newshape"_a);
     m.def("reshape",
           [](const ArrayBodyPtr& a, py::args args) {
               if (args.size() == 0) {
@@ -447,30 +433,24 @@ void InitChainerxManipulation(pybind11::module& m) {
               }
               return MoveArrayBody(Reshape(Array{a}, ToShape(args)));
           },
-          py::arg("a"));
+          "a"_a);
     m.def("squeeze",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis) {
               return MoveArrayBody(Squeeze(Array{a}, ToAxes(axis)));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr);
-    m.def("squeeze",
-          [](const ArrayBodyPtr& a, int8_t axis) { return MoveArrayBody(Squeeze(Array{a}, Axes{axis})); },
-          py::arg("a"),
-          py::arg("axis"));
-    m.def("expand_dims",
-          [](const ArrayBodyPtr& a, int8_t axis) { return MoveArrayBody(ExpandDims(Array{a}, axis)); },
-          py::arg("a"),
-          py::arg("axis"));
+          "a"_a,
+          "axis"_a = nullptr);
+    m.def("squeeze", [](const ArrayBodyPtr& a, int8_t axis) { return MoveArrayBody(Squeeze(Array{a}, Axes{axis})); }, "a"_a, "axis"_a);
+    m.def("expand_dims", [](const ArrayBodyPtr& a, int8_t axis) { return MoveArrayBody(ExpandDims(Array{a}, axis)); }, "a"_a, "axis"_a);
     m.def("swapaxes",
           [](const ArrayBodyPtr& a, int8_t axis1, int8_t axis2) { return MoveArrayBody(Swapaxes(Array{a}, axis1, axis2)); },
-          py::arg("a"),
-          py::arg("axis1"),
-          py::arg("axis2"));
+          "a"_a,
+          "axis1"_a,
+          "axis2"_a);
     m.def("broadcast_to",
           [](const ArrayBodyPtr& array, py::handle shape) { return MoveArrayBody(Array{array}.BroadcastTo(ToShape(shape))); },
-          py::arg("array"),
-          py::arg("shape"));
+          "array"_a,
+          "shape"_a);
     m.def("concatenate",
           [](py::sequence arrays, nonstd::optional<int8_t> axis) {
               std::vector<Array> xs;
@@ -480,8 +460,8 @@ void InitChainerxManipulation(pybind11::module& m) {
               });
               return MoveArrayBody(Concatenate(xs, axis));
           },
-          py::arg("arrays"),
-          py::arg("axis") = 0);
+          "arrays"_a,
+          "axis"_a = 0);
     m.def("stack",
           [](py::sequence arrays, int8_t axis) {
               std::vector<Array> xs;
@@ -491,10 +471,10 @@ void InitChainerxManipulation(pybind11::module& m) {
               });
               return MoveArrayBody(Stack(xs, axis));
           },
-          py::arg("arrays"),
-          py::arg("axis") = 0);
-    m.def("atleast_2d", [](const ArrayBodyPtr& a) { return MoveArrayBody(AtLeast2D(Array{a})); }, py::arg("a"));
-    m.def("atleast_3d", [](const ArrayBodyPtr& a) { return MoveArrayBody(AtLeast3D(Array{a})); }, py::arg("a"));
+          "arrays"_a,
+          "axis"_a = 0);
+    m.def("atleast_2d", [](const ArrayBodyPtr& a) { return MoveArrayBody(AtLeast2D(Array{a})); }, "a"_a);
+    m.def("atleast_3d", [](const ArrayBodyPtr& a) { return MoveArrayBody(AtLeast3D(Array{a})); }, "a"_a);
     m.def("hstack",
           [](py::sequence arrays) {
               std::vector<Array> xs;
@@ -504,7 +484,7 @@ void InitChainerxManipulation(pybind11::module& m) {
               });
               return MoveArrayBody(HStack(xs));
           },
-          py::arg("arrays"));
+          "arrays"_a);
     m.def("vstack",
           [](py::sequence arrays) {
               std::vector<Array> xs;
@@ -514,7 +494,7 @@ void InitChainerxManipulation(pybind11::module& m) {
               });
               return MoveArrayBody(VStack(xs));
           },
-          py::arg("arrays"));
+          "arrays"_a);
     m.def("dstack",
           [](py::sequence arrays) {
               std::vector<Array> xs;
@@ -524,7 +504,7 @@ void InitChainerxManipulation(pybind11::module& m) {
               });
               return MoveArrayBody(DStack(xs));
           },
-          py::arg("arrays"));
+          "arrays"_a);
 
     m.def("split",
           [](const ArrayBodyPtr& ary, py::handle indices_or_sections, int8_t axis) {
@@ -611,299 +591,242 @@ void InitChainerxManipulation(pybind11::module& m) {
               throw py::type_error{std::string{"indices_or_sections not understood: "} +
                                    py::cast<std::string>(py::repr(indices_or_sections))};
           },
-          py::arg("ary"),
-          py::arg("indices_or_sections"),
-          py::arg("axis") = 0);
+          "ary"_a,
+          "indices_or_sections"_a,
+          "axis"_a = 0);
     m.def("moveaxis",
           [](const ArrayBodyPtr& a, const std::vector<int8_t>& source, const std::vector<int8_t>& destination) {
               return MoveArrayBody(Moveaxis(Array{a}, Axes{source.begin(), source.end()}, Axes{destination.begin(), destination.end()}));
           },
-          py::arg("a"),
-          py::arg("source") = nullptr,
-          py::arg("destination") = nullptr);
+          "a"_a,
+          "source"_a = nullptr,
+          "destination"_a = nullptr);
     m.def("moveaxis",
           [](const ArrayBodyPtr& a, py::tuple source, py::tuple destination) {
               return MoveArrayBody(Moveaxis(Array{a}, ToAxes(source), ToAxes(destination)));
           },
-          py::arg("a"),
-          py::arg("source") = nullptr,
-          py::arg("destination") = nullptr);
+          "a"_a,
+          "source"_a = nullptr,
+          "destination"_a = nullptr);
     m.def("moveaxis",
           [](const ArrayBodyPtr& a, int8_t source, int8_t destination) {
               return MoveArrayBody(Moveaxis(Array{a}, {source}, {destination}));
           },
-          py::arg("a"),
-          py::arg("source") = nullptr,
-          py::arg("destination") = nullptr);
+          "a"_a,
+          "source"_a = nullptr,
+          "destination"_a = nullptr);
 }
 
 void InitChainerxMath(pybind11::module& m) {
     // math routines
-    m.def("negative", [](const ArrayBodyPtr& x) { return MoveArrayBody(Negative(Array{x})); }, py::arg("x"));
-    m.def("add",
-          [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} + Array{x2}); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("add", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Add(Array{x1}, x2)); }, py::arg("x1"), py::arg("x2"));
-    m.def("add", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Add(x1, Array{x2})); }, py::arg("x1"), py::arg("x2"));
-    m.def("subtract",
-          [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} - Array{x2}); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("subtract",
-          [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Subtract(Array{x1}, x2)); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("subtract",
-          [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Subtract(x1, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("multiply",
-          [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} * Array{x2}); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("multiply",
-          [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Multiply(Array{x1}, x2)); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("multiply",
-          [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Multiply(x1, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("divide",
-          [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} / Array{x2}); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("divide", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Divide(Array{x1}, x2)); }, py::arg("x1"), py::arg("x2"));
-    m.def("divide", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Divide(x1, Array{x2})); }, py::arg("x1"), py::arg("x2"));
+    m.def("negative", [](const ArrayBodyPtr& x) { return MoveArrayBody(Negative(Array{x})); }, "x"_a);
+    m.def("add", [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} + Array{x2}); }, "x1"_a, "x2"_a);
+    m.def("add", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Add(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("add", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Add(x1, Array{x2})); }, "x1"_a, "x2"_a);
+    m.def("subtract", [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} - Array{x2}); }, "x1"_a, "x2"_a);
+    m.def("subtract", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Subtract(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("subtract", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Subtract(x1, Array{x2})); }, "x1"_a, "x2"_a);
+    m.def("multiply", [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} * Array{x2}); }, "x1"_a, "x2"_a);
+    m.def("multiply", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Multiply(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("multiply", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Multiply(x1, Array{x2})); }, "x1"_a, "x2"_a);
+    m.def("divide", [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Array{x1} / Array{x2}); }, "x1"_a, "x2"_a);
+    m.def("divide", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Divide(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("divide", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Divide(x1, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("floor_divide",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(FloorDivide(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("floor_divide",
-          [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(FloorDivide(Array{x1}, x2)); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("floor_divide",
-          [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(FloorDivide(x1, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
+    m.def("floor_divide", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(FloorDivide(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("floor_divide", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(FloorDivide(x1, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("true_divide",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(TrueDivide(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("true_divide",
-          [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(TrueDivide(Array{x1}, x2)); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("true_divide",
-          [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(TrueDivide(x1, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
+    m.def("true_divide", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(TrueDivide(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("true_divide", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(TrueDivide(x1, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("sum",
           [](const ArrayBodyPtr& a, int8_t axis, bool keepdims) { return MoveArrayBody(Sum(Array{a}, Axes{axis}, keepdims)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("sum",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Sum(Array{a}, ToAxes(axis), keepdims));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
-    m.def("maximum", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Maximum(Array{x1}, x2)); }, py::arg("x1"), py::arg("x2"));
-    m.def("maximum", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Maximum(x1, Array{x2})); }, py::arg("x1"), py::arg("x2"));
+          "a"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
+    m.def("maximum", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Maximum(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("maximum", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Maximum(x1, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("maximum",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Maximum(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("minimum", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Minimum(Array{x1}, x2)); }, py::arg("x1"), py::arg("x2"));
-    m.def("minimum", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Minimum(x1, Array{x2})); }, py::arg("x1"), py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
+    m.def("minimum", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Minimum(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("minimum", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Minimum(x1, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("minimum",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Minimum(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("erf", [](const ArrayBodyPtr& x) { return MoveArrayBody(Erf(Array{x})); }, py::arg("x"));
-    m.def("exp", [](const ArrayBodyPtr& x) { return MoveArrayBody(Exp(Array{x})); }, py::arg("x"));
-    m.def("expm1", [](const ArrayBodyPtr& x) { return MoveArrayBody(Expm1(Array{x})); }, py::arg("x"));
-    m.def("exp2", [](const ArrayBodyPtr& x) { return MoveArrayBody(Exp2(Array{x})); }, py::arg("x"));
-    m.def("log", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log(Array{x})); }, py::arg("x"));
-    m.def("log10", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log10(Array{x})); }, py::arg("x"));
-    m.def("log2", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log2(Array{x})); }, py::arg("x"));
-    m.def("log1p", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log1p(Array{x})); }, py::arg("x"));
+          "x1"_a,
+          "x2"_a);
+    m.def("erf", [](const ArrayBodyPtr& x) { return MoveArrayBody(Erf(Array{x})); }, "x"_a);
+    m.def("exp", [](const ArrayBodyPtr& x) { return MoveArrayBody(Exp(Array{x})); }, "x"_a);
+    m.def("expm1", [](const ArrayBodyPtr& x) { return MoveArrayBody(Expm1(Array{x})); }, "x"_a);
+    m.def("exp2", [](const ArrayBodyPtr& x) { return MoveArrayBody(Exp2(Array{x})); }, "x"_a);
+    m.def("log", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log(Array{x})); }, "x"_a);
+    m.def("log10", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log10(Array{x})); }, "x"_a);
+    m.def("log2", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log2(Array{x})); }, "x"_a);
+    m.def("log1p", [](const ArrayBodyPtr& x) { return MoveArrayBody(Log1p(Array{x})); }, "x"_a);
     m.def("logsumexp",
           [](const ArrayBodyPtr& x, int8_t axis, bool keepdims) { return MoveArrayBody(LogSumExp(Array{x}, Axes{axis}, keepdims)); },
-          py::arg("x"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "x"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("logsumexp",
           [](const ArrayBodyPtr& x, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(LogSumExp(Array{x}, ToAxes(axis), keepdims));
           },
-          py::arg("x"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "x"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     m.def("log_softmax",
           [](const ArrayBodyPtr& x, int8_t axis) { return MoveArrayBody(LogSoftmax(Array{x}, Axes{axis})); },
-          py::arg("x"),
-          py::arg("axis"));
+          "x"_a,
+          "axis"_a);
     m.def("log_softmax",
           [](const ArrayBodyPtr& x, const nonstd::optional<std::vector<int8_t>>& axis) {
               return MoveArrayBody(LogSoftmax(Array{x}, ToAxes(axis)));
           },
-          py::arg("x"),
-          py::arg("axis") = nullptr);
-    m.def("sigmoid", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sigmoid(Array{x})); }, py::arg("x"));
-    m.def("relu", [](const ArrayBodyPtr& x) { return MoveArrayBody(Relu(Array{x})); }, py::arg("x"));
-    m.def("softmax",
-          [](const ArrayBodyPtr& x, int8_t axis) { return MoveArrayBody(Softmax(Array{x}, Axes{axis})); },
-          py::arg("x"),
-          py::arg("axis"));
+          "x"_a,
+          "axis"_a = nullptr);
+    m.def("sigmoid", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sigmoid(Array{x})); }, "x"_a);
+    m.def("relu", [](const ArrayBodyPtr& x) { return MoveArrayBody(Relu(Array{x})); }, "x"_a);
+    m.def("softmax", [](const ArrayBodyPtr& x, int8_t axis) { return MoveArrayBody(Softmax(Array{x}, Axes{axis})); }, "x"_a, "axis"_a);
     m.def("softmax",
           [](const ArrayBodyPtr& x, const nonstd::optional<std::vector<int8_t>>& axis) {
               return MoveArrayBody(Softmax(Array{x}, ToAxes(axis)));
           },
-          py::arg("x"),
-          py::arg("axis") = nullptr);
-    m.def("square", [](const ArrayBodyPtr& x) { return MoveArrayBody(Square(Array{x})); }, py::arg("x"));
+          "x"_a,
+          "axis"_a = nullptr);
+    m.def("square", [](const ArrayBodyPtr& x) { return MoveArrayBody(Square(Array{x})); }, "x"_a);
     m.def("squared_difference",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(SquaredDifference(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("sqrt", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sqrt(Array{x})); }, py::arg("x"));
+          "x1"_a,
+          "x2"_a);
+    m.def("sqrt", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sqrt(Array{x})); }, "x"_a);
     m.def("power",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Power(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("power", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Power(Array{x1}, x2)); }, py::arg("x1"), py::arg("x2"));
-    m.def("power", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Power(x1, Array{x2})); }, py::arg("x1"), py::arg("x2"));
-    m.def("sinh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sinh(Array{x})); }, py::arg("x"));
-    m.def("cosh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Cosh(Array{x})); }, py::arg("x"));
-    m.def("tanh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Tanh(Array{x})); }, py::arg("x"));
-    m.def("arcsinh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arcsinh(Array{x})); }, py::arg("x"));
-    m.def("arccosh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arccosh(Array{x})); }, py::arg("x"));
-    m.def("sin", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sin(Array{x})); }, py::arg("x"));
-    m.def("cos", [](const ArrayBodyPtr& x) { return MoveArrayBody(Cos(Array{x})); }, py::arg("x"));
-    m.def("abs", [](const ArrayBodyPtr& x) { return MoveArrayBody(Absolute(Array{x})); }, py::arg("x"));
+          "x1"_a,
+          "x2"_a);
+    m.def("power", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(Power(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("power", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Power(x1, Array{x2})); }, "x1"_a, "x2"_a);
+    m.def("sinh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sinh(Array{x})); }, "x"_a);
+    m.def("cosh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Cosh(Array{x})); }, "x"_a);
+    m.def("tanh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Tanh(Array{x})); }, "x"_a);
+    m.def("arcsinh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arcsinh(Array{x})); }, "x"_a);
+    m.def("arccosh", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arccosh(Array{x})); }, "x"_a);
+    m.def("sin", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sin(Array{x})); }, "x"_a);
+    m.def("cos", [](const ArrayBodyPtr& x) { return MoveArrayBody(Cos(Array{x})); }, "x"_a);
+    m.def("abs", [](const ArrayBodyPtr& x) { return MoveArrayBody(Absolute(Array{x})); }, "x"_a);
     m.attr("absolute") = m.attr("abs");
-    m.def("tan", [](const ArrayBodyPtr& x) { return MoveArrayBody(Tan(Array{x})); }, py::arg("x"));
-    m.def("arcsin", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arcsin(Array{x})); }, py::arg("x"));
-    m.def("arccos", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arccos(Array{x})); }, py::arg("x"));
-    m.def("arctan", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arctan(Array{x})); }, py::arg("x"));
+    m.def("tan", [](const ArrayBodyPtr& x) { return MoveArrayBody(Tan(Array{x})); }, "x"_a);
+    m.def("arcsin", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arcsin(Array{x})); }, "x"_a);
+    m.def("arccos", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arccos(Array{x})); }, "x"_a);
+    m.def("arctan", [](const ArrayBodyPtr& x) { return MoveArrayBody(Arctan(Array{x})); }, "x"_a);
     m.def("arctan2",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(Arctan2(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("fabs", [](const ArrayBodyPtr& x) { return MoveArrayBody(Fabs(Array{x})); }, py::arg("x"));
-    m.def("sign", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sign(Array{x})); }, py::arg("x"));
-    m.def("ceil", [](const ArrayBodyPtr& x) { return MoveArrayBody(Ceil(Array{x})); }, py::arg("x"));
-    m.def("floor", [](const ArrayBodyPtr& x) { return MoveArrayBody(Floor(Array{x})); }, py::arg("x"));
-    m.def("isnan", [](const ArrayBodyPtr& x) { return MoveArrayBody(IsNan(Array{x})); }, py::arg("x"));
-    m.def("isinf", [](const ArrayBodyPtr& x) { return MoveArrayBody(IsInf(Array{x})); }, py::arg("x"));
-    m.def("isfinite", [](const ArrayBodyPtr& x) { return MoveArrayBody(IsFinite(Array{x})); }, py::arg("x"));
+          "x1"_a,
+          "x2"_a);
+    m.def("fabs", [](const ArrayBodyPtr& x) { return MoveArrayBody(Fabs(Array{x})); }, "x"_a);
+    m.def("sign", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sign(Array{x})); }, "x"_a);
+    m.def("ceil", [](const ArrayBodyPtr& x) { return MoveArrayBody(Ceil(Array{x})); }, "x"_a);
+    m.def("floor", [](const ArrayBodyPtr& x) { return MoveArrayBody(Floor(Array{x})); }, "x"_a);
+    m.def("isnan", [](const ArrayBodyPtr& x) { return MoveArrayBody(IsNan(Array{x})); }, "x"_a);
+    m.def("isinf", [](const ArrayBodyPtr& x) { return MoveArrayBody(IsInf(Array{x})); }, "x"_a);
+    m.def("isfinite", [](const ArrayBodyPtr& x) { return MoveArrayBody(IsFinite(Array{x})); }, "x"_a);
     m.def("bitwise_and",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseAnd(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("bitwise_and",
-          [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(BitwiseAnd(Array{x1}, x2)); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("bitwise_and",
-          [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseAnd(x1, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
+    m.def("bitwise_and", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(BitwiseAnd(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("bitwise_and", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseAnd(x1, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("bitwise_or",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseOr(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("bitwise_or",
-          [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(BitwiseOr(Array{x1}, x2)); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("bitwise_or",
-          [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseOr(x1, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
+    m.def("bitwise_or", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(BitwiseOr(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("bitwise_or", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseOr(x1, Array{x2})); }, "x1"_a, "x2"_a);
     m.def("bitwise_xor",
           [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseXor(Array{x1}, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("bitwise_xor",
-          [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(BitwiseXor(Array{x1}, x2)); },
-          py::arg("x1"),
-          py::arg("x2"));
-    m.def("bitwise_xor",
-          [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseXor(x1, Array{x2})); },
-          py::arg("x1"),
-          py::arg("x2"));
+          "x1"_a,
+          "x2"_a);
+    m.def("bitwise_xor", [](const ArrayBodyPtr& x1, Scalar x2) { return MoveArrayBody(BitwiseXor(Array{x1}, x2)); }, "x1"_a, "x2"_a);
+    m.def("bitwise_xor", [](Scalar x1, const ArrayBodyPtr& x2) { return MoveArrayBody(BitwiseXor(x1, Array{x2})); }, "x1"_a, "x2"_a);
 }
 
 void InitChainerxSorting(pybind11::module& m) {
     // sorting routines
     m.def("argmax",
           [](const ArrayBodyPtr& a, const nonstd::optional<int8_t>& axis) { return MoveArrayBody(ArgMax(Array{a}, ToAxes(axis))); },
-          py::arg("a"),
-          py::arg("axis") = nullptr);
+          "a"_a,
+          "axis"_a = nullptr);
     m.def("argmin",
           [](const ArrayBodyPtr& a, const nonstd::optional<int8_t>& axis) { return MoveArrayBody(ArgMin(Array{a}, ToAxes(axis))); },
-          py::arg("a"),
-          py::arg("axis") = nullptr);
+          "a"_a,
+          "axis"_a = nullptr);
 }
 
 void InitChainerxStatistics(pybind11::module& m) {
     // statistics routines
     m.def("amax",
           [](const ArrayBodyPtr& a, int8_t axis, bool keepdims) { return MoveArrayBody(AMax(Array{a}, Axes{axis}, keepdims)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("amax",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(AMax(Array{a}, ToAxes(axis), keepdims));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     m.attr("max") = m.attr("amax");
     m.def("amin",
           [](const ArrayBodyPtr& a, int8_t axis, bool keepdims) { return MoveArrayBody(AMin(Array{a}, Axes{axis}, keepdims)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("amin",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(AMin(Array{a}, ToAxes(axis), keepdims));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     m.attr("min") = m.attr("amin");
     m.def("mean",
           [](const ArrayBodyPtr& a, int8_t axis, bool keepdims) { return MoveArrayBody(Mean(Array{a}, Axes{axis}, keepdims)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("mean",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Mean(Array{a}, ToAxes(axis), keepdims));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
     m.def("var",
           [](const ArrayBodyPtr& a, int8_t axis, bool keepdims) { return MoveArrayBody(Var(Array{a}, Axes{axis}, keepdims)); },
-          py::arg("a"),
-          py::arg("axis"),
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a,
+          "keepdims"_a = false);
     m.def("var",
           [](const ArrayBodyPtr& a, const nonstd::optional<std::vector<int8_t>>& axis, bool keepdims) {
               return MoveArrayBody(Var(Array{a}, ToAxes(axis), keepdims));
           },
-          py::arg("a"),
-          py::arg("axis") = nullptr,
-          py::arg("keepdims") = false);
+          "a"_a,
+          "axis"_a = nullptr,
+          "keepdims"_a = false);
 }
 
 void InitChainerxConnection(pybind11::module& m) {
@@ -926,12 +849,12 @@ void InitChainerxConnection(pybind11::module& m) {
                            ToStackVector<int64_t>(pad, ndim),
                            cover_all));
           },
-          py::arg("x"),
-          py::arg("w"),
-          py::arg("b") = nullptr,
-          py::arg("stride") = 1,
-          py::arg("pad") = 0,
-          py::arg("cover_all") = false);
+          "x"_a,
+          "w"_a,
+          "b"_a = nullptr,
+          "stride"_a = 1,
+          "pad"_a = 0,
+          "cover_all"_a = false);
     m.def("conv_transpose",
           [](const ArrayBodyPtr& x,
              const ArrayBodyPtr& w,
@@ -950,21 +873,21 @@ void InitChainerxConnection(pybind11::module& m) {
                       ToStackVector<int64_t>(pad, ndim),
                       outsize.has_value() ? nonstd::optional<Dims>{ToStackVector<int64_t>(*outsize, ndim)} : nonstd::nullopt));
           },
-          py::arg("x"),
-          py::arg("w"),
-          py::arg("b") = nullptr,
-          py::arg("stride") = 1,
-          py::arg("pad") = 0,
-          py::arg("outsize") = nullptr);
+          "x"_a,
+          "w"_a,
+          "b"_a = nullptr,
+          "stride"_a = 1,
+          "pad"_a = 0,
+          "outsize"_a = nullptr);
     m.def("linear",
           [](const ArrayBodyPtr& x, const ArrayBodyPtr& w, const nonstd::optional<ArrayBodyPtr>& b, int8_t n_batch_axes) {
               return MoveArrayBody(
                       Linear(Array{x}, Array{w}, b.has_value() ? nonstd::optional<Array>{Array{*b}} : nonstd::nullopt, n_batch_axes));
           },
-          py::arg("x"),
-          py::arg("w"),
-          py::arg("b") = nullptr,
-          py::arg("n_batch_axes") = 1);
+          "x"_a,
+          "w"_a,
+          "b"_a = nullptr,
+          "n_batch_axes"_a = 1);
 }
 
 void InitChainerxNormalization(pybind11::module& m) {
@@ -981,14 +904,14 @@ void InitChainerxNormalization(pybind11::module& m) {
               return MoveArrayBody(
                       BatchNorm(Array{x}, Array{gamma}, Array{beta}, Array{running_mean}, Array{running_var}, eps, decay, ToAxes(axis)));
           },
-          py::arg("x"),
-          py::arg("gamma"),
-          py::arg("beta"),
-          py::arg("running_mean"),
-          py::arg("running_var"),
-          py::arg("eps") = 2e-5,
-          py::arg("decay") = 0.9,
-          py::arg("axis") = nullptr);
+          "x"_a,
+          "gamma"_a,
+          "beta"_a,
+          "running_mean"_a,
+          "running_var"_a,
+          "eps"_a = 2e-5,
+          "decay"_a = 0.9,
+          "axis"_a = nullptr);
     m.def("fixed_batch_norm",
           [](const ArrayBodyPtr& x,
              const ArrayBodyPtr& gamma,
@@ -999,13 +922,13 @@ void InitChainerxNormalization(pybind11::module& m) {
              const nonstd::optional<std::vector<int8_t>>& axis) {
               return MoveArrayBody(FixedBatchNorm(Array{x}, Array{gamma}, Array{beta}, Array{mean}, Array{var}, eps, ToAxes(axis)));
           },
-          py::arg("x"),
-          py::arg("gamma"),
-          py::arg("beta"),
-          py::arg("mean"),
-          py::arg("var"),
-          py::arg("eps") = 2e-5,
-          py::arg("axis") = nullptr);
+          "x"_a,
+          "gamma"_a,
+          "beta"_a,
+          "mean"_a,
+          "var"_a,
+          "eps"_a = 2e-5,
+          "axis"_a = nullptr);
 }
 
 void InitChainerxPooling(pybind11::module& m) {
@@ -1022,11 +945,11 @@ void InitChainerxPooling(pybind11::module& m) {
                               ToStackVector<int64_t>(pad, ndim),
                               cover_all));
           },
-          py::arg("x"),
-          py::arg("ksize"),
-          py::arg("stride") = py::none(),
-          py::arg("pad") = 0,
-          py::arg("cover_all") = false);
+          "x"_a,
+          "ksize"_a,
+          "stride"_a = py::none(),
+          "pad"_a = 0,
+          "cover_all"_a = false);
     m.def("average_pool",
           [](const ArrayBodyPtr& x, py::handle ksize, py::handle stride, py::handle pad, const std::string& pad_mode) {
               Array x_array{x};
@@ -1048,11 +971,11 @@ void InitChainerxPooling(pybind11::module& m) {
                       ToStackVector<int64_t>(pad, ndim),
                       mode));
           },
-          py::arg("x"),
-          py::arg("ksize"),
-          py::arg("stride") = py::none(),
-          py::arg("pad") = 0,
-          py::arg("pad_mode") = "ignore");
+          "x"_a,
+          "ksize"_a,
+          "stride"_a = py::none(),
+          "pad"_a = 0,
+          "pad_mode"_a = "ignore");
 }
 
 }  // namespace

--- a/chainerx_cc/chainerx/python/testing/device_buffer.cc
+++ b/chainerx_cc/chainerx/python/testing/device_buffer.cc
@@ -23,7 +23,7 @@ namespace testing {
 namespace testing_internal {
 
 namespace py = pybind11;  // standard convention
-using namespace py::literals;
+using py::literals::operator""_a;
 
 // A device buffer that upon construction allocates device memory and creates a py::buffer_info, sharing ownership of the managed data
 // (py::buffer_info only holds a raw pointer and does not manage the lifetime of the pointed data). Memoryviews created from this buffer

--- a/chainerx_cc/chainerx/python/testing/device_buffer.cc
+++ b/chainerx_cc/chainerx/python/testing/device_buffer.cc
@@ -23,6 +23,7 @@ namespace testing {
 namespace testing_internal {
 
 namespace py = pybind11;  // standard convention
+using namespace py::literals;
 
 // A device buffer that upon construction allocates device memory and creates a py::buffer_info, sharing ownership of the managed data
 // (py::buffer_info only holds a raw pointer and does not manage the lifetime of the pointed data). Memoryviews created from this buffer
@@ -72,10 +73,10 @@ void InitChainerxDeviceBuffer(pybind11::module& m) {
               std::shared_ptr<void> device_data = python_internal::GetDevice(device).FromHostMemory(host_data, bytes);
               return PyDeviceBuffer{device_data, item_size, format, shape.ndim(), shape, Strides{shape, dtype}};
           }),
-          py::arg("shape"),
-          py::arg("dtype"),
-          py::arg("data"),
-          py::arg("device") = nullptr);
+          "shape"_a,
+          "dtype"_a,
+          "data"_a,
+          "device"_a = nullptr);
     c.def_buffer([](const PyDeviceBuffer& self) {
         // py::buffer_info cannot be copied.
         std::shared_ptr<py::buffer_info> info = self.info();

--- a/chainerx_cc/chainerx/python/testing/testing_module.cc
+++ b/chainerx_cc/chainerx/python/testing/testing_module.cc
@@ -13,7 +13,7 @@ namespace testing {
 namespace testing_internal {
 
 namespace py = pybind11;
-using namespace py::literals;
+using py::literals::operator""_a;
 
 void InitChainerxTestingModule(pybind11::module& m) {
     InitChainerxDeviceBuffer(m);

--- a/chainerx_cc/chainerx/python/testing/testing_module.cc
+++ b/chainerx_cc/chainerx/python/testing/testing_module.cc
@@ -13,6 +13,7 @@ namespace testing {
 namespace testing_internal {
 
 namespace py = pybind11;
+using namespace py::literals;
 
 void InitChainerxTestingModule(pybind11::module& m) {
     InitChainerxDeviceBuffer(m);
@@ -25,9 +26,9 @@ void InitChainerxTestingModule(pybind11::module& m) {
               }
               return python_internal::MakeArray(array, array.dtype(), true, device);
           },
-          py::arg("array"),
-          py::arg("keepstrides") = false,
-          py::arg("device") = nullptr);
+          "array"_a,
+          "keepstrides"_a = false,
+          "device"_a = nullptr);
 }
 
 }  // namespace testing_internal


### PR DESCRIPTION
Seems this style is more smart and it's only needed in chainerx_cc/chainerx/python:
https://pybind11.readthedocs.io/en/stable/basics.html#keyword-arguments
> The `_a` suffix forms a C++11 literal which is equivalent to `arg`. Note that the literal operator must first be made visible with the directive `using namespace pybind11::literals`. This does not bring in anything else from the `pybind11` namespace except for literals.