### PR TITLE
refactor mutiprocess updater hyperparam tuning

### DIFF
--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -744,7 +744,7 @@ class GradientMethod(Optimizer):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
         self._use_fp32_update = False
-        self.hyperparam.batch_size_factor = 1
+        self.hyperparam.grad_scale_factor = 1
 
     def setup(self, link):
         super(GradientMethod, self).setup(link)
@@ -865,12 +865,12 @@ class GradientMethod(Optimizer):
                 param.update_rule.use_fp32_update()
 
     @property
-    def batch_size_factor(self):
-        return self.hyperparam.batch_size_factor
+    def grad_scale_factor(self):
+        return self.hyperparam.grad_scale_factor
 
-    @batch_size_factor.setter
-    def batch_size_factor(self, batch_size_factor):
-        self.hyperparam.batch_size_factor = batch_size_factor
+    @grad_scale_factor.setter
+    def grad_scale_factor(self, grad_scale_factor):
+        self.hyperparam.grad_scale_factor = grad_scale_factor
 
 
 class HyperparameterProxy(object):

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -744,6 +744,7 @@ class GradientMethod(Optimizer):
         super(GradientMethod, self).__init__()
         self.hyperparam = Hyperparameter()
         self._use_fp32_update = False
+        self.hyperparam.batch_size_factor = 1
 
     def setup(self, link):
         super(GradientMethod, self).setup(link)
@@ -862,6 +863,14 @@ class GradientMethod(Optimizer):
         if link is not None:
             for param in link.params():
                 param.update_rule.use_fp32_update()
+
+    @property
+    def batch_size_factor(self):
+        return self.hyperparam.batch_size_factor
+
+    @batch_size_factor.setter
+    def batch_size_factor(self, batch_size_factor):
+        self.hyperparam.batch_size_factor = batch_size_factor
 
 
 class HyperparameterProxy(object):

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -60,8 +60,8 @@ class AdaDeltaRule(optimizer.UpdateRule):
             return
         msg, msdx = self.state['msg'], self.state['msdx']
         rho = self.hyperparam.rho
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = self.hyperparam.eps / batch_size_factor**2
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = self.hyperparam.eps / grad_scale_factor**2
 
         msg *= rho
         msg += (1 - rho) * grad * grad
