### PR TITLE
Fix AdamW update rule regression on CPU

### DIFF
--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -217,7 +217,7 @@ class AdamRule(optimizer.UpdateRule):
         # param -=
         #  eta * (step * m - weight_decay_rate * param)
         _inplace_axpby(
-            param.data, 1.0 - hp.weight_decay_rate, -hp.eta, step * m)
+            param.data, 1.0 - hp.eta * hp.weight_decay_rate, -hp.eta, step * m)
 
     def update_core_gpu(self, param):
         grad = param.grad

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -145,4 +145,40 @@ class TestOptimizerLossScaling(unittest.TestCase):
             self.optimizer.loss_scaling(scale=-1)
 
 
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        # CPU
+        {},
+        # Intel
+        {'use_ideep': True},
+        # CUDA
+        {'use_cuda': True, 'cuda_device': 0},
+        # ChainerX
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+    ]
+)
+class TestAdamW(unittest.TestCase):
+
+    def test_adam_w(self, backend_config):
+        xp = backend_config.xp
+        device = backend_config.device
+
+        link = chainer.Link(x=(1,))
+        link.to_device(device)
+
+        opt = optimizers.Adam(eta=0.5, weight_decay_rate=0.1)
+        opt.setup(link)
+
+        link.x.data.fill(1)
+        link.x.grad = device.send(xp.ones_like(link.x.data))
+
+        opt.update()
+
+        # compare against the value computed with v5 impl
+        testing.assert_allclose(link.x.data, np.array([0.9495]),
+                                atol=1e-7, rtol=1e-7)
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Fix #7365.

I added a simple test to check against the behavior of a past version. We may want similar tests for other optimizers, too (out-of-scope of this PR, though). Feel free to discuss if there is a better way to catch this kind of regression.