### PR TITLE
[backport] Fix typo in `F.squeeze` documentation

### DIFF
--- a/chainer/functions/array/squeeze.py
+++ b/chainer/functions/array/squeeze.py
@@ -17,7 +17,7 @@ def argone(iterable):
 
 class Squeeze(function_node.FunctionNode):
 
-    """Remove demensions of size one from the shape of a ndarray."""
+    """Remove dimensions of size one from the shape of a ndarray."""
 
     def __init__(self, axis=None):
 
@@ -68,7 +68,7 @@ class Squeeze(function_node.FunctionNode):
 
 
 def squeeze(x, axis=None):
-    """Remove demensions of size one from the shape of a ndarray.
+    """Remove dimensions of size one from the shape of a ndarray.
 
     Args:
         x (:class:`~chainer.Variable` or :ref:`ndarray`):


### PR DESCRIPTION
Backport of #7682