### PR TITLE
Add support for input with different dtypes for 'linalg.solve' in ChainerX

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/linalg.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/linalg.cu
@@ -169,15 +169,14 @@ class CudaSolveKernel : public SolveKernel {
 public:
     void Call(const Array& a, const Array& b, const Array& out) override {
         Device& device = a.device();
-        Dtype dtype = a.dtype();
         CudaSetDeviceScope scope{device.index()};
 
         CHAINERX_ASSERT(a.ndim() == 2);
         CHAINERX_ASSERT(a.shape()[0] == a.shape()[1]);
 
-        VisitFloatingPointDtype(dtype, [&](auto pt) {
+        VisitFloatingPointDtype(out.dtype(), [&](auto pt) {
             using T = typename decltype(pt)::type;
-            SolveImpl<T>(a, b, out);
+            SolveImpl<T>(a.dtype() == out.dtype() ? a : a.AsType(out.dtype()), b.dtype() == out.dtype() ? b : b.AsType(out.dtype()), out);
         });
     }
 };

--- a/chainerx_cc/chainerx/native/native_device/linalg.cc
+++ b/chainerx_cc/chainerx/native/native_device/linalg.cc
@@ -157,9 +157,9 @@ public:
         CHAINERX_ASSERT(a.ndim() == 2);
         CHAINERX_ASSERT(a.shape()[0] == a.shape()[1]);
 
-        VisitFloatingPointDtype(a.dtype(), [&](auto pt) {
+        VisitFloatingPointDtype(out.dtype(), [&](auto pt) {
             using T = typename decltype(pt)::type;
-            SolveImpl<T>(a, b, out);
+            SolveImpl<T>(a.dtype() == out.dtype() ? a : a.AsType(out.dtype()), b.dtype() == out.dtype() ? b : b.AsType(out.dtype()), out);
         });
 #else  // CHAINERX_ENABLE_LAPACK
         (void)a;  // unused

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
@@ -131,6 +131,26 @@ class TestSolve(NumpyLinalgOpTest):
 @op_utils.op_test(['native:0', 'cuda:0'])
 @chainer.testing.parameterize(*(
     chainer.testing.product({
+        'shape': [(3, 3)],
+        'dtypes': [('float64', 'float32'), ('float32', 'float64')]
+    })
+))
+class TestSolveMixedDtype(NumpyLinalgOpTest):
+
+    def generate_inputs(self):
+        a = numpy.random.random(self.shape).astype(self.dtypes[0])
+        b = numpy.random.random(self.shape[0]).astype(self.dtypes[1])
+        return a, b
+
+    def forward_xp(self, inputs, xp):
+        a, b = inputs
+        out = xp.linalg.solve(a, b)
+        return out,
+
+
+@op_utils.op_test(['native:0', 'cuda:0'])
+@chainer.testing.parameterize(*(
+    chainer.testing.product({
         'shape': [(2, 3), (3, 2)],
         'dtype': ['float32', 'float64']
     })
@@ -139,6 +159,25 @@ class TestSolveFailing(NumpyLinalgOpTest):
 
     forward_accept_errors = (numpy.linalg.LinAlgError,
                              chainerx.DimensionError)
+
+    def generate_inputs(self):
+        a = numpy.random.random(self.shape).astype(self.dtype)
+        b = numpy.random.random(self.shape).astype(self.dtype)
+        return a, b
+
+    def forward_xp(self, inputs, xp):
+        a, b = inputs
+        out = xp.linalg.solve(a, b)
+        return out,
+
+
+@op_utils.op_test(['native:0', 'cuda:0'])
+@chainer.testing.parameterize_pytest('shape', [(3, 3)])
+@chainer.testing.parameterize_pytest('dtype', ['float16'])
+class TestSolveDtypeFailing(NumpyLinalgOpTest):
+
+    forward_accept_errors = (TypeError,
+                             chainerx.DtypeError)
 
     def generate_inputs(self):
         a = numpy.random.random(self.shape).astype(self.dtype)
@@ -207,23 +246,4 @@ class TestInverseDtypeFailing(NumpyLinalgOpTest):
     def forward_xp(self, inputs, xp):
         a, = inputs
         out = xp.linalg.inv(a)
-        return out,
-
-
-@op_utils.op_test(['native:0', 'cuda:0'])
-@chainer.testing.parameterize_pytest('shape', [(3, 3)])
-@chainer.testing.parameterize_pytest('dtype', ['float16'])
-class TestSolveDtypeFailing(NumpyLinalgOpTest):
-
-    forward_accept_errors = (TypeError,
-                             chainerx.DtypeError)
-
-    def generate_inputs(self):
-        a = numpy.random.random(self.shape).astype(self.dtype)
-        b = numpy.random.random(self.shape).astype(self.dtype)
-        return a, b
-
-    def forward_xp(self, inputs, xp):
-        a, b = inputs
-        out = xp.linalg.solve(a, b)
         return out,

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
@@ -111,35 +111,19 @@ class NumpyLinalgOpTest(op_utils.NumpyOpTest):
     chainer.testing.product({
         'shape': [(1, 1), (3, 3), (6, 6)],
         'b_columns': [(), (1,), (3,), (4,)],
-        'dtype': ['float32', 'float64']
+        'dtypes': [
+            ('float32', 'float32'),
+            ('float64', 'float64'),
+            ('float64', 'float32'),
+            ('float32', 'float64')]
     })
 ))
 class TestSolve(NumpyLinalgOpTest):
 
     def generate_inputs(self):
-        a = numpy.random.random(self.shape).astype(self.dtype)
-        b = numpy.random.random(
-            (self.shape[0], *self.b_columns)).astype(self.dtype)
-        return a, b
-
-    def forward_xp(self, inputs, xp):
-        a, b = inputs
-        out = xp.linalg.solve(a, b)
-        return out,
-
-
-@op_utils.op_test(['native:0', 'cuda:0'])
-@chainer.testing.parameterize(*(
-    chainer.testing.product({
-        'shape': [(3, 3)],
-        'dtypes': [('float64', 'float32'), ('float32', 'float64')]
-    })
-))
-class TestSolveMixedDtype(NumpyLinalgOpTest):
-
-    def generate_inputs(self):
         a = numpy.random.random(self.shape).astype(self.dtypes[0])
-        b = numpy.random.random(self.shape[0]).astype(self.dtypes[1])
+        b = numpy.random.random(
+            (self.shape[0], *self.b_columns)).astype(self.dtypes[1])
         return a, b
 
     def forward_xp(self, inputs, xp):


### PR DESCRIPTION
With this PR `linalg.solve` supports input with different dtypes.

With reference to #6764.