### PR TITLE
Fix doc of `backend.copyto`

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -44,9 +44,11 @@ def copyto(dst, src):
     another device.
 
     Args:
-        dst (`numpy.ndarray`, `cupy.ndarray` or `ideep4py.mdarray`):
+        dst (:class:`numpy.ndarray`, :class:`cupy.ndarray`, \
+        :class:`ideep4py.mdarray` or :class:`chainerx.ndarray`):
             Destination array.
-        src (`numpy.ndarray`, `cupy.ndarray` or `ideep4py.mdarray`):
+        src (:class:`numpy.ndarray`, :class:`cupy.ndarray`, \
+        :class:`ideep4py.mdarray` or :class:`chainerx.ndarray`):
             Source array.
 
     """


### PR DESCRIPTION
#7226 didn't fix the doc.  Is it a public spec of `chainer.backend.copyto` to support `chainerx.ndarray`?
