### PR TITLE
Fix `initializers.Identity` for ideep backend

### DIFF
--- a/chainer/initializers/constant.py
+++ b/chainer/initializers/constant.py
@@ -32,12 +32,7 @@ class Identity(initializer.Initializer):
                              'for 2D squared matrices.')
 
         device = backend.get_device_from_array(array)
-        # ideep64 does not support fill_diagonal
-        if isinstance(device, chainer.backends.intel64.Intel64Device):
-            array[...] = device.xp.identity(shape[0]) * self.scale
-        else:
-            array[...] = 0
-            device.xp.fill_diagonal(array, self.scale)
+        array[...] = device.xp.identity(shape[0]) * self.scale
 
 
 class _Constant(initializer.Initializer):

--- a/chainer/initializers/normal.py
+++ b/chainer/initializers/normal.py
@@ -27,14 +27,15 @@ class Normal(initializer.Initializer):
         super(Normal, self).__init__(dtype)
 
     def __call__(self, array):
-        xp = backend.get_array_module(array)
+        device = backend.get_device_from_array(array)
         args = {'loc': 0.0, 'scale': self.scale, 'size': array.shape}
-        if xp is cuda.cupy:
+        if device.xp is cuda.cupy:
             # Only CuPy supports dtype option
             if self.dtype == numpy.float32 or self.dtype == numpy.float16:
                 # float16 is not supported in cuRAND
                 args['dtype'] = numpy.float32
-        array[...] = xp.random.normal(**args)
+
+        array[...] = device.xp.random.normal(**args)
 
 
 class LeCunNormal(initializer.Initializer):

--- a/chainer/initializers/orthogonal.py
+++ b/chainer/initializers/orthogonal.py
@@ -65,7 +65,7 @@ class Orthogonal(initializer.Initializer):
     def __call__(self, array):
         if self.dtype is not None:
             assert array.dtype == self.dtype
-        xp = backend.get_array_module(array)
+        device = backend.get_device_from_array(array)
         if not array.shape:  # 0-dim case
             array[...] = self.scale * (2 * numpy.random.randint(2) - 1)
         elif not array.size:
@@ -90,4 +90,4 @@ class Orthogonal(initializer.Initializer):
             q *= numpy.copysign(self.scale, numpy.diag(r))
             if transpose:
                 q = q.T
-            array[...] = xp.asarray(q.reshape(array.shape))
+            array[...] = device.xp.asarray(q.reshape(array.shape))

--- a/chainer/initializers/uniform.py
+++ b/chainer/initializers/uniform.py
@@ -28,8 +28,8 @@ class Uniform(initializer.Initializer):
     def __call__(self, array):
         if self.dtype is not None:
             assert array.dtype == self.dtype
-        xp = backend.get_array_module(array)
-        array[...] = xp.random.uniform(
+        device = backend.get_device_from_array(array)
+        array[...] = device.xp.random.uniform(
             low=-self.scale, high=self.scale, size=array.shape)
 
 

--- a/tests/chainer_tests/initializer_tests/test_constant.py
+++ b/tests/chainer_tests/initializer_tests/test_constant.py
@@ -1,16 +1,24 @@
 import unittest
 
+import chainer
 from chainer import backend
-from chainer.backends import cuda
 from chainer import initializers
 from chainer import testing
-from chainer.testing import attr
 import numpy
 
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_ideep': 'always'},
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+    ]
+)
 class TestIdentity(unittest.TestCase):
 
     scale = 0.1
@@ -28,18 +36,16 @@ class TestIdentity(unittest.TestCase):
             w, self.scale * numpy.identity(len(self.shape)),
             **self.check_options)
 
-    def test_initializer_cpu(self):
+    def test_initializer(self, backend_config):
         w = numpy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
+        w = backend_config.get_array(w)
+        with chainer.using_device(backend_config.device):
+            self.check_initializer(w)
 
-    @attr.gpu
-    def test_initializer_gpu(self):
-        w = cuda.cupy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
-
-    def check_shaped_initializer(self, xp):
+    def check_shaped_initializer(self, backend_config):
         initializer = initializers.Identity(
             scale=self.scale, dtype=self.dtype)
+        xp = backend_config.xp
         w = initializers.generate_array(initializer, self.shape, xp)
         self.assertIs(backend.get_array_module(w), xp)
         self.assertTupleEqual(w.shape, self.shape)
