### PR TITLE
Pin typing == 3.6.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ set CHAINER_PYTHON_350_FORCE environment variable to 1."""
 requirements = {
     'install': [
         'setuptools',
-        'typing',
-        'typing_extensions',
+        'typing==3.6.6',
+        'typing_extensions==3.6.6',
         'filelock',
         'numpy>=1.9.0',
         # protobuf 3.8.0rc1 causes CI errors.


### PR DESCRIPTION
typing == 3.7.4 doesn't work well with Python2.
https://ci.preferred.jp/chainer.py2.cv/15182/

This PR is kind a hot fix.