### PR TITLE
Bugfix for pytest 2x2

### DIFF
--- a/chainermn/communicators/two_dimensional_communicator.py
+++ b/chainermn/communicators/two_dimensional_communicator.py
@@ -54,7 +54,7 @@ class TwoDimensionalCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         itemsize = 4
         n_elems_total = _memory_utility.count_grad_elements(params,
                                                             zero_fill)
-        n_elems_per_node_2d = int(math.ceil(n_elems_total / self.size))
+        n_elems_per_node_2d = int(math.ceil(n_elems_total / self.inter_size))
         n_elems_per_node_1d = n_elems_per_node_2d * self.inter_size
         n_bytes_per_node_1d = n_elems_per_node_1d * itemsize
         n_bytes_per_node_2d = n_elems_per_node_2d * itemsize


### PR DESCRIPTION
This commit fixes a bug on two_dimensional_communicator, which can be
triggered when running on a certain mpi topology.
This closes #6882 

Thank you for creating a pull request!

Please double-check the following.

- Read [our contribution guide](https://docs.chainer.org/en/stable/contribution.html).
  - Does your code conform to our coding guidelines?
  - Did you write sufficient test code?
  - Did you write sufficient documentation?
- Also, take a look at [our compatibility policy](https://docs.chainer.org/en/stable/compatibility.html).
