### PR TITLE
Add `tri*` routines to ChainerX

### DIFF
--- a/chainerx/__init__.pyi
+++ b/chainerx/__init__.pyi
@@ -943,6 +943,20 @@ def transpose(
         a: ndarray,
         axes: tp.Optional[tp.Union[int, tp.List[int]]]=None) -> ndarray: ...
 
+
+def tri(N: int,
+        M: tp.Optional[int]=None,
+        k: int=...,
+        dtype: tp.Optional[tp.Any]=...,
+        device: tp.Optional[Device]=None) -> ndarray: ...
+
+
+def tril(m: ndarray, k: int=...) -> ndarray: ...
+
+
+def triu(m: ndarray, k: int=...) -> ndarray: ...
+
+
 def vstack(arrays: tp.List[ndarray]) -> ndarray: ...
 
 def where(cond: ndarray, x: ndarray, y: ndarray) -> ndarray: ...

--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -77,6 +77,57 @@ Returns:
 .. seealso:: :func:`numpy.eye`
 """)
 
+
+    _docs.set_doc(
+        chainerx.tri,
+        """tri(N, M=None, k=0, dtype=float64, device=None)
+Returns a 2-D array with ones at and below the given diagonal
+and zeros elsewhere.
+Args:
+    N (int): Number of rows.
+    M (int): Number of columns. M == N by default.
+    k (int): Index of the diagonal. Zero indicates the main diagonal,
+        a positive index an upper diagonal, and a negative index a lower
+        diagonal.
+    dtype: Data type.
+    device (~chainerx.Device): Device on which the array is allocated.
+        If omitted, :ref:`the default device <chainerx_device>` is chosen.
+Returns:
+    ~chainerx.ndarray: A 2-D array with given diagonals filled ones at and
+    below the given diagonal and zeros elsewhere.
+.. seealso:: :func:`numpy.tri`
+""")
+
+    _docs.set_doc(
+        chainerx.tril,
+        """tril(m, k=0)
+Lower triangle of an array.
+Returns a copy of an array with elements above the k-th diagonal zeroed.
+Args:
+    m (~chainerx.ndarray): Input array.
+    k (int): Index of the diagonal. Zero indicates the main diagonal,
+        a positive index an upper diagonal, and a negative index a lower
+        diagonal.
+Returns:
+    ~chainerx.ndarray: Lower triangle of ``m``.
+.. seealso:: :func:`numpy.tril`
+""")
+
+    _docs.set_doc(
+        chainerx.triu,
+        """triu(m, k=0)
+Upper triangle of an array.
+Returns a copy of an array with elements below the k-th diagonal zeroed.
+Args:
+    m (~chainerx.ndarray): Input array.
+    k (int): Index of the diagonal. Zero indicates the main diagonal,
+        a positive index an upper diagonal, and a negative index a lower
+        diagonal.
+Returns:
+    ~chainerx.ndarray: Upper triangle of ``m``.
+.. seealso:: :func:`numpy.triu`
+""")
+
     _docs.set_doc(
         chainerx.identity,
         """identity(n, dtype=None, device=None)

--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -77,7 +77,6 @@ Returns:
 .. seealso:: :func:`numpy.eye`
 """)
 
-
     _docs.set_doc(
         chainerx.tri,
         """tri(N, M=None, k=0, dtype=float64, device=None)

--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -79,7 +79,7 @@ Returns:
 
     _docs.set_doc(
         chainerx.tri,
-        """tri(N, M=None, k=0, dtype=float64, device=None)
+        """tri(N, M=None, k=0, dtype=float32, device=None)
 Returns a 2-D array with ones at and below the given diagonal
 and zeros elsewhere.
 

--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -82,6 +82,7 @@ Returns:
         """tri(N, M=None, k=0, dtype=float64, device=None)
 Returns a 2-D array with ones at and below the given diagonal
 and zeros elsewhere.
+
 Args:
     N (int): Number of rows.
     M (int): Number of columns. M == N by default.
@@ -91,9 +92,11 @@ Args:
     dtype: Data type.
     device (~chainerx.Device): Device on which the array is allocated.
         If omitted, :ref:`the default device <chainerx_device>` is chosen.
+
 Returns:
     ~chainerx.ndarray: A 2-D array with given diagonals filled ones at and
     below the given diagonal and zeros elsewhere.
+
 .. seealso:: :func:`numpy.tri`
 """)
 
