### PR TITLE
fix "zero division" in resize image

### DIFF
--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -176,10 +176,8 @@ def compute_indices_and_weights(out_size, in_size, mode, align_corners, xp):
     H, W = in_size
     if mode == 'bilinear':
         if align_corners:
-            y_scale = (H - 1) / (out_H - 1)
-            x_scale = (W - 1) / (out_W - 1)
-            v = xp.arange(out_H, dtype=numpy.float) * y_scale
-            u = xp.arange(out_W, dtype=numpy.float) * x_scale
+            v = xp.linspace(0, H - 1, num=out_H, dtype=numpy.float)
+            u = xp.linspace(0, W - 1, num=out_W, dtype=numpy.float)
         else:
             y_scale = H / out_H
             x_scale = W / out_W


### PR DESCRIPTION
Hello, I found that my source code that running at v6 causes an error at v7.

The corresponding source code is as follows.
```
hoge = F.resize_images(hoge, (100, 1))
hoge = F.resize_images(hoge, (1, 100))
```

This problem is caused by the following PR.
#7429 #7443 

The problem is `y_scale = (H - 1) / (out_H - 1)` because when output size was 1, zero division will happen. 
I wonder why we calculate `y_scale = (H - 1) / (out_H - 1)` here, and bilinear mode and nearest options  calculate `y_scale = H / out_H` instead of `y_scale = (H - 1) / (out_H - 1)`

But the easy solution is to change the part back into the v6 as follows.
https://github.com/chainer/chainer/blob/7191660634e151dd4f27e97437bee5c53bef177c/chainer/functions/array/resize_images.py#L195

I provide a modified source code according to previous code.
