### PR TITLE
Update pybind version

### DIFF
--- a/chainerx_cc/third_party/pybind11.cmake
+++ b/chainerx_cc/third_party/pybind11.cmake
@@ -4,7 +4,7 @@ project(pybind11-download NONE)
 include(ExternalProject)
 ExternalProject_Add(pybind11
     GIT_REPOSITORY    https://github.com/pybind/pybind11.git
-    GIT_TAG           v2.2.4
+    GIT_TAG           v2.3.0
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/pybind11"
     BINARY_DIR        ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
PR #7561 uses `py::ellipsis` which is supported from v2.3.0.