@@ -101,14 +104,18 @@ Returns:
         chainerx.tril,
         """tril(m, k=0)
 Lower triangle of an array.
+
 Returns a copy of an array with elements above the k-th diagonal zeroed.
+
 Args:
     m (~chainerx.ndarray): Input array.
     k (int): Index of the diagonal. Zero indicates the main diagonal,
         a positive index an upper diagonal, and a negative index a lower
         diagonal.
+
 Returns:
     ~chainerx.ndarray: Lower triangle of ``m``.
+
 .. seealso:: :func:`numpy.tril`
 """)
 
@@ -116,14 +123,18 @@ Returns:
         chainerx.triu,
         """triu(m, k=0)
 Upper triangle of an array.
+
 Returns a copy of an array with elements below the k-th diagonal zeroed.
+
 Args:
     m (~chainerx.ndarray): Input array.
     k (int): Index of the diagonal. Zero indicates the main diagonal,
         a positive index an upper diagonal, and a negative index a lower
         diagonal.
+
 Returns:
     ~chainerx.ndarray: Upper triangle of ``m``.
+
 .. seealso:: :func:`numpy.triu`
 """)
 

--- a/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
@@ -212,6 +212,33 @@ public:
 
 CHAINERX_CUDA_REGISTER_KERNEL(FillKernel, CudaFillKernel);
 
+template <typename T>
+struct TriImpl {
+    using CudaType = cuda_internal::DataType<T>;
+    __device__ void operator()(int64_t i, CudaType& out) {
+        int64_t row = i % m;
+        int64_t col = i / m;
+        out = row <= col + k ? CudaType{1} : CudaType{0};
+    }
+    int64_t m;
+    int64_t k;
+};
+
+class CudaTriKernel : public TriKernel {
+public:
+    void Call(int64_t k, const Array& out) override {
+        Device& device = out.device();
+        CudaSetDeviceScope scope{device.index()};
+        VisitDtype(out.dtype(), [k, &out](auto pt) {
+            using T = typename decltype(pt)::type;
+            int64_t m = out.shape()[1];
+            Elementwise<T>(TriImpl<T>{m, k}, out);
+        });
+    }
+};
+
+CHAINERX_CUDA_REGISTER_KERNEL(TriKernel, CudaTriKernel);
+
 }  // namespace
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
@@ -216,9 +216,9 @@ template <typename T>
 struct TriImpl {
     using CudaType = cuda_internal::DataType<T>;
     __device__ void operator()(int64_t i, CudaType& out) {
-        int64_t row = i % m;
-        int64_t col = i / m;
-        out = row <= col + k ? CudaType{1} : CudaType{0};
+        int64_t row = i / m;
+        int64_t col = i % m;
+        out = col <= row + k ? CudaType{1} : CudaType{0};
     }
     int64_t m;
     int64_t k;

--- a/chainerx_cc/chainerx/kernels/creation.h
+++ b/chainerx_cc/chainerx/kernels/creation.h
@@ -59,4 +59,13 @@ public:
     virtual void Call(double start, double stop, const Array& out) = 0;
 };
 
+class TriKernel : public Kernel {
+public:
+    static const char* name() { return "Tri"; }
+
+    // Creates a 2-dimensional array with ones at and below the given diagonal.
+    // out must be a 2-dim array.
+    virtual void Call(int64_t k, const Array& out) = 0;
+};
+
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/native/native_device/fill.cc
+++ b/chainerx_cc/chainerx/native/native_device/fill.cc
@@ -159,6 +159,28 @@ public:
 
 CHAINERX_NATIVE_REGISTER_KERNEL(FillKernel, NativeFillKernel);
 
