### PR TITLE
Remove `squared_difference` and fix docs

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -732,13 +732,14 @@ def _docs_loss():
         """Element-wise absolute error function.
 
 Computes the element-wise absolute error :math:`L` between two inputs
-:math:`x_0` and :math:`x_1` defined as follows.
+:math:`x_1` and :math:`x_2` defined as follows.
+
 .. math::
-    L = |x_0 - x_1|
+    L = |x_1 - x_2|
 
 Args:
-    x0 (~chainerx.ndarray): Input variable.
     x1 (~chainerx.ndarray): Input variable.
+    x2 (~chainerx.ndarray): Input variable.
 
 Returns:
     :class:`~chainerx.ndarray`: A variable holding an array representing
@@ -751,13 +752,13 @@ Returns:
         chainerx.squared_error,
         """Element-wise squared error function.
 
-Computes the squared error between two variables:
-.. math::
-    (x_0 - x_1)^2
-where operation is done in elementwise manner.
-Note that the error is not scaled by 1/2:
+Computes the element-wise squared error :math:`L` between two inputs
+:math:`x_1` and :math:`x_2` defined as follows.
 
-Can be used to compute Mean Squared Error by just calling `mean()`
+.. math::
+    L = (x_1 - x_2)^2
+
+Can be used to compute mean squared error by just calling `mean()`
 on the output array.
 
 Args:
