### PR TITLE
Correct `FunctionNode.forward` output type message

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -331,6 +331,17 @@ Use apply() method instead.\
                 'Actual: {}'.format(self.label, type(outputs)))
 
         if not chainer.is_arrays_compatible(outputs):
+            if not all(
+                    isinstance(y, chainer.get_array_types())
+                    for y in outputs):
+                raise TypeError(
+                    'forward output must be a tuple of ndarrays.\n'
+                    'Function: {}\n'
+                    'Actual output types: {}'
+                    .format(
+                        self.label,
+                        tuple(type(y) for y in outputs)))
+
             raise TypeError(
                 'incompatible array types are mixed in the forward output '
                 '({}).\n'

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -426,14 +426,27 @@ Actual: 1 < 2"""
             f.apply((v,))
 
 
-class TestFunctionNodeInconsistentBackends(unittest.TestCase):
+class TestFunctionNodeForwardTypeCheck(unittest.TestCase):
 
     def setUp(self):
         self.x1 = numpy.random.rand(2, 3).astype(numpy.float32)
         self.x2 = numpy.random.rand(2, 3).astype(numpy.float32)
 
+    def test_invalid_output_type(self):
+        class FunctionNode(chainer.FunctionNode):
+
+            def forward(self, inputs):
+                return object(),
+
+        f = FunctionNode()
+        x1 = chainer.Variable(self.x1)
+
+        with self.assertRaisesRegex(
+                TypeError, 'forward output must be a tuple of ndarrays'):
+            f.apply((x1,))
+
     @attr.gpu
-    def test_inconsistent_inputs(self):
+    def test_inconsistent_input_backends(self):
         class FunctionNode(chainer.FunctionNode):
 
             def forward(self, inputs):
@@ -451,7 +464,7 @@ class TestFunctionNodeInconsistentBackends(unittest.TestCase):
             f.apply((x1, x2))
 
     @attr.gpu
-    def test_inconsistent_outputs(self):
+    def test_inconsistent_output_backends(self):
         class FunctionNode(chainer.FunctionNode):
 
             def forward(self, inputs):

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -441,8 +441,10 @@ class TestFunctionNodeForwardTypeCheck(unittest.TestCase):
         f = FunctionNode()
         x1 = chainer.Variable(self.x1)
 
-        with self.assertRaisesRegex(
-                TypeError, 'forward output must be a tuple of ndarrays'):
+        with six.assertRaisesRegex(
+                self,
+                TypeError,
+                'forward output must be a tuple of ndarrays'):
             f.apply((x1,))
 
     @attr.gpu


### PR DESCRIPTION
Fixes #7654