### PR TITLE
Allow `None` inputs to gradient check and generating `None` gradients in `FunctionTestCase`

### DIFF
--- a/chainer/testing/function_link.py
+++ b/chainer/testing/function_link.py
@@ -275,10 +275,10 @@ class FunctionTestBase(object):
             grad_outputs = self._generate_grad_outputs(outputs)
             grad_grad_inputs = self._generate_grad_grad_inputs(inputs)
 
+            # Drop ggx corresponding to non-differentiable inputs.
             # Generated `grad_grad_inputs`, the upstream gradients for the
             # double backward test, may contain `None` for omitted gradients.
             # These must be propagated to the gradient check.
-            # Drop ggx corresponding to non-differentiable inputs.
             grad_grad_inputs = [
                 ggx for ggx in grad_grad_inputs
                 if (ggx is None or ggx.dtype.kind == 'f')]

--- a/chainer/testing/function_link.py
+++ b/chainer/testing/function_link.py
@@ -1122,7 +1122,7 @@ def _check_array_types(arrays, device, func_name):
             '`{}()` must return a tuple, '
             'not {}.'.format(func_name, type(arrays)))
     if not all(
-            isinstance(a, device.supported_array_types) or a is None
+            a is None or isinstance(a, device.supported_array_types)
             for a in arrays):
         raise TypeError(
             '{}() must return a tuple of arrays supported by device {} or'

--- a/chainer/testing/function_link.py
+++ b/chainer/testing/function_link.py
@@ -277,7 +277,8 @@ class FunctionTestBase(object):
 
             # Drop ggx corresponding to non-differentiable inputs.
             grad_grad_inputs = [
-                ggx for ggx in grad_grad_inputs if ggx.dtype.kind == 'f']
+                ggx for ggx in grad_grad_inputs
+                if (ggx is None or ggx.dtype.kind == 'f')]
 
             inputs = backend_config.get_array(inputs)
             grad_outputs = backend_config.get_array(grad_outputs)
@@ -1120,10 +1121,12 @@ def _check_array_types(arrays, device, func_name):
         raise TypeError(
             '`{}()` must return a tuple, '
             'not {}.'.format(func_name, type(arrays)))
