### PR TITLE
Fix `optimizer_hooks.GradientHardClipping` for scalar array

### DIFF
--- a/chainer/optimizer_hooks/gradient_hard_clipping.py
+++ b/chainer/optimizer_hooks/gradient_hard_clipping.py
@@ -52,7 +52,7 @@ class GradientHardClipping(object):
             # supports kwarg `out`.
             if xp == backend.chainerx \
                     or isinstance(param.grad, backend.intel64.mdarray):
-                grad[:] = grad.clip(self.lower_bound, self.upper_bound)
+                grad[...] = grad.clip(self.lower_bound, self.upper_bound)
             else:
                 # Save on new object allocation when using numpy and cupy
                 # using kwarg `out`

--- a/tests/chainer_tests/optimizer_hooks_tests/test_gradient_clipping.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_gradient_clipping.py
@@ -8,6 +8,8 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
+import utils
+
 
 _backend_params = [
     # NumPy
@@ -38,21 +40,10 @@ class SimpleLink(chainer.Link):
 class TestGradientClipping(unittest.TestCase):
 
     def setUp(self):
-        num_params = 3
-        arrs = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(num_params)]
-        grads = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(num_params)]
-        params = []
-        for arr, grad in zip(arrs, grads):
-            param = chainer.Parameter(arr)
-            param.grad = grad
-            params.append(param)
-
-        self.target = SimpleLink(params)
-        self.norm = math.sqrt(sum([g.ravel().dot(g.ravel()) for g in grads]))
+        self.target = utils.ParametersLink.from_param_props(
+            ((2, 3), (2, 0, 1), ()))
+        self.norm = math.sqrt(sum([
+            np.square(param.grad).sum() for param in self.target.params()]))
 
     def check_clipping(self, backend_configs, rate):
         target = self.target

--- a/tests/chainer_tests/optimizer_hooks_tests/test_gradient_hard_clipping.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_gradient_hard_clipping.py
@@ -2,10 +2,12 @@ import unittest
 
 import numpy as np
 
-import chainer
 from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
+
+from chainer_tests.optimizer_hooks_tests import utils
+
 
 _backend_params = [
     # NumPy
@@ -21,35 +23,14 @@ _backend_params = [
 ]
 
 
-class SimpleLink(chainer.Link):
-
-    def __init__(self, params):
-        super(SimpleLink, self).__init__()
-        with self.init_scope():
-            for i, p in enumerate(params):
-                setattr(self, 'p{}'.format(i), p)
-
-
 @testing.backend.inject_backend_tests(None, _backend_params)
 @testing.backend.inject_backend_tests(None, _backend_params)
 @testing.backend.inject_backend_tests(None, _backend_params)
 class TestGradientHardClipping(unittest.TestCase):
 
     def setUp(self):
-        num_params = 3
-        arrs = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(num_params)]
-        grads = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(num_params)]
-        params = []
-        for arr, grad in zip(arrs, grads):
-            param = chainer.Parameter(arr)
-            param.grad = grad
-            params.append(param)
-
-        self.target = SimpleLink(params)
+        self.target = utils.ParametersLink.from_param_props(
+            ((2, 3), (2, 0, 1), ()))
 
     def check_hardclipping(self, backend_configs):
         target = self.target

