### PR TITLE
Implement IntervalTrigger.__str__

### DIFF
--- a/chainer/training/triggers/interval_trigger.py
+++ b/chainer/training/triggers/interval_trigger.py
@@ -111,3 +111,11 @@ class IntervalTrigger(object):
 
     def get_training_length(self):
         return (self.period, self.unit)
+
+    def __str__(self):
+        """Returns a string describing the class and interval
+
+        Returns:
+            str: IntervalTrigger(<period>, '<unit>')
+        """
+        return '%s(%d, \'%s\')' % (self.__class__.__name__, self.period, self.unit)

--- a/chainer/training/triggers/interval_trigger.py
+++ b/chainer/training/triggers/interval_trigger.py
@@ -118,6 +118,6 @@ class IntervalTrigger(object):
         Returns:
             str: IntervalTrigger(<period>, '<unit>')
         """
-        return '%s(%d, \'%s\')' % (
+        return '{}({}, \'{}\')'.format(
             self.__class__.__name__, self.period, self.unit
         )

--- a/chainer/training/triggers/interval_trigger.py
+++ b/chainer/training/triggers/interval_trigger.py
@@ -118,4 +118,6 @@ class IntervalTrigger(object):
         Returns:
             str: IntervalTrigger(<period>, '<unit>')
         """
-        return '%s(%d, \'%s\')' % (self.__class__.__name__, self.period, self.unit)
+        return '%s(%d, \'%s\')' % (
+            self.__class__.__name__, self.period, self.unit
+        )

--- a/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
@@ -122,7 +122,8 @@ class TestIntervalTrigger(unittest.TestCase):
         expected = 'IntervalTrigger({}, \'{}\')'.format(*self.interval)
         actual = str(trigger)
 
-        self.assertEqual(expected, actual)
+        assert expected == actual, 'Expected "{}" == "{}"'.format(
+            expected, actual)
 
 
 class TestInvalidIntervalTrigger(unittest.TestCase):

--- a/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
@@ -116,6 +116,14 @@ class TestIntervalTrigger(unittest.TestCase):
                 trainer.updater.update()
                 self.assertEqual(trigger(trainer), expected)
 
+    def test_str(self):
+        trigger = training.triggers.IntervalTrigger(*self.interval)
+
+        expected = 'IntervalTrigger(%d, \'%s\')' % tuple(self.interval)
+        actual = str(trigger)
+
+        self.assertEqual(expected, actual)
+
 
 class TestInvalidIntervalTrigger(unittest.TestCase):
 

--- a/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
+++ b/tests/chainer_tests/training_tests/triggers_tests/test_interval_trigger.py
@@ -119,7 +119,7 @@ class TestIntervalTrigger(unittest.TestCase):
     def test_str(self):
         trigger = training.triggers.IntervalTrigger(*self.interval)
 
-        expected = 'IntervalTrigger(%d, \'%s\')' % tuple(self.interval)
+        expected = 'IntervalTrigger({}, \'{}\')'.format(*self.interval)
         actual = str(trigger)
 
         self.assertEqual(expected, actual)


### PR DESCRIPTION
This PR implements `IntervalTrigger.__str__`.

I want this because I'm setting an IntervalTrigger as a default argument for `argparse.ArgumentParser` and the help message is now messy like below.
```
  --log-interval N_iter
                        Frequency of log. (default: <chainer.training.triggers
                        .interval_trigger.IntervalTrigger object at
                        0x2aebbea172e8>)
```