-    if not all(isinstance(a, device.supported_array_types) for a in arrays):
+    if not all(
+            isinstance(a, device.supported_array_types) or a is None
+            for a in arrays):
         raise TypeError(
-            '{}() must return a tuple of arrays supported by device {}.\n'
-            'Actual: {}'.format(
+            '{}() must return a tuple of arrays supported by device {} or'
+            ' None.\nActual: {}'.format(
                 func_name, device, tuple([type(a) for a in arrays])))
 
 

--- a/chainer/testing/function_link.py
+++ b/chainer/testing/function_link.py
@@ -275,6 +275,9 @@ class FunctionTestBase(object):
             grad_outputs = self._generate_grad_outputs(outputs)
             grad_grad_inputs = self._generate_grad_grad_inputs(inputs)
 
+            # Generated `grad_grad_inputs`, the upstream gradients for the
+            # double backward test, may contain `None` for omitted gradients.
+            # These must be propagated to the gradient check.
             # Drop ggx corresponding to non-differentiable inputs.
             grad_grad_inputs = [
                 ggx for ggx in grad_grad_inputs
@@ -348,13 +351,13 @@ class FunctionTestCase(FunctionTestBase, unittest.TestCase):
 
     ``generate_grad_outputs(self, outputs_template)``
         Returns a tuple of output gradient arrays of type
-        :class:`numpy.ndarray`.
+        :class:`numpy.ndarray` or ``None`` for omitted the gradients.
         ``outputs_template`` is a tuple of template arrays. The returned arrays
         are expected to have the same shapes and dtypes as the template arrays.
 
     ``generate_grad_grad_inputs(self, inputs_template)``
         Returns a tuple of the second order input gradient arrays of type
-        :class:`numpy.ndarray`.
+        :class:`numpy.ndarray` or ``None`` for omitted gradients.
         ``input_template`` is a tuple of template arrays. The returned arrays
         are expected to have the same shapes and dtypes as the template arrays.
 

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import six
 
 import chainer
 from chainer import functions
@@ -128,6 +129,12 @@ def inject_backend_tests():
         {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': numpy.array([]),
          'slices': [slice(None, None)]
          },
+        {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [2, 5],
+         'slices': [
+             (slice(None), slice(None, 2)),
+             (slice(None), slice(2, 5)),
+             (slice(None), slice(5, None))],
+         'grad_outputs_is_none': [False, True, False]},
     ],
     [
         {'dtype': numpy.float16},
@@ -138,11 +145,25 @@ def inject_backend_tests():
 @inject_backend_tests()
 class TestSplitAxis(testing.FunctionTestCase):
 
+    grad_outputs_is_none = None
+
     def generate_inputs(self):
         shape = self.shape
         dtype = self.dtype
         x = numpy.arange(numpy.prod(shape), dtype=dtype).reshape(shape)
         return x,
+
+    def generate_grad_outputs(self, outputs_template):
+        grad_outputs = tuple([
+            numpy.random.uniform(-1, 1, a.shape).astype(a.dtype)
+            for a in outputs_template])
+
+        if self.grad_outputs_is_none is not None:
+            grad_outputs = tuple(
+                None if is_none else g for is_none, g,
+                in six.moves.zip(self.grad_outputs_is_none, grad_outputs))
+
+        return grad_outputs
 
     def forward(self, inputs, device):
         x, = inputs

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -129,6 +129,9 @@ def inject_backend_tests():
         {'shape': (10, 4, 3, 2), 'axis': 0, 'ys_section': numpy.array([]),
          'slices': [slice(None, None)]
          },
+        # Functions with multiple outputs may receive `None` upstream gradients
+        # in their backward method, `split_axis` must handle this case
+        # (by constructing 0-filled variables for `None` gradients).
         {'shape': (2, 7, 3), 'axis': 1, 'ys_section': [2, 5],
          'slices': [
              (slice(None), slice(None, 2)),
@@ -145,6 +148,9 @@ def inject_backend_tests():
 @inject_backend_tests()
 class TestSplitAxis(testing.FunctionTestCase):
 
+    # A list of booleans. If element i is `True`, the i-th upstream gradient is
+    # generated as `None`. Default is `None`, in which case all gradients are
+    # ndarrays.
     grad_outputs_is_none = None
 
     def generate_inputs(self):

--- a/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_split_axis.py
@@ -165,6 +165,7 @@ class TestSplitAxis(testing.FunctionTestCase):
             for a in outputs_template])
 
         if self.grad_outputs_is_none is not None:
+            assert len(self.grad_outputs_is_none) == len(grad_outputs)
             grad_outputs = tuple(
                 None if is_none else g for is_none, g,
                 in six.moves.zip(self.grad_outputs_is_none, grad_outputs))

--- a/tests/chainer_tests/testing_tests/test_function_link.py
+++ b/tests/chainer_tests/testing_tests/test_function_link.py
@@ -106,7 +106,8 @@ def _backward_correct(x1, x2, gy1, gy2, none_gy_as_zero=False):
 
 
 def _double_backward_correct(
-        x1, x2, gy1, gy2, ggx1, ggx2, none_gy_as_zero=False,
+        x1, x2, gy1, gy2, ggx1, ggx2,
+        none_gy_as_zero=False,
         none_ggx_as_zero=False):
     if none_gy_as_zero:
         if gy1 is None:


### PR DESCRIPTION
Allow `None` in gradient check inputs and `None` gradients to be generated by `FunctionTestCase`.

This is needed if we want to allow generating `None` "gy" and still test double backward (in this case, the inputs to gradient check for double backward will include `None`) or generate `None` "ggx". This applies to functions with multiple outputs e.g. https://github.com/chainer/chainer/pull/7805.