### PR TITLE
Fix `F.clipped_relu` test for NumPy 1.17

### DIFF
--- a/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
+++ b/tests/chainer_tests/functions_tests/activation_tests/test_clipped_relu.py
@@ -45,7 +45,7 @@ class TestClippedReLU(testing.FunctionTestCase):
 
     def forward_expected(self, inputs):
         x, = inputs
-        y = utils.force_array(x.clip(0, self.z))
+        y = utils.force_array(x.clip(0, self.z), x.dtype)
         return y,
 
 
@@ -118,7 +118,7 @@ class TestReLU6(testing.FunctionTestCase):
 
     def forward_expected(self, inputs):
         x, = inputs
-        y = utils.force_array(x.clip(0, 6.0))
+        y = utils.force_array(x.clip(0, 6.0), x.dtype)
         return y,
 
 


### PR DESCRIPTION
Part of #7741

From NumPy 1.17, `x.clip(0, self.z)` returns `float64` array even if `x.dtype` is `float16`.