### PR TITLE
Comment out tests for deprecated communicators

### DIFF
--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -99,27 +99,27 @@ gpu_params = [Param(p) for p in [
         'model_dtype': np.float16,
         'multi_node': True,
     }, {
-        'communicator_class': HierarchicalCommunicator,
-        'multi_node': True,
-    }, {
-        'communicator_class': HierarchicalCommunicator,
-        'model_dtype': np.float16,
-        'multi_node': True,
-    }, {
-        'communicator_class': TwoDimensionalCommunicator,
-        'multi_node': True,
-    }, {
-        'communicator_class': TwoDimensionalCommunicator,
-        'model_dtype': np.float16,
-        'multi_node': True,
-    }, {
-        'communicator_class': SingleNodeCommunicator,
-        'multi_node': False,
-    }, {
-        'communicator_class': SingleNodeCommunicator,
-        'model_dtype': np.float16,
-        'multi_node': False,
-    }, {
+    #     'communicator_class': HierarchicalCommunicator,
+    #     'multi_node': True,
+    # }, {
+    #     'communicator_class': HierarchicalCommunicator,
+    #     'model_dtype': np.float16,
+    #     'multi_node': True,
+    # }, {
+    #     'communicator_class': TwoDimensionalCommunicator,
+    #     'multi_node': True,
+    # }, {
+    #     'communicator_class': TwoDimensionalCommunicator,
+    #     'model_dtype': np.float16,
+    #     'multi_node': True,
+    # }, {
+    #     'communicator_class': SingleNodeCommunicator,
+    #     'multi_node': False,
+    # }, {
+    #     'communicator_class': SingleNodeCommunicator,
+    #     'model_dtype': np.float16,
+    #     'multi_node': False,
+    # }, {
         'communicator_class': NonCudaAwareCommunicator,
         'multi_node': True,
     }, {


### PR DESCRIPTION
Some communicators will be deperecated in the next release. 
One of the communicators, TwoDimensionalCommunicator, has a bug and fixed in #7509 .
However, the bug is not fixed in the master becasue they will be simply removed.
The bug does not matter eventually, but for now hinders integration tests for other PRs.

In this PR, tests for the deperecated communicators are commented out, so other PRs can pass tests.