### PR TITLE
Support ChainerX multi-node evaluation

### DIFF
--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -1,5 +1,7 @@
 import six
 
+import chainer
+
 
 def create_multi_node_evaluator(actual_evaluator, communicator):
     """Create a multi node evaluator from a normal evaluator.
@@ -26,6 +28,10 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
 
     def new_evaluate(self):
         local_mean_dict = self._mn_original_evaluate()
+
+        for key in local_mean_dict.keys():
+            local_mean_dict[key] = chainer.backend.from_chx(local_mean_dict[key])
+
         global_mean_dict = {
             name:
             self._mn_communicator.allreduce_obj(


### PR DESCRIPTION
As I mentioned at #7476, ChainerX doesn't support the buffer protocol.
In order to support multi-node evaluation on distributed ChainerX training,
I added typecasting before the communication of the evaluation result.

I think the evaluation may not be a performance bottleneck, so in this case, this is enough.

I checked this PR with #6387 so please test with this.