### PR TITLE
Improve chainerx import check

### DIFF
--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -6,8 +6,18 @@ try:
 except ImportError:
     chainer_root_dir = os.path.abspath(__file__ + '../../..')
     raise ImportError(
-        'Reinstall Chainer in "editable" mode.\n'
-        '$ pip install -e {}'.format(chainer_root_dir))
+        '''\
+Cannot import chainerx because _build_info.py cannot be found.
+
+The chainerx module being imported was not correctly installed by \
+`pip install`.
+
+It may be caused by either of the following reasons.
+
+1. You are directly importing chainer source files without installing it with \
+`pip install`.
+2. You installed chainer in non-editable mode (`pip install` without -e) and \
+are importing chainer source files instead of the installed module.''')
 
 if _build_info.build_chainerx:
     from chainerx import _core

--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -4,7 +4,6 @@ import warnings
 try:
     from chainerx import _build_info
 except ImportError:
-    chainer_root_dir = os.path.abspath(__file__ + '../../..')
     raise ImportError(
         '''\
 Cannot import chainerx because _build_info.py cannot be found.

--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -8,8 +8,8 @@ except ImportError:
         '''\
 Cannot import chainerx because _build_info.py cannot be found.
 
-The chainerx module being imported was not correctly installed by \
-`pip install`.
+The chainer and chainerx module being imported was not correctly \
+installed by `pip install`.
 
 It may be caused by either of the following reasons.
 

--- a/chainerx/__init__.py
+++ b/chainerx/__init__.py
@@ -1,8 +1,13 @@
 import os
 import warnings
 
-from chainerx import _build_info
-
+try:
+    from chainerx import _build_info
+except ImportError:
+    chainer_root_dir = os.path.abspath(__file__ + '../../..')
+    raise ImportError(
+        'Reinstall Chainer in "editable" mode.\n'
+        '$ pip install -e {}'.format(chainer_root_dir))
 
 if _build_info.build_chainerx:
     from chainerx import _core


### PR DESCRIPTION
Fix #7730.
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/imanishi/chainer/chainerx/__init__.py", line 10, in <module>
    '$ pip install -e {}'.format(root_dir))
ImportError: Reinstall Chainer in "editable" mode.
$ pip install -e /home/imanishi/chainer
```