### PR TITLE
Fixes an error on chainer.grad for multiple devices

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -1072,8 +1072,8 @@ def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
             with chainer.using_device(y.device):
                 gy_data = y.device.xp.ones_like(y.array)
                 gy = variable.Variable(gy_data, requires_grad=False)
-            if loss_scale is not None:
-                gy.data *= loss_scale
+                if loss_scale is not None:
+                    gy.data *= loss_scale
         grads[y.node] = gy
 
     if grad_inputs is not None:


### PR DESCRIPTION
Some operations where not inside the `with chainer.using(device)` on `chainer.grad`
leading to errors when refactoring the grad tests to use different devices.