### PR TITLE
Fix PickleDataset crash when use multiprocessing

### DIFF
--- a/chainer/datasets/pickle_dataset.py
+++ b/chainer/datasets/pickle_dataset.py
@@ -1,5 +1,5 @@
 import io
-import multiprocessing.util as mputil
+import multiprocessing.util
 import threading
 
 import six
@@ -96,7 +96,8 @@ class PickleDataset(dataset_mixin.DatasetMixin):
             self._positions.append(position)
 
         self._lock = threading.RLock()
-        mputil.register_after_fork(self, PickleDataset._after_fork)
+        multiprocessing.util.register_after_fork(
+            self, PickleDataset._after_fork)
 
     def _after_fork(self):
         if callable(getattr(self._reader, 'after_fork', None)):

--- a/chainer/datasets/pickle_dataset.py
+++ b/chainer/datasets/pickle_dataset.py
@@ -137,7 +137,7 @@ class _FileReader(io.RawIOBase):
         self._fp = open(self._path, 'rb')
 
     def after_fork(self):
-        """ re-open file avoid race condition """
+        """Reopens the file to avoid race condition."""
         self.close()
         self._open()
 

--- a/chainer/datasets/pickle_dataset.py
+++ b/chainer/datasets/pickle_dataset.py
@@ -96,6 +96,8 @@ class PickleDataset(dataset_mixin.DatasetMixin):
             self._positions.append(position)
 
         self._lock = threading.RLock()
+
+        # TODO: Avoid using undocumented feature
         multiprocessing.util.register_after_fork(
             self, PickleDataset._after_fork)
 
@@ -128,6 +130,14 @@ class PickleDataset(dataset_mixin.DatasetMixin):
 
 
 class _FileReader(io.RawIOBase):
+    """A file-like class implemented `after_fork()` hook
+
+    The method :meth:`after_fork` is called in the child process after forking,
+    and it closes and reopens the file object to avoid race condition caused by
+    open file description.
+    See: https://www.securecoding.cert.org/confluence/x/ZQG7AQ
+    """
+
     def __init__(self, path):
         super(_FileReader, self).__init__()
         self._path = path

--- a/chainer/datasets/pickle_dataset.py
+++ b/chainer/datasets/pickle_dataset.py
@@ -1,3 +1,5 @@
+import io
+import multiprocessing.util as mputil
 import threading
 
 import six
@@ -94,6 +96,11 @@ class PickleDataset(dataset_mixin.DatasetMixin):
             self._positions.append(position)
 
         self._lock = threading.RLock()
+        mputil.register_after_fork(self, PickleDataset._after_fork)
+
+    def _after_fork(self):
+        if callable(getattr(self._reader, 'after_fork', None)):
+            self._reader.after_fork()
 
     def close(self):
         """Closes a file reader.
@@ -119,6 +126,45 @@ class PickleDataset(dataset_mixin.DatasetMixin):
             return pickle.load(self._reader)
 
 
+class _FileReader(io.RawIOBase):
+    def __init__(self, path):
+        super(_FileReader, self).__init__()
+        self._path = path
+        self._fp = None
+        self._open()
+
+    def _open(self):
+        self._fp = open(self._path, 'rb')
+
+    def after_fork(self):
+        """ re-open file avoid race condition """
+        self.close()
+        self._open()
+
+    # file-like interface
+
+    def flush(self):
+        self._fp.flush()
+
+    def close(self):
+        self._fp.close()
+
+    def fileno(self):
+        return self._fp.fileno()
+
+    def seekable(self):
+        return self._fp.seekable()
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        return self._fp.seek(offset, whence)
+
+    def tell(self):
+        return self._fp.tell()
+
+    def readinto(self, b):
+        return self._fp.readinto(b)
+
+
 def open_pickle_dataset(path):
     """Opens a dataset stored in a given path.
 
