### PR TITLE
Fix `Parameter.dtype` for uninitialized parameter

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1700,6 +1700,19 @@ class Parameter(Variable):
             self.initializer, self.update_rule, self.device)
         return _recover_parameter, args
 
+    @property
+    def dtype(self):
+        array = self.array
+        if array is not None:
+            return array.dtype
+        # uninitialized
+        initializer = self.initializer
+        if hasattr(initializer, 'dtype'):
+            return numpy.dtype(initializer.dtype)
+        raise RuntimeError(
+            'Dtype of the parameter is not determined yet because it\'s '
+            'uninitialized and dtype was not explicitly given.')
+
     def to_cpu(self):
         return self.to_device(backend.CpuDevice())
 

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1989,6 +1989,25 @@ class TestUninitializedParameter(unittest.TestCase):
         # TODO(sonots): Support addgrad with ChainerX
         raise unittest.SkipTest('ChainerX does not support addgrad')
 
+    def test_dtype_given_by_initializer(self):
+        class MyInitializer(object):
+            dtype = 'float16'
+
+            def __call__(self, array):
+                assert False  # never called
+
+        param = chainer.Parameter(MyInitializer())
+        assert param.dtype == np.float16
+
+    def test_dtype_not_given(self):
+        class MyInitializer(object):
+            def __call__(self, array):
+                assert False  # never called
+
+        param = chainer.Parameter(MyInitializer())
+        with pytest.raises(RuntimeError):
+            param.dtype
+
 
 class TestDebugPrint(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #7734

Note that `Variable.dtype` is out of scope.
`Variable(None)` should be eventually prohibited (#6116).
