### PR TITLE
Update description for resnet.prepare

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -488,8 +488,7 @@ def prepare(image, size=(224, 224)):
         image (PIL.Image or numpy.ndarray): Input image.
             If an input is ``numpy.ndarray``, its shape must be
             ``(height, width)``, ``(height, width, channels)``,
-            or ``(channels, height, width)``, and
-            the order of the channels must be RGB.
+            or ``(channels, height, width)``.
         size (pair of ints): Size of converted images.
             If ``None``, the given image is not resized.
 


### PR DESCRIPTION
The current description says that the input image must be in RGB format, whereas on line 512-513 it converts the image to RGB style. This means that if the user has already pre-converted the image, the channels would be swapped.

The current description of the method call says that the function converts it to RGB. 

Alternative fix: change the `must be RGB` to `must be BGR`.