@@ -74,8 +74,8 @@ class AdaDeltaRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = self.hyperparam.eps / batch_size_factor**2
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = self.hyperparam.eps / grad_scale_factor**2
         if AdaDeltaRule._kernel is None:
             AdaDeltaRule._kernel = cuda.elementwise(
                 'T grad, T one_minus_rho, T eps',

--- a/chainer/optimizers/ada_delta.py
+++ b/chainer/optimizers/ada_delta.py
@@ -60,7 +60,8 @@ class AdaDeltaRule(optimizer.UpdateRule):
             return
         msg, msdx = self.state['msg'], self.state['msdx']
         rho = self.hyperparam.rho
-        eps = self.hyperparam.eps
+        batch_size_factor = self.hyperparam.batch_size_factor
+        eps = self.hyperparam.eps / batch_size_factor**2
 
         msg *= rho
         msg += (1 - rho) * grad * grad
@@ -73,6 +74,8 @@ class AdaDeltaRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
+        batch_size_factor = self.hyperparam.batch_size_factor
+        eps = self.hyperparam.eps / batch_size_factor**2
         if AdaDeltaRule._kernel is None:
             AdaDeltaRule._kernel = cuda.elementwise(
                 'T grad, T one_minus_rho, T eps',
@@ -83,7 +86,7 @@ class AdaDeltaRule(optimizer.UpdateRule):
                    param -= dx;''',
                 'adadelta')
         AdaDeltaRule._kernel(
-            grad, 1 - self.hyperparam.rho, self.hyperparam.eps, param.data,
+            grad, 1 - self.hyperparam.rho, eps, param.data,
             self.state['msg'], self.state['msdx'])
 
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -57,7 +57,8 @@ class AdaGradRule(optimizer.UpdateRule):
             return
 
         lr = self.hyperparam.lr
-        eps = self.hyperparam.eps
+        batch_size_factor = self.hyperparam.batch_size_factor
+        eps = self.hyperparam.eps / batch_size_factor
         h = self.state['h']
 
         h += grad * grad
@@ -67,6 +68,8 @@ class AdaGradRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
+        batch_size_factor = self.hyperparam.batch_size_factor
+        eps = self.hyperparam.eps / batch_size_factor
         if AdaGradRule._kernel is None:
             AdaGradRule._kernel = cuda.elementwise(
                 'T grad, T lr, T eps',
@@ -74,7 +77,7 @@ class AdaGradRule(optimizer.UpdateRule):
                 '''h += grad * grad;
                    param -= lr * grad / (sqrt(h) + eps);''',
                 'adagrad')
-        AdaGradRule._kernel(grad, self.hyperparam.lr, self.hyperparam.eps,
+        AdaGradRule._kernel(grad, self.hyperparam.lr, eps,
                             param.data, self.state['h'])
 
 

--- a/chainer/optimizers/ada_grad.py
+++ b/chainer/optimizers/ada_grad.py
@@ -57,8 +57,8 @@ class AdaGradRule(optimizer.UpdateRule):
             return
 
         lr = self.hyperparam.lr
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = self.hyperparam.eps / batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = self.hyperparam.eps / grad_scale_factor
         h = self.state['h']
 
         h += grad * grad
@@ -68,8 +68,8 @@ class AdaGradRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = self.hyperparam.eps / batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = self.hyperparam.eps / grad_scale_factor
         if AdaGradRule._kernel is None:
             AdaGradRule._kernel = cuda.elementwise(
                 'T grad, T lr, T eps',

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -193,8 +193,8 @@ class AdamRule(optimizer.UpdateRule):
         self._check_eps(dtype)
         grad = grad.astype(dtype, copy=False)
 
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = self.hyperparam.eps / batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = self.hyperparam.eps / grad_scale_factor
 
         m, v = self.state['m'], self.state['v']
 
@@ -232,8 +232,8 @@ class AdamRule(optimizer.UpdateRule):
 
         # TODO(ecastill): verify that eps reduction applies to all Adam
         # derived methods
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = self.hyperparam.eps / batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = self.hyperparam.eps / grad_scale_factor
 
         if self._dummy is None:
             self._dummy = cuda.cupy.empty((0,), dtype=dtype)

--- a/chainer/optimizers/corrected_momentum_sgd.py
+++ b/chainer/optimizers/corrected_momentum_sgd.py
@@ -59,8 +59,8 @@ class CorrectedMomentumSGDRule(optimizer.UpdateRule):
         if grad is None:
             return
         v = self.state['v']
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         if isinstance(v, intel64.mdarray):
             v.inplace_axpby(self.hyperparam.momentum,
                             -1, grad)
@@ -74,8 +74,8 @@ class CorrectedMomentumSGDRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         cuda.elementwise(
             'T grad, T lr, T momentum',
             'T param, T v',

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -61,9 +61,10 @@ class MomentumSGDRule(optimizer.UpdateRule):
         if grad is None:
             return
         v = self.state['v']
+        batch_size_factor = self.hyperparam.batch_size_factor
+        lr = self.hyperparam.lr * batch_size_factor
         if isinstance(v, intel64.mdarray):
-            v.inplace_axpby(self.hyperparam.momentum, -
-                            self.hyperparam.lr, grad)
+            v.inplace_axpby(self.hyperparam.momentum, -lr, grad)
             param.data += v
         else:
             v *= self.hyperparam.momentum
@@ -74,6 +75,8 @@ class MomentumSGDRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
+        batch_size_factor = self.hyperparam.batch_size_factor
+        lr = self.hyperparam.lr * batch_size_factor
         if MomentumSGDRule._kernel is None:
             MomentumSGDRule._kernel = cuda.elementwise(
                 'T grad, T lr, T momentum',
@@ -82,7 +85,7 @@ class MomentumSGDRule(optimizer.UpdateRule):
                    param += v;''',
                 'momentum_sgd')
         MomentumSGDRule._kernel(
-            grad, self.hyperparam.lr, self.hyperparam.momentum, param.data,
+            grad, lr, self.hyperparam.momentum, param.data,
             self.state['v'])
 
 

--- a/chainer/optimizers/momentum_sgd.py
+++ b/chainer/optimizers/momentum_sgd.py
@@ -61,8 +61,8 @@ class MomentumSGDRule(optimizer.UpdateRule):
         if grad is None:
             return
         v = self.state['v']
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         if isinstance(v, intel64.mdarray):
             v.inplace_axpby(self.hyperparam.momentum, -lr, grad)
             param.data += v
@@ -75,8 +75,8 @@ class MomentumSGDRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         if MomentumSGDRule._kernel is None:
             MomentumSGDRule._kernel = cuda.elementwise(
                 'T grad, T lr, T momentum',

--- a/chainer/optimizers/msvag.py
+++ b/chainer/optimizers/msvag.py
@@ -104,8 +104,8 @@ class MSVAGRule(optimizer.UpdateRule):
             if numpy.isnan(factor):
                 factor = 0
 
-        batch_size_factor = hp.batch_size_factor
-        lr = hp.lr * batch_size_factor
+        grad_scale_factor = hp.grad_scale_factor
+        lr = hp.lr * grad_scale_factor
         param.data -= hp.eta * (lr * mt * factor +
                                 hp.weight_decay_rate * param.data)
 
@@ -122,8 +122,8 @@ class MSVAGRule(optimizer.UpdateRule):
                (((1.0 - self.beta_power) ** 2) * (1.0 - hp.beta ** 2)))
         rho = min(rho, 0.9999)
 
-        batch_size_factor = hp.batch_size_factor
-        lr = hp.lr * batch_size_factor
+        grad_scale_factor = hp.grad_scale_factor
+        lr = hp.lr * grad_scale_factor
         cuda.elementwise(
             'T grad, T lr, T one_minus_beta, T eta, \
              T weight_decay_rate, T beta_power, T rho',

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -56,8 +56,8 @@ class NesterovAGRule(optimizer.UpdateRule):
             return
         v = self.state['v']
 
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         momentum = self.hyperparam.momentum
 
         v *= momentum
@@ -69,8 +69,8 @@ class NesterovAGRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         if NesterovAGRule._kernel is None:
             NesterovAGRule._kernel = cuda.elementwise(
                 'T grad, T lr, T momentum',

--- a/chainer/optimizers/nesterov_ag.py
+++ b/chainer/optimizers/nesterov_ag.py
@@ -55,7 +55,10 @@ class NesterovAGRule(optimizer.UpdateRule):
         if grad is None:
             return
         v = self.state['v']
-        lr, momentum = self.hyperparam.lr, self.hyperparam.momentum
+
+        batch_size_factor = self.hyperparam.batch_size_factor
+        lr = self.hyperparam.lr * batch_size_factor
+        momentum = self.hyperparam.momentum
 
         v *= momentum
         v -= lr * grad
@@ -66,6 +69,8 @@ class NesterovAGRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
+        batch_size_factor = self.hyperparam.batch_size_factor
+        lr = self.hyperparam.lr * batch_size_factor
         if NesterovAGRule._kernel is None:
             NesterovAGRule._kernel = cuda.elementwise(
                 'T grad, T lr, T momentum',
@@ -76,7 +81,7 @@ class NesterovAGRule(optimizer.UpdateRule):
                 ''',
                 'nesterov_ag')
         NesterovAGRule._kernel(
-            grad, self.hyperparam.lr, self.hyperparam.momentum,
+            grad, lr, self.hyperparam.momentum,
             param.data, self.state['v'])
 
 

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -74,8 +74,8 @@ class RMSpropRule(optimizer.UpdateRule):
             return
         hp = self.hyperparam
         eps = grad.dtype.type(hp.eps)
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = eps / batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = eps / grad_scale_factor
         if hp.eps != 0 and eps == 0:
             raise ValueError(
                 'eps of RMSprop optimizer is too small for {} ({})'.format(
@@ -96,8 +96,8 @@ class RMSpropRule(optimizer.UpdateRule):
             return
         hp = self.hyperparam
         eps = grad.dtype.type(hp.eps)
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = eps / batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = eps / grad_scale_factor
         if eps == 0:
             raise ValueError(
                 'eps of RMSprop optimizer is too small for {} ({})'.format(

--- a/chainer/optimizers/rmsprop.py
+++ b/chainer/optimizers/rmsprop.py
@@ -74,6 +74,8 @@ class RMSpropRule(optimizer.UpdateRule):
             return
         hp = self.hyperparam
         eps = grad.dtype.type(hp.eps)
+        batch_size_factor = self.hyperparam.batch_size_factor
+        eps = eps / batch_size_factor
         if hp.eps != 0 and eps == 0:
             raise ValueError(
                 'eps of RMSprop optimizer is too small for {} ({})'.format(
@@ -94,6 +96,8 @@ class RMSpropRule(optimizer.UpdateRule):
             return
         hp = self.hyperparam
         eps = grad.dtype.type(hp.eps)
+        batch_size_factor = self.hyperparam.batch_size_factor
+        eps = eps / batch_size_factor
         if eps == 0:
             raise ValueError(
                 'eps of RMSprop optimizer is too small for {} ({})'.format(

--- a/chainer/optimizers/rmsprop_graves.py
+++ b/chainer/optimizers/rmsprop_graves.py
@@ -74,8 +74,8 @@ class RMSpropGravesRule(optimizer.UpdateRule):
         n, g, delta = self.state['n'], self.state['g'], self.state['delta']
         hp = self.hyperparam
 
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = hp.eps / batch_size_factor**2
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = hp.eps / grad_scale_factor**2
 
         n *= hp.alpha
         n += (1 - hp.alpha) * grad * grad
@@ -90,8 +90,8 @@ class RMSpropGravesRule(optimizer.UpdateRule):
         if grad is None:
             return
         hp = self.hyperparam
-        batch_size_factor = self.hyperparam.batch_size_factor
-        eps = hp.eps / batch_size_factor**2
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        eps = hp.eps / grad_scale_factor**2
         if RMSpropGravesRule._kernel is None:
             RMSpropGravesRule._kernel = cuda.elementwise(
                 'T grad, T lr, T alpha, T momentum, T eps',

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -44,20 +44,24 @@ class SGDRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
+        batch_size_factor = self.hyperparam.batch_size_factor
+        lr = self.hyperparam.lr * batch_size_factor
         if isinstance(param.data, intel64.mdarray):
             param.data.inplace_axpby(1.0, -self.hyperparam.lr, grad)
         else:
-            param.data -= self.hyperparam.lr * grad
+            param.data -= lr * grad
 
     def update_core_gpu(self, param):
         grad = param.grad
         if grad is None:
             return
+        batch_size_factor = self.hyperparam.batch_size_factor
+        lr = self.hyperparam.lr * batch_size_factor
         if SGDRule._kernel is None:
             SGDRule._kernel = cuda.elementwise(
                 'T grad, T lr', 'T param',
                 'param -= lr * grad', 'sgd')
-        SGDRule._kernel(grad, self.hyperparam.lr, param.data)
+        SGDRule._kernel(grad, lr, param.data)
 
 
 class SGD(optimizer.GradientMethod):

--- a/chainer/optimizers/sgd.py
+++ b/chainer/optimizers/sgd.py
@@ -44,8 +44,8 @@ class SGDRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         if isinstance(param.data, intel64.mdarray):
             param.data.inplace_axpby(1.0, -self.hyperparam.lr, grad)
         else:
@@ -55,8 +55,8 @@ class SGDRule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         if SGDRule._kernel is None:
             SGDRule._kernel = cuda.elementwise(
                 'T grad, T lr', 'T param',

--- a/chainer/optimizers/smorms3.py
+++ b/chainer/optimizers/smorms3.py
@@ -60,8 +60,8 @@ class SMORMS3Rule(optimizer.UpdateRule):
             return
         mem, g, g2 = self.state['mem'], self.state['g'], self.state['g2']
 
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
 
         r = 1 / (mem + 1)
         g = (1 - r) * g + r * grad
@@ -77,8 +77,8 @@ class SMORMS3Rule(optimizer.UpdateRule):
         grad = param.grad
         if grad is None:
             return
-        batch_size_factor = self.hyperparam.batch_size_factor
-        lr = self.hyperparam.lr * batch_size_factor
+        grad_scale_factor = self.hyperparam.grad_scale_factor
+        lr = self.hyperparam.lr * grad_scale_factor
         if SMORMS3Rule._kernel is None:
             SMORMS3Rule._kernel = cuda.elementwise(
                 'T grad, T lr, T eps',

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -143,23 +143,11 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
         for iterator in iterators[1:]:
             assert len(iterator.dataset) == len(iterators[0].dataset)
 
-        # Correct optimizer parameters for new minibatch size
-        optim = optimizer.__class__.__name__
-        if optim in ('Adam', 'AdaGrad', 'RMSprop'):
-            optimizer.eps *= len(devices)
-            warnings.warn('optimizer.eps is changed to {} '
+        if len(devices) > 1:
+            optimizer.batch_size_factor = 1.0/len(devices)
+            warnings.warn('optimizer.batch_size_factor is changed to {} '
                           'by MultiprocessParallelUpdater for new batch size.'.
-                          format(optimizer.eps))
-        elif optim in ('RMSpropGraves', 'AdaDelta'):
-            optimizer.eps *= len(devices) ** 2  # not quite right for AdaDelta
-            warnings.warn('optimizer.eps is changed to {} '
-                          'by MultiprocessParallelUpdater for new batch size.'.
-                          format(optimizer.eps))
-        elif hasattr(optimizer, 'lr'):
-            optimizer.lr /= len(devices)
-            warnings.warn('optimizer.lr is changed to {} '
-                          'by MultiprocessParallelUpdater for new batch size.'.
-                          format(optimizer.lr))
+                          format(optimizer.batch_size_factor))
 
         super(MultiprocessParallelUpdater, self).__init__(
             iterator=iterators[0],

--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -144,10 +144,10 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
             assert len(iterator.dataset) == len(iterators[0].dataset)
 
         if len(devices) > 1:
-            optimizer.batch_size_factor = 1.0/len(devices)
-            warnings.warn('optimizer.batch_size_factor is changed to {} '
-                          'by MultiprocessParallelUpdater for new batch size.'.
-                          format(optimizer.batch_size_factor))
+            optimizer.grad_scale_factor = 1.0/len(devices)
+            warnings.warn('optimizer.grad_scale_factor is changed to {} by'
+                          'MultiprocessParallelUpdater for the new batch size.'
+                          .format(optimizer.grad_scale_factor))
 
         super(MultiprocessParallelUpdater, self).__init__(
             iterator=iterators[0],

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -44,9 +44,9 @@ class TestOptimizerHyperparameter(unittest.TestCase):
     def test_hyperparams(self):
         self.create()
         default = self.optimizer.hyperparam.get_dict()
-        # batch_size_factor is not a parameter to the constructor
+        # grad_scale_factor is not a parameter to the constructor
         # of the optimizers
-        del default['batch_size_factor']
+        del default['grad_scale_factor']
         for name, default_value in six.iteritems(default):
             self.create()
             self.assertEqual(self.get_hyperparam(name), default_value)

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -44,6 +44,9 @@ class TestOptimizerHyperparameter(unittest.TestCase):
     def test_hyperparams(self):
         self.create()
         default = self.optimizer.hyperparam.get_dict()
+        # batch_size_factor is not a parameter to the constructor
+        # of the optimizers
+        del default['batch_size_factor']
         for name, default_value in six.iteritems(default):
             self.create()
             self.assertEqual(self.get_hyperparam(name), default_value)


### PR DESCRIPTION
#7481 related

avoids hardcoding of optimizers in the `MultiprocessParallelUpdater` to tune
some hyperparameters according to the number of devices.

Provides an interface in the optimizer class to do this update