### PR TITLE
Use `backend.get_array_module` not `cuda.get_array_module`

### DIFF
--- a/chainer/distribution.py
+++ b/chainer/distribution.py
@@ -1,6 +1,6 @@
 import copy
 
-from chainer.backends import cuda
+from chainer import backend
 
 
 class Distribution(object):
@@ -334,7 +334,7 @@ class Distribution(object):
         Depending on which of CPU/GPU this distribution is on, this property
         returns :mod:`numpy` or :mod:`cupy`.
         """
-        return cuda.get_array_module(*self.params.values())
+        return backend.get_array_module(*self.params.values())
 
 
 _KLDIVERGENCE = {}

--- a/chainer/distributions/cauchy.py
+++ b/chainer/distributions/cauchy.py
@@ -77,7 +77,7 @@ class Cauchy(distribution.Distribution):
     def mean(self):
         warnings.warn('Mean of the cauchy distribution is undefined.',
                       RuntimeWarning)
-        xp = cuda.get_array_module(self.loc)
+        xp = chainer.backend.get_array_module(self.loc)
         return chainer.as_variable(xp.full_like(self.loc.data, xp.nan))
 
     @property
@@ -85,7 +85,7 @@ class Cauchy(distribution.Distribution):
         return {'loc': self.loc, 'scale': self.scale}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.loc)
+        xp = chainer.backend.get_array_module(self.loc)
         if xp is cuda.cupy:
             eps = xp.random.standard_cauchy(
                 (n,)+self.loc.shape, dtype=self.loc.dtype)
@@ -105,5 +105,5 @@ class Cauchy(distribution.Distribution):
     def variance(self):
         warnings.warn('Variance of the cauchy distribution is undefined.',
                       RuntimeWarning)
-        xp = cuda.get_array_module(self.loc)
+        xp = chainer.backend.get_array_module(self.loc)
         return chainer.as_variable(xp.full_like(self.loc.data, xp.nan))

--- a/chainer/distributions/chisquare.py
+++ b/chainer/distributions/chisquare.py
@@ -61,7 +61,7 @@ class Chisquare(distribution.Distribution):
         return {'k': self.k}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.k)
+        xp = chainer.backend.get_array_module(self.k)
         if xp is cuda.cupy:
             eps = xp.random.chisquare(
                 self.k.data, (n,)+self.k.shape, dtype=self.k.dtype)

--- a/chainer/distributions/dirichlet.py
+++ b/chainer/distributions/dirichlet.py
@@ -1,7 +1,6 @@
 import numpy
 
 import chainer
-from chainer.backends import cuda
 from chainer import distribution
 from chainer.functions.array import expand_dims
 from chainer.functions.math import digamma
@@ -74,7 +73,7 @@ class Dirichlet(distribution.Distribution):
 
     def sample_n(self, n):
         obo_alpha = self.alpha.data.reshape(-1, self.event_shape[0])
-        xp = cuda.get_array_module(self.alpha)
+        xp = chainer.backend.get_array_module(self.alpha)
         if xp is numpy:
             eps = [xp.random.dirichlet(
                 one_alpha, size=(n,)).astype(numpy.float32)

--- a/chainer/distributions/exponential.py
+++ b/chainer/distributions/exponential.py
@@ -74,7 +74,7 @@ class Exponential(distribution.Distribution):
         return {'lam': self.lam}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.lam)
+        xp = chainer.backend.get_array_module(self.lam)
         if xp is cuda.cupy:
             eps = xp.random.standard_exponential(
                 (n,)+self.lam.shape, dtype=self.lam.dtype)

--- a/chainer/distributions/gamma.py
+++ b/chainer/distributions/gamma.py
@@ -68,7 +68,7 @@ class Gamma(distribution.Distribution):
         return {'k': self.k, 'theta': self.theta}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.k)
+        xp = chainer.backend.get_array_module(self.k)
         if xp is cuda.cupy:
             eps = xp.random.gamma(
                 self.k.data, size=(n,) + self.batch_shape, dtype=self.k.dtype)

--- a/chainer/distributions/geometric.py
+++ b/chainer/distributions/geometric.py
@@ -52,7 +52,7 @@ class Geometric(distribution.Distribution):
         return {'p': self.p}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.p)
+        xp = chainer.backend.get_array_module(self.p)
         if xp is cuda.cupy:
             eps = xp.random.geometric(
                 self.p.data,

--- a/chainer/distributions/gumbel.py
+++ b/chainer/distributions/gumbel.py
@@ -76,7 +76,7 @@ class Gumbel(distribution.Distribution):
         return {'loc': self.loc, 'scale': self.scale}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.loc)
+        xp = chainer.backend.get_array_module(self.loc)
         if xp is cuda.cupy:
             eps = xp.random.gumbel(
                 size=(n,)+self.batch_shape, dtype=self.loc.dtype)

--- a/chainer/distributions/one_hot_categorical.py
+++ b/chainer/distributions/one_hot_categorical.py
@@ -76,7 +76,7 @@ class OneHotCategorical(distribution.Distribution):
         return {'p': self.p}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.p)
+        xp = chainer.backend.get_array_module(self.p)
         obo_p = self.p.data.reshape((-1,) + self.event_shape)
         eye = xp.eye(self.event_shape[0], dtype=self.p.dtype)
         eps = [_random_choice(xp, one_p.shape[0], size=(n,), p=one_p)

--- a/chainer/distributions/pareto.py
+++ b/chainer/distributions/pareto.py
@@ -82,7 +82,7 @@ class Pareto(distribution.Distribution):
         return {'scale': self.scale, 'alpha': self.alpha}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.scale)
+        xp = chainer.backend.get_array_module(self.scale)
         if xp is cuda.cupy:
             eps = xp.random.pareto(
                 self.alpha.data, (n,)+self.batch_shape, dtype=self.alpha.dtype)

--- a/chainer/distributions/poisson.py
+++ b/chainer/distributions/poisson.py
@@ -62,7 +62,7 @@ class Poisson(distribution.Distribution):
         return {'lam': self.lam}
 
     def sample_n(self, n):
-        xp = cuda.get_array_module(self.lam)
+        xp = chainer.backend.get_array_module(self.lam)
         if xp is cuda.cupy:
             eps = xp.random.poisson(
                 self.lam.data, size=(n,)+self.batch_shape, dtype=xp.float32)

--- a/chainer/functions/activation/slstm.py
+++ b/chainer/functions/activation/slstm.py
@@ -261,7 +261,7 @@ def slstm_grad_grad(c_prev1, a1, i1, f1,
                     o, c, gc, gh,
                     ggc_prev1, gga1, ggi1, ggf1, ggo1,
                     ggc_prev2, gga2, ggi2, ggf2, ggo2):
-    xp = cuda.get_array_module(a1)
+    xp = backend.get_array_module(a1)
     sig_o = _sigmoid(o, xp)
     gsig_o = _grad_sigmoid(sig_o)
     ggsig_o = _grad_grad_sigmoid(sig_o)

--- a/chainer/functions/array/as_strided.py
+++ b/chainer/functions/array/as_strided.py
@@ -1,6 +1,7 @@
 import numpy as np
 import six
 
+from chainer import backend
 from chainer.backends import cuda
 from chainer import function_node
 from chainer.utils import type_check
@@ -251,7 +252,7 @@ class AsStridedGrad(function_node.FunctionNode):
         if gy.dtype not in np.sctypes['float']:
             raise TypeError('Only float is supported for back propagation')
 
-        xp = cuda.get_array_module(gy)
+        xp = backend.get_array_module(gy)
         input_geometry = self.input_geometry
         itemsize = input_geometry.itemsize
 
@@ -262,7 +263,7 @@ class AsStridedGrad(function_node.FunctionNode):
         #  [redundant axis]
         #  axis with shape==0, shape==1 or strides==0
         if 0 in gy.shape:
-            return cuda.get_array_module(gy).zeros(input_geometry.shape)
+            return backend.get_array_module(gy).zeros(input_geometry.shape)
         else:
             out_shape = tuple([
                 self.shape[i] for i in six.moves.range(gy.ndim)

--- a/chainer/functions/connection/linear.py
+++ b/chainer/functions/connection/linear.py
@@ -1,6 +1,6 @@
 import numpy
 
-from chainer.backends import cuda
+from chainer import backend
 from chainer.backends import intel64
 from chainer import function_node
 import chainer.functions
@@ -102,7 +102,7 @@ class LinearFunction(function_node.FunctionNode):
         # In order to be compatible with the "static graph" feature, it is
         # required that all output arrays of this forward
         # function be allocated explicitly:
-        xp = cuda.get_array_module(x)
+        xp = backend.get_array_module(x)
         y = xp.empty((x.shape[0], W.shape[0]), dtype=x.dtype)
 
         # This is required because all of the "static_*()" functions

--- a/chainer/functions/loss/discriminative_loss.py
+++ b/chainer/functions/loss/discriminative_loss.py
@@ -1,4 +1,4 @@
-from chainer.backends import cuda
+from chainer import backend
 from chainer.functions.activation.relu import relu
 from chainer.functions.array.broadcast import broadcast_to
 from chainer.functions.math.basic_math import absolute
@@ -81,7 +81,7 @@ class DiscriminativeMarginBasedClusteringLoss(object):
 
         l_dist = 0.0
         count = 0
-        xp = cuda.get_array_module(embeddings)
+        xp = backend.get_array_module(embeddings)
 
         emb = embeddings[None, :]
         emb = broadcast_to(emb, (emb.shape[1],

--- a/chainer/functions/math/arctanh.py
+++ b/chainer/functions/math/arctanh.py
@@ -1,4 +1,4 @@
-from chainer.backends import cuda
+from chainer import backend
 from chainer import function_node
 from chainer import utils
 from chainer.utils import type_check
@@ -17,7 +17,7 @@ class Arctanh(function_node.FunctionNode):
     def forward(self, inputs):
         self.retain_inputs((0,))
         x, = inputs
-        xp = cuda.get_array_module(x)
+        xp = backend.get_array_module(x)
         y = xp.arctanh(x)
         return utils.force_array(y, dtype=x.dtype),
 

--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -1,5 +1,4 @@
 import chainer
-from chainer.backends import cuda
 from chainer import function_node
 import chainer.functions
 from chainer.utils import precision
@@ -27,7 +26,7 @@ class BatchDet(function_node.FunctionNode):
         self.retain_inputs((0,))
         self.retain_outputs((0,))
         x, = inputs
-        xp = cuda.get_array_module(x)
+        xp = chainer.backend.get_array_module(x)
         detx = xp.linalg.det(x)
         return detx,
 

--- a/chainer/graph_optimizations/static_graph.py
+++ b/chainer/graph_optimizations/static_graph.py
@@ -174,7 +174,7 @@ class ArrayInfo(object):
         self.shape = array.shape
         self.dtype = array.dtype
         # either numpy or cupy
-        self.ndarray_module = cuda.get_array_module(array)
+        self.ndarray_module = chainer.backend.get_array_module(array)
         if self.ndarray_module is cuda.cupy:
             # device id, if available.
             self.device = cuda.get_device_from_array(array)

--- a/chainer/training/extensions/variable_statistics_plot.py
+++ b/chainer/training/extensions/variable_statistics_plot.py
@@ -115,7 +115,7 @@ class Statistician(object):
             out['std'] = x.std(axis=axis)
 
         if self.percentile_sigmas:
-            xp = cuda.get_array_module(x)
+            xp = backend.get_array_module(x)
             p = xp.percentile(x, self.percentile_sigmas, axis=axis)
             out['percentile'] = p
 

--- a/docs/source/examples/dcgan.rst
+++ b/docs/source/examples/dcgan.rst
@@ -300,7 +300,7 @@ the optimizers.
     Note that the type of arrays on CPU  is ``numpy.ndarray``, while the type
     of arrays on GPU is ``cupy.ndarray``. However, users do not need to write
     ``if`` condition explicitly, because the appropriate array module can be
-    obtained by ``xp = chainer.backends.cuda.get_array_module(variable.array)``.
+    obtained by ``xp = chainer.backend.get_array_module(variable.array)``.
     If ``variable`` is on GPU, ``cupy`` is assigned to ``xp``, otherwise
     ``numpy`` is assigned to ``xp``.
 

--- a/docs/source/guides/functions.rst
+++ b/docs/source/guides/functions.rst
@@ -308,7 +308,7 @@ It can be written straight-forward as follows:
    Of course, the module in such environment is almost useless, but if the interpreter does not run through the code accessing CUDA-dedicated functions, the code is still valid.
 
 The CPU and GPU implementations are almost same, except that :mod:`numpy` is replaced by :mod:`cupy` in ``forward_gpu``.
-We can unify these functions using the :func:`chainer.backends.cuda.get_array_module` function.
+We can unify these functions using the :func:`chainer.backend.get_array_module` function.
 This function accepts arbitrary number of arrays, and returns an appropriate module for them.
 See the following code:
 

--- a/examples/imagenet/dali_util.py
+++ b/examples/imagenet/dali_util.py
@@ -125,7 +125,7 @@ class DaliConverter(object):
     def __call__(self, inputs, device=None):
         """Convert DALI arrays to Numpy/CuPy arrays"""
 
-        xp = cuda.get_array_module(self.perturbation)
+        xp = chainer.backend.get_array_module(self.perturbation)
         if xp is not cuda.cupy:
             self.perturbation = cuda.to_gpu(self.perturbation, device)
 

--- a/tests/chainer_tests/distributions_tests/test_bernoulli.py
+++ b/tests/chainer_tests/distributions_tests/test_bernoulli.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+from chainer import backend
 from chainer.backends import cuda
 from chainer import distributions
 from chainer import gradient_check
@@ -68,7 +69,7 @@ class TestBernoulli(testing.distribution_unittest):
             log_prob = self.gpu_dist.log_prob(cuda.to_gpu(smp)).data
         else:
             log_prob = self.cpu_dist.log_prob(smp).data
-        xp = cuda.get_array_module(log_prob)
+        xp = backend.get_array_module(log_prob)
         if self.binary_check:
             self.assertTrue(xp.all(log_prob == -xp.inf))
         else:
@@ -87,7 +88,7 @@ class TestBernoulli(testing.distribution_unittest):
             prob = self.gpu_dist.prob(cuda.to_gpu(smp)).data
         else:
             prob = self.cpu_dist.prob(smp).data
-        xp = cuda.get_array_module(prob)
+        xp = backend.get_array_module(prob)
         if self.binary_check:
             self.assertTrue(xp.all(prob == 0))
         else:

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_roi_max_align_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_roi_max_align_2d.py
@@ -102,7 +102,7 @@ class TestROIMaxAlign2D(unittest.TestCase):
                 x, rois, roi_indices, outsize=self.outsize,
                 spatial_scale=self.spatial_scale,
                 sampling_ratio=self.sampling_ratio)
-            xp = cuda.get_array_module(y)
+            xp = chainer.backend.get_array_module(y)
             y = functions.where(
                 xp.isinf(y.array), xp.zeros(y.shape, dtype=y.dtype), y)
             return y


### PR DESCRIPTION
This PR replaces (deprecated) `cuda.get_array_module` with `chainer.backend.get_array_module` / `backend.get_array_module`.

Before
```shell
~/.ghq/github.com/crcrpar/chainer master ⇡
py37 ❯ git grep -n -e cuda\.get_array_module
chainer/distribution.py:337:        return cuda.get_array_module(*self.params.values())
chainer/distributions/cauchy.py:80:        xp = cuda.get_array_module(self.loc)
chainer/distributions/cauchy.py:88:        xp = cuda.get_array_module(self.loc)
chainer/distributions/cauchy.py:108:        xp = cuda.get_array_module(self.loc)
chainer/distributions/chisquare.py:64:        xp = cuda.get_array_module(self.k)
chainer/distributions/dirichlet.py:77:        xp = cuda.get_array_module(self.alpha)
chainer/distributions/exponential.py:77:        xp = cuda.get_array_module(self.lam)
chainer/distributions/gamma.py:71:        xp = cuda.get_array_module(self.k)
chainer/distributions/geometric.py:55:        xp = cuda.get_array_module(self.p)
chainer/distributions/gumbel.py:79:        xp = cuda.get_array_module(self.loc)
chainer/distributions/one_hot_categorical.py:79:        xp = cuda.get_array_module(self.p)
chainer/distributions/pareto.py:85:        xp = cuda.get_array_module(self.scale)
chainer/distributions/poisson.py:65:        xp = cuda.get_array_module(self.lam)
chainer/functions/activation/slstm.py:264:    xp = cuda.get_array_module(a1)
chainer/functions/array/as_strided.py:254:        xp = cuda.get_array_module(gy)
chainer/functions/array/as_strided.py:265:            return cuda.get_array_module(gy).zeros(input_geometry.shape)
chainer/functions/connection/linear.py:105:        xp = cuda.get_array_module(x)
chainer/functions/loss/discriminative_loss.py:84:        xp = cuda.get_array_module(embeddings)
chainer/functions/math/arctanh.py:20:        xp = cuda.get_array_module(x)
chainer/functions/math/det.py:30:        xp = cuda.get_array_module(x)
chainer/graph_optimizations/static_graph.py:177:        self.ndarray_module = cuda.get_array_module(array)
chainer/training/extensions/variable_statistics_plot.py:118:            xp = cuda.get_array_module(x)
docs/source/examples/dcgan.rst:303:    obtained by ``xp = chainer.backends.cuda.get_array_module(variable.array)``.
docs/source/guides/functions.rst:311:We can unify these functions using the :func:`chainer.backends.cuda.get_array_module` function.
docs/source/reference/backends.rst:88:   chainer.backends.cuda.get_array_module
docs/source/upgrade.rst:136:In addition to ``chainer.backends``, we introduced ``chainer.backend``. This subpackage contains utility functions that span several backends. For instance, it includes :func:`chainer.backend.get_array_module` which used to be defined in :func:`chainer.backends.cuda.get_array_module`. Both can be used but the latter will be deprecated.
docs/source/upgrade_v2.rst:312:               xp = chainer.cuda.get_array_module(inputs[0])
docs/source/upgrade_v2.rst:327:               xp = chainer.cuda.get_array_module(inputs[0])
examples/imagenet/dali_util.py:128:        xp = cuda.get_array_module(self.perturbation)
tests/chainer_tests/distributions_tests/test_bernoulli.py:71:        xp = cuda.get_array_module(log_prob)
tests/chainer_tests/distributions_tests/test_bernoulli.py:90:        xp = cuda.get_array_module(prob)
tests/chainer_tests/functions_tests/pooling_tests/test_roi_max_align_2d.py:105:            xp = cuda.get_array_module(y)
```

After
```shell
~/.ghq/github.com/crcrpar/chainer use-backend-getarraymodule ⇡
py37 ❯ git grep -n -e cuda\.get_array_module
docs/source/examples/dcgan.rst:303:    obtained by ``xp = chainer.backends.cuda.get_array_module(variable.array)``.
docs/source/guides/functions.rst:311:We can unify these functions using the :func:`chainer.backends.cuda.get_array_module` function.
docs/source/reference/backends.rst:88:   chainer.backends.cuda.get_array_module
docs/source/upgrade.rst:136:In addition to ``chainer.backends``, we introduced ``chainer.backend``. This subpackage contains utility functions that span several backends. For instance, it includes :func:`chainer.backend.get_array_module` which used to be defined in :func:`chainer.backends.cuda.get_array_module`. Both can be used but the latter will be deprecated.
docs/source/upgrade_v2.rst:312:               xp = chainer.cuda.get_array_module(inputs[0])
docs/source/upgrade_v2.rst:327:               xp = chainer.cuda.get_array_module(inputs[0])
```