### PR TITLE
Fix Adam FP16 overflow on gpu kernels

### DIFF
--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -246,6 +246,9 @@ class AdamRule(optimizer.UpdateRule):
                        m_ += one_minus_beta1 * (grad_ - m_);
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
                        vhat_ = max(vhat_, v_);
+                       vhat = static_cast<T>(vhat_);
+                       m = static_cast<T>(m_);
+                       v = static_cast<T>(v_);
                        param -= eta *
                            (max(min(alpha_t / (sqrt(vhat_) + eps), upper),
                                 lower) * m_ + weight_decay_rate * param);''',
@@ -268,6 +271,8 @@ class AdamRule(optimizer.UpdateRule):
                        T v_ = static_cast<T>(v);
                        m_ += one_minus_beta1 * (grad_ - m_);
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
+                       m = static_cast<T>(m_);
+                       v = static_cast<T>(v_);
                        param -= eta *
                            (max(min(alpha_t / (sqrt(v_) + eps), upper),
                                 lower) * m_ + weight_decay_rate * param);''',
@@ -290,6 +295,9 @@ class AdamRule(optimizer.UpdateRule):
                        m_ += one_minus_beta1 * (grad_ - m_);
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
                        vhat_ = max(vhat_, v_);
+                       vhat = static_cast<T>(vhat_);
+                       m = static_cast<T>(m_);
+                       v = static_cast<T>(v_);
                        param -= eta * (alpha_t * m_ / (sqrt(vhat_) + eps) +
                                        weight_decay_rate * param);''',
                     'adam')
@@ -299,6 +307,7 @@ class AdamRule(optimizer.UpdateRule):
                 hp.eta, hp.weight_decay_rate, self._dummy,
                 param.data, self.state['m'], self.state['v'],
                 self.state['vhat'])
+            print(self.state['m'], self.state['v'], self.state['vhat'])
         else:
             if AdamRule._kernel is None:
                 AdamRule._kernel = cuda.elementwise(
@@ -310,6 +319,8 @@ class AdamRule(optimizer.UpdateRule):
                        T v_ = static_cast<T>(v);
                        m_ += one_minus_beta1 * (grad_ - m_);
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
+                       m = static_cast<T>(m_);
+                       v = static_cast<T>(v_);
                        param -= eta * (alpha_t * m_ / (sqrt(v_) + eps) +
                                        weight_decay_rate * param);''',
                     'adam')

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -307,7 +307,6 @@ class AdamRule(optimizer.UpdateRule):
                 hp.eta, hp.weight_decay_rate, self._dummy,
                 param.data, self.state['m'], self.state['v'],
                 self.state['vhat'])
-            print(self.state['m'], self.state['v'], self.state['vhat'])
         else:
             if AdamRule._kernel is None:
                 AdamRule._kernel = cuda.elementwise(

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -247,8 +247,8 @@ class AdamRule(optimizer.UpdateRule):
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
                        vhat_ = max(vhat_, v_);
                        vhat = static_cast<T>(vhat_);
-                       m = static_cast<T>(m_);
-                       v = static_cast<T>(v_);
+                       m = static_cast<P>(m_);
+                       v = static_cast<P>(v_);
                        param -= eta *
                            (max(min(alpha_t / (sqrt(vhat_) + eps), upper),
                                 lower) * m_ + weight_decay_rate * param);''',
@@ -271,8 +271,8 @@ class AdamRule(optimizer.UpdateRule):
                        T v_ = static_cast<T>(v);
                        m_ += one_minus_beta1 * (grad_ - m_);
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
-                       m = static_cast<T>(m_);
-                       v = static_cast<T>(v_);
+                       m = static_cast<P>(m_);
+                       v = static_cast<P>(v_);
                        param -= eta *
                            (max(min(alpha_t / (sqrt(v_) + eps), upper),
                                 lower) * m_ + weight_decay_rate * param);''',
@@ -296,8 +296,8 @@ class AdamRule(optimizer.UpdateRule):
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
                        vhat_ = max(vhat_, v_);
                        vhat = static_cast<T>(vhat_);
-                       m = static_cast<T>(m_);
-                       v = static_cast<T>(v_);
+                       m = static_cast<P>(m_);
+                       v = static_cast<P>(v_);
                        param -= eta * (alpha_t * m_ / (sqrt(vhat_) + eps) +
                                        weight_decay_rate * param);''',
                     'adam')
@@ -319,8 +319,8 @@ class AdamRule(optimizer.UpdateRule):
                        T v_ = static_cast<T>(v);
                        m_ += one_minus_beta1 * (grad_ - m_);
                        v_ += one_minus_beta2 * (grad_ * grad_ - v_);
-                       m = static_cast<T>(m_);
-                       v = static_cast<T>(v_);
+                       m = static_cast<P>(m_);
+                       v = static_cast<P>(v_);
                        param -= eta * (alpha_t * m_ / (sqrt(v_) + eps) +
                                        weight_decay_rate * param);''',
                     'adam')

