### PR TITLE
Tiny Fix of `BackwardContext` comment

### DIFF
--- a/chainerx_cc/chainerx/backward_context.h
+++ b/chainerx_cc/chainerx/backward_context.h
@@ -71,7 +71,7 @@ class BackwardContext {
 public:
     // Ctor
     //
-    // `input_grads_storage` is where input gradients returned by backward functions will be stored.
+    // `input_grads` is where input gradients returned by backward functions will be stored.
     // Its size must be equal to the number of input arrays whose gradients are to be returned in this single backward function (1 in most
     // ordinary functions).
     BackwardContext(


### PR DESCRIPTION
The comment seems incorrect to me because I don't see any argument/variable named `"input_grads_storage"`.