### PR TITLE
Example fix: stateful triggers cannot be reused

### DIFF
--- a/examples/text_classification/train_text_classifier.py
+++ b/examples/text_classification/train_text_classifier.py
@@ -114,15 +114,16 @@ def main():
         test_iter, model,
         converter=convert_seq, device=device))
 
-    # Take a best snapshot
-    record_trigger = training.triggers.MaxValueTrigger(
-        'validation/main/accuracy', (1, 'epoch'))
+    # Take a snapshot of Trainer every epoch
     trainer.extend(
         extensions.snapshot(filename='snapshot_epoch_{.updater.epoch}'),
-        trigger=record_trigger)
+        trigger=(1, 'epoch'))
+    # Take the best snapshot of the model
+    best_trigger = training.triggers.MaxValueTrigger(
+        'validation/main/accuracy', (1, 'epoch'))
     trainer.extend(extensions.snapshot_object(
         model, 'best_model.npz'),
-        trigger=record_trigger)
+        trigger=best_trigger)
 
     # Write a log of evaluation statistics for each epoch
     trainer.extend(extensions.LogReport())


### PR DESCRIPTION
With the original example, the best model will never be saved as the trigger is consumed with the Trainer snapshot, whose extension is added right before the extension for best model added. As triggers are stateful, one trigger object cannot be used for multiple extensions (If reusing a trigger for multiple extensions is really the use case, maybe we could change Chainer, though...). Anyway we might have cleared this out at document. BTW is example bug is also to be tagged as bug?

Thanks for finding this out, @chezou .