### PR TITLE
Make devices hashable

### DIFF
--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -90,6 +90,9 @@ class Device(object):
     def __ne__(self, other):
         return not (self == other)
 
+    def __hash__(self):
+        return hash(self.name)
+
     def create_context(self):
         """Returns a context manager in which the device is made current.
 

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -15,6 +15,8 @@ class ChainerxDevice(_backend.Device):
     xp = chainerx
     supported_array_types = (chainerx.ndarray,)
 
+    __hash__ = _backend.Device.__hash__
+
     def __init__(self, device):
         # type: (chainerx.Device) -> None
 

--- a/chainer/backends/_cpu.py
+++ b/chainer/backends/_cpu.py
@@ -16,6 +16,8 @@ class CpuDevice(_backend.Device):
     xp = numpy
     supported_array_types = (numpy.ndarray,)
 
+    __hash__ = _backend.Device.__hash__
+
     @staticmethod
     def from_array(array):
         if isinstance(array, numpy.ndarray):

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -207,6 +207,8 @@ class GpuDevice(_backend.Device):
     xp = cupy
     supported_array_types = (ndarray,)
 
+    __hash__ = _backend.Device.__hash__
+
     def __init__(self, device):
         check_cuda_available()
         assert isinstance(device, Device)

--- a/chainer/backends/intel64.py
+++ b/chainer/backends/intel64.py
@@ -31,6 +31,8 @@ class Intel64Device(_backend.Device):
     name = '@intel64'
     supported_array_types = (numpy.ndarray, mdarray)
 
+    __hash__ = _backend.Device.__hash__
+
     def __init__(self):
         check_ideep_available()
         super(Intel64Device, self).__init__()

--- a/tests/chainer_tests/backends_tests/test_chainerx.py
+++ b/tests/chainer_tests/backends_tests/test_chainerx.py
@@ -25,6 +25,7 @@ class TestChainerxDevice(unittest.TestCase):
         assert device.supported_array_types == (chainerx.ndarray,)
         assert device.name == backend_config.chainerx_device
         assert str(device) == backend_config.chainerx_device
+        assert isinstance(hash(device), int)  # hashable
 
         # fallback_device
         chainerx_device_comps = backend_config.chainerx_device.split(':')

--- a/tests/chainer_tests/backends_tests/test_cpu.py
+++ b/tests/chainer_tests/backends_tests/test_cpu.py
@@ -6,6 +6,12 @@ from chainer import backend
 from chainer import testing
 
 
+class TestCpuDevice(unittest.TestCase):
+
+    def test_hashable(self):
+        assert isinstance(hash(backend.CpuDevice()), int)
+
+
 class TestCpuDeviceFromArray(unittest.TestCase):
 
     def check_device(self, device):

--- a/tests/chainer_tests/backends_tests/test_cuda.py
+++ b/tests/chainer_tests/backends_tests/test_cuda.py
@@ -481,6 +481,7 @@ class TestGpuDevice(unittest.TestCase):
         assert isinstance(device, backend.GpuDevice)
         assert isinstance(device.device, cuda.cupy.cuda.Device)
         assert device.device.id == device_id
+        assert isinstance(hash(device), int)  # hashable
 
         assert device.xp is cuda.cupy
         assert device.supported_array_types == (cuda.ndarray,)

--- a/tests/chainer_tests/backends_tests/test_intel64.py
+++ b/tests/chainer_tests/backends_tests/test_intel64.py
@@ -15,6 +15,7 @@ class TestIntel64Device(unittest.TestCase):
         assert device.supported_array_types == (numpy.ndarray, intel64.mdarray)
         assert device.name == '@intel64'
         assert str(device) == '@intel64'
+        assert isinstance(hash(device), int)  # hashable
 
     def test_init(self):
         device = backend.Intel64Device()


### PR DESCRIPTION
Background: `_sum_sqnorm_grads` in #7641

`devices_map` would not be required. 