### PR TITLE
Fix GroupNormalization tests

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_group_normalization.py
@@ -27,7 +27,7 @@ def _simple_group_normalization(x, groups, gamma, beta, eps=1e-5):
 
 
 @testing.parameterize(*(testing.product({
-    'shape': [(1, 4, 5, 5), (5, 4, 15)],
+    'shape': [(1, 4, 5, 3), (5, 4, 7), (3, 20)],
     'groups': [1, 2, 4],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
     'eps': [1e-5, 1e-1],

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -9,7 +9,6 @@ from chainer import gradient_check
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 
 
 @testing.parameterize(*(testing.product({
@@ -42,12 +41,10 @@ class GroupNormalizationTest(unittest.TestCase):
             testing.assert_allclose(
                 y.data, y_one_each.data, **self.check_forward_options)
 
-    @condition.retry(3)
     def test_forward_cpu(self):
         self.check_forward(self.x)
 
     @attr.gpu
-    @condition.retry(3)
     def test_forward_gpu(self):
         self.link.to_gpu()
         self.check_forward(cuda.to_gpu(self.x))
@@ -58,7 +55,6 @@ class GroupNormalizationTest(unittest.TestCase):
         self.test_forward_gpu()
 
     @attr.multi_gpu(2)
-    @condition.retry(3)
     def test_forward_multi_gpu(self):
         with cuda.get_device_from_id(1):
             self.link.to_gpu()
@@ -72,13 +68,11 @@ class GroupNormalizationTest(unittest.TestCase):
             (self.link.gamma, self.link.beta),
             eps=1e-2, **self.check_backward_options)
 
-    @condition.retry(3)
     def test_backward_cpu(self):
         self.link(numpy.zeros(self.shape, dtype='f'))
         self.check_backward(self.x, self.gy)
 
     @attr.gpu
-    @condition.retry(3)
     def test_backward_gpu(self):
         self.link.to_gpu()
         self.link(cuda.cupy.zeros(self.shape, dtype='f'))
@@ -107,14 +101,12 @@ class TestInitialize(unittest.TestCase):
                                              initial_beta=self.initial_beta)
         self.shape = (1, self.size, 1)
 
-    @condition.retry(3)
     def test_initialize_cpu(self):
         self.link(numpy.zeros(self.shape, dtype='f'))
         testing.assert_allclose(self.initial_gamma, self.link.gamma.data)
         testing.assert_allclose(self.initial_beta, self.link.beta.data)
 
     @attr.gpu
-    @condition.retry(3)
     def test_initialize_gpu(self):
         self.link.to_gpu()
         self.link(cuda.cupy.zeros(self.shape, dtype='f'))

--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -13,7 +13,7 @@ from chainer.testing import condition
 
 
 @testing.parameterize(*(testing.product({
-    'shape': [(1, 4, 5, 5), (5, 4, 15), (3, 8)],
+    'shape': [(1, 4, 5, 3), (5, 4, 7), (3, 20)],
     'groups': [1, 2, 4],
     'dtype': [numpy.float32],
 })))


### PR DESCRIPTION
This PR improves `shape` parameters in group normalization tests:

1. Use smaller array.
2. The config `dict(shape=(3, 8), groups=4)` has unstable backward because it
   standardizes the inputs per two samples.

Close #6911.