### PR TITLE
Remove ChainerX `CopyKernel`

### DIFF
--- a/chainerx_cc/chainerx/array.cc
+++ b/chainerx_cc/chainerx/array.cc
@@ -31,6 +31,7 @@
 #include "chainerx/dtype.h"
 #include "chainerx/error.h"
 #include "chainerx/graph.h"
+#include "chainerx/kernels/creation.h"
 #include "chainerx/kernels/misc.h"
 #include "chainerx/macro.h"
 #include "chainerx/native/native_backend.h"
@@ -395,7 +396,8 @@ Array Array::AsType(Dtype dtype, bool copy) const {
     }
 
     Array out = Empty(shape(), dtype, device());
-    device().backend().CallKernel<AsTypeKernel>(*this, out);
+    // Note: In CopyKernel, Input Array Elements are casted to the type of Output Array.
+    device().backend().CallKernel<CopyKernel>(*this, out);
 
     if (GetKind(dtype) == DtypeKind::kFloat) {
         BackwardBuilder bb{"astype", *this, out};

--- a/chainerx_cc/chainerx/cuda/cuda_device/copy.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/copy.cu
@@ -12,23 +12,19 @@
 #include "chainerx/device.h"
 #include "chainerx/dtype.h"
 #include "chainerx/kernels/creation.h"
-#include "chainerx/kernels/misc.h"
-#include "chainerx/routines/creation.h"
 
 namespace chainerx {
 namespace cuda {
 namespace {
 
-CHAINERX_CUDA_REGISTER_ELTWISE_UNARY_KERNEL(CopyKernel, { out = x; });
-
 template <typename InT, typename OutT>
-struct AsTypeImpl {
+struct CopyImpl {
     using InCudaType = cuda_internal::DataType<InT>;
     using OutCudaType = cuda_internal::DataType<OutT>;
     __device__ void operator()(int64_t /*i*/, InCudaType a, OutCudaType& out) { out = static_cast<OutCudaType>(a); }
 };
 
-class CudaAsTypeKernel : public AsTypeKernel {
+class CudaCopyKernel : public CopyKernel {
 public:
     void Call(const Array& a, const Array& out) override {
         Device& device = a.device();
@@ -37,13 +33,13 @@ public:
         auto do_astype = [&](auto in_pt, auto out_pt) {
             using InT = typename decltype(in_pt)::type;
             using OutT = typename decltype(out_pt)::type;
-            Elementwise<const InT, OutT>(AsTypeImpl<InT, OutT>{}, a, out);
+            Elementwise<const InT, OutT>(CopyImpl<InT, OutT>{}, a, out);
         };
         VisitDtype(out.dtype(), [&](auto out_pt) { VisitDtype(a.dtype(), do_astype, out_pt); });
     }
 };
 
-CHAINERX_CUDA_REGISTER_KERNEL(AsTypeKernel, CudaAsTypeKernel);
+CHAINERX_CUDA_REGISTER_KERNEL(CopyKernel, CudaCopyKernel);
 
 }  // namespace
 }  // namespace cuda

--- a/chainerx_cc/chainerx/kernels/misc.h
+++ b/chainerx_cc/chainerx/kernels/misc.h
@@ -13,14 +13,6 @@ public:
     virtual void Call(const Array& out, Scalar value) = 0;
 };
 
-// Casts the elements from one array to the other dtype, and store into the other.
-class AsTypeKernel : public Kernel {
-public:
-    static const char* name() { return "AsType"; }
-
-    virtual void Call(const Array& a, const Array& out) = 0;
-};
-
 class SqrtKernel : public Kernel {
 public:
     static const char* name() { return "Sqrt"; }

--- a/chainerx_cc/chainerx/native/native_device/copy.cc
+++ b/chainerx_cc/chainerx/native/native_device/copy.cc
@@ -6,18 +6,14 @@
 #include "chainerx/device.h"
 #include "chainerx/dtype.h"
 #include "chainerx/kernels/creation.h"
-#include "chainerx/kernels/misc.h"
 #include "chainerx/native/elementwise.h"
 #include "chainerx/native/kernel_regist.h"
-#include "chainerx/routines/creation.h"
 
 namespace chainerx {
 namespace native {
 namespace {
 
-CHAINERX_NATIVE_REGISTER_ELTWISE_UNARY_KERNEL(CopyKernel, { out = x; });
-
-class NativeAsTypeKernel : public AsTypeKernel {
+class NativeCopyKernel : public CopyKernel {
 public:
     void Call(const Array& a, const Array& out) override {
         a.device().CheckDevicesCompatible(a, out);
@@ -33,7 +29,7 @@ public:
     }
 };
 
-CHAINERX_NATIVE_REGISTER_KERNEL(AsTypeKernel, NativeAsTypeKernel);
+CHAINERX_NATIVE_REGISTER_KERNEL(CopyKernel, NativeCopyKernel);
 
 }  // namespace
 }  // namespace native

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -217,7 +217,8 @@ Array AsContiguous(const Array& a, Dtype dtype) {
     Array out = Empty(a.shape(), dtype, a.device());
     {
         NoBackpropModeScope scope{};
-        a.device().backend().CallKernel<AsTypeKernel>(a.AsGradStopped(), out);
+        // Note: In CopyKernel, Input Array Elements are casted to the type of Output Array.
+        a.device().backend().CallKernel<CopyKernel>(a.AsGradStopped(), out);
     }
 
     if (GetKind(dtype) == DtypeKind::kFloat) {

--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -447,7 +447,8 @@ Array ConcatenateImpl(const std::vector<Array>& arrays, int8_t axis) {
             Array sliced_out = internal::MakeArray(shape, strides, out_dtype, device, out.data(), out_offset);
             Dtype in_dtype = array.dtype();
             in_dtypes.emplace_back(in_dtype);
-            device.backend().CallKernel<AsTypeKernel>(array, sliced_out);
+            // Note: In CopyKernel, Input Array Elements are casted to the type of Output Array.
+            device.backend().CallKernel<CopyKernel>(array, sliced_out);
             array_refs.emplace_back(ConstArrayRef{array});
             out_offset += strides[axis] * shape[axis];
         }


### PR DESCRIPTION
As CopyKernel is a special case of AsTypeKernel.

https://github.com/chainer/chainer/projects/2#card-20163727

Have done reverse of what is mentioned on card as CopyKernel is subset of 
AsTypeKernel.