### PR TITLE
Revert "Allow bool evaluation in `type_check`"

### DIFF
--- a/chainer/utils/type_check.py
+++ b/chainer/utils/type_check.py
@@ -482,12 +482,6 @@ class BoolBinaryOperator(BinaryOperator, Testable):
                 '{0} {1} {2}'.format(self.lhs, self.exp, self.rhs),
                 '{0} {1} {2}'.format(left, self.inv, right))
 
-    def __bool__(self):
-        return self.eval()
-
-    def __nonzero__(self):
-        return self.__bool__()
-
 
 class InvalidType(Exception):
     """Raised when types of data for forward/backward are invalid.

--- a/tests/chainer_tests/utils_tests/test_type_check.py
+++ b/tests/chainer_tests/utils_tests/test_type_check.py
@@ -290,20 +290,18 @@ class TestBoolBinaryOperator(unittest.TestCase):
 
     def test_eval(self):
         self.assertTrue(self.op1.eval())
-        self.assertFalse(self.op2.eval())
 
     def test_expect(self):
-        self.op1.expect()
         with self.assertRaises(T.InvalidType):
             self.op2.expect()
 
     def test_bool(self):
-        self.assertTrue(bool(self.op1))
-        self.assertFalse(bool(self.op2))
+        with self.assertRaises(RuntimeError):
+            bool(self.op1)
 
     def test_bool_operator(self):
-        self.assertFalse(not self.op1)
-        self.assertTrue(not self.op2)
+        with self.assertRaises(RuntimeError):
+            not self.op1
 
 
 class TestLazyGetItem(unittest.TestCase):


### PR DESCRIPTION
Reverts chainer/chainer#6414, because the discussion on the benefit brought by #6414 surely supersedes what the current behavior does hasn't finished.