### PR TITLE
Fix AMSGrad with intel64 backend

### DIFF
--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -204,7 +204,7 @@ class AdamRule(optimizer.UpdateRule):
             vhat = self.state['vhat']
             # For iDeep
             if isinstance(vhat, intel64.mdarray):
-                vhat = numpy.maximum(vhat, v)
+                vhat[...] = numpy.maximum(vhat, v)
             else:
                 numpy.maximum(vhat, v, out=vhat)
         else:

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -181,4 +181,59 @@ class TestAdamW(unittest.TestCase):
                                 atol=1e-7, rtol=1e-7)
 
 
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        # CPU
+        {},
+        # Intel
+        {'use_ideep': True},
+        # CUDA
+        {'use_cuda': True, 'cuda_device': 0},
+        # ChainerX
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+    ]
+)
+class TestAMSGrad(unittest.TestCase):
+
+    def test_amsgrad(self, backend_config):
+        device = backend_config.device
+
+        link = chainer.Link(x=(4,))
+        x = link.x
+        x.data.fill(0)
+        link.to_device(device)
+
+        opt = optimizers.Adam(alpha=0.01, beta2=0.7, amsgrad=True)
+        opt.setup(link)
+
+        x.grad = device.send(np.array([1, -1, 10, -10], np.float32))
+        opt.update()
+        testing.assert_allclose(
+            x.update_rule.state['v'],
+            [0.3, 0.3, 30, 30],
+            atol=1e-7, rtol=1e-7)
+        testing.assert_allclose(
+            x.data,
+            [-0.01, 0.01, -0.01, 0.01],
+            atol=1e-7, rtol=1e-7)
+
+        x.grad = device.send(np.array([-10, -10, -1, -1], np.float32))
+        opt.update()
+        testing.assert_allclose(
+            x.update_rule.state['v'],
+            [30.21, 30.21, 21.3, 21.3],
+            atol=1e-7, rtol=1e-7)
+        testing.assert_allclose(
+            x.update_rule.state['vhat'],
+            [30.21, 30.21, 30, 30],
+            atol=1e-7, rtol=1e-7)
+        testing.assert_allclose(
+            x.data,
+            # result with NumPy
+            [-0.00377703, 0.01745388, -0.01548985, 0.01686232],
+            atol=1e-7, rtol=1e-7)
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
AMSGrad's state `vhat` should be updated.  The intention of `out=vhat` (https://github.com/chainer/chainer/pull/4032#discussion_r169032555) was unclear, which led to an error in #6388 (2f05180c8a02b5651ff5d9b51324d6400be7bd04).