### PR TITLE
[backport] Fix y_shape not used in tests

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_crelu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_crelu.py
@@ -60,6 +60,7 @@ class TestCReLU(testing.FunctionTestCase):
         expected_latter = numpy.maximum(-x, 0)
         expected = numpy.concatenate(
             (expected_former, expected_latter), axis=self.axis)
+        assert expected.shape == self.y_shape
         return expected,
 
 

--- a/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_maxout.py
@@ -68,7 +68,9 @@ class TestNonparameterizedMaxout(testing.FunctionTestCase):
 
     def forward_expected(self, inputs):
         x, = inputs
-        return _maxout(x, self.pool_size, self.axis),
+        expected = _maxout(x, self.pool_size, self.axis)
+        assert expected.shape == self.y_shape
+        return expected,
 
 
 @testing.parameterize(


### PR DESCRIPTION
Backport of #7610