@@ -48,12 +54,9 @@ class TestIdentity(unittest.TestCase):
             w, self.scale * numpy.identity(len(self.shape)),
             **self.check_options)
 
-    def test_shaped_initializer_cpu(self):
-        self.check_shaped_initializer(numpy)
-
-    @attr.gpu
-    def test_shaped_initializer_gpu(self):
-        self.check_shaped_initializer(cuda.cupy)
+    def test_shaped_initializer(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_shaped_initializer(backend_config)
 
 
 @testing.parameterize(
@@ -75,6 +78,15 @@ class TestIdentityInvalid(unittest.TestCase):
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_ideep': 'always'},
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+    ]
+)
 class TestConstant(unittest.TestCase):
 
     fill_value = 0.1
@@ -92,18 +104,16 @@ class TestConstant(unittest.TestCase):
             w, numpy.full(self.shape, self.fill_value),
             **self.check_options)
 
-    def test_initializer_cpu(self):
+    def test_initializer(self, backend_config):
         w = numpy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
+        w = backend_config.get_array(w)
+        with chainer.using_device(backend_config.device):
+            self.check_initializer(w)
 
-    @attr.gpu
-    def test_initializer_gpu(self):
-        w = cuda.cupy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
-
-    def check_shaped_initializer(self, xp):
+    def check_shaped_initializer(self, backend_config):
         initializer = initializers.Constant(
             fill_value=self.fill_value, dtype=self.dtype)
+        xp = backend_config.xp
         w = initializers.generate_array(initializer, self.shape, xp)
         self.assertIs(backend.get_array_module(w), xp)
         self.assertTupleEqual(w.shape, self.shape)
@@ -112,12 +122,9 @@ class TestConstant(unittest.TestCase):
             w, numpy.full(self.shape, self.fill_value),
             **self.check_options)
 
-    def test_shaped_initializer_cpu(self):
-        self.check_shaped_initializer(numpy)
-
-    @attr.gpu
-    def test_shaped_initializer_gpu(self):
-        self.check_shaped_initializer(cuda.cupy)
+    def test_shaped_initializer(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_shaped_initializer(backend_config)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/initializer_tests/test_normal.py
+++ b/tests/chainer_tests/initializer_tests/test_normal.py
@@ -3,6 +3,7 @@ import unittest
 
 import numpy
 
+import chainer
 from chainer import backend
 from chainer.backends import cuda
 from chainer import initializers
@@ -43,6 +44,18 @@ default_fan = {
         'dtype': [numpy.float16, numpy.float32, numpy.float64],
     })
 ))
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_ideep': 'always'},
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+    ]
+)
 class NormalBase(unittest.TestCase):
 
     def setUp(self):
@@ -59,33 +72,30 @@ class NormalBase(unittest.TestCase):
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
 
-    def test_initializer_cpu(self):
+    def test_initializer(self, backend_config):
         w = numpy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
+        w = backend_config.get_array(w)
+        with chainer.using_device(backend_config.device):
+            self.check_initializer(w)
 
-    @attr.gpu
-    def test_initializer_gpu(self):
-        w = cuda.cupy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
-
-    def check_shaped_initializer(self, xp):
+    def check_shaped_initializer(self, backend_config):
         initializer = self.target(dtype=self.dtype, **self.target_kwargs)
+        xp = backend_config.xp
         w = initializers.generate_array(initializer, self.shape, xp)
         self.assertIs(backend.get_array_module(w), xp)
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
 
