### PR TITLE
Configure tolerances of `F.average_pooling_2d` test

### DIFF
--- a/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_average_pooling_2d.py
@@ -38,6 +38,7 @@ class TestAveragePooling2D(testing.FunctionTestCase):
         if self.dtype == numpy.float16:
             self.check_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
             self.check_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
+            self.check_double_backward_options = {'atol': 5e-4, 'rtol': 5e-3}
 
     def generate_inputs(self):
         x = numpy.random.uniform(-1, 1, (2, 3, 4, 3)).astype(self.dtype)


### PR DESCRIPTION
Fixes #7703
`check_double_backward_options` was not configured.