### PR TITLE
Get number of remaining batches from iterator

### DIFF
--- a/chainer/dataset/iterator.py
+++ b/chainer/dataset/iterator.py
@@ -72,6 +72,17 @@ class Iterator(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.finalize()
 
+    def remaining_size(self):
+        """Returns remaining number of batches of the epoch.
+
+        .. note::
+           This method is optional to inherited iterators; underlying
+           dataset may or may not have fixed length. Developers have
+           make sure this method is implemented before running it.
+
+        """
+        raise NotImplementedError
+
     def serialize(self, serializer):
         """Serializes the internal state of the iterator.
 

--- a/chainer/iterators/multiprocess_iterator.py
+++ b/chainer/iterators/multiprocess_iterator.py
@@ -211,6 +211,13 @@ class MultiprocessIterator(iterator.Iterator):
             return None
         return self._previous_epoch_detail
 
+    def remaining_batch_num(self):
+        remain = len(self.dataset) - self.current_position
+        if remain % self.batch_size == 0:
+            return remain // self.batch_size
+        else:
+            return remain // self.batch_size + 1
+
     def serialize(self, serializer):
         current_position = serializer('current_position',
                                       self.current_position)

--- a/chainer/iterators/multithread_iterator.py
+++ b/chainer/iterators/multithread_iterator.py
@@ -121,6 +121,13 @@ class MultithreadIterator(iterator.Iterator):
             return None
         return self._previous_epoch_detail
 
+    def remaining_batch_num(self):
+        remain = len(self.dataset) - self.current_position
+        if remain % self.batch_size == 0:
+            return remain // self.batch_size
+        else:
+            return remain // self.batch_size + 1
+
     def serialize(self, serializer):
         current_position = serializer(
             'current_position', self.current_position)

--- a/chainer/iterators/serial_iterator.py
+++ b/chainer/iterators/serial_iterator.py
@@ -102,6 +102,13 @@ class SerialIterator(iterator.Iterator):
             return None
         return self._previous_epoch_detail
 
+    def remaining_batch_num(self):
+        remain = len(self.dataset) - self.current_position
+        if remain % self.batch_size == 0:
+            return remain // self.batch_size
+        else:
+            return remain // self.batch_size + 1
+
     def serialize(self, serializer):
         current_position = serializer('current_position',
                                       self.current_position)


### PR DESCRIPTION
I want to discuss the naming and spec of the iterator expansion, thus this is marked as WIP. 

For efficient and correct multi-node evaluation remaining number of batches is an important information for multi-node evaluation coordinator, which behaves like [rank==0 process in apply_iterator](https://github.com/chainer/chainercv/blob/v0.13.1/chainercv/utils/iterator/apply_to_iterator.py#L125) (although it does not stream batches but just send out all examples). This work is part of https://github.com/chainer/chainer/issues/7305 and will be followed with new multi-node evaluator pull request.

c.f. https://github.com/chainer/chainer/pull/7327