### PR TITLE
Fix protobuf dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,7 @@ requirements = {
         'typing_extensions',
         'filelock',
         'numpy>=1.9.0',
-        # protobuf 3.8.0rc1 causes CI errors.
-        # TODO(niboshi): Probably we should always use pip in CIs for
-        # installing chainer. It avoids pre-release dependencies by default.
-        # See also: https://github.com/pypa/setuptools/issues/855
-        'protobuf>=3.0.0,<3.8.0rc1',
+        'protobuf>=3.0.0',
         'six>=1.9.0',
     ],
     'stylecheck': [


### PR DESCRIPTION
Remove unnecessary protobuf version restriciton.

* `pip install` is now used in chainer-test so this restriciton is no longer needed. https://github.com/chainer/chainer-test/pull/509
* This also fixes #7523