### PR TITLE
Add batched_copy to All Communicators

### DIFF
--- a/chainermn/communicators/__init__.py
+++ b/chainermn/communicators/__init__.py
@@ -81,25 +81,24 @@ def create_communicator(
         raise ValueError(
             'allreduce_grad_dtype is only available'
             'at \'pure_nccl\' communicator.')
-    if communicator_name != 'pure_nccl' and batched_copy:
-        raise ValueError(
-            'batched_copy is only available'
-            'at \'pure_nccl\' communicator.')
 
     if communicator_name == 'naive':
         from chainermn.communicators.naive_communicator \
             import NaiveCommunicator
-        return NaiveCommunicator(mpi_comm=mpi_comm)
+        return NaiveCommunicator(mpi_comm=mpi_comm,
+                                 batched_copy=batched_copy)
 
     elif communicator_name == 'flat':
         from chainermn.communicators.flat_communicator \
             import FlatCommunicator
-        return FlatCommunicator(mpi_comm=mpi_comm)
+        return FlatCommunicator(mpi_comm=mpi_comm,
+                                batched_copy=batched_copy)
 
     elif communicator_name == 'non_cuda_aware':
         from chainermn.communicators.non_cuda_aware_communicator \
             import NonCudaAwareCommunicator
-        return NonCudaAwareCommunicator(mpi_comm=mpi_comm)
+        return NonCudaAwareCommunicator(mpi_comm=mpi_comm,
+                                        batched_copy=batched_copy)
 
     elif communicator_name == 'pure_nccl':
         from chainermn.communicators.pure_nccl_communicator \
@@ -111,7 +110,8 @@ def create_communicator(
     elif communicator_name == 'dummy':
         from chainermn.communicators.dummy_communicator \
             import DummyCommunicator
-        return DummyCommunicator(mpi_comm=mpi_comm)
+        return DummyCommunicator(mpi_comm=mpi_comm,
+                                 batched_copy=batched_copy)
 
     else:
         raise ValueError(

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -2,6 +2,7 @@ import ctypes
 
 import mpi4py.MPI
 import numpy as np
+from chainermn.communicators import _communication_utility
 
 import chainer.backends
 try:
@@ -9,6 +10,30 @@ try:
     _cupy_avail = True
 except Exception:
     _cupy_avail = False
+
+
+class ParamsData(object):
+    def __init__(self, params, attr_name, zero_fill):
+        n_params = len(params)
+        params_dptr = np.empty(n_params, dtype=np.int64)
+        params_dtype = np.empty(n_params, dtype=np.int32)
+        params_size_csum = np.empty(n_params+1, dtype=np.int32)
+        params_size_csum[0] = 0
+        for i, param in enumerate(params):
+            v = getattr(param, attr_name)
+            if attr_name == 'grad' and v is None and zero_fill:
+                v = param.xp.zeros_like(param.data)
+                setattr(param, attr_name, v)
+            params_dptr[i] = v.data.ptr
+            if v.dtype not in [np.float16, np.float32]:
+                raise ValueError('dtype must be float16 or float32.')
+            params_dtype[i] = _communication_utility._get_nccl_type_id(v.dtype)
+            params_size_csum[i+1] = params_size_csum[i] + v.size
+        self.n_params = n_params
+        self.n_elems = params_size_csum[n_params]
+        self.size_csum = chainer.cuda.cupy.asarray(params_size_csum)
+        self.dtype = chainer.cuda.cupy.asarray(params_dtype)
+        self.dptr = chainer.cuda.cupy.asarray(params_dptr)
 
 
 class HostPinnedMemory(object):
@@ -168,3 +193,138 @@ def get_device_memory_pointer(array):
             array.data.ptr,
             ctypes.POINTER(ctypes.c_ubyte * array.nbytes)
         ).contents
+
+
+def _batched_pack_params(params_data, buffer, dtype):
+    n_params = params_data.n_params
+    n_elems = params_data.n_elems
+    params_dptr = params_data.dptr
+    params_dtype = params_data.dtype
+    params_size_csum = params_data.size_csum
+    buf_dtype = _communication_utility._get_nccl_type_id(dtype)
+    n_threads = 128
+    n_blocks = (n_elems + n_threads - 1) // n_threads
+    _cupy_batched_pack_params()(
+        (n_blocks, ), (n_threads, ),
+        (buffer.memory.ptr, buf_dtype, n_elems,
+         params_dptr, params_dtype, params_size_csum, n_params))
+
+
+def _batched_unpack_params(params_data, buffer, dtype):
+    n_params = params_data.n_params
+    n_elems = params_data.n_elems
+    params_dptr = params_data.dptr
+    params_dtype = params_data.dtype
+    params_size_csum = params_data.size_csum
+    buf_dtype = _communication_utility._get_nccl_type_id(dtype)
+    n_threads = 128
+    n_blocks = (n_elems + n_threads - 1) // n_threads
+    _cupy_batched_unpack_params()(
+        (n_blocks, ), (n_threads, ),
+        (buffer.memory.ptr, buf_dtype, n_elems,
+         params_dptr, params_dtype, params_size_csum, n_params))
+
+
+def _cupy_batched_pack_params():
+    return chainer.cuda.raw(r'''
+#include <cupy/carray.cuh>
+#define NCCL_FLOAT16  6
+#define NCCL_FLOAT32  7
+    extern "C" __global__
+    void cupy_batched_pack_params(
+            void *dst0, int dst_dtype, int n_elems,
+            unsigned long *params_dptr, int *params_dtype,
+            int *params_size_csum, int n_params) {
+        int tid = threadIdx.x + blockIdx.x * blockDim.x;
+        if (tid >= n_elems) return;
+        int j_min = 0;
+        int j_max = n_params - 1;
+        int j;
+        while (1) {
+            j = (j_min + j_max) / 2;
+            if (tid < params_size_csum[j]) {
+                j_max = j - 1;
+                continue;
+            }
+            if (tid >= params_size_csum[j+1]){
+                j_min = j + 1;
+                continue;
+            }
+            break;
+        }
+        assert(tid >= params_size_csum[j]);
+        assert(tid < params_size_csum[j+1]);
+        int src_dtype = params_dtype[j];
+        int src_idx = tid - params_size_csum[j];
+        if (dst_dtype == NCCL_FLOAT16) {
+            half* dst = (half*) dst0;
+            if (src_dtype == NCCL_FLOAT16) {
+                dst[tid] = (half) (((half*) (params_dptr[j]))[src_idx]);
+            }
+            else if (src_dtype == NCCL_FLOAT32) {
+                dst[tid] = (half) (((float*) (params_dptr[j]))[src_idx]);
+            }
+        }
+        else if (dst_dtype == NCCL_FLOAT32) {
+            float* dst = (float*) dst0;
+            if (src_dtype == NCCL_FLOAT16) {
+                dst[tid] = (float) (((half*) (params_dptr[j]))[src_idx]);
+            }
+            else if (src_dtype == NCCL_FLOAT32) {
+                dst[tid] = (float) (((float*) (params_dptr[j]))[src_idx]);
+            }
+       }
+    }
+    ''', 'cupy_batched_pack_params')
+
+
+def _cupy_batched_unpack_params():
+    return chainer.cuda.raw(r'''
+#include <cupy/carray.cuh>
+#define NCCL_FLOAT16  6
+#define NCCL_FLOAT32  7
+    extern "C" __global__
+    void cupy_batched_unpack_params(
+            void *src0, int src_dtype, int n_elems,
+            unsigned long *params_dptr, int *params_dtype,
+            int *params_size_csum, int n_params) {
+        int tid = threadIdx.x + blockIdx.x * blockDim.x;
+        if (tid >= n_elems) return;
+        int j_min = 0;
+        int j_max = n_params - 1;
+        int j;
+        while (1) {
+            j = (j_min + j_max) / 2;
+            if (tid < params_size_csum[j]) {
+                j_max = j - 1;
+                continue;
+            }
+            if (tid >= params_size_csum[j+1]){
+                j_min = j + 1;
+                continue;
+            }
+            break;
+        }
+        assert(tid >= params_size_csum[j]);
+        assert(tid < params_size_csum[j+1]);
+        int dst_dtype = params_dtype[j];
+        int dst_idx = tid - params_size_csum[j];
+        if (src_dtype == NCCL_FLOAT16) {
+            half* src = (half*) src0;
+            if (dst_dtype == NCCL_FLOAT16) {
+                ((half*) (params_dptr[j]))[dst_idx] = (half) src[tid];
+            }
+            else if (dst_dtype == NCCL_FLOAT32) {
+                ((float*) (params_dptr[j]))[dst_idx] = (float) src[tid];
+            }
+        }
+        else if (src_dtype == NCCL_FLOAT32) {
+            float* src = (float*) src0;
+            if (dst_dtype == NCCL_FLOAT16) {
+                ((half*) (params_dptr[j]))[dst_idx] = (half) src[tid];
+            }
+            else if (dst_dtype == NCCL_FLOAT32) {
+                ((float*) (params_dptr[j]))[dst_idx] = (float) src[tid];
+            }
+       }
+    }''', 'cupy_batched_unpack_params')

--- a/chainermn/communicators/dummy_communicator.py
+++ b/chainermn/communicators/dummy_communicator.py
@@ -1,5 +1,6 @@
 from chainermn.communicators import _memory_utility
 from chainermn.communicators import mpi_communicator_base
+import numpy as np
 
 
 class DummyCommunicator(mpi_communicator_base.MpiCommunicatorBase):
@@ -10,10 +11,12 @@ class DummyCommunicator(mpi_communicator_base.MpiCommunicatorBase):
     This class does not pass the tests.
     """
 
-    def __init__(self, mpi_comm):
+    def __init__(self, mpi_comm,
+                 batched_copy=False):
         super(DummyCommunicator, self).__init__(mpi_comm)
 
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
+        self.batched_copy = batched_copy
 
     def multi_node_mean_grad(self, model, zero_fill=False):
         params = _memory_utility.extract_params_set_grad(model, zero_fill)
@@ -23,8 +26,12 @@ class DummyCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         n_bytes_total = n_elems_total * itemsize
         self.gpu_buffer_a.assign(n_bytes_total)
 
-        _memory_utility.pack_params(
-            params, 'grad', self.gpu_buffer_a, zero_fill)
+        self._pack_params_to_buffer(params, 'grad',
+                                    buffer=self.gpu_buffer_a,
+                                    allreduce_grad_dtype=np.float32,
+                                    zero_fill=zero_fill)
 
-        _memory_utility.unpack_params(
-            params, 'grad', self.gpu_buffer_a, zero_fill)
+        self._unpack_params_from_buffer(params, 'grad',
+                                        buffer=self.gpu_buffer_a,
+                                        allreduce_grad_dtype=np.float32,
+                                        zero_fill=zero_fill)

--- a/chainermn/communicators/flat_communicator.py
+++ b/chainermn/communicators/flat_communicator.py
@@ -6,11 +6,14 @@ from chainermn.communicators import mpi_communicator_base
 
 class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
-    def __init__(self, mpi_comm):
+    def __init__(self, mpi_comm,
+                 batched_copy=False):
         super(FlatCommunicator, self).__init__(mpi_comm)
 
         self.gpu_buffer_a = _memory_utility.DeviceMemory()
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
+
+        self.batched_copy = batched_copy
 
     def multi_node_mean_grad(self, model, zero_fill=False):
         params = _memory_utility.extract_params_set_grad(model, zero_fill)
@@ -23,11 +26,12 @@ class FlatCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
         allreduce_grad_dtype = np.float32
 
-        _memory_utility.pack_params(
-            params, 'grad', self.gpu_buffer_a, allreduce_grad_dtype, zero_fill)
+        self._pack_params_to_buffer(params, 'grad', buffer=self.gpu_buffer_a,
+                                    allreduce_grad_dtype=allreduce_grad_dtype,
+                                    zero_fill=zero_fill)
 
         self._multi_node_mean(self.gpu_buffer_a.array(n_elems_total),
                               self.gpu_buffer_b.array(n_elems_total))
 
-        _memory_utility.unpack_params(
-            params, 'grad', self.gpu_buffer_b, allreduce_grad_dtype, zero_fill)
+        self._unpack_params_from_buffer(params, 'grad', self.gpu_buffer_b,
+                                        allreduce_grad_dtype, zero_fill)

--- a/chainermn/communicators/mpi_communicator_base.py
+++ b/chainermn/communicators/mpi_communicator_base.py
@@ -703,3 +703,40 @@ class MpiCommunicatorBase(communicator_base.CommunicatorBase):
 
         if chainer.is_debug():
             self._ensure_all_finite(recvbuf)
+
+    def _pack_params_to_buffer(self, params, attr_name, buffer,
+                               allreduce_grad_dtype, zero_fill, stream=None):
+
+        if self.batched_copy:
+            params_data = _memory_utility.ParamsData(params,
+                                                     attr_name, zero_fill)
+            _memory_utility._batched_pack_params(
+                params_data, buffer,
+                allreduce_grad_dtype)
+            self.params_data = params_data
+        else:
+            _memory_utility.pack_params(
+                params, attr_name,
+                buffer,
+                transfer_dtype=allreduce_grad_dtype,
+                zero_fill=zero_fill,
+                stream=stream)
+
+    def _unpack_params_from_buffer(self, params, attr_name, buffer,
+                                   allreduce_grad_dtype,
+                                   zero_fill, stream=None):
+        if self.batched_copy:
+            if self.params_data is not None:
+                params_data = self.params_data
+                self.params_data = None
+            else:
+                params_data = _memory_utility.ParamsData(
+                    params, attr_name, zero_fill)
+            _memory_utility._batched_unpack_params(
+                params_data, buffer,
+                allreduce_grad_dtype)
+            return
+        else:
+            _memory_utility.unpack_params(
+                params, attr_name, buffer,
+                allreduce_grad_dtype, zero_fill, stream)

--- a/chainermn/communicators/naive_communicator.py
+++ b/chainermn/communicators/naive_communicator.py
@@ -4,8 +4,10 @@ from chainermn.communicators import mpi_communicator_base
 
 class NaiveCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
-    def __init__(self, mpi_comm):
+    def __init__(self, mpi_comm,
+                 batched_copy=False):
         super(NaiveCommunicator, self).__init__(mpi_comm)
+        self.batched_copy = batched_copy
 
     def multi_node_mean_grad(self, model, zero_fill=False):
         params = _memory_utility.extract_params_set_grad(model, zero_fill)

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -13,7 +13,9 @@ from chainermn import nccl
 
 class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
-    def __init__(self, mpi_comm):
+    def __init__(self, mpi_comm,
+                 batched_copy=False):
+
         super(NonCudaAwareCommunicator, self).__init__(mpi_comm)
         if not nccl._available:
             raise RuntimeError(
@@ -35,6 +37,8 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.gpu_buffer_b = _memory_utility.DeviceMemory()
         self.cpu_buffer_a = _memory_utility.HostPinnedMemory()
         self.cpu_buffer_b = _memory_utility.HostPinnedMemory()
+
+        self.batched_copy = batched_copy
 
     def finalize(self):
         super(NonCudaAwareCommunicator, self).finalize()
@@ -89,8 +93,9 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
 
         allreduce_grad_dtype = np.float32
 
-        _memory_utility.pack_params(
-            params, 'grad', self.gpu_buffer_a, allreduce_grad_dtype, zero_fill)
+        self._pack_params_to_buffer(params, 'grad', buffer=self.gpu_buffer_a,
+                                    allreduce_grad_dtype=allreduce_grad_dtype,
+                                    zero_fill=zero_fill)
 
         if chainer.is_debug():
             stream.synchronize()
@@ -138,5 +143,5 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             stream.synchronize()
             self._ensure_all_finite(self.gpu_buffer_b.array(n_elems_total))
 
-        _memory_utility.unpack_params(
-            params, 'grad', self.gpu_buffer_b, allreduce_grad_dtype, zero_fill)
+        self._unpack_params_from_buffer(params, 'grad', self.gpu_buffer_b,
+                                        allreduce_grad_dtype, zero_fill)

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -102,7 +102,8 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             chainer.cuda.Stream.null.synchronize()
 
         # pack grads from params -> buffer A
-        self._pack_params_to_buffer(params, allreduce_grad_dtype,
+        self._pack_params_to_buffer(params, 'grad', self.gpu_buffer_a,
+                                    allreduce_grad_dtype,
                                     zero_fill, stream)
 
         # Allreduce from buffer A -> buffer B
@@ -112,7 +113,8 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
                                    allreduce_grad_dtype, stream)
 
         # unpack params from buffer A -> params
-        self._unpack_params_from_buffer(params, allreduce_grad_dtype,
+        self._unpack_params_from_buffer(params, 'grad', self.gpu_buffer_b,
+                                        allreduce_grad_dtype,
                                         zero_fill, stream)
 
     def _prepare_allreduce_pack_buffer(self, allreduce_grad_dtype, n_elems):
@@ -127,38 +129,6 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
             needs_sync = True
 
         return needs_sync
-
-    def _pack_params_to_buffer(self, params, allreduce_grad_dtype,
-                               zero_fill, stream):
-        if self.batched_copy:
-            params_data = _ParamsData(params, 'grad', zero_fill)
-            _batched_pack_params(params_data, self.gpu_buffer_a,
-                                 allreduce_grad_dtype)
-            self.params_data = params_data
-            # self.params_data will be re-used by _unpack_params_from_buffer
-        else:
-            _memory_utility.pack_params(
-                params, 'grad',
-                self.gpu_buffer_a,
-                transfer_dtype=allreduce_grad_dtype,
-                zero_fill=zero_fill,
-                stream=stream)
-
-    def _unpack_params_from_buffer(self, params,
-                                   allreduce_grad_dtype, zero_fill, stream):
-        if self.batched_copy:
-            if self.params_data is not None:
-                params_data = self.params_data
-                self.params_data = None
-            else:
-                params_data = _ParamsData(params, 'grad', zero_fill)
-            _batched_unpack_params(params_data, self.gpu_buffer_b,
-                                   allreduce_grad_dtype)
-            return
-        else:
-            _memory_utility.unpack_params(
-                params, 'grad', self.gpu_buffer_b,
-                allreduce_grad_dtype, zero_fill, stream)
 
     def _multi_node_mean_nccl(self, sendbuf, recvbuf,
                               n_elems, dtype, stream=None):
@@ -200,162 +170,3 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         if chainer.is_debug():
             stream.synchronize()
             self._ensure_all_finite(recvbuf.array(n_elems, dtype=dtype))
-
-
-class _ParamsData(object):
-    def __init__(self, params, attr_name, zero_fill):
-        n_params = len(params)
-        params_dptr = np.empty(n_params, dtype=np.int64)
-        params_dtype = np.empty(n_params, dtype=np.int32)
-        params_size_csum = np.empty(n_params+1, dtype=np.int32)
-        params_size_csum[0] = 0
-        for i, param in enumerate(params):
-            v = getattr(param, attr_name)
-            if attr_name == 'grad' and v is None and zero_fill:
-                v = param.xp.zeros_like(param.data)
-                setattr(param, attr_name, v)
-            params_dptr[i] = v.data.ptr
-            if v.dtype not in [np.float16, np.float32]:
-                raise ValueError('dtype must be float16 or float32.')
-            params_dtype[i] = _communication_utility._get_nccl_type_id(v.dtype)
-            params_size_csum[i+1] = params_size_csum[i] + v.size
-        self.n_params = n_params
-        self.n_elems = params_size_csum[n_params]
-        self.size_csum = chainer.cuda.cupy.asarray(params_size_csum)
-        self.dtype = chainer.cuda.cupy.asarray(params_dtype)
-        self.dptr = chainer.cuda.cupy.asarray(params_dptr)
-
-
-def _batched_pack_params(params_data, buffer, dtype):
-    n_params = params_data.n_params
-    n_elems = params_data.n_elems
-    params_dptr = params_data.dptr
-    params_dtype = params_data.dtype
-    params_size_csum = params_data.size_csum
-    buf_dtype = _communication_utility._get_nccl_type_id(dtype)
-    n_threads = 128
-    n_blocks = (n_elems + n_threads - 1) // n_threads
-    _cupy_batched_pack_params()(
-        (n_blocks, ), (n_threads, ),
-        (buffer.memory.ptr, buf_dtype, n_elems,
-         params_dptr, params_dtype, params_size_csum, n_params))
-
-
-def _batched_unpack_params(params_data, buffer, dtype):
-    n_params = params_data.n_params
-    n_elems = params_data.n_elems
-    params_dptr = params_data.dptr
-    params_dtype = params_data.dtype
-    params_size_csum = params_data.size_csum
-    buf_dtype = _communication_utility._get_nccl_type_id(dtype)
-    n_threads = 128
-    n_blocks = (n_elems + n_threads - 1) // n_threads
-    _cupy_batched_unpack_params()(
-        (n_blocks, ), (n_threads, ),
-        (buffer.memory.ptr, buf_dtype, n_elems,
-         params_dptr, params_dtype, params_size_csum, n_params))
-
-
-def _cupy_batched_pack_params():
-    return chainer.cuda.raw(r'''
-#include <cupy/carray.cuh>
-#define NCCL_FLOAT16  6
-#define NCCL_FLOAT32  7
-    extern "C" __global__
-    void cupy_batched_pack_params(
-            void *dst0, int dst_dtype, int n_elems,
-            unsigned long *params_dptr, int *params_dtype,
-            int *params_size_csum, int n_params) {
-        int tid = threadIdx.x + blockIdx.x * blockDim.x;
-        if (tid >= n_elems) return;
-        int j_min = 0;
-        int j_max = n_params - 1;
-        int j;
-        while (1) {
-            j = (j_min + j_max) / 2;
-            if (tid < params_size_csum[j]) {
-                j_max = j - 1;
-                continue;
-            }
-            if (tid >= params_size_csum[j+1]){
-                j_min = j + 1;
-                continue;
-            }
-            break;
-        }
-        assert(tid >= params_size_csum[j]);
-        assert(tid < params_size_csum[j+1]);
-        int src_dtype = params_dtype[j];
-        int src_idx = tid - params_size_csum[j];
-        if (dst_dtype == NCCL_FLOAT16) {
-            half* dst = (half*) dst0;
-            if (src_dtype == NCCL_FLOAT16) {
-                dst[tid] = (half) (((half*) (params_dptr[j]))[src_idx]);
-            }
-            else if (src_dtype == NCCL_FLOAT32) {
-                dst[tid] = (half) (((float*) (params_dptr[j]))[src_idx]);
-            }
-        }
-        else if (dst_dtype == NCCL_FLOAT32) {
-            float* dst = (float*) dst0;
-            if (src_dtype == NCCL_FLOAT16) {
-                dst[tid] = (float) (((half*) (params_dptr[j]))[src_idx]);
-            }
-            else if (src_dtype == NCCL_FLOAT32) {
-                dst[tid] = (float) (((float*) (params_dptr[j]))[src_idx]);
-            }
-       }
-    }
-    ''', 'cupy_batched_pack_params')
-
-
-def _cupy_batched_unpack_params():
-    return chainer.cuda.raw(r'''
-#include <cupy/carray.cuh>
-#define NCCL_FLOAT16  6
-#define NCCL_FLOAT32  7
-    extern "C" __global__
-    void cupy_batched_unpack_params(
-            void *src0, int src_dtype, int n_elems,
-            unsigned long *params_dptr, int *params_dtype,
-            int *params_size_csum, int n_params) {
-        int tid = threadIdx.x + blockIdx.x * blockDim.x;
-        if (tid >= n_elems) return;
-        int j_min = 0;
-        int j_max = n_params - 1;
-        int j;
-        while (1) {
-            j = (j_min + j_max) / 2;
-            if (tid < params_size_csum[j]) {
-                j_max = j - 1;
-                continue;
-            }
-            if (tid >= params_size_csum[j+1]){
-                j_min = j + 1;
-                continue;
-            }
-            break;
-        }
-        assert(tid >= params_size_csum[j]);
-        assert(tid < params_size_csum[j+1]);
-        int dst_dtype = params_dtype[j];
-        int dst_idx = tid - params_size_csum[j];
-        if (src_dtype == NCCL_FLOAT16) {
-            half* src = (half*) src0;
-            if (dst_dtype == NCCL_FLOAT16) {
-                ((half*) (params_dptr[j]))[dst_idx] = (half) src[tid];
-            }
-            else if (dst_dtype == NCCL_FLOAT32) {
-                ((float*) (params_dptr[j]))[dst_idx] = (float) src[tid];
-            }
-        }
-        else if (src_dtype == NCCL_FLOAT32) {
-            float* src = (float*) src0;
-            if (dst_dtype == NCCL_FLOAT16) {
-                ((half*) (params_dptr[j]))[dst_idx] = (half) src[tid];
-            }
-            else if (dst_dtype == NCCL_FLOAT32) {
-                ((float*) (params_dptr[j]))[dst_idx] = (float) src[tid];
-            }
-       }
-    }''', 'cupy_batched_unpack_params')

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -62,7 +62,7 @@ class Param(object):
         self.nccl1 = False
         self.model_dtype = None
         self.allreduce_grad_dtype = None
-        self.batched_copy = False
+        self.batched_copy = True
         self.global_dtype = None
         self.__dict__.update(param)
 
@@ -126,28 +126,24 @@ gpu_params = [Param(p) for p in [
         'nccl1': False,
         'model_dtype': np.float16,
         'allreduce_grad_dtype': np.float16,
-        'batched_copy': True,
     }, {
         'communicator_class': PureNcclCommunicator,
         'multi_node': True,
         'nccl1': False,
         'model_dtype': np.float16,
         'allreduce_grad_dtype': np.float32,
-        'batched_copy': True,
     }, {
         'communicator_class': PureNcclCommunicator,
         'multi_node': True,
         'nccl1': False,
         'model_dtype': np.float32,
         'allreduce_grad_dtype': np.float32,
-        'batched_copy': True,
     }, {
         'communicator_class': PureNcclCommunicator,
         'multi_node': True,
         'nccl1': False,
         'model_dtype': np.float32,
         'allreduce_grad_dtype': np.float16,
-        'batched_copy': True,
     }]]
 
 


### PR DESCRIPTION
This commit does following adjustments:
1. moving the batched_copy from pure_nccl_communicator to the
base class of communicators, which enables batched_copy in all the
communicators.
2. A batched_copy parameter is added to the __init__ of all the
communicators.
3. The warning when using batched_copy on creating communicators
other than pure_nccl_communicator is removed.

