### PR TITLE
Fix flaky TestHuberLoss

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_loss.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_loss.py
@@ -125,9 +125,6 @@ class TestGaussianKLDivergence(LossBase):
 ))
 class TestHuberLoss(LossBase):
 
-    # Absolute is non-differentiable at zero.
-    dodge_nondifferentiable = True
-
     def generate_inputs(self):
         x, t = super().generate_inputs()
         mask = numpy.abs(numpy.abs(x - t) - self.delta) > 1e-3

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_loss.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_loss.py
@@ -128,6 +128,11 @@ class TestHuberLoss(LossBase):
     # Absolute is non-differentiable at zero.
     dodge_nondifferentiable = True
 
+    def generate_inputs(self):
+        x, t = super().generate_inputs()
+        mask = numpy.abs(numpy.abs(x - t) - self.delta) > 1e-3
+        return x * mask, t * mask
+
     def forward_xp(self, inputs, xp):
         x, t = inputs
         if xp is chainerx:


### PR DESCRIPTION
Fix #7696.
Fixed flaky `chainerx.huber_loss` backward/double-backward test like as #6924.