### PR TITLE
Do not assert that inputs are not None in `FunctionAdapter`

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -212,7 +212,7 @@ class FunctionAdapter(function_node.FunctionNode):
 
         # Check gradients
         for x, gx in six.moves.zip(self.inputs, gxs):
-            if gx is not None:
+            if x is not None and gx is not None:
                 variable._check_grad_type(self, x, True, gx)
 
         # Convert input gradients back to ChainerX


### PR DESCRIPTION
Follow up of https://github.com/chainer/chainer/pull/7831 for old-style functions. However, I'm not sure this change (removal of assertion) is correct and would like to hear opinions.

Related https://github.com/chainer/chainer/pull/7805#discussion_r310342676 and the associated CI results https://travis-ci.org/chainer/chainer/jobs/567272295.