-    def test_shaped_initializer_cpu(self):
-        self.check_shaped_initializer(numpy)
+    def test_shaped_initializer(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_shaped_initializer(backend_config)
 
-    @attr.gpu
-    def test_shaped_initializer_gpu(self):
-        self.check_shaped_initializer(cuda.cupy)
-
-    def check_initializer_statistics(self, xp, n):
+    def check_initializer_statistics(self, backend_config, n):
         from scipy import stats
 
-        ws = xp.empty((n,) + self.shape, dtype=self.dtype)
+        xp = backend_config.xp
+        ws = numpy.empty((n,) + self.shape, dtype=self.dtype)
+        ws = backend_config.get_array(ws)
         for i in range(n):
             initializer = self.target(**self.target_kwargs)
             initializer(xp.squeeze(ws[i:i+1], axis=0))
@@ -111,27 +121,16 @@ class NormalBase(unittest.TestCase):
 
     @testing.with_requires('scipy')
     @condition.retry(3)
-    def test_initializer_statistics_cpu(self):
-        self.check_initializer_statistics(numpy, 100)
-
-    @attr.gpu
-    @testing.with_requires('scipy')
-    @condition.retry(3)
-    def test_initializer_statistics_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 100)
+    def test_initializer_statistics(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_initializer_statistics(backend_config, 100)
 
     @attr.slow
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_slow_cpu(self):
-        self.check_initializer_statistics(numpy, 10000)
-
-    @attr.slow
-    @attr.gpu
-    @testing.with_requires('scipy')
-    @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_slow_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 10000)
+    def test_initializer_statistics_slow(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_initializer_statistics(backend_config, 10000)
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/initializer_tests/test_orthogonal.py
+++ b/tests/chainer_tests/initializer_tests/test_orthogonal.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import chainer
 from chainer import backend
 from chainer.backends import cuda
 from chainer import initializers
@@ -25,6 +26,15 @@ from chainer.testing import condition
         'dtype': [numpy.float32, numpy.float64],
     })
 ))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_ideep': 'always'},
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+    ]
+)
 class OrthogonalBase(unittest.TestCase):
 
     target = initializers.Orthogonal
@@ -45,33 +55,29 @@ class OrthogonalBase(unittest.TestCase):
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
 
-    def test_initializer_cpu(self):
+    def test_initializer(self, backend_config):
         w = numpy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
+        w = backend_config.get_array(w)
+        with chainer.using_device(backend_config.device):
+            self.check_initializer(w)
 
-    @attr.gpu
-    def test_initializer_gpu(self):
-        w = cuda.cupy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
-
-    def check_shaped_initializer(self, xp):
+    def check_shaped_initializer(self, backend_config):
         initializer = self.target(dtype=self.dtype, **self.target_kwargs)
+        xp = backend_config.xp
         w = initializers.generate_array(initializer, self.shape, xp)
         self.assertIs(backend.get_array_module(w), xp)
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
 
-    def test_shaped_initializer_cpu(self):
-        self.check_shaped_initializer(numpy)
-
-    @attr.gpu
-    def test_shaped_initializer_gpu(self):
-        self.check_shaped_initializer(cuda.cupy)
+    def test_shaped_initializer(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_shaped_initializer(backend_config)
 
     def check_orthogonality(self, w):
         initializer = self.target(**self.target_kwargs)
         initializer(w)
         w = w.astype(numpy.float64).reshape(self.dim_out, self.dim_in)
+
         if self.dim_in >= self.dim_out:
             n = self.dim_out
             dots = w.dot(w.T)
@@ -83,19 +89,17 @@ class OrthogonalBase(unittest.TestCase):
             dots, numpy.identity(n) * expected_scale**2,
             **self.check_options)
 
-    def test_orthogonality_cpu(self):
+    def test_orthogonality(self, backend_config):
         w = numpy.empty(self.shape, dtype=self.dtype)
-        self.check_orthogonality(w)
+        w = backend_config.get_array(w)
+        with chainer.using_device(backend_config.device):
+            self.check_orthogonality(w)
 
-    @attr.gpu
-    def test_orthogonality_gpu(self):
-        w = cuda.cupy.empty(self.shape, dtype=self.dtype)
-        self.check_orthogonality(w)
-
-    def check_initializer_statistics(self, xp, n):
+    def check_initializer_statistics(self, backend_config, n):
         from scipy import stats
-
-        ws = xp.empty((n,) + self.shape, dtype=self.dtype)
+        xp = backend_config.xp
+        ws = numpy.empty((n,) + self.shape, dtype=self.dtype)
+        ws = backend_config.get_array(ws)
         for i in range(n):
             initializer = self.target(**self.target_kwargs)
             initializer(xp.squeeze(ws[i:i+1], axis=0))
@@ -125,27 +129,16 @@ class OrthogonalBase(unittest.TestCase):
 
     @testing.with_requires('scipy')
     @condition.retry(3)
