### PR TITLE
Remove moved comment

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -556,9 +556,6 @@ class Variable(object):
 
     def _init_impl(self, data, device, name, grad, grad_valid, requires_grad,
                    is_chainerx_array, node):
-        # Use a list as a data structure to hold the data array indirectly to
-        # abstract its initialized/uninitialized state.
-
         # `device` must be of type chainer.backend.Device.
         # Check is skipped for performance.
 


### PR DESCRIPTION
Follow up #7146.

Apparently #7146 tried to fix this incorrectly placed comment, but forgot to remove the one in the original place.