### PR TITLE
ChainerX + ChainerMN integraiton on MNIST

### DIFF
--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -5,6 +5,7 @@ import numpy as np
 from chainermn.communicators import _communication_utility
 
 import chainer.backends
+import chainerx
 try:
     import cupy as cp
     _cupy_avail = True
@@ -188,6 +189,11 @@ def get_device_memory_pointer(array):
 
     if xp is np:
         return array
+    elif xp is chainerx:
+        return ctypes.cast(
+            array.data_ptr,
+            ctypes.POINTER(ctypes.c_ubyte * array.nbytes)
+        ).contents
     else:
         return ctypes.cast(
             array.data.ptr,

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -83,6 +83,9 @@ class DeviceMemory(object):
             self.memory = cp.cuda.alloc(size)
 
     def _get_memory_pointer_from_chainerx(self, array):
+        # Currently, ChainerMN requires CuPy to support ChainerX.
+        # This is because ChainerX's backend does not provide a raw
+        # memory pointer class.
         return cp.cuda.MemoryPointer(
             cp.cuda.UnownedMemory(
                 array.data_ptr + array.offset,

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -226,8 +226,8 @@ def get_device_memory_pointer(array):
     elif xp is chx:
         backend_name = array.device.backend.name
         if backend_name not in ['native', 'cuda']:
-            raise ValueError('{} is an unsupported backend in ChainerMN'.format(
-                backend_name))
+            raise ValueError(
+                '{} is an unsupported backend'.format(backend_name))
         return ctypes.cast(
             array.data_ptr,
             ctypes.POINTER(ctypes.c_ubyte * array.nbytes)

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -42,8 +42,8 @@ class HostPinnedMemory(object):
 
     def __init__(self):
         if not _cupy_avail:
-            raise RuntimeError("HostPinnedMemory cannot be used: " +
-                               "Cupy is not available.")
+            raise RuntimeError('HostPinnedMemory cannot be used: ' +
+                               'Cupy is not available.')
         self.size = 0
         self.memory = None
 
@@ -72,8 +72,8 @@ class DeviceMemory(object):
 
     def __init__(self):
         if not _cupy_avail:
-            raise RuntimeError("DeviceMemory cannot be used: " +
-                               "Cupy is not available.")
+            raise RuntimeError('DeviceMemory cannot be used: ' +
+                               'Cupy is not available.')
         self.size = 0
         self.memory = None
 

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -102,7 +102,8 @@ class DeviceMemory(object):
         elif xp == chx:
             src_data = self._get_memory_pointer_from_chainerx(src)
         else:
-            raise ValueError('{} is an unsupported array module'.format(type(src)))
+            raise ValueError(
+                '{} is from an unsupported array module'.format(type(src)))
         if stream is None:
             dst.copy_from_device(src_data, size)
         else:
@@ -116,7 +117,8 @@ class DeviceMemory(object):
         elif xp == chx:
             dst_data = self._get_memory_pointer_from_chainerx(dst)
         else:
-            raise ValueError('{} is an unsupported array module'.format(type(dst)))
+            raise ValueError(
+                '{} is from an unsupported array module'.format(type(dst)))
         if stream is None:
             dst_data.copy_from_device(src, size)
         else:
@@ -216,7 +218,7 @@ def get_device_memory_pointer(array):
 
     if xp is np:
         return array
-    elif _cupy_avail and xp is cp:
+    elif xp is cp:
         return ctypes.cast(
             array.data.ptr,
             ctypes.POINTER(ctypes.c_ubyte * array.nbytes)
@@ -231,7 +233,8 @@ def get_device_memory_pointer(array):
             ctypes.POINTER(ctypes.c_ubyte * array.nbytes)
         ).contents
     else:
-        raise ValueError('{} is an unsupported array module'.format(type(array)))
+        raise ValueError(
+            '{} is from an unsupported array module'.format(type(array)))
 
 
 def _batched_pack_params(params_data, buffer, dtype, stream=None):

--- a/chainermn/communicators/_memory_utility.py
+++ b/chainermn/communicators/_memory_utility.py
@@ -93,7 +93,7 @@ class DeviceMemory(object):
                 array,
                 array.device.index),
             0)
-            
+
     def from_device(self, src, size, offset=0, stream=None):
         dst = self.memory + offset
         xp = chainer.backend.get_array_module(src)
@@ -414,4 +414,3 @@ def _cupy_batched_unpack_params():
             }
        }
     }''', 'cupy_batched_unpack_params')
-

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -225,7 +225,8 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
         #       a simple allreduce operation cannot be applied in evaluation.
         #   (2) allreduce_obj calls mpi4py.allreduce, which pickles the object
         #   (3) chainerx.ndarray preserves CUDA device internally when pickled
-        #   (4) Error is caused when an ndarray is unpickled in another process
+        #   (4) An error will occur when an ndarray is unpickled in another
+        #       process
         array0 = list(local_mean_dict.values())[0]
         xp = backend.get_array_module(array0)
         if xp == chx and array0.device.backend.name == 'cuda':

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -220,7 +220,7 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
         local_mean_dict = self._mn_original_evaluate()
 
         # ChainerX support:
-        # We need convert chainerx ndarray to CuPy array because
+        # We need convert chainerx ndarray to Native array because
         #   (1) allreduce_obj is used to compute global mean values
         #   (2) allreduce_obj calls mpi4py.allreduce, which pickles the object
         #   (3) chainerx.ndarray preserves CUDA device internally when pickled

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -3,7 +3,6 @@ import six
 
 from chainer.training import extension
 from chainer import backend
-from chainer import backends
 from chainer.dataset import convert
 from chainer import function
 from chainer.utils import argument

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -3,9 +3,11 @@ import six
 
 from chainer.training import extension
 from chainer import backend
+from chainer import backends
 from chainer.dataset import convert
 from chainer import function
 from chainer.utils import argument
+import chainerx as chx
 
 
 class GenericMultiNodeEvaluator(extension.Extension):
@@ -216,6 +218,23 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
 
     def new_evaluate(self):
         local_mean_dict = self._mn_original_evaluate()
+
+        # ChainerX support:
+        # We need convert chainerx ndarray to CuPy array because
+        #   (1) allreduce_obj is used to compute global mean values
+        #   (2) allreduce_obj calls mpi4py.allreduce, which pickles the object
+        #   (3) chainerx.ndarray preserves CUDA device internally when pickled
+        #   (4) Error is caused when an ndarray is unpickled in another process
+        array0 = list(local_mean_dict.values())[0]
+        xp = backend.get_array_module(array0)
+        if xp == chx and array0.device.backend.name == 'cuda':
+            # Results of evaluation is fairly small, so
+            # the ndarray is transferred to CPU and allreduce()-ed.
+            local_mean_dict = {
+                name: backends._cpu._array_to_cpu(value)
+                for name, value in local_mean_dict.items()
+            }
+
         global_mean_dict = {
             name:
             self._mn_communicator.allreduce_obj(

--- a/chainermn/extensions/multi_node_evaluator.py
+++ b/chainermn/extensions/multi_node_evaluator.py
@@ -231,7 +231,7 @@ def create_multi_node_evaluator(actual_evaluator, communicator):
             # Results of evaluation is fairly small, so
             # the ndarray is transferred to CPU and allreduce()-ed.
             local_mean_dict = {
-                name: backends._cpu._array_to_cpu(value)
+                name: chx.to_numpy(value)
                 for name, value in local_mean_dict.items()
             }
 

--- a/examples/chainermn/mnist/train_mnist.py
+++ b/examples/chainermn/mnist/train_mnist.py
@@ -8,6 +8,7 @@ import chainer.functions as F
 import chainer.links as L
 from chainer import training
 from chainer.training import extensions
+import chainerx
 
 import chainermn
 
@@ -15,12 +16,12 @@ import chainermn
 class MLP(chainer.Chain):
 
     def __init__(self, n_units, n_out):
-        super(MLP, self).__init__(
+        super(MLP, self).__init__()
+        with self.init_scope():
             # the size of the inputs to each layer will be inferred
-            l1=L.Linear(784, n_units),  # n_in -> n_units
-            l2=L.Linear(n_units, n_units),  # n_units -> n_units
-            l3=L.Linear(n_units, n_out),  # n_units -> n_out
-        )
+            self.l1 = L.Linear(None, n_units)  # n_in -> n_units
+            self.l2 = L.Linear(None, n_units)  # n_units -> n_units
+            self.l3 = L.Linear(None, n_out)  # n_units -> n_out
 
     def __call__(self, x):
         h1 = F.relu(self.l1(x))
@@ -38,6 +39,8 @@ def main():
                         help='Number of sweeps over the dataset to train')
     parser.add_argument('--gpu', '-g', action='store_true',
                         help='Use GPU')
+    parser.add_argument('--chainerx', '-x', action='store_true',
+                        default=False, help='Use ChainerX')
     parser.add_argument('--out', '-o', default='result',
                         help='Directory to output the result')
     parser.add_argument('--resume', '-r', default='',
@@ -53,13 +56,19 @@ def main():
             print('Error: \'naive\' communicator does not support GPU.\n')
             exit(-1)
         comm = chainermn.create_communicator(args.communicator)
-        device = comm.intra_rank
+        if args.chainerx:
+            device = chainer.get_device('cuda:{}'.format(comm.intra_rank))
+        else:
+            device = chainer.get_device(comm.intra_rank)
     else:
         if args.communicator != 'naive':
             print('Warning: using naive communicator '
                   'because only naive supports CPU-only execution')
         comm = chainermn.create_communicator('naive')
-        device = -1
+        if args.chainerx:
+            device = chainer.get_device('native')
+        else:
+            device = chainer.get_device(-1)
 
     if comm.rank == 0:
         print('==========================================')
@@ -73,9 +82,9 @@ def main():
         print('==========================================')
 
     model = L.Classifier(MLP(args.unit, 10))
-    if device >= 0:
-        chainer.cuda.get_device_from_id(device).use()
-        model.to_gpu()
+
+    print(device)
+    model.to_device(device)
 
     # Create a multi node optimizer from a standard Chainer optimizer.
     optimizer = chainermn.create_multi_node_optimizer(
@@ -106,7 +115,10 @@ def main():
     # Some display and output extensions are necessary only for one worker.
     # (Otherwise, there would just be repeated outputs.)
     if comm.rank == 0:
-        trainer.extend(extensions.DumpGraph('main/loss'))
+        if device.xp is not chainerx:
+            # Disabled for ChainerX.
+            # See examples/mnist/train_mnist.py
+            trainer.extend(extensions.DumpGraph('main/loss'))
         trainer.extend(extensions.LogReport())
         trainer.extend(extensions.PrintReport(
             ['epoch', 'main/loss', 'validation/main/loss',

--- a/examples/chainermn/mnist/train_mnist.py
+++ b/examples/chainermn/mnist/train_mnist.py
@@ -83,7 +83,6 @@ def main():
 
     model = L.Classifier(MLP(args.unit, 10))
 
-    print(device)
     model.to_device(device)
 
     # Create a multi node optimizer from a standard Chainer optimizer.

--- a/examples/chainermn/mnist/train_mnist.py
+++ b/examples/chainermn/mnist/train_mnist.py
@@ -116,6 +116,8 @@ def main():
     if comm.rank == 0:
         if device.xp is not chainerx:
             # Disabled for ChainerX.
+            # This is because ChainerX doesn't have a public API set
+            # to traverse computational graphs.
             # See examples/mnist/train_mnist.py
             trainer.extend(extensions.DumpGraph('main/loss'))
         trainer.extend(extensions.LogReport())


### PR DESCRIPTION
This PR implements ChainerMN on ChainerX integration.

With this PR, the MNIST example works on ChainerX.

Note that you need to set the following environmental variables when you install Chainer fro m source to activate ChainerX.
```
export CHAINERX_BUILD_CUDA=1
export CHAINERX_ENABLE_BLAS=1
export CHAINER_BUILD_CHAINERX=1
```

```
export MAKEFLAGS=-j16
```
is also helpful.
