### PR TITLE
Fixes spectral normalization chainerx conversion

### DIFF
--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -247,10 +247,12 @@ class SpectralNormalization(link_hook.LinkHook):
                 else:
                     with chainer.using_device(device):
                         _, s, _ = xp.linalg.svd(array)
+                s = fallback._to_chx(s)
             else:
                 _, s, _ = link.xp.linalg.svd(weight_matrix)
+                s0 = chainer.utils.force_array(s[0])
             with link.init_scope():
-                link.gamma = variable.Parameter(s[0], ())
+                link.gamma = variable.Parameter(s0)
         self._initialized = True
 
     def normalize_weight(self, link):

--- a/chainer/link_hooks/spectral_normalization.py
+++ b/chainer/link_hooks/spectral_normalization.py
@@ -250,7 +250,7 @@ class SpectralNormalization(link_hook.LinkHook):
                 s = fallback._to_chx(s)
             else:
                 _, s, _ = link.xp.linalg.svd(weight_matrix)
-                s0 = chainer.utils.force_array(s[0])
+            s0 = chainer.utils.force_array(s[0])
             with link.init_scope():
                 link.gamma = variable.Parameter(s0)
         self._initialized = True


### PR DESCRIPTION
When doing spectral normalization, if using chainerx 
the link gamma parameter is not being converted back to chainerx after the fallback due to the lack of svd.

This PR proposes to use @toslunar solution in #7455 to avoid this issue.

This PR enables #7520 spectral_normalization tests to complete without errors.