-    def test_initializer_statistics_cpu(self):
-        self.check_initializer_statistics(numpy, 100)
-
-    @attr.gpu
-    @testing.with_requires('scipy')
-    @condition.retry(3)
-    def test_initializer_statistics_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 100)
+    def test_initializer_statistics(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_initializer_statistics(backend_config, 100)
 
     @attr.slow
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_slow_cpu(self):
-        self.check_initializer_statistics(numpy, 10000)
-
-    @attr.slow
-    @attr.gpu
-    @testing.with_requires('scipy')
-    @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_slow_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 10000)
+    def test_initializer_statistics_slow(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_initializer_statistics(backend_config, 10000)
 
 
 class TestEmpty(unittest.TestCase):

--- a/tests/chainer_tests/initializer_tests/test_uniform.py
+++ b/tests/chainer_tests/initializer_tests/test_uniform.py
@@ -3,6 +3,7 @@ import unittest
 
 import numpy
 
+import chainer
 from chainer import backend
 from chainer.backends import cuda
 from chainer import initializers
@@ -44,6 +45,15 @@ default_fan = {
         'dtype': [numpy.float16, numpy.float32, numpy.float64],
     })
 ))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {},
+        {'use_ideep': 'always'},
+        {'use_cuda': True, 'cuda_device': 0},
+        {'use_cuda': True, 'cuda_device': 1},
+    ]
+)
 class TestUniform(unittest.TestCase):
 
     def setUp(self):
@@ -60,33 +70,30 @@ class TestUniform(unittest.TestCase):
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
 
-    def test_initializer_cpu(self):
+    def test_initializer(self, backend_config):
         w = numpy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
+        w = backend_config.get_array(w)
+        with chainer.using_device(backend_config.device):
+            self.check_initializer(w)
 
-    @attr.gpu
-    def test_initializer_gpu(self):
-        w = cuda.cupy.empty(self.shape, dtype=self.dtype)
-        self.check_initializer(w)
-
-    def check_shaped_initializer(self, xp):
+    def check_shaped_initializer(self, backend_config):
         initializer = self.target(dtype=self.dtype, **self.target_kwargs)
+        xp = backend_config.xp
         w = initializers.generate_array(initializer, self.shape, xp)
         self.assertIs(backend.get_array_module(w), xp)
         self.assertTupleEqual(w.shape, self.shape)
         self.assertEqual(w.dtype, self.dtype)
 
-    def test_shaped_initializer_cpu(self):
-        self.check_shaped_initializer(numpy)
+    def test_shaped_initializer(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_shaped_initializer(backend_config)
 
-    @attr.gpu
-    def test_shaped_initializer_gpu(self):
-        self.check_shaped_initializer(cuda.cupy)
-
-    def check_initializer_statistics(self, xp, n):
+    def check_initializer_statistics(self, backend_config, n):
         from scipy import stats
 
-        ws = xp.empty((n,) + self.shape, dtype=self.dtype)
+        xp = backend_config.xp
+        ws = numpy.empty((n,) + self.shape, dtype=self.dtype)
+        ws = backend_config.get_array(ws)
         for i in range(n):
             initializer = self.target(**self.target_kwargs)
             initializer(xp.squeeze(ws[i:i+1], axis=0))
@@ -115,27 +122,16 @@ class TestUniform(unittest.TestCase):
 
     @testing.with_requires('scipy')
     @condition.retry(3)
-    def test_initializer_statistics_cpu(self):
-        self.check_initializer_statistics(numpy, 100)
-
-    @attr.gpu
-    @testing.with_requires('scipy')
-    @condition.retry(3)
-    def test_initializer_statistics_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 100)
+    def test_initializer_statistics(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_initializer_statistics(backend_config, 100)
 
     @attr.slow
     @testing.with_requires('scipy')
     @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_slow_cpu(self):
-        self.check_initializer_statistics(numpy, 10000)
-
-    @attr.slow
-    @attr.gpu
-    @testing.with_requires('scipy')
-    @condition.repeat_with_success_at_least(5, 3)
-    def test_initializer_statistics_slow_gpu(self):
-        self.check_initializer_statistics(cuda.cupy, 10000)
+    def test_initializer_statistics_slow(self, backend_config):
+        with chainer.using_device(backend_config.device):
+            self.check_initializer_statistics(backend_config, 10000)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Initializers were not checking the actual device id in multi gpu environments.

The lack of tests using the cuda_id 1 hid this behavior.

This PR fixes this problem and reworks the test to use the `inject_backend_tests`

ChainerX support will be added in another PR.