@@ -142,7 +188,7 @@ def open_pickle_dataset(path):
     .. seealso: chainer.datasets.PickleDataset
 
     """
-    reader = open(path, 'rb')
+    reader = _FileReader(path)
     return PickleDataset(reader)
 
 

--- a/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
@@ -4,7 +4,8 @@ import multiprocessing
 import os
 import sys
 import unittest
-from unittest.mock import patch, mock_open
+
+import mock
 
 from chainer import datasets
 from chainer import testing
@@ -90,8 +91,8 @@ class TestPickleDatasetHelper(unittest.TestCase):
             assert dataset[0] == 1
 
     def test_file_reader_after_fork(self):
-        m = mock_open()
-        with patch('chainer.datasets.pickle_dataset.open', m):
+        m = mock.mock_open()
+        with mock.patch('chainer.datasets.pickle_dataset.open', m):
             r = _FileReader(self.path)
 
             m.assert_called_once_with(self.path, 'rb')
@@ -101,7 +102,7 @@ class TestPickleDatasetHelper(unittest.TestCase):
             r.after_fork()
 
             m.assert_called_once_with(self.path, 'rb')
-            m().close.assert_called_once()
+            m().close.assert_called_once_with()
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
@@ -10,7 +10,7 @@ import mock
 from chainer import datasets
 from chainer import testing
 from chainer import utils
-from chainer.datasets.pickle_dataset import _FileReader
+from chainer.datasets import pickle_dataset
 
 
 class ReaderMock(object):
@@ -93,7 +93,7 @@ class TestPickleDatasetHelper(unittest.TestCase):
     def test_file_reader_after_fork(self):
         m = mock.mock_open()
         with mock.patch('chainer.datasets.pickle_dataset.open', m):
-            r = _FileReader(self.path)
+            r = pickle_dataset._FileReader(self.path)
 
             m.assert_called_once_with(self.path, 'rb')
             m().close.assert_not_called()

--- a/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
@@ -1,11 +1,42 @@
+import ctypes
 import io
+import multiprocessing
 import os
 import sys
 import unittest
+from unittest.mock import patch, mock_open
 
 from chainer import datasets
 from chainer import testing
 from chainer import utils
+from chainer.datasets.pickle_dataset import _FileReader
+
+
+class ReaderMock(object):
+    def __init__(self, io_):
+        self.io = io_
+        self._lock = multiprocessing.RLock()
+        self._hook_called = multiprocessing.Value(ctypes.c_int, 0, lock=False)
+        self._last_caller_pid = multiprocessing.Value(
+            ctypes.c_int, -1, lock=False)
+
+    @property
+    def n_hook_called(self):
+        with self._lock:
+            return self._hook_called.value
+
+    @property
+    def last_caller_pid(self):
+        with self._lock:
+            return self._last_caller_pid.value
+
+    def __getattr__(self, name):
+        return getattr(self.io, name)
+
+    def after_fork(self):
+        with self._lock:
+            self._hook_called.value += 1
+            self._last_caller_pid.value = os.getpid()
 
 
 class TestPickleDataset(unittest.TestCase):
@@ -26,6 +57,20 @@ class TestPickleDataset(unittest.TestCase):
         assert dataset[2] == 1.5
         assert dataset[1] == 'hello'
 
+    def test_after_fork(self):
+        writer = datasets.PickleDatasetWriter(self.io)
+        writer.write(1)
+        writer.flush()
+
+        reader = ReaderMock(self.io)
+        _ = datasets.PickleDataset(reader)
+        assert reader.n_hook_called == 0
+        p = multiprocessing.Process()
+        p.start()
+        p.join()
+        assert reader.n_hook_called == 1
+        assert reader.last_caller_pid == p.pid
+
 
 class TestPickleDatasetHelper(unittest.TestCase):
 
@@ -43,6 +88,20 @@ class TestPickleDatasetHelper(unittest.TestCase):
 
         with datasets.open_pickle_dataset(self.path) as dataset:
             assert dataset[0] == 1
+
+    def test_file_reader_after_fork(self):
+        m = mock_open()
+        with patch('chainer.datasets.pickle_dataset.open', m):
+            r = _FileReader(self.path)
+
+            m.assert_called_once_with(self.path, 'rb')
+            m().close.assert_not_called()
+
+            m.reset_mock()
+            r.after_fork()
+
+            m.assert_called_once_with(self.path, 'rb')
+            m().close.assert_called_once()
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
@@ -64,13 +64,19 @@ class TestPickleDataset(unittest.TestCase):
         writer.flush()
 
         reader = ReaderMock(self.io)
-        _ = datasets.PickleDataset(reader)
+        # Assign to avoid destruction of the instance
+        # before creation a child process
+        dataset = datasets.PickleDataset(reader)
+
         assert reader.n_hook_called == 0
         p = multiprocessing.Process()
         p.start()
         p.join()
         assert reader.n_hook_called == 1
         assert reader.last_caller_pid == p.pid
+
+        # Touch to suppress "unused variable' warning
+        del dataset
 
 
 class TestPickleDatasetHelper(unittest.TestCase):


### PR DESCRIPTION
fix: #7589

If already addressing this issue, I apologize.

I resolved this issue by using `multiprocessing.util.register_after_fork()` .
This function register hooks to be triggered when initializing child process.

`_FileReader` is a wrapper to hold filepath and re-open the file after fork.