### PR TITLE
Skip flaky `TestConv*TensorCore`

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_connection.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_connection.py
@@ -174,6 +174,12 @@ class TestConvTensorCore(_ConvTestBase, op_utils.ChainerOpTest):
     out_dtype = 'float16'
     cover_all = False
 
+    def __init__(self):
+        # TODO(imanishi): Skip only if compute_capability < 70.
+        # Huge floating-point error often arises, because our CI environment
+        # have no Tensor Cores.
+        raise unittest.SkipTest()
+
     def generate_inputs(self):
         x, w, b = super().generate_inputs()
         return _convert_to_nhwc_layout(x), w, b
@@ -357,6 +363,12 @@ class TestConvTransposeTensorCore(
     pad = 0
     in_dtypes = ('float16', 'float16', 'float16')
     out_dtype = 'float16'
+
+    def __init__(self):
+        # TODO(imanishi): Skip only if compute_capability < 70.
+        # Huge floating-point error often arises, because our CI environment
+        # have no Tensor Cores.
+        raise unittest.SkipTest()
 
     def generate_inputs(self):
         x, w, b = super().generate_inputs()


### PR DESCRIPTION
Fix #7686.