--- a/chainer/optimizers/adam.py
+++ b/chainer/optimizers/adam.py
@@ -240,12 +240,15 @@ class AdamRule(optimizer.UpdateRule):
                     'T eps, T eta, T weight_decay_rate, raw T dummy',
                     'P param, P m, P v, P vhat',
                     '''T grad_ = static_cast<T>(grad);
-                       m += one_minus_beta1 * (grad_ - m);
-                       v += one_minus_beta2 * (grad_ * grad - v);
-                       vhat = max(vhat, v);
+                       T m_ = static_cast<T>(m);
+                       T v_ = static_cast<T>(v);
+                       T vhat_ = static_cast<T>(vhat);
+                       m_ += one_minus_beta1 * (grad_ - m_);
+                       v_ += one_minus_beta2 * (grad_ * grad_ - v_);
+                       vhat_ = max(vhat_, v_);
                        param -= eta *
-                           (max(min(alpha_t / (sqrt(vhat) + eps), upper),
-                                lower) * m + weight_decay_rate * param);''',
+                           (max(min(alpha_t / (sqrt(vhat_) + eps), upper),
+                                lower) * m_ + weight_decay_rate * param);''',
                     'amsbound')
             AdamRule._amsbound_kernel(
                 grad, self.alpha_t, 1 - hp.beta1,
@@ -261,11 +264,13 @@ class AdamRule(optimizer.UpdateRule):
                     'T eps, T eta, T weight_decay_rate, raw T dummy',
                     'P param, P m, P v',
                     '''T grad_ = static_cast<T>(grad);
-                       m += one_minus_beta1 * (grad_ - m);
-                       v += one_minus_beta2 * (grad_ * grad_ - v);
+                       T m_ = static_cast<T>(m);
+                       T v_ = static_cast<T>(v);
+                       m_ += one_minus_beta1 * (grad_ - m_);
+                       v_ += one_minus_beta2 * (grad_ * grad_ - v_);
                        param -= eta *