@@ -773,93 +774,65 @@ Returns:
 
     _docs.set_doc(
         chainerx.huber_loss,
-        """Computes the Huber loss.
+        """Element-wise Huber loss.
 
-    The Huber loss is similar to the :func:`mean_squared_error` but is less
-    sensitive to outliers in the data. It is defined as
+The Huber loss is similar to the squared error but is less sensitive to
+outliers in the data. It is defined as
 
-    .. math::
+.. math::
 
-        L_{\\delta}(a) = \\left \\{ \\begin{array}{cc}
-        \\frac{1}{2} a^2 & {\\rm if~|a| \\leq \\delta} \\\\
-        \\delta (|a| - \\frac{1}{2} \\delta) & {\\rm otherwise,}
-        \\end{array} \\right.
+    L_{\\delta}(a) = \\left \\{ \\begin{array}{cc}
+    \\frac{1}{2} a^2 & {\\rm if~|a| \\leq \\delta} \\\\
+    \\delta (|a| - \\frac{1}{2} \\delta) & {\\rm otherwise,}
+    \\end{array} \\right.
 
-    where :math:`a = x - t` is the difference between the input :math:`x`
-    and the target :math:`t`.
+where :math:`a = x - t` is the difference between the input :math:`x`
+and the target :math:`t`.
 
-    The loss is a variable whose value depends on the value of
-    the option ``reduce``. If it is ``'no'``, it holds the elementwise
-    loss values. If it is ``'sum_along_second_axis'``, loss values are
-    summed up along the second axis (i.e. ``axis=1``).
+See: `Huber loss - Wikipedia <https://en.wikipedia.org/wiki/Huber_loss>`_.
 
-    See: `Huber loss - Wikipedia <https://en.wikipedia.org/wiki/Huber_loss>`_.
+Args:
+    x (~chainerx.ndarray): Input variable.
+    t (~chainerx.ndarray): Target variable for regression.
+    delta (float): Constant variable for Huber loss function as used in
+        definition.
 
-    Args:
-        x (~chainerx.ndarray): Input variable.
-            The shape of ``x`` should be (:math:`N`, :math:`K`, ...) if
-            ``reduce='sum_along_second_axis'``.
-        t (~chainerx.ndarray): Target variable for
-            regression. The shape of ``t`` should be
-            (:math:`N`, :math:`K`, ...) if ``reduce='sum_along_second_axis'``.
-        delta (float): Constant variable for Huber loss function
-            as used in definition.
-        reduce (str): Reduction option. Its value must be either
-            ``'sum_along_second_axis'`` or ``'no'``. Otherwise,
-            :class:`ValueError` is raised.
-
-    Returns:
-        :class:`~chainerx.ndarray`:
-            A variable object holding a scalar array of the
-            Huber loss :math:`L_{\\delta}`.
-            If ``reduce`` is ``'no'``, the output variable holds array
-            whose shape is same as one of (hence both of) input variables.
-            If it is ``'sum_along_second_axis'``, the shape of the array
-            is same as the input variables, except the second axis is removed.
+Returns:
+    :class:`~chainerx.ndarray`:
+        A variable object holding an array representing the Huber loss
+        :math:`L_{\\delta}` of the two inputs.
 
 .. seealso:: :func:`chainer.functions.huber_loss`
 """)
 
     _docs.set_doc(
         chainerx.gaussian_kl_divergence,
-        """Computes the KL-divergence of Gaussian variables from the standard one.
+        """Element-wise KL-divergence of Gaussian variables from the standard one.
 
-    Given two variable ``mean`` representing :math:`\\mu` and ``ln_var``
-    representing :math:`\\log(\\sigma^2)`, this function calculates
-    the KL-divergence in elementwise manner between the given multi-dimensional
-    Gaussian :math:`N(\\mu, S)` and the standard Gaussian :math:`N(0, I)`
+Given two variable ``mean`` representing :math:`\\mu` and ``ln_var``
+representing :math:`\\log(\\sigma^2)`, this function calculates
+the element-wise KL-divergence between the given multi-dimensional
+Gaussian :math:`N(\\mu, S)` and the standard Gaussian :math:`N(0, I)`
 
-    .. math::
+.. math::
 
-       D_{\\mathbf{KL}}(N(\\mu, S) \\| N(0, I)),
+   D_{\\mathbf{KL}}(N(\\mu, S) \\| N(0, I)),
 
-    where :math:`S` is a diagonal matrix such that :math:`S_{ii} = \\sigma_i^2`
-    and :math:`I` is an identity matrix.
+where :math:`S` is a diagonal matrix such that :math:`S_{ii} = \\sigma_i^2`
+and :math:`I` is an identity matrix.
 
-    The output is a variable whose value depends on the value of
-    the option ``reduce``. If it is ``'no'``, it holds the elementwise
-    loss values. If it is ``'sum'`` or ``'mean'``, loss values are summed up
-    or averaged respectively.
+Args:
+    mean (~chainerx.ndarray):
+        A variable representing mean of given
+        gaussian distribution, :math:`\\mu`.
+    ln_var (~chainerx.ndarray):
+        A variable representing logarithm of
+        variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
 
-    Args:
-        mean (~chainerx.ndarray):
-            A variable representing mean of given
-            gaussian distribution, :math:`\\mu`.
-        ln_var (~chainerx.ndarray):
-            A variable representing logarithm of
-            variance of given gaussian distribution, :math:`\\log(\\sigma^2)`.
-        reduce (str): Reduction option. Its value must be either
-            ``'sum'``, ``'mean'`` or ``'no'``. Otherwise, :class:`ValueError`
-            is raised.
-
-    Returns:
-        :class:`~chainerx.ndarray`:
-            A variable representing KL-divergence between
-            given gaussian distribution and the standard gaussian.
-            If ``reduce`` is ``'no'``, the output variable holds array
-            whose shape is same as one of (hence both of) input variables.
-            If it is ``'sum'`` or ``'mean'``, the output variable holds a
-            scalar value.
+Returns:
+    :class:`~chainerx.ndarray`:
+        A variable representing KL-divergence between
+        given gaussian distribution and the standard gaussian.
 
 .. seealso:: :func:`chainer.functions.gaussian_kl_divergence`
 """)

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -709,10 +709,6 @@ void InitChainerxHyperbolic(pybind11::module& m) {
 
 void InitChainerxMisc(pybind11::module& m) {
     m.def("square", [](const ArrayBodyPtr& x) { return MoveArrayBody(Square(Array{x})); }, "x"_a);
-    m.def("squared_difference",
-          [](const ArrayBodyPtr& x1, const ArrayBodyPtr& x2) { return MoveArrayBody(SquaredDifference(Array{x1}, Array{x2})); },
-          "x1"_a,
-          "x2"_a);
     m.def("sqrt", [](const ArrayBodyPtr& x) { return MoveArrayBody(Sqrt(Array{x})); }, "x"_a);
     m.def("abs", [](const ArrayBodyPtr& x) { return MoveArrayBody(Absolute(Array{x})); }, "x"_a);
     m.attr("absolute") = m.attr("abs");

--- a/chainerx_cc/chainerx/routines/loss.cc
+++ b/chainerx_cc/chainerx/routines/loss.cc
@@ -11,7 +11,7 @@ namespace chainerx {
 
 Array AbsoluteError(const Array& x1, const Array& x2) { return Absolute(x1 - x2); }
 
-Array SquaredError(const Array& x1, const Array& x2) { return SquaredDifference(x1, x2); }
+Array SquaredError(const Array& x1, const Array& x2) { return Square(x1 - x2); }
 
 Array GaussianKLDivergence(const Array& mean, const Array& ln_var) { return (Square(mean) + Exp(ln_var) - ln_var - 1) * 0.5; }
 

--- a/chainerx_cc/chainerx/routines/misc.cc
+++ b/chainerx_cc/chainerx/routines/misc.cc
@@ -161,8 +161,6 @@ Array Square(const Array& x) {
     return out;
 }
 
-Array SquaredDifference(const Array& x1, const Array& x2) { return Square(x1 - x2); }
-
 Array Absolute(const Array& x) {
     Array x_flip_1 = IfGreaterElse(x, 0.0, 0.0, -x);
     Array x_flip_2 = IfLessElse(x, 0.0, 0.0, x);

--- a/chainerx_cc/chainerx/routines/misc.h
+++ b/chainerx_cc/chainerx/routines/misc.h
@@ -9,8 +9,6 @@ Array Sqrt(const Array& x);
 
 Array Square(const Array& x);
 
-Array SquaredDifference(const Array& x1, const Array& x2);
-
 Array Absolute(const Array& x);
 
 Array Fabs(const Array& x);

--- a/docs/source/chainerx/reference/routines.rst
+++ b/docs/source/chainerx/reference/routines.rst
@@ -124,7 +124,7 @@ Logic functions
    chainerx.not_equal
 
 Loss functions
----------------
+--------------
 
 .. autosummary::
    :toctree: generated/

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_misc.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_misc.py
@@ -77,59 +77,6 @@ def test_square_invalid_dtypes(device):
 
 @op_utils.op_test(['native:0', 'cuda:0'])
 @chainer.testing.parameterize(*(
-    # Special shapes
-    chainer.testing.product({
-        'shape': [(), (0,), (1,), (2, 0, 3), (1, 1, 1), (2, 3)],
-        'in_dtypes,out_dtype': (
-            dtype_utils.make_same_in_out_dtypes(
-                2, chainerx.testing.float_dtypes)),
-        'input_lhs': ['random'],
-        'input_rhs': ['random'],
-    })
-    # Special values
-    + chainer.testing.product({
-        'shape': [(2, 3)],
-        'in_dtypes,out_dtype': (
-            dtype_utils.make_same_in_out_dtypes(
-                2, chainerx.testing.float_dtypes)),
-        'input_lhs': ['random', float('inf'), -float('inf'), float('nan')],
-        'input_rhs': ['random', float('inf'), -float('inf'), float('nan')],
-        'skip_backward_test': [True],
-        'skip_double_backward_test': [True],
-    })
-))
-class TestSquaredDifference(op_utils.OpTest):
-
-    def setup(self):
-        x1_dtype, x2_dtype = self.in_dtypes
-
-        if x1_dtype == 'float16' or x2_dtype == 'float16':
-            self.check_forward_options.update({'atol': 3e-3, 'rtol': 3e-3})
-            self.check_backward_options.update({'atol': 1e-2, 'rtol': 5e-2})
-            self.check_double_backward_options.update(
-                {'atol': 1e-2, 'rtol': 5e-2})
-
-    def generate_inputs(self):
-        shape = self.shape
-        x1_dtype, x2_dtype = self.in_dtypes
-        x1 = array_utils.uniform(shape, x1_dtype)
-        x2 = array_utils.uniform(shape, x2_dtype)
-        return x1, x2
-
-    def forward_chainerx(self, inputs):
-        x1, x2 = inputs
-        y = chainerx.squared_difference(x1, x2)
-        return y,
-
-    def forward_expected(self, inputs):
-        x1, x2 = inputs
-        y = numpy.asarray(
-            numpy.square(numpy.subtract(x1, x2))).astype(x1.dtype)
-        return y,
-
-
-@op_utils.op_test(['native:0', 'cuda:0'])
-@chainer.testing.parameterize(*(
     chainer.testing.product({
         'shape': [(), (0,), (1,), (2, 0, 3), (1, 1, 1), (2, 3)],
         'in_dtypes,out_dtype': math_utils.in_out_float_dtypes_math_functions,


### PR DESCRIPTION
Follow up of https://github.com/chainer/chainer/pull/7063.

Removed `squared_difference` as it's a duplicate of `squared_error`. Which one to keep could be discussed but the one that's kept is closer to MSE and might be easier to find. It might however sound unnatural in a situation where we don't want to compute any losses.

Also fixed documentations of functions introduced in #7063.