### PR TITLE
[backport] Fix `PickleDataset` crash when using multiprocessing

### DIFF
--- a/chainer/datasets/pickle_dataset.py
+++ b/chainer/datasets/pickle_dataset.py
@@ -1,3 +1,5 @@
+import io
+import multiprocessing.util
 import threading
 
 import six
@@ -95,6 +97,14 @@ class PickleDataset(dataset_mixin.DatasetMixin):
 
         self._lock = threading.RLock()
 
+        # TODO: Avoid using undocumented feature
+        multiprocessing.util.register_after_fork(
+            self, PickleDataset._after_fork)
+
+    def _after_fork(self):
+        if callable(getattr(self._reader, 'after_fork', None)):
+            self._reader.after_fork()
+
     def close(self):
         """Closes a file reader.
 
@@ -117,6 +127,53 @@ class PickleDataset(dataset_mixin.DatasetMixin):
         with self._lock:
             self._reader.seek(self._positions[index])
             return pickle.load(self._reader)
+
+
+class _FileReader(io.RawIOBase):
+    """A file-like class implemented `after_fork()` hook
+
+    The method :meth:`after_fork` is called in the child process after forking,
+    and it closes and reopens the file object to avoid race condition caused by
+    open file description.
+    See: https://www.securecoding.cert.org/confluence/x/ZQG7AQ
+    """
+
+    def __init__(self, path):
+        super(_FileReader, self).__init__()
+        self._path = path
+        self._fp = None
+        self._open()
+
+    def _open(self):
+        self._fp = open(self._path, 'rb')
+
+    def after_fork(self):
+        """Reopens the file to avoid race condition."""
+        self.close()
+        self._open()
+
+    # file-like interface
+
+    def flush(self):
+        self._fp.flush()
+
+    def close(self):
+        self._fp.close()
+
+    def fileno(self):
+        return self._fp.fileno()
+
+    def seekable(self):
+        return self._fp.seekable()
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        return self._fp.seek(offset, whence)
+
+    def tell(self):
+        return self._fp.tell()
+
+    def readinto(self, b):
+        return self._fp.readinto(b)
 
 
 def open_pickle_dataset(path):
@@ -142,7 +199,7 @@ def open_pickle_dataset(path):
     .. seealso: chainer.datasets.PickleDataset
 
     """
-    reader = open(path, 'rb')
+    reader = _FileReader(path)
     return PickleDataset(reader)
 
 


### PR DESCRIPTION
Backport of #7625