### PR TITLE
Fix ChainerX non native deserialization

### DIFF
--- a/chainer/serializers/hdf5.py
+++ b/chainer/serializers/hdf5.py
@@ -3,6 +3,7 @@ import sys
 import numpy
 import six
 
+from chainer.backends import _chainerx
 from chainer.backends import _cpu
 from chainer.backends import cuda
 from chainer.backends import intel64
@@ -155,8 +156,8 @@ class HDF5Deserializer(serializer.Deserializer):
         if value is None:
             return numpy.asarray(dataset)
         if isinstance(value, chainerx.ndarray):
-            value_view = chainerx.to_numpy(value, copy=False)
-            dataset.read_direct(value_view)
+            value[...] = _chainerx._array_to_chainerx(
+                numpy.asarray(dataset), value.device)
         elif isinstance(value, numpy.ndarray):
             dataset.read_direct(value)
         elif isinstance(value, cuda.ndarray):

--- a/chainer/serializers/npz.py
+++ b/chainer/serializers/npz.py
@@ -1,6 +1,7 @@
 import numpy
 import six
 
+from chainer.backends import _chainerx
 from chainer.backends import _cpu
 from chainer.backends import cuda
 from chainer.backends import intel64
@@ -178,8 +179,8 @@ class NpzDeserializer(serializer.Deserializer):
         if value is None:
             return dataset
         if isinstance(value, chainerx.ndarray):
-            value_view = chainerx.to_numpy(value, copy=False)
-            numpy.copyto(value_view, dataset)
+            value[...] = _chainerx._array_to_chainerx(
+                numpy.asarray(dataset), value.device)
         elif isinstance(value, numpy.ndarray):
             numpy.copyto(value, dataset)
         elif isinstance(value, cuda.ndarray):

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -149,6 +149,12 @@ class TestHDF5Deserializer(unittest.TestCase):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(chainerx.asarray(y))
 
+    @attr.chainerx
+    @attr.gpu
+    def test_deserialize_chainerx_non_native(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        self.check_deserialize(chainerx.asarray(y, device='cuda:0'))
+
     def test_deserialize_cpu(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(y)

--- a/tests/chainer_tests/serializers_tests/test_npz.py
+++ b/tests/chainer_tests/serializers_tests/test_npz.py
@@ -144,6 +144,12 @@ class TestNpzDeserializer(unittest.TestCase):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(chainerx.asarray(y), 'y')
 
+    @attr.chainerx
+    @attr.gpu
+    def test_deserialize_chainerx_non_native(self):
+        y = numpy.empty((2, 3), dtype=numpy.float32)
+        self.check_deserialize(chainerx.asarray(y, device='cuda:0'), 'y')
+
     def test_deserialize_cpu(self):
         y = numpy.empty((2, 3), dtype=numpy.float32)
         self.check_deserialize(y, 'y')


### PR DESCRIPTION
Fixed https://github.com/chainer/chainer/issues/7829 (npz and HDF5). The copy logic is simply the same as in `backend.copyto`.