### PR TITLE
Fix backward of `split_axis` for intel64 when `grad_ouputs` contains `None`

### DIFF
--- a/chainer/functions/array/split_axis.py
+++ b/chainer/functions/array/split_axis.py
@@ -108,14 +108,15 @@ class SplitAxis(function_node.FunctionNode):
         return tuple(chainerx.split(x, self.indices_or_sections, self.axis))
 
     def forward(self, inputs):
+        x, = inputs
+        self._xp = backend.get_array_module(x)
+
         # Currently iDeep only supports 4 dims
         if (intel64.should_use_ideep('>=auto')
                 and intel64.inputs_all_ready(inputs, (4,))
                 and self._ideep_is_supported(inputs)):
             return self._forward_ideep(inputs)
 
-        x, = inputs
-        self._xp = backend.get_array_module(x)
         indices_or_sections = self.indices_or_sections
         ret = self._xp.split(x, indices_or_sections, self.axis)
         if self._xp == numpy and not _numpy_split_ok:


### PR DESCRIPTION
If `SplitAxis.backward` is called with `None` upstream gradients, zero-filled arrays are constructed using `self._xp`. However, this `self._xp` attribute is not set for the intel64 path. This PR fixes this issue.

Depends on https://github.com/chainer/chainer/pull/7831.