### PR TITLE
Add finalize method to CommunicatorBase class

### DIFF
--- a/chainermn/communicators/communicator_base.py
+++ b/chainermn/communicators/communicator_base.py
@@ -209,6 +209,16 @@ class CommunicatorBase(six.with_metaclass(ABCMeta)):
         '''
         raise NotImplementedError()
 
+    def finalize(self):
+        """Finalizes and cleans up internal resource.
+
+        The communicator SHALL NOT be used after calling this ``finalize()``.
+        The behaviour is undefined when calling ``finalize`` on the same
+        communicator multiple times.
+
+        """
+        pass
+
     # on objects
     @abstractmethod
     def send_obj(self, obj, dest, tag):

--- a/chainermn/communicators/non_cuda_aware_communicator.py
+++ b/chainermn/communicators/non_cuda_aware_communicator.py
@@ -36,6 +36,12 @@ class NonCudaAwareCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.cpu_buffer_a = _memory_utility.HostPinnedMemory()
         self.cpu_buffer_b = _memory_utility.HostPinnedMemory()
 
+    def finalize(self):
+        super(NonCudaAwareCommunicator, self).finalize()
+        if self.intra_nccl_comm is not None:
+            self.intra_nccl_comm.destroy()
+            self.intra_nccl_comm = None
+
     def _init_comms(self):
         if self.inter_mpi_comm is not None:
             assert self.intra_nccl_comm is not None

--- a/chainermn/communicators/pure_nccl_communicator.py
+++ b/chainermn/communicators/pure_nccl_communicator.py
@@ -47,6 +47,12 @@ class PureNcclCommunicator(mpi_communicator_base.MpiCommunicatorBase):
         self.allreduce_dtype_to_grad_dtype_kernel = None
         self.params_data = None
 
+    def finalize(self):
+        super(PureNcclCommunicator, self).finalize()
+        if self.nccl_comm is not None:
+            self.nccl_comm.destroy()
+            self.nccl_comm = None
+
     def _init_comms(self):
         if self.nccl_comm is not None:
             return

--- a/docs/source/chainermn/reference/index.rst
+++ b/docs/source/chainermn/reference/index.rst
@@ -13,7 +13,7 @@ Communicators
               alltoall, split, send, recv, bcast, gather, allreduce,
               send_obj, recv_obj, bcast_obj, gather_obj,
               allreduce_obj, bcast_data, multi_node_mean_grad, allreduce_grad,
-              allgather
+              allgather, finalize
 
 
 Optimizers and Evaluators

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -203,21 +203,6 @@ def create_communicator(param, use_gpu):
     return communicator
 
 
-def destroy_communicator(comm):
-    """Destroy internal NCCL communicator.
-
-    When too many NCCL communicator are alive, NCCL produces
-    unhandled CUDA error. To avoid this, we need to make sure to
-    destory NCCL communicator after every use.
-    """
-    if hasattr(comm, 'nccl_comm') and comm.nccl_comm is not None:
-        comm.nccl_comm.destroy()
-        comm.nccl_comm = None
-    if hasattr(comm, 'intra_nccl_cojmm') and comm.intra_nccl_comm is not None:
-        comm.intra_nccl_comm.destroy()
-        comm.intra_nccl_comm = None
-
-
 def check_send_and_recv(communicator, *shape):
     if communicator.size < 2:
         pytest.skip('This test is for multiple nodes')
@@ -351,7 +336,7 @@ def check_send_recv(param, use_gpu):
         np.ones((50, 20, 5)).astype(np.float32)]
     check_send_and_recv_tuple(communicator, data)
 
-    destroy_communicator(communicator)
+    communicator.finalize()
 
 
 def check_multi_node_mean_grad_mixed_dtype(param, model, use_gpu):
@@ -427,7 +412,7 @@ def check_multi_node_mean_grad_mixed_dtype(param, model, use_gpu):
                                     (base + 1) * np.ones((4, 3)))
 
     mpi_comm.barrier()
-    destroy_communicator(communicator)
+    communicator.finalize()
 
 
 def check_collective_communication(param, use_gpu):
@@ -468,7 +453,7 @@ def check_collective_communication(param, use_gpu):
     # barrier() requires before destructor of PureNcclCommunicator
     # because communication may not be finished.
     mpi_comm.barrier()
-    destroy_communicator(communicator)
+    communicator.finalize()
 
 
 # chainer.testing.parameterize is not available at functions
@@ -505,6 +490,28 @@ class TestPureNcclCommunicator(unittest.TestCase):
         with self.assertRaises(ValueError):
             PureNcclCommunicator(self.mpi_comm, allreduce_grad_dtype=np.int32)
 
+    @chainer.testing.attr.gpu
+    def test_finalize(self):
+        communicator = PureNcclCommunicator(self.mpi_comm)
+        communicator._init_comms()
+        communicator.finalize()
+        self.assertIsNone(communicator.nccl_comm)
+
+
+class TestNonCudaAwareCommunicator(unittest.TestCase):
+
+    def setUp(self):
+        if nccl.get_build_version() < 2000:
+            pytest.skip('This test requires NCCL version >= 2.0')
+        self.mpi_comm = mpi4py.MPI.COMM_WORLD
+
+    @chainer.testing.attr.gpu
+    def test_finalize(self):
+        communicator = NonCudaAwareCommunicator(self.mpi_comm)
+        communicator._init_comms()
+        communicator.finalize()
+        self.assertIsNone(communicator.intra_nccl_comm)
+
 
 class TestDifferentDtype(unittest.TestCase):
 
@@ -527,7 +534,7 @@ class TestDifferentDtype(unittest.TestCase):
 
     def teardown(self):
         if self.communicator:
-            destroy_communicator(self.communicator)
+            self.communicator.finalize()
 
     def check_send_recv(self, x):
         if self.communicator.rank == 0:
@@ -802,7 +809,7 @@ class TestNonContiguousArray(unittest.TestCase):
 
     def teardown(self):
         if self.communicator:
-            destroy_communicator(self.communicator)
+            self.communicator.finalize()
 
     def check_send(self):
         if self.communicator.rank == 0:
@@ -855,7 +862,7 @@ class TestMpiCommunicatorBase(unittest.TestCase):
 
     def teardown(self):
         if self.communicator:
-            destroy_communicator(self.communicator)
+            self.communicator.finalize()
 
     def check_send_recv_obj(self, x, tag=0,
                             use_any_recv=True, use_status=False):


### PR DESCRIPTION
This commit adds finalize function to the mpi_communicator_base.
The `finalize` finalizes and cleans up resource of the communicator.
After the `finalize` is called, the communicator should not be used again.

In `finalized` is overrided in `non_cuda_aware_communicator` and `pure_nccl_communicator` to clean up the intra nccl communicator
