### PR TITLE
Fix `GradientMethod` ChainerX fallback for uninitialized parameters

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -8,7 +8,6 @@ import numpy
 import six
 
 import chainer
-from chainer import backend
 from chainer import link as link_module
 from chainer import optimizer_hooks
 from chainer import serializer as serializer_module
@@ -280,50 +279,51 @@ class UpdateRule(object):
 
         """
         grad_array = param.grad
-        backend_name = param.array.device.backend.name
-        if backend_name not in ('native', 'cuda'):
-            raise RuntimeError(
-                'Default implementation of Optimizer.update_core_chainerx is '
-                'only provided for native or cuda backends (actual: {}). '
-                'Override Optimizer.update_core_chainerx() to implement '
-                'custom update logic.'.format(backend_name))
+
+        device = param.device
+        fallback_device = device.fallback_device
 
         # Convert state arrays to NumPy/CuPy
-        chainerx_state_arrays = {}
-        for state_name, st in self.state.items():
-            st = self.state[state_name]
-            if isinstance(st, chainerx.ndarray):
-                fallback_arr = backend.from_chx(st)
-                self.state[state_name] = fallback_arr
-                chainerx_state_arrays[state_name] = (st, fallback_arr)
+        chainerx_state_arrays = None
+        state = self.state
+        if state is not None:
+            chainerx_state_arrays = {}
+            for state_name, st in state.items():
+                if isinstance(st, chainerx.ndarray):
+                    fallback_arr = fallback_device.send(st)
+                    state[state_name] = fallback_arr
+                    chainerx_state_arrays[state_name] = (st, fallback_arr)
 
         # Create a temporary parameter with memory-shared NumPy/CuPy array
         # If the ChainerX parameter has a cached NumPy/CuPy copy, use the
         # cache and avoid redundant conversion. Else, create the cache here
         # and use it.
         if param._chainerx_fallback_array is None:
-            param._chainerx_fallback_array = backend.from_chx(
-                param.array)
+            param._chainerx_fallback_array = fallback_device.send(param.array)
 
         temp_param = variable.Variable._init_unchecked(
-            param._chainerx_fallback_array, is_chainerx_array=False)
+            param._chainerx_fallback_array,
+            device=fallback_device,
+            is_chainerx_array=False)
 
         if grad_array is not None:
             temp_param._set_grad_without_check(
-                backend.from_chx(grad_array))
+                fallback_device.send(grad_array))
 
         # Update
         self.update_core(temp_param)
 
         # Restore state arrays
-        for state_name, (arr, fallback_arr) in chainerx_state_arrays.items():
-            cur_arr = self.state[state_name]
-            if cur_arr is not fallback_arr:
-                # The optimizer altered the reference of the state, instead of
-                # updating it in-place. We need to convert the new state back
-                # to ChainerX.
-                arr = backend.to_chx(cur_arr)
-            self.state[state_name] = arr
+        if chainerx_state_arrays:
+            for state_name, (arr, fallback_arr) in (
+                    chainerx_state_arrays.items()):
+                cur_arr = state[state_name]
+                if cur_arr is not fallback_arr:
+                    # The optimizer altered the reference of the state, instead
+                    # of updating it in-place. We need to convert the new state
+                    # back to ChainerX.
+                    arr = device.send(cur_arr)
+                state[state_name] = arr
 
     def init_state(self, param):
         """Initializes the state.


### PR DESCRIPTION
Fixes #7312
Takes over #7313

After writing tests, I found that relying on `from_chx` causes `update_core_cpu` to be incorrectly called for `cuda:0` ChainerX parameter if it's uninitialized. It has been fixed altogether.