### PR TITLE
Emit build info of ChainerX and stop hiding `ImportError`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 build
 \#*\#
 .\#*
+_build_info.py
 .coverage
 .eggs/
 _readthedocs_build

--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -1,16 +1,14 @@
 import os
-import sys
 import warnings
 
+from chainerx import _build_info
 
-if sys.version_info[0] < 3:
-    _available = False
+
+if _build_info.build_chainerx:
+    from chainerx import _core
+    _available = True
 else:
-    try:
-        from chainerx import _core
-        _available = True
-    except Exception:
-        _available = False
+    _available = False
 
 
 if _available:

--- a/chainerx_build_helper.py
+++ b/chainerx_build_helper.py
@@ -12,6 +12,13 @@ import setuptools
 from setuptools.command import build_ext
 
 
+def emit_build_info(build_chainerx):
+    dirname = os.path.dirname(__file__)
+    filename = os.path.join(dirname, 'chainerx/_build_info.py')
+    with open(filename, mode='w') as f:
+        f.write('build_chainerx = {}\n'.format(build_chainerx))
+
+
 class CMakeExtension(setuptools.Extension):
 
     def __init__(self, name, build_targets, sourcedir=''):
@@ -89,6 +96,10 @@ class CMakeBuild(build_ext.build_ext):
 
 
 def config_setup_kwargs(setup_kwargs, build_chainerx):
+
+    # TODO(imanishi): Call this function with setuptools.
+    emit_build_info(build_chainerx)
+
     if not build_chainerx:
         # `chainerx` package needs to be able to be imported even if ChainerX
         # is unavailable.


### PR DESCRIPTION
Fix #7349.