### PR TITLE
Fix eps in `Contrastive.backward`

### DIFF
--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -70,8 +70,8 @@ class Contrastive(function_node.FunctionNode):
             alpha = gy[:, None]
         alpha = chainer.functions.broadcast_to(alpha, y.shape)
         dist = chainer.functions.repeat(dist[:, None], x_dim, axis=1)
-        # avoid division by zero, 1e-7 is sufficiently small value that can be
-        # represented even in half precision
+        # avoid division by zero, 1e-7 is not sufficiently small value because
+        # 1e7 cannot be represented in half precision.
         eps = 5e-3 if dist.dtype == 'float16' else 1e-7
         dist = chainer.functions.maximum(
             dist, xp.full(dist.shape, eps, dtype=dist.dtype))

--- a/chainer/functions/loss/contrastive.py
+++ b/chainer/functions/loss/contrastive.py
@@ -72,8 +72,9 @@ class Contrastive(function_node.FunctionNode):
         dist = chainer.functions.repeat(dist[:, None], x_dim, axis=1)
         # avoid division by zero, 1e-7 is sufficiently small value that can be
         # represented even in half precision
+        eps = 5e-3 if dist.dtype == 'float16' else 1e-7
         dist = chainer.functions.maximum(
-            dist, xp.full(dist.shape, 1e-7, dtype=dist.dtype))
+            dist, xp.full(dist.shape, eps, dtype=dist.dtype))
         # similar pair
         gx0 = alpha * y.astype(alpha.dtype) * diff
         # dissimilar pair


### PR DESCRIPTION
Related to #7704.
In `Contrastive.backward`, eps(=`1e-7`) is added to `dist` to avoid zero-division. However, when the dtype of input arrays are `float16` it cause overflow because float16 arrays can't express `1e7`.