### PR TITLE
Fix `TestAccuracy`: Randomly reduce testing parameters

### DIFF
--- a/.pfnci/hint.pbtxt
+++ b/.pfnci/hint.pbtxt
@@ -10,7 +10,6 @@ rules { name: "chainer_tests/functions_tests/activation_tests/test_elu.py" xdist
 
 # Slow tests take 60+ seconds.
 rules { name: "chainer_tests/functions_tests/activation_tests/test_crelu.py" xdist: 4 deadline: 240 }
-rules { name: "chainer_tests/functions_tests/evaluation_tests/test_accuracy.py" xdist: 4 deadline: 240 }
 rules { name: "chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py" xdist: 8 deadline: 240 }
 rules { name: "chainer_tests/functions_tests/math_tests/test_sparse_matmul.py" xdist: 4 deadline: 240 }
 rules { name: "chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py" xdist: 4 deadline: 240 }
@@ -58,6 +57,7 @@ rules { name: "chainer_tests/functions_tests/connection_tests/test_convolution_n
 rules { name: "chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py" }
 rules { name: "chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py" }
 rules { name: "chainer_tests/functions_tests/connection_tests/test_embed_id.py" }
+rules { name: "chainer_tests/functions_tests/evaluation_tests/test_accuracy.py" }
 rules { name: "chainer_tests/functions_tests/loss_tests/test_contrastive.py" }
 rules { name: "chainer_tests/functions_tests/loss_tests/test_negative_sampling.py" }
 rules { name: "chainer_tests/functions_tests/loss_tests/test_sigmoid_cross_entropy.py" }

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -14,19 +14,32 @@ from chainer.utils import type_check
 
 
 def _testing_pairwise(*parameters):
+    """Generate combinations that cover all pairs.
+
+    The argument is the same as `chainer.testing.product_dict`.
+
+    """
+    # parameters: [[dict<str, _>]]
     rs = numpy.random.RandomState(seed=0)
+    # parameters: [[(int, dict)]]
     parameters = [list(enumerate(dicts)) for dicts in parameters]
 
+    # uncovered: dict<(int, int), set<(int, int)>>
+    # `(k_i, k_j) in uncovered[(i, j)]` iff there has not been a combination
+    # that selects k_i-th item of i-th choice and k_j-th item of j-th choice.
     uncovered = {}
     for (i, dicts_i), (j, dicts_j) in itertools.combinations(
             enumerate(parameters), 2):
         uncovered[(i, j)] = set(itertools.product(
             range(len(dicts_i)), range(len(dicts_j))))
 
+    # product_dicts: [[(int, dict)]]
     product_dicts = list(itertools.product(*parameters))
     rs.shuffle(product_dicts)
     for product_dict in product_dicts:
         count = 0
+        # ks: [int]
+        # dicts: [dict]
         ks, dicts = zip(*product_dict)
         for (i, k_i), (j, k_j) in itertools.combinations(
                 enumerate(ks), 2):

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -12,6 +12,13 @@ from chainer.utils import force_array
 from chainer.utils import type_check
 
 
+def _random_select(prob, params):
+    rs = numpy.random.RandomState(seed=0)
+    for p in params:
+        if rs.rand() < prob:
+            yield p
+
+
 def accuracy(x, t, ignore_label):
     x_ = numpy.rollaxis(x, 1, x.ndim).reshape(t.size, -1)
     t_ = t.ravel()
@@ -37,8 +44,9 @@ def accuracy(x, t, ignore_label):
         return float(count) / total
 
 
-@testing.parameterize(
-    *testing.product_dict(
+@testing.parameterize(*_random_select(
+    0.3,
+    testing.product_dict(
         [{'x_shape': (10, 3), 't_shape': (10,)},
          {'x_shape': (10, 3, 1), 't_shape': (10,)},
          {'x_shape': (10, 3, 1, 1), 't_shape': (10,)},
@@ -57,7 +65,7 @@ def accuracy(x, t, ignore_label):
          {'label_dtype': numpy.int32},
          {'label_dtype': numpy.int64}]
     )
-)
+))
 @testing.fix_random()
 @testing.inject_backend_tests(
     None,

--- a/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
+++ b/tests/chainer_tests/functions_tests/evaluation_tests/test_accuracy.py
@@ -1,4 +1,5 @@
 import itertools
+import typing as tp  # NOQA
 import unittest
 
 import numpy
@@ -13,38 +14,38 @@ from chainer.utils import force_array
 from chainer.utils import type_check
 
 
-def _testing_pairwise(*parameters):
+def _testing_pairwise(
+        *parameters  # type: tp.Iterable[tp.Dict[str, tp.Any]]
+):
+    # type: (...) -> tp.Iterator[tp.Dict[str, tp.Any]]
     """Generate combinations that cover all pairs.
 
     The argument is the same as `chainer.testing.product_dict`.
 
     """
-    # parameters: [[dict<str, _>]]
-    parameters = [list(dicts) for dicts in parameters]
+    parameter_lists = [list(dicts) for dicts in parameters]  # type: tp.List[tp.List[tp.Dict[str, tp.Any]]]  # NOQA
 
     for nd_index in sorted(_nd_indices_to_cover_each_2d(
-            [len(dicts) for dicts in parameters])):
+            [len(dicts) for dicts in parameter_lists])):
         yield {
             k: v
-            for i, dicts in zip(nd_index, parameters)
+            for i, dicts in zip(nd_index, parameter_lists)
             for k, v in dicts[i].items()}
 
 
 def _nd_indices_to_cover_each_2d(shape):
+    # type: (tp.Sequence[int]) -> tp.Iterator[tp.Tuple[int, ...]]
     rs = numpy.random.RandomState(seed=0)
     n = len(shape)
-    # indices: [[int]]
-    indices = [list(range(length)) for length in shape]
+    indices = [list(range(length)) for length in shape]  # type: tp.List[tp.List[int]]  # NOQA
 
-    # uncovered: dict<(int, int), set<(int, int)>>
     # `(k_i, k_j) in uncovered[(i, j)]` iff it has not been yielded
     # `nd_index` such that `(nd_index[i], nd_inde[j]) == (k_i, k_j)`.
-    uncovered = {}
+    uncovered = {}  # type: tp.Dict[tp.Tuple[int, int], tp.Set[tp.Tuple[int, int]]]  # NOQA
     for i, j in itertools.combinations(range(n), 2):
         uncovered[(i, j)] = set(itertools.product(indices[i], indices[j]))
 
-    # nd_indices: [[int]]
-    nd_indices = list(itertools.product(*indices))
+    nd_indices = list(itertools.product(*indices))  # type: tp.List[tp.Tuple[int, ...]]  # NOQA
     rs.shuffle(nd_indices)
     for nd_index in nd_indices:
         count = 0


### PR DESCRIPTION
Close #7819.

It's unlikely for `TestAccuracy` to fail with only a few testing parameters, because the implementation of `F.accuracy` is not complicated.