### PR TITLE
Fix deadlock on MultiprocessIterator and MultiprocessParallelUpdater

### DIFF
--- a/chainer/training/updaters/multiprocess_parallel_updater.py
+++ b/chainer/training/updaters/multiprocess_parallel_updater.py
@@ -265,6 +265,8 @@ class MultiprocessParallelUpdater(standard_updater.StandardUpdater):
         for worker in self._workers:
             worker.join()
 
+        super(MultiprocessParallelUpdater, self).finalize()
+
 
 def _calc_loss(model, in_arrays):
     if isinstance(in_arrays, tuple):


### PR DESCRIPTION
When using MultiprocessIterator in conjunction with MultiprocessParallelUpdater
The iterators are not finalized on MultiprocessParallelUpdater.finalize method.

The iterator state is cleanup while the python process exits and the iterator internal state is now inconsistent. The iterator uses an internal thread that gets stuck and tries to perpetually join it 
deadlocking the execution.