-                           (max(min(alpha_t / (sqrt(v) + eps), upper),
-                                lower) * m + weight_decay_rate * param);''',
+                           (max(min(alpha_t / (sqrt(v_) + eps), upper),
+                                lower) * m_ + weight_decay_rate * param);''',
                     'adabound')
             AdamRule._adabound_kernel(
                 grad, self.alpha_t, 1 - hp.beta1,
@@ -279,10 +284,13 @@ class AdamRule(optimizer.UpdateRule):
                     'T eps, T eta, T weight_decay_rate, raw T dummy',
                     'P param, P m, P v, P vhat',
                     '''T grad_ = static_cast<T>(grad);
-                       m += one_minus_beta1 * (grad_ - m);
-                       v += one_minus_beta2 * (grad_ * grad_ - v);
-                       vhat = max(vhat, v);
-                       param -= eta * (alpha_t * m / (sqrt(vhat) + eps) +
+                       T m_ = static_cast<T>(m);
+                       T v_ = static_cast<T>(v);
+                       T vhat_ = static_cast<T>(vhat);
+                       m_ += one_minus_beta1 * (grad_ - m_);
+                       v_ += one_minus_beta2 * (grad_ * grad_ - v_);
+                       vhat_ = max(vhat_, v_);
+                       param -= eta * (alpha_t * m_ / (sqrt(vhat_) + eps) +
                                        weight_decay_rate * param);''',
                     'adam')
             AdamRule._amsgrad_kernel(
@@ -298,9 +306,11 @@ class AdamRule(optimizer.UpdateRule):
                     'T eps, T eta, T weight_decay_rate, raw T dummy',
                     'P param, P m, P v',
                     '''T grad_ = static_cast<T>(grad);
-                       m += one_minus_beta1 * (grad_ - m);
-                       v += one_minus_beta2 * (grad_ * grad_ - v);
-                       param -= eta * (alpha_t * m / (sqrt(v) + eps) +
+                       T m_ = static_cast<T>(m);
+                       T v_ = static_cast<T>(v);
+                       m_ += one_minus_beta1 * (grad_ - m_);
+                       v_ += one_minus_beta2 * (grad_ * grad_ - v_);
+                       param -= eta * (alpha_t * m_ / (sqrt(v_) + eps) +
                                        weight_decay_rate * param);''',
                     'adam')
             AdamRule._kernel(

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -212,27 +212,27 @@ class TestAMSGrad(unittest.TestCase):
         opt.update()
         testing.assert_allclose(
             x.update_rule.state['v'],
-            np.array([0.3, 0.3, 30, 30]),
+            [0.3, 0.3, 30, 30],
             atol=1e-7, rtol=1e-7)
         testing.assert_allclose(
             x.data,
-            np.array([-0.01, 0.01, -0.01, 0.01]),
+            [-0.01, 0.01, -0.01, 0.01],
             atol=1e-7, rtol=1e-7)
 
         x.grad = device.send(np.array([-10, -10, -1, -1], np.float32))
         opt.update()
         testing.assert_allclose(
             x.update_rule.state['v'],
-            np.array([30.21, 30.21, 21.3, 21.3]),
+            [30.21, 30.21, 21.3, 21.3],
             atol=1e-7, rtol=1e-7)
         testing.assert_allclose(
             x.update_rule.state['vhat'],
-            np.array([30.21, 30.21, 30, 30]),
+            [30.21, 30.21, 30, 30],
             atol=1e-7, rtol=1e-7)
         testing.assert_allclose(
             x.data,
             # result with NumPy
-            np.array([-0.00377703, 0.01745388, -0.01548985, 0.01686232]),
+            [-0.00377703, 0.01745388, -0.01548985, 0.01686232],
             atol=1e-7, rtol=1e-7)
 
 

--- a/tests/chainer_tests/optimizers_tests/test_optimizers.py
+++ b/tests/chainer_tests/optimizers_tests/test_optimizers.py
@@ -212,27 +212,27 @@ class TestAMSGrad(unittest.TestCase):
         opt.update()
         testing.assert_allclose(
             x.update_rule.state['v'],
-            [0.3, 0.3, 30, 30],
+            np.array([0.3, 0.3, 30, 30]),
             atol=1e-7, rtol=1e-7)
         testing.assert_allclose(
             x.data,
-            [-0.01, 0.01, -0.01, 0.01],
+            np.array([-0.01, 0.01, -0.01, 0.01]),
             atol=1e-7, rtol=1e-7)
 
         x.grad = device.send(np.array([-10, -10, -1, -1], np.float32))
         opt.update()
         testing.assert_allclose(
             x.update_rule.state['v'],
-            [30.21, 30.21, 21.3, 21.3],
+            np.array([30.21, 30.21, 21.3, 21.3]),
             atol=1e-7, rtol=1e-7)
         testing.assert_allclose(
             x.update_rule.state['vhat'],
-            [30.21, 30.21, 30, 30],
+            np.array([30.21, 30.21, 30, 30]),
             atol=1e-7, rtol=1e-7)
         testing.assert_allclose(
             x.data,
             # result with NumPy
-            [-0.00377703, 0.01745388, -0.01548985, 0.01686232],
+            np.array([-0.00377703, 0.01745388, -0.01548985, 0.01686232]),
             atol=1e-7, rtol=1e-7)
 
 


### PR DESCRIPTION
Fix #7690

Found that it was due to lack of precision as some values were not being converted to FP32 during intermediate calculations.
