### PR TITLE
Reverse input array for non-contiguous tests

### DIFF
--- a/chainer/testing/array.py
+++ b/chainer/testing/array.py
@@ -77,7 +77,7 @@ def _as_noncontiguous_array(array):
 
         device = backend.get_device_from_array(a)
         xp = device.xp
-        slices = (slice(None, None, 2),) * a.ndim
+        slices = (slice(None, None, -2),) * a.ndim
         with chainer.using_device(device):
             ret = xp.empty(tuple([s * 2 for s in a.shape]), dtype=a.dtype)
             ret[slices] = a


### PR DESCRIPTION
This PR reproduces the bug: #7726.
~Merge #7727 first.~