### PR TITLE
Remove unused lambda capture of `axis`

### DIFF
--- a/chainerx_cc/chainerx/routines/reduction.cc
+++ b/chainerx_cc/chainerx/routines/reduction.cc
@@ -134,7 +134,7 @@ Array Cumsum(const Array& a, absl::optional<int8_t> axis) {
     // TODO(aksub99): Improve backward implementation to prevent flipping gout twice.
     BackwardBuilder bb{"cumsum", a_reshaped, out};
     if (BackwardBuilder::Target bt = bb.CreateTarget(0)) {
-        bt.Define([axis, axis_norm, in_shape = a_reshaped.shape()](BackwardContext& bctx) {
+        bt.Define([axis_norm, in_shape = a_reshaped.shape()](BackwardContext& bctx) {
             const Array& gout = *bctx.output_grad();
             Array input_grad = Flip(Cumsum(Flip(gout, axis_norm), axis_norm), axis_norm);
             bctx.input_grad() = input_grad.Reshape(in_shape);


### PR DESCRIPTION
Removed an unused lambda capture in the `Cumsum` routine.

Reference: https://travis-ci.org/chainer/chainer/jobs/562937926#L3237