+class NativeTriKernel : public TriKernel {
+public:
+    void Call(int64_t k, const Array& out) override {
+        VisitDtype(out.dtype(), [k, &out](auto pt) {
+            using T = typename decltype(pt)::type;
+            struct Impl {
+                void operator()(int64_t i, T& out) {
+                    int64_t row = i % m;
+                    int64_t col = i / m;
+                    out = row <= col + k ? T{1} : T{0};
+                }
+                int64_t m;
+                int64_t k;
+            };
+            int64_t m = out.shape()[1];
+            Elementwise<T>(Impl{m, k}, out);
+        });
+    }
+};
+
+CHAINERX_NATIVE_REGISTER_KERNEL(TriKernel, NativeTriKernel);
+
 }  // namespace
 }  // namespace native
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/native/native_device/fill.cc
+++ b/chainerx_cc/chainerx/native/native_device/fill.cc
@@ -166,9 +166,9 @@ public:
             using T = typename decltype(pt)::type;
             struct Impl {
                 void operator()(int64_t i, T& out) {
-                    int64_t row = i % m;
-                    int64_t col = i / m;
-                    out = row <= col + k ? T{1} : T{0};
+                    int64_t row = i / m;
+                    int64_t col = i % m;
+                    out = col <= row + k ? T{1} : T{0};
                 }
                 int64_t m;
                 int64_t k;

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -282,7 +282,7 @@ void InitChainerxCreation(pybind11::module& m) {
           "N"_a,
           "M"_a = nullptr,
           "k"_a = 0,
-          "dtype"_a = "float64",
+          "dtype"_a = "float32",
           "device"_a = nullptr);
     m.def("tril", [](const ArrayBodyPtr& m, int64_t k) { return MoveArrayBody(Tril(Array{m}, k)); }, "m"_a, "k"_a = 0);
     m.def("triu", [](const ArrayBodyPtr& m, int64_t k) { return MoveArrayBody(Triu(Array{m}, k)); }, "m"_a, "k"_a = 0);

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -277,10 +277,7 @@ void InitChainerxCreation(pybind11::module& m) {
           "device"_a = nullptr);
     m.def("tri",
           [](int64_t n, absl::optional<int64_t> m, int64_t k, py::handle dtype, py::handle device) {
-              if (!m.has_value()) {
-                  m = n;
-              }
-              return MoveArrayBody(Tri(n, m.value(), k, GetDtype(dtype), GetDevice(device)));
+              return MoveArrayBody(Tri(n, m, k, GetDtype(dtype), GetDevice(device)));
           },
           "N"_a,
           "M"_a = nullptr,

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -247,7 +247,7 @@ void InitChainerxCreation(pybind11::module& m) {
           "N"_a,
           "M"_a = nullptr,
           "k"_a = 0,
-          "dtype"_a = "float64",
+          "dtype"_a = "float32",
           "device"_a = nullptr);
     m.def("diag",
           [](const ArrayBodyPtr& v, int64_t k, py::handle device) { return MoveArrayBody(Diag(Array{v}, k, GetDevice(device))); },

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -275,6 +275,20 @@ void InitChainerxCreation(pybind11::module& m) {
           "endpoint"_a = true,
           "dtype"_a = nullptr,
           "device"_a = nullptr);
+    m.def("tri",
+          [](int64_t n, absl::optional<int64_t> m, int64_t k, py::handle dtype, py::handle device) {
+              if (!m.has_value()) {
+                  m = n;
+              }
+              return MoveArrayBody(Tri(n, m.value(), k, GetDtype(dtype), GetDevice(device)));
+          },
+          "N"_a,
+          "M"_a = nullptr,
+          "k"_a = 0,
+          "dtype"_a = "float64",
+          "device"_a = nullptr);
+    m.def("tril", [](const ArrayBodyPtr& m, int64_t k) { return MoveArrayBody(Tril(Array{m}, k)); }, "m"_a, "k"_a = 0);
+    m.def("triu", [](const ArrayBodyPtr& m, int64_t k) { return MoveArrayBody(Triu(Array{m}, k)); }, "m"_a, "k"_a = 0);
 }
 
 void InitChainerxIndexing(pybind11::module& m) {

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -247,7 +247,7 @@ void InitChainerxCreation(pybind11::module& m) {
           "N"_a,
           "M"_a = nullptr,
           "k"_a = 0,
-          "dtype"_a = "float32",
+          "dtype"_a = "float64",
           "device"_a = nullptr);
     m.def("diag",
           [](const ArrayBodyPtr& v, int64_t k, py::handle device) { return MoveArrayBody(Diag(Array{v}, k, GetDevice(device))); },

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -196,7 +196,7 @@ Array Eye(int64_t n, absl::optional<int64_t> m, absl::optional<int64_t> k, absl:
         k = 0;
     }
     if (!dtype.has_value()) {
-        dtype = Dtype::kFloat64;
+        dtype = Dtype::kFloat32;
     }
     if (n < 0 || m < 0) {
         throw DimensionError{"Negative dimensions are not allowed"};

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -21,6 +21,7 @@
 #include "chainerx/kernels/creation.h"
 #include "chainerx/kernels/misc.h"
 #include "chainerx/macro.h"
+#include "chainerx/routines/indexing.h"
 #include "chainerx/routines/type_util.h"
 #include "chainerx/scalar.h"
 #include "chainerx/shape.h"
@@ -334,6 +335,68 @@ Array Linspace(
             device.backend().CallKernel<LinspaceKernel>(start_value, stop_value, out);
         }
     }
+    return out;
+}
+
+Array Tri(int64_t n, absl::optional<int64_t> m, absl::optional<int64_t> k, absl::optional<Dtype> dtype, Device& device) {
+    if (!m.has_value()) {
+        m = n;
+    }
+    if (!k.has_value()) {
+        k = 0;
+    }
+    if (!dtype.has_value()) {
+        dtype = Dtype::kFloat64;
+    }
+    if (n < 0 || m < 0) {
+        throw DimensionError{"Negative dimensions are not allowed"};
+    }
+
+    Array out = Empty({n, m.value()}, dtype.value(), device);
+    {
+        NoBackpropModeScope scope{};
+        device.backend().CallKernel<TriKernel>(k.value(), out);
+    }
+    return out;
+}
+
+Array Tril(const Array& m, int64_t k = 0) {
+    Array out = Empty(m.shape(), m.dtype(), m.device());
+    {
+        NoBackpropModeScope scope{};
+        Array mask = Tri(m.shape()[m.ndim() - 2], m.shape()[m.ndim() - 1], k, Dtype::kBool, m.device());
+        out = Where(mask, m, 0);
+    }
+
+    BackwardBuilder bb{"tril", m, out};
+    if (BackwardBuilder::Target bt = bb.CreateTarget(0)) {
+        bt.Define([k](BackwardContext& bctx) {
+            const Array& gout = *bctx.output_grad();
+            bctx.input_grad() = Tril(gout, k);
+        });
+    }
+    bb.Finalize();
+
+    return out;
+}
+
+Array Triu(const Array& m, int64_t k = 0) {
+    Array out = Empty(m.shape(), m.dtype(), m.device());
+    {
+        NoBackpropModeScope scope{};
+        Array mask = Tri(m.shape()[m.ndim() - 2], m.shape()[m.ndim() - 1], k - 1, Dtype::kBool, m.device());
+        out = Where(mask, 0, m);
+    }
+
+    BackwardBuilder bb{"triu", m, out};
+    if (BackwardBuilder::Target bt = bb.CreateTarget(0)) {
+        bt.Define([k](BackwardContext& bctx) {
+            const Array& gout = *bctx.output_grad();
+            bctx.input_grad() = Triu(gout, k);
+        });
+    }
+    bb.Finalize();
+
     return out;
 }
 

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -346,7 +346,7 @@ Array Tri(int64_t n, absl::optional<int64_t> m, absl::optional<int64_t> k, absl:
         k = 0;
     }
     if (!dtype.has_value()) {
-        dtype = Dtype::kFloat64;
+        dtype = Dtype::kFloat32;
     }
     // NumPy returns 0-sized array for the input with negative dimensions.
     // This is a flaw in NumPy's implementation. Other array creation routines raise an error for negative dimensions.

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -348,6 +348,8 @@ Array Tri(int64_t n, absl::optional<int64_t> m, absl::optional<int64_t> k, absl:
     if (!dtype.has_value()) {
         dtype = Dtype::kFloat64;
     }
+    // NumPy returns 0-sized array for the input with negative dimensions.
+    // This is a flaw in NumPy's implementation. Other array creation routines raise an error for negative dimensions.
     if (n < 0 || m < 0) {
         throw DimensionError{"Negative dimensions are not allowed"};
     }

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -196,7 +196,7 @@ Array Eye(int64_t n, absl::optional<int64_t> m, absl::optional<int64_t> k, absl:
         k = 0;
     }
     if (!dtype.has_value()) {
-        dtype = Dtype::kFloat32;
+        dtype = Dtype::kFloat64;
     }
     if (n < 0 || m < 0) {
         throw DimensionError{"Negative dimensions are not allowed"};

--- a/chainerx_cc/chainerx/routines/creation.h
+++ b/chainerx_cc/chainerx/routines/creation.h
@@ -112,4 +112,14 @@ Array Linspace(
         const absl::optional<Dtype>& dtype = absl::nullopt,
         Device& device = GetDefaultDevice());
 
+// Creates a 2-dimensional array with ones at and below the given diagonal and zeros elsewhere.
+Array Tri(
+        int64_t n, absl::optional<int64_t> m, absl::optional<int64_t> k, absl::optional<Dtype> dtype, Device& device = GetDefaultDevice());
+
+// Creates a lower triangle of an array.
+Array Tril(const Array& m, int64_t k);
+
+// Creates an upper triangle of an array.
+Array Triu(const Array& m, int64_t k);
+
 }  // namespace chainerx

--- a/docs/source/chainerx/reference/routines.rst
+++ b/docs/source/chainerx/reference/routines.rst
@@ -37,6 +37,9 @@ Array creation routines
    chainerx.linspace
    chainerx.diag
    chainerx.diagflat
+   chainerx.tri
+   chainerx.tril
+   chainerx.triu
 
 Activation functions
 --------------------

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -1238,6 +1238,12 @@ def test_tri_with_device(device):
     chainer.testing.product({
         'shape': [(3, 3), (4, 3), (2, 3, 4)],
         'k': [0, 1, -1, 5, -5]
+    }) +
+    chainer.testing.product({
+        'shape': [(3,)],
+        'k': [0, 1, -1, 5, -5],
+        'skip_backward_test': [True],
+        'skip_double_backward_test': [True]
     })
 ))
 class TestTrilTriu(op_utils.NumpyOpTest):

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -1179,27 +1179,25 @@ def test_copy(xp, shape, dtype, device, is_module):
 
 
 @chainerx.testing.numpy_chainerx_array_equal()
-@pytest.mark.parametrize('N,M,k', [
-    (2, 1, -2),
-    (2, 1, -1),
-    (2, 1, 0),
-    (2, 1, 1),
-    (2, 1, 2),
-    (3, 4, -4),
-    (3, 4, -1),
-    (3, 4, 1),
-    (3, 4, 4),
-    (6, 3, 1),
-    (6, 3, -1),
-    (3, 6, 1),
-    (3, 6, -1),
+@pytest.mark.parametrize('shape,k', [
+    ((2,), -1),
+    ((2,), 0),
+    ((2,), 1),
+    ((3, 3), -1),
+    ((3, 3), 0),
+    ((3, 3), 1),
+    ((4, 3), -1),
+    ((4, 3), 0),
+    ((4, 3), 1),
+    ((4, 3), 5),
+    ((4, 3), -5),
 ])
 @pytest.mark.parametrize_device(['native:0', 'cuda:0'])
 @chainerx.testing.parametrize_dtype_specifier('dtype_spec')
-def test_tri(xp, N, M, k, dtype_spec, device):
+def test_tri(xp, shape, k, dtype_spec, device):
     if xp is numpy and isinstance(dtype_spec, chainerx.dtype):
         dtype_spec = dtype_spec.name
-    out = xp.tri(N, M, k, dtype_spec)
+    out = xp.tri(*shape, k=k, dtype=dtype_spec)
     if dtype_spec in (None, Unspecified):
         out = dtype_utils.cast_if_numpy_array(xp, out, 'float32')
     return out
@@ -1208,8 +1206,8 @@ def test_tri(xp, N, M, k, dtype_spec, device):
 @op_utils.op_test(['native:0', 'cuda:0'])
 @chainer.testing.parameterize(*(
     chainer.testing.product({
-        'shape': [(2, 1), (3, 4), (6, 3), (3, 6)],
-        'k': [0, 1, -1]
+        'shape': [(3, 3), (4, 3), (2, 3, 4)],
+        'k': [0, 1, -1, 5, -5]
     })
 ))
 class TestTrilTriu(op_utils.NumpyOpTest):

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -1203,6 +1203,36 @@ def test_tri(xp, shape, k, dtype_spec, device):
     return out
 
 
+@chainerx.testing.numpy_chainerx_array_equal()
+@pytest.mark.parametrize('N,M,k', [
+    (3, None, 1),
+    (3, 4, None),
+    (3, None, None),
+])
+@pytest.mark.parametrize_device(['native:0', 'cuda:0'])
+@chainerx.testing.parametrize_dtype_specifier('dtype_spec')
+def test_tri_with_default(xp, N, M, k, dtype_spec, device):
+    if xp is numpy and isinstance(dtype_spec, chainerx.dtype):
+        dtype_spec = dtype_spec.name
+
+    if M is None and k is None:
+        return xp.tri(N, dtype=dtype_spec)
+    elif M is None:
+        return xp.tri(N, k=k, dtype=dtype_spec)
+    elif k is None:
+        return xp.tri(N, M=M, dtype=dtype_spec)
+    assert False
+
+
+@pytest.mark.parametrize(
+    'device', [None, 'native:1', chainerx.get_device('native:1')])
+def test_tri_with_device(device):
+    a = chainerx.tri(1, 2, 1, 'float32', device)
+    b = chainerx.tri(1, 2, 1, 'float32')
+    array_utils.check_device(a, device)
+    chainerx.testing.assert_array_equal_ex(a, b)
+
+
 @op_utils.op_test(['native:0', 'cuda:0'])
 @chainer.testing.parameterize(*(
     chainer.testing.product({


### PR DESCRIPTION
This PR adds [`tri`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.tri.html), [`tril`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.tril.html), [`triu`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.triu.html) routines.

With reference to #6423 and #6764