--- a/tests/chainer_tests/optimizer_hooks_tests/test_gradient_hard_clipping.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_gradient_hard_clipping.py
@@ -6,7 +6,7 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
-from chainer_tests.optimizer_hooks_tests import utils
+import utils
 
 
 _backend_params = [

--- a/tests/chainer_tests/optimizer_hooks_tests/test_gradient_lars.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_gradient_lars.py
@@ -7,7 +7,7 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
-from chainer_tests.optimizer_hooks_tests import utils
+import utils
 
 
 _backend_params = [

--- a/tests/chainer_tests/optimizer_hooks_tests/test_gradient_noise.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_gradient_noise.py
@@ -4,7 +4,6 @@ import itertools
 import mock
 import numpy as np
 
-import chainer
 from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing

--- a/tests/chainer_tests/optimizer_hooks_tests/test_gradient_noise.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_gradient_noise.py
@@ -8,7 +8,7 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
-from chainer_tests.optimizer_hooks_tests import utils
+import utils
 
 
 _backend_params = [

--- a/tests/chainer_tests/optimizer_hooks_tests/test_lasso.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_lasso.py
@@ -7,6 +7,8 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
+from chainer_tests.optimizer_hooks_tests import utils
+
 
 _backend_params = [
     # NumPy
@@ -22,34 +24,13 @@ _backend_params = [
 ]
 
 
-class SimpleLink(chainer.Link):
-
-    def __init__(self, params):
-        super(SimpleLink, self).__init__()
-        with self.init_scope():
-            for i, p in enumerate(params):
-                setattr(self, 'p{}'.format(i), p)
-
-
 @testing.backend.inject_backend_tests(None, _backend_params)
 @testing.backend.inject_backend_tests(None, _backend_params)
 @testing.backend.inject_backend_tests(None, _backend_params)
 class TestLasso(unittest.TestCase):
     def setUp(self):
-        num_params = 3
-        arrs = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(num_params)]
-        grads = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(num_params)]
-        params = []
-        for arr, grad in zip(arrs, grads):
-            param = chainer.Parameter(arr)
-            param.grad = grad
-            params.append(param)
-
-        self.target = SimpleLink(params)
+        self.target = utils.ParametersLink.from_param_props(
+            ((2, 3), (2, 0, 1), ()))
 
     def check_lasso(self, backend_configs):
         target = self.target
@@ -67,7 +48,7 @@ class TestLasso(unittest.TestCase):
 
         # Compute using optimizer_hook
         opt = optimizers.SGD(lr=1)
-        opt.setup(self.target)
+        opt.setup(target)
         opt.add_hook(optimizer_hooks.Lasso(decay))
         opt.update()
 

--- a/tests/chainer_tests/optimizer_hooks_tests/test_lasso.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_lasso.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy as np
 
-import chainer
 from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing

--- a/tests/chainer_tests/optimizer_hooks_tests/test_lasso.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_lasso.py
@@ -6,7 +6,7 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
-from chainer_tests.optimizer_hooks_tests import utils
+import utils
 
 
 _backend_params = [

--- a/tests/chainer_tests/optimizer_hooks_tests/test_weight_decay.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_weight_decay.py
@@ -8,7 +8,7 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
-from chainer_tests.optimizer_hooks_tests import utils
+import utils
 
 
 _backend_params = [

--- a/tests/chainer_tests/optimizer_hooks_tests/test_weight_decay.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_weight_decay.py
@@ -8,6 +8,8 @@ from chainer import optimizer_hooks
 from chainer import optimizers
 from chainer import testing
 
+from chainer_tests.optimizer_hooks_tests import utils
+
 
 _backend_params = [
     # NumPy
@@ -23,35 +25,14 @@ _backend_params = [
 ]
 
 
-class SimpleLink(chainer.Link):
-
-    def __init__(self, params):
-        super(SimpleLink, self).__init__()
-        with self.init_scope():
-            for i, p in enumerate(params):
-                setattr(self, 'p{}'.format(i), p)
-
-
 @testing.backend.inject_backend_tests(None, _backend_params)
 @testing.backend.inject_backend_tests(None, _backend_params)
 @testing.backend.inject_backend_tests(None, _backend_params)
 class TestWeightDecay(unittest.TestCase):
 
     def setUp(self):
-        self.num_params = 3
-        arrs = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(self.num_params)]
-        grads = [
-            np.random.uniform(-3, 3, (2, 3)).astype(np.float32)
-            for _ in range(self.num_params)]
-        params = []
-        for arr, grad in zip(arrs, grads):
-            param = chainer.Parameter(arr)
-            param.grad = grad
-            params.append(param)
-
-        self.target = SimpleLink(params)
+        self.target = utils.ParametersLink.from_param_props(
+            ((2, 3), (2, 0, 1), ()))
 
     def check_weight_decay(self, backend_configs):
         target = self.target

--- a/tests/chainer_tests/optimizer_hooks_tests/utils.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/utils.py
@@ -1,0 +1,39 @@
+import numpy
+
+import chainer
+
+
+class ParametersLink(chainer.Link):
+    '''Link with specific parameters.'''
+
+    def __init__(self, params):
+        super(ParametersLink, self).__init__()
+        with self.init_scope():
+            for i, p in enumerate(params):
+                setattr(self, 'p{}'.format(i), p)
+
+    @staticmethod
+    def from_param_props(shapes, dtypes=numpy.float32):
+        # Creates a ParameterLink from the given parameter properties.
+        assert isinstance(shapes, (tuple, list))
+        assert all(isinstance(s, tuple) for s in shapes)
+
+        n_params = len(shapes)
+
+        if not isinstance(dtypes, (tuple, list)):
+            dtypes = (dtypes,) * n_params
+
+        arrs = [
+            numpy.random.uniform(-3, 3, shape).astype(dtype)
+            for shape, dtype in zip(shapes, dtypes)]
+        grads = [
+            numpy.random.uniform(-3, 3, shape).astype(dtype)
+            for shape, dtype in zip(shapes, dtypes)]
+
+        params = []
+        for arr, grad in zip(arrs, grads):
+            param = chainer.Parameter(arr)
+            param.grad = grad
+            params.append(param)
+
+        return ParametersLink(params)

--- a/tests/chainer_tests/test_runnable.py
+++ b/tests/chainer_tests/test_runnable.py
@@ -1,5 +1,6 @@
 import io
 import os
+import re
 import unittest
 
 from chainer import testing
@@ -9,9 +10,10 @@ class TestRunnable(unittest.TestCase):
 
     def test_runnable(self):
         cwd = os.path.dirname(__file__)
+        regex = re.compile(r'^test_.*\.py$')
         for dirpath, dirnames, filenames in os.walk(cwd):
             for filename in filenames:
-                if not filename.endswith('.py') or '__init__' in filename:
+                if not regex.match(filename):
                     continue
                 path = os.path.join(dirpath, filename)
                 with io.open(path, encoding='utf-8') as f:


### PR DESCRIPTION
Fixes #7759

This PR was originally intended to refactor the tests (#7759) but I found a bug in `optimizer_hooks.GradientHardClipping`. I can split the PR if it's preferable.