### PR TITLE
Unique -> deterministic

### DIFF
--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -522,7 +522,7 @@ class TestDifferentDtype(unittest.TestCase):
 
         # dtypes to be tested
         # DO NOT USE chainer.testing.parameterize
-        # (because running order of generated test cases is not unique)
+        # (because running order of generated test cases is not deterministic)
         self.dtypes = [np.int32, np.int64, np.float32, np.float64]
 
     def teardown(self):


### PR DESCRIPTION
The `unique` here is confusing, which can mean the opposite to some people.
For example:
	Each run has an unique order => Each run has a different order.
`Deterministic` is more clear as an opposite to `Random`.