### PR TITLE
Refactor convolution functions tests

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -11,7 +11,7 @@ from chainer.testing import backend
 
 
 @testing.parameterize(*(testing.product({
-    'c_contiguous': [True, False],
+    'contiguous': ['C', None],
     'cover_all': [True, False],
     'x_dtype': [numpy.float32],
     'W_dtype': [numpy.float32],
@@ -19,7 +19,7 @@ from chainer.testing import backend
     'groups': [1, 2],
     'nobias': [True, False],
 }) + testing.product({
-    'c_contiguous': [False],
+    'contiguous': [None],
     'cover_all': [False],
     'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
@@ -102,6 +102,12 @@ class TestConvolution2DFunction(testing.FunctionTestCase):
             return x, W, b
 
     def forward_expected(self, inputs):
+        """
+        Current forward_expected implementation depends on
+        F.convolution_2d itself and thus it's only capable
+        of checking consistency between backends, not absolute
+        correctness of computations
+        """
         if self.nobias:
             x, W = inputs
             b = None

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -35,8 +35,7 @@ from chainer.utils import conv
     'nobias': [True, False],
 })))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward',
-     'test_consistency_regression_forward'],
+    None,
     # CPU tests
     [{}]
     # GPU tests

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -36,7 +36,7 @@ from chainer.utils import conv
 })))
 @testing.inject_backend_tests(
     ['test_forward', 'test_backward', 'test_double_backward',
-     'test_consistency_forward', 'test_consistency_regression_forward'],
+     'test_consistency_regression_forward'],
     # CPU tests
     [{}]
     # GPU tests
@@ -97,6 +97,12 @@ class TestConvolutionND(testing.FunctionTestCase):
             return x, W, b
 
     def forward_expected(self, inputs):
+        """
+        Current forward_expected implementation depends on
+        F.convolution_nd itself and thus it's only capable
+        of checking consistency between backends, not absolute
+        correctness of computations
+        """
         if self.nobias:
             x, W = inputs
             b = None
@@ -119,40 +125,6 @@ class TestConvolutionND(testing.FunctionTestCase):
             cover_all=self.cover_all, dilate=self.dilate,
             groups=self.groups)
         return y,
-
-    def check_forward_consistency(self, backend_config):
-        inputs = self.generate_inputs()
-        if self.nobias:
-            x, W = inputs
-            b = None
-        else:
-            x, W, b = inputs
-        x_cpu = chainer.Variable(x)
-        W_cpu = chainer.Variable(W)
-        b_cpu = None if b is None else chainer.Variable(b)
-        y_cpu = F.convolution_nd(
-            x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
-            cover_all=self.cover_all, dilate=self.dilate,
-            groups=self.groups)
-
-        x = backend_config.get_array(x)
-        W = backend_config.get_array(W)
-        if self.nobias:
-            b = None
-        else:
-            b = backend_config.get_array(b)
-        with backend_config:
-            y_gpu = F.convolution_nd(
-                x, W, b, stride=self.stride, pad=self.pad,
-                cover_all=self.cover_all, dilate=self.dilate,
-                groups=self.groups)
-
-        testing.assert_allclose(
-            y_cpu.array, y_gpu.array, **self.check_forward_options)
-
-    def test_consistency_forward(self, backend_config):
-        if backend_config.use_cuda or backend_config.use_chainerx:
-            self.check_forward_consistency(backend_config)
 
     def check_forward_consistency_regression(self, backend_config):
         inputs = self.generate_inputs()

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -77,16 +77,13 @@ class TestDeconvolution2DFunction(testing.FunctionTestCase):
 
         self.outsize = (outh, outw) if self.test_outsize else None
 
-        if numpy.float16 in (self.x_dtype, self.W_dtype):
-            self.check_forward_options.update({
-                'atol': 1e-3, 'rtol': 1e-2
-            })
-            self.check_backward_options.update({
-                'atol': 1e-3, 'rtol': 1e-2
-            })
-            self.check_double_backward_options.update({
-                'atol': 1e-3, 'rtol': 1e-2
-            })
+        if self.x_dtype == numpy.float16:
+            self.check_forward_options.update(atol=5e-3, rtol=5e-2)
+            self.check_backward_options.update(atol=5e-3, rtol=5e-2)
+            self.check_double_backward_options.update(atol=5e-3, rtol=5e-2)
+        elif self.W_dtype == numpy.float16:
+            self.check_backward_options.update(atol=5e-3, rtol=5e-2)
+            self.check_double_backward_options.update(atol=5e-3, rtol=5e-2)
 
     def generate_inputs(self):
         W = numpy.random.normal(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -20,7 +20,7 @@ def _pair(x):
 
 @parameterize(*(testing.product([
     testing.product({
-        'c_contiguous': [True],
+        'contiguous': ['C'],
         'test_outsize': [True, False],
         'nobias': [True],
         'stride': [1, 2],
@@ -30,7 +30,7 @@ def _pair(x):
         'groups': [1, 2],
     })
     + testing.product({
-        'c_contiguous': [False],
+        'contiguous': [None],
         'test_outsize': [True],
         'nobias': [False],
         'stride': [1, 2],
@@ -113,6 +113,12 @@ class TestDeconvolution2DFunction(testing.FunctionTestCase):
             return x, W, b
 
     def forward_expected(self, inputs):
+        """
+        Current forward_expected implementation depends on
+        F.deconvolution_2d itself and thus it's only capable
+        of checking consistency between backends, not absolute
+        correctness of computations
+        """
         if self.nobias:
             x, W = inputs
             b = None

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -41,7 +41,7 @@ def _pair(x):
     }),
 ])))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward'],
+    None,
     # CPU tests
     testing.product({
         'use_cuda': [False],

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -43,18 +43,29 @@ def _pair(x):
 @testing.inject_backend_tests(
     ['test_forward', 'test_backward', 'test_double_backward'],
     # CPU tests
-    [{}]
-    # GPU tests
-    + testing.product({
-        'use_cuda': [True],
-        'use_cudnn': ['never', 'always'],
+    testing.product({
+        'use_cuda': [False],
+        'use_ideep': ['never', 'always'],
     })
+    # GPU tests
+    + testing.product([
+        [{'use_cuda': True}],
+
+        # Without cuDNN
+        testing.product({
+            'use_cudnn': ['never'],
+        })
+        # With cuDNN
+        + testing.product({
+            'use_cudnn': ['always'],
+            'cudnn_deterministic': [True, False],
+            'autotune': [True, False],
+        })])
     # ChainerX tests
-    + [
-        {'use_chainerx': True, 'chainerx_device': 'native:0'},
-        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
-    ]
-)
+    + testing.product({
+        'use_chainerx': [True],
+        'chainerx_device': ['native:0', 'cuda:0'],
+    }))
 class TestDeconvolution2DFunction(testing.FunctionTestCase):
 
     def setUp(self):

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -5,12 +5,9 @@ import numpy
 import chainer
 from chainer.backends import cuda
 import chainer.functions as F
-from chainer import gradient_check
 from chainer import testing
 from chainer.testing import array
 from chainer.testing import attr
-from chainer.testing import backend
-from chainer.testing import condition
 from chainer.testing import parameterize
 from chainer.utils import conv
 
@@ -43,180 +40,93 @@ def _pair(x):
         'groups': [1, 2],
     }),
 ])))
-@backend.inject_backend_tests(
+@testing.inject_backend_tests(
     ['test_forward', 'test_backward', 'test_double_backward'],
     # CPU tests
-    testing.product({
-        'use_cuda': [False],
-        'use_ideep': ['never', 'always'],
-    })
+    [{}]
     # GPU tests
-    + testing.product([
-        [{'use_cuda': True}],
-
-        # Without cuDNN
-        testing.product({
-            'use_cudnn': ['never'],
-        })
-        # With cuDNN
-        + testing.product({
-            'use_cudnn': ['always'],
-            'cudnn_deterministic': [True, False],
-            'autotune': [True, False],
-        })])
-    # ChainerX tests
     + testing.product({
-        'use_chainerx': [True],
-        'chainerx_device': ['native:0', 'cuda:0'],
-    }))
-class TestDeconvolution2DFunction(unittest.TestCase):
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+    ]
+)
+class TestDeconvolution2DFunction(testing.FunctionTestCase):
 
     def setUp(self):
-        in_channels_a_group = 3
-        out_channels_a_group = 2
-        self.in_channels = in_channels_a_group * self.groups
-        self.out_channels = out_channels_a_group * self.groups
+        self.N = 2
+        self.inh, self.inw = 4, 3
+        self.in_channels_a_group = 3
+        self.out_channels_a_group = 2
+        self.in_channels = self.in_channels_a_group * self.groups
+        self.out_channels = self.out_channels_a_group * self.groups
         self.ksize = 3
         self.pad = 1
-        kh, kw = _pair(self.ksize)
-        sh, sw = _pair(self.stride)
-        ph, pw = _pair(self.pad)
+        self.kh, self.kw = _pair(self.ksize)
+        self.sh, self.sw = _pair(self.stride)
+        self.ph, self.pw = _pair(self.pad)
 
-        W = numpy.random.normal(
-            0, numpy.sqrt(1. / (kh * kw * in_channels_a_group)),
-            (self.in_channels, out_channels_a_group, kh, kw)
-        ).astype(self.W_dtype)
-        b = None if self.nobias else numpy.random.uniform(
-            -1, 1, self.out_channels).astype(self.x_dtype)
+        outh = conv.get_deconv_outsize(self.inh, self.kh, self.sh,
+                                       self.ph, d=self.dilate)
+        outw = conv.get_deconv_outsize(self.inw, self.kw, self.sw,
+                                       self.pw, d=self.dilate)
 
-        N = 2
-        inh, inw = 4, 3
-        outh = conv.get_deconv_outsize(inh, kh, sh, ph, d=self.dilate)
-        outw = conv.get_deconv_outsize(inw, kw, sw, pw, d=self.dilate)
         self.outsize = (outh, outw) if self.test_outsize else None
+
+        if numpy.float16 in (self.x_dtype, self.W_dtype):
+            self.check_forward_options.update({
+                'atol': 1e-3, 'rtol': 1e-2
+            })
+            self.check_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-2
+            })
+            self.check_double_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-2
+            })
+
+    def generate_inputs(self):
+        W = numpy.random.normal(
+            0, numpy.sqrt(1. / (self.kh * self.kw * self.in_channels_a_group)),
+            (self.in_channels, self.out_channels_a_group, self.kh, self.kw)
+        ).astype(self.W_dtype)
+
         x = numpy.random.uniform(
-            -1, 1, (N, self.in_channels, inh, inw)).astype(self.x_dtype)
-        gy = numpy.random.uniform(
-            -1, 1, (N, self.out_channels, outh, outw)).astype(self.x_dtype)
+            -1, 1, (self.N, self.in_channels,
+                    self.inh, self.inw)).astype(self.x_dtype)
+        if self.nobias:
+            return x, W
+        else:
+            b = numpy.random.uniform(
+                -1, 1, self.out_channels).astype(self.x_dtype)
+            return x, W, b
 
-        ggx = numpy.random.uniform(-1, 1, x.shape).astype(
-            self.x_dtype)
-        ggW = numpy.random.uniform(-1, 1, W.shape).astype(
-            self.W_dtype)
-        ggb = None if self.nobias else numpy.random.uniform(
-            -1, 1, b.shape).astype(self.x_dtype)
+    def forward_expected(self, inputs):
+        if self.nobias:
+            x, W = inputs
+            b = None
+        else:
+            x, W, b = inputs
+        y_expected = F.deconvolution_2d(
+            x, W, b, stride=self.stride, pad=self.pad,
+            outsize=self.outsize, dilate=self.dilate,
+            groups=self.groups)
+        return y_expected.array,
 
-        self.inputs = [x, W, b]
-        self.grad_outputs = [gy]
-        self.grad_grad_inputs = [ggx, ggW, ggb]
-
-        self.test_forward_options = {}
-        self.check_backward_options = {'dtype': numpy.float64}
-        self.check_double_backward_options = {'dtype': numpy.float64}
-        if self.x_dtype == numpy.float16:
-            self.test_forward_options.update(atol=5e-3, rtol=5e-2)
-            self.check_backward_options.update(atol=5e-4, rtol=5e-3)
-            self.check_double_backward_options.update(atol=5e-3, rtol=5e-2)
-        elif self.W_dtype == numpy.float16:
-            self.check_backward_options.update(atol=5e-4, rtol=5e-3)
-            self.check_double_backward_options.update(atol=5e-3, rtol=5e-2)
-
-    def forward_cpu(self, inputs):
-        x, W, b = inputs
-        x_cpu = chainer.Variable(x)
-        W_cpu = chainer.Variable(W)
-        b_cpu = None if b is None else chainer.Variable(b)
-        with chainer.using_config('use_ideep', 'never'):
-            y_cpu = F.deconvolution_2d(
-                x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
-                outsize=self.outsize, dilate=self.dilate, groups=self.groups)
-        return y_cpu,
-
-    def check_forward(self, inputs, backend_config):
-        y_expected, = self.forward_cpu(inputs)
-
-        x, W, b = backend_config.get_array(inputs)
-        x = chainer.Variable(x)
-        W = chainer.Variable(W)
-        b = None if b is None else chainer.Variable(b)
-
-        with backend_config:
-            y_actual = F.deconvolution_2d(
-                x, W, b, stride=self.stride, pad=self.pad,
-                outsize=self.outsize, dilate=self.dilate, groups=self.groups)
-
-        assert y_expected.data.dtype == self.x_dtype
-        assert y_actual.data.dtype == self.x_dtype
-        testing.assert_allclose(
-            y_expected.data, y_actual.data, **self.test_forward_options)
-
-    @attr.gpu
-    def test_forward(self, backend_config):
-        self.check_forward(self.inputs, backend_config)
-
-    def check_backward(self, inputs, grad_outputs, backend_config):
-        inputs = backend_config.get_array(inputs)
-        grad_outputs = backend_config.get_array(grad_outputs)
-
-        if not self.c_contiguous:
-            inputs = array._as_noncontiguous_array(inputs)
-            grad_outputs = array._as_noncontiguous_array(grad_outputs)
-
-        x_data, W_data, b_data = inputs
-        y_grad, = grad_outputs
-
-        args = (x_data, W_data)
-        if b_data is not None:
-            args = args + (b_data,)
-
-        def f(*args):
-            return F.deconvolution_2d(
-                *args, stride=self.stride, pad=self.pad, outsize=self.outsize,
-                dilate=self.dilate, groups=self.groups)
-
-        with backend_config:
-            gradient_check.check_backward(
-                f, args, y_grad, **self.check_backward_options)
-
-    @condition.retry(10)
-    def test_backward(self, backend_config):
-        self.check_backward(self.inputs, self.grad_outputs, backend_config)
-
-    def check_double_backward(
-            self, inputs, grad_outputs, grad_grad_inputs, backend_config):
-        inputs = backend_config.get_array(inputs)
-        grad_outputs = backend_config.get_array(grad_outputs)
-        grad_grad_inputs = backend_config.get_array(grad_grad_inputs)
-
-        if not self.c_contiguous:
-            inputs = array._as_noncontiguous_array(inputs)
-            grad_outputs = array._as_noncontiguous_array(grad_outputs)
-            grad_grad_inputs = array._as_noncontiguous_array(grad_grad_inputs)
-
-        x_data, W_data, b_data = inputs
-        y_grad, = grad_outputs
-        x_grad_grad, W_grad_grad, b_grad_grad = grad_grad_inputs
-
-        args = (x_data, W_data)
-        grad_grads = (x_grad_grad, W_grad_grad)
-        if b_data is not None:
-            args = args + (b_data,)
-            grad_grads = grad_grads + (b_grad_grad,)
-
-        def f(*args):
-            return F.deconvolution_2d(
-                *args, stride=self.stride, pad=self.pad, outsize=self.outsize,
-                dilate=self.dilate, groups=self.groups)
-
-        with backend_config:
-            gradient_check.check_double_backward(
-                f, args, y_grad, grad_grads,
-                **self.check_double_backward_options)
-
-    @condition.retry(10)
-    def test_double_backward(self, backend_config):
-        self.check_double_backward(self.inputs, self.grad_outputs,
-                                   self.grad_grad_inputs, backend_config)
+    def forward(self, inputs, device):
+        if self.nobias:
+            x, W = inputs
+            b = None
+        else:
+            x, W, b = inputs
+        y = F.deconvolution_2d(
+            x, W, b, stride=self.stride, pad=self.pad,
+            outsize=self.outsize, dilate=self.dilate,
+            groups=self.groups)
+        return y,
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -5,14 +5,10 @@ import numpy
 from operator import mul
 
 import chainer
-from chainer import backend
 from chainer.backends import cuda
 import chainer.functions as F
-from chainer import gradient_check
 from chainer import testing
-from chainer.testing import array
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.testing import parameterize
 from chainer.utils import conv
 from chainer.utils import type_check
@@ -52,91 +48,142 @@ from chainer.utils import type_check
     'W_dtype': [numpy.float32],
     'autotune': [False],
 }))
-class TestDeconvolutionND(unittest.TestCase):
+@testing.inject_backend_tests(
+    ['test_forward', 'test_backward', 'test_double_backward',
+     'test_consistency_forward', 'test_consistency_regression_forward'],
+    # CPU tests
+    [{}]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+    ]
+)
+class TestDeconvolutionND(testing.FunctionTestCase):
 
     def setUp(self):
-        N = 2
-        in_channels = 4
-        out_channels = 2
-        ndim = len(self.dims)
-        ksize = (3,) * ndim
-        self.stride = (2,) * ndim
-        self.pad = (1,) * ndim
-        self.dilate = (self.dilate,) * ndim
+        self.N = 2
+        self.in_channels = 4
+        self.out_channels = 2
+        self.ndim = len(self.dims)
+        self.ksize = (3,) * self.ndim
+        self.stride = (2,) * self.ndim
+        self.pad = (1,) * self.ndim
+        self.dilate = (self.dilate,) * self.ndim
 
-        W_scale = numpy.sqrt(1. / functools.reduce(mul, ksize, in_channels))
-        W_shape = (in_channels, out_channels // self.groups) + ksize
-        self.W = numpy.random.normal(0, W_scale, W_shape).astype(self.W_dtype)
-        self.b = numpy.random.uniform(-1, 1, out_channels).astype(self.b_dtype)
-        self.check_double_backward_options = {
-            'dtype': numpy.float64, 'atol': 5e-3, 'rtol': 5e-2}
+        self.W_scale = numpy.sqrt(1. / functools.reduce(mul, self.ksize,
+                                                        self.in_channels))
+        self.W_shape = (self.in_channels,
+                        self.out_channels // self.groups) + self.ksize
 
         outs = tuple(
             conv.get_deconv_outsize(d, k, s, p, d=di)
             for (d, k, s, p, di)
-            in zip(self.dims, ksize, self.stride, self.pad, self.dilate))
+            in zip(self.dims, self.ksize, self.stride, self.pad, self.dilate))
         self.outsize = outs if self.test_outsize else None
-        x_shape = (N, in_channels) + self.dims
-        self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.x_dtype)
-        gy_shape = (N, out_channels) + outs
-        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.x_dtype)
+        self.x_shape = (self.N, self.in_channels) + self.dims
+        self.gy_shape = (self.N, self.out_channels) + outs
 
-        self.ggx = numpy.random.uniform(
-            -1, 1, self.x.shape).astype(self.x.dtype)
-        self.ggW = numpy.random.uniform(
-            -1, 1, self.W.shape).astype(self.W.dtype)
-        self.ggb = numpy.random.uniform(
-            -1, 1, self.b.shape).astype(self.b.dtype)
-
-        self.test_forward_options = {}
-        self.check_backward_options = {
-            'dtype': numpy.float64, 'atol': 3e-5, 'rtol': 3e-4}
+        self.check_backward_options.update({'atol': 3e-5, 'rtol': 3e-4})
+        self.check_double_backward_options.update({'atol': 5e-3, 'rtol': 5e-2})
         if (self.x_dtype == numpy.float16 or self.W_dtype == numpy.float16
                 or self.b_dtype == numpy.float16):
-            self.test_forward_options = {'atol': 5e-4, 'rtol': 5e-3}
-            self.check_backward_options = {
-                'dtype': numpy.float64, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+            self.check_forward_options.update({'atol': 5e-4, 'rtol': 5e-3})
+            self.check_backward_options.update({
+                'atol': 2 ** -4, 'rtol': 2 ** -4})
+            self.check_double_backward_options.update({
+                'atol': 2 ** -4, 'rtol': 2 ** -4})
 
-    def check_forward_consistency(self, use_cudnn='always'):
-        x_cpu = chainer.Variable(self.x)
-        W_cpu = chainer.Variable(self.W)
-        b_cpu = None if self.nobias else chainer.Variable(self.b)
+    def before_test(self, test_name):
+        self.backend_config.autotune = self.autotune
+
+    def generate_inputs(self):
+        W = numpy.random.normal(
+            0, self.W_scale, self.W_shape).astype(self.W_dtype)
+        x = numpy.random.uniform(-1, 1, self.x_shape).astype(self.x_dtype)
+        if self.nobias:
+            return x, W
+        else:
+            b = numpy.random.uniform(
+                -1, 1, self.out_channels).astype(self.x_dtype)
+            return x, W, b
+
+    def forward_expected(self, inputs):
+        if self.nobias:
+            x, W = inputs
+            b = None
+        else:
+            x, W, b = inputs
+        y_expected = F.deconvolution_nd(
+            x, W, b, stride=self.stride, pad=self.pad,
+            outsize=self.outsize, dilate=self.dilate,
+            groups=self.groups)
+        return y_expected.array,
+
+    def forward(self, inputs, device):
+        if self.nobias:
+            x, W = inputs
+            b = None
+        else:
+            x, W, b = inputs
+        y = F.deconvolution_nd(
+            x, W, b, stride=self.stride, pad=self.pad,
+            outsize=self.outsize, dilate=self.dilate,
+            groups=self.groups)
+        return y,
+
+    def check_forward_consistency(self, backend_config):
+        inputs = self.generate_inputs()
+        if self.nobias:
+            x, W = inputs
+            b = None
+        else:
+            x, W, b = inputs
+        x_cpu = chainer.Variable(x)
+        W_cpu = chainer.Variable(W)
+        b_cpu = None if self.nobias else chainer.Variable(b)
         y_cpu = F.deconvolution_nd(
             x_cpu, W_cpu, b_cpu, stride=self.stride, pad=self.pad,
             outsize=self.outsize, dilate=self.dilate,
             groups=self.groups)
 
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        W_gpu = chainer.Variable(cuda.to_gpu(self.W))
-        b_gpu = None if self.nobias else chainer.Variable(cuda.to_gpu(self.b))
-        with chainer.using_config('use_cudnn', use_cudnn):
-            with chainer.using_config('autotune', self.autotune):
-                y_gpu = F.deconvolution_nd(
-                    x_gpu, W_gpu, b_gpu, stride=self.stride, pad=self.pad,
-                    outsize=self.outsize, dilate=self.dilate,
-                    groups=self.groups)
+        x = backend_config.get_array(x)
+        W = backend_config.get_array(W)
+        if self.nobias:
+            b = None
+        else:
+            b = backend_config.get_array(b)
+        with backend_config:
+            y_gpu = F.deconvolution_nd(
+                x, W, b, stride=self.stride, pad=self.pad,
+                outsize=self.outsize, dilate=self.dilate,
+                groups=self.groups)
 
-        self.assertEqual(y_cpu.data.dtype, self.x_dtype)
-        self.assertEqual(y_gpu.data.dtype, self.x_dtype)
         testing.assert_allclose(
-            y_cpu.data, y_gpu.data.get(), **self.test_forward_options)
+            y_cpu.array, y_gpu.array, **self.check_forward_options)
 
-    @attr.cudnn
-    def test_forward_consistency_cudnn(self):
-        self.check_forward_consistency(use_cudnn='always')
+    def test_consistency_forward(self, backend_config):
+        if backend_config.use_cuda or backend_config.use_chainerx:
+            self.check_forward_consistency(backend_config)
 
-    @attr.gpu
-    def test_forward_consistency_im2col(self):
-        self.check_forward_consistency(use_cudnn='never')
+    def check_forward_consistency_regression(self, backend_config):
+        inputs = self.generate_inputs()
+        if self.nobias:
+            x, W = inputs
+            b = None
+        else:
+            x, W, b = inputs
+        x = chainer.Variable(backend_config.get_array(x))
+        W = chainer.Variable(backend_config.get_array(W))
+        if b is not None:
+            b = chainer.Variable(backend_config.get_array(b))
 
-    def check_forward_consistency_regression(self, x_data, W_data, b_data,
-                                             use_cudnn='always'):
-        if x_data.dtype != b_data.dtype:
-            raise unittest.SkipTest(
-                'F.deconvolution_2d does not support x.dtype != b.dtype')
-        x = chainer.Variable(x_data)
-        W = chainer.Variable(W_data)
-        b = None if self.nobias else chainer.Variable(b_data)
+        use_cudnn = backend_config.use_cudnn
 
         with chainer.using_config('use_cudnn', use_cudnn):
             y_nd = F.deconvolution_nd(x, W, b, stride=self.stride,
@@ -147,168 +194,12 @@ class TestDeconvolutionND(unittest.TestCase):
                                       dilate=self.dilate)
 
         testing.assert_allclose(
-            y_nd.data, y_2d.data, **self.test_forward_options)
+            y_nd.array, y_2d.array, **self.check_forward_options)
 
-    def test_forward_consistency_regression_cpu(self):
-        # Regression test to deconvolution_nd.
+    def test_consistency_regression_forward(self, backend_config):
+        # Regression test to convolution_2d.
         if len(self.dims) == 2:
-            self.check_forward_consistency_regression(self.x, self.W, self.b)
-
-    @attr.cudnn
-    def test_forward_consistency_regression_cudnn(self):
-        # Regression test to deconvolution_nd.
-        if len(self.dims) == 2:
-            self.check_forward_consistency_regression(
-                cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b),
-                use_cudnn='always')
-
-    @attr.gpu
-    def test_forward_consistency_regression_im2col(self):
-        # Regression test to deconvolution_nd.
-        if len(self.dims) == 2:
-            self.check_forward_consistency_regression(
-                cuda.to_gpu(self.x), cuda.to_gpu(self.W), cuda.to_gpu(self.b),
-                use_cudnn='never')
-
-    def check_backward(self, *inputs, **kwargs):
-        use_cudnn, = chainer.utils.argument.parse_kwargs(
-            kwargs, ('use_cudnn', 'never'))
-        if not self.c_contiguous:
-            inputs = array._as_noncontiguous_array(inputs)
-
-        x_data, W_data, b_data, y_grad = inputs
-
-        args = (x_data, W_data)
-        if b_data is not None:
-            args += (b_data,)
-
-        def f(*args):
-            return F.deconvolution_nd(*args, stride=self.stride, pad=self.pad,
-                                      outsize=self.outsize, dilate=self.dilate,
-                                      groups=self.groups)
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            with chainer.using_config('autotune', self.autotune):
-                gradient_check.check_backward(
-                    f, args, y_grad, **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.W, self.b, self.gy)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_backward_cudnn(self):
-        b = None if self.b is None else cuda.to_gpu(self.b)
-        self.check_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.W), b,
-            cuda.to_gpu(self.gy), use_cudnn='always')
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        b = None if self.b is None else cuda.to_gpu(self.b)
-        self.check_backward(
-            cuda.to_gpu(self.x), cuda.to_gpu(self.W), b,
-            cuda.to_gpu(self.gy), use_cudnn='never')
-
-    @attr.chainerx
-    @condition.retry(3)
-    def test_backward_chainerx_cpu(self):
-        self.check_backward(
-            backend.to_chx(self.x), backend.to_chx(self.W),
-            backend.to_chx(self.b), backend.to_chx(self.gy))
-
-    @attr.chainerx
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_chainerx_gpu(self):
-        self.check_backward(
-            backend.to_chx(self.x).to_device('cuda'),
-            backend.to_chx(self.W).to_device('cuda'),
-            backend.to_chx(self.b).to_device('cuda'),
-            backend.to_chx(self.gy).to_device('cuda'))
-
-    def check_double_backward(
-            self, inputs, grad_outputs, grad_grad_inputs, use_cudnn='always'):
-        if not self.c_contiguous:
-            inputs = array._as_noncontiguous_array(inputs)
-            grad_outputs = array._as_noncontiguous_array(grad_outputs)
-            grad_grad_inputs = array._as_noncontiguous_array(grad_grad_inputs)
-
-        x_data, W_data, b_data = inputs
-        y_grad, = grad_outputs
-        x_grad_grad, W_grad_grad, b_grad_grad = grad_grad_inputs
-
-        args = (x_data, W_data)
-        grad_grads = (x_grad_grad, W_grad_grad)
-        if b_data is not None:
-            args += (b_data,)
-            grad_grads += (b_grad_grad,)
-
-        def f(*args):
-            return F.deconvolution_nd(
-                *args, stride=self.stride, pad=self.pad, outsize=self.outsize,
-                dilate=self.dilate, groups=self.groups)
-
-        with chainer.using_config('use_cudnn', use_cudnn):
-            with chainer.using_config('autotune', self.autotune):
-                gradient_check.check_double_backward(
-                    f, args, y_grad, grad_grads,
-                    **self.check_double_backward_options)
-
-    @condition.retry(3)
-    def test_double_backward_cpu(self):
-        inputs = [self.x, self.W, self.b]
-        grad_outputs = [self.gy]
-        grad_grad_inputs = [self.ggx, self.ggW, self.ggb]
-        self.check_double_backward(
-            inputs, grad_outputs, grad_grad_inputs)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_double_backward_cudnn(self):
-        b = None if self.b is None else cuda.to_gpu(self.b)
-        inputs = [cuda.to_gpu(self.x), cuda.to_gpu(self.W), b]
-        grad_outputs = cuda.to_gpu([self.gy])
-        grad_grad_inputs = cuda.to_gpu([self.ggx, self.ggW, self.ggb])
-        self.check_double_backward(
-            inputs, grad_outputs, grad_grad_inputs, use_cudnn='always')
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_double_backward_gpu(self):
-        b = None if self.b is None else cuda.to_gpu(self.b)
-        inputs = [cuda.to_gpu(self.x), cuda.to_gpu(self.W), b]
-        grad_outputs = cuda.to_gpu([self.gy])
-        grad_grad_inputs = cuda.to_gpu([self.ggx, self.ggW, self.ggb])
-        self.check_double_backward(
-            inputs, grad_outputs, grad_grad_inputs, use_cudnn='never')
-
-    @attr.chainerx
-    @condition.retry(3)
-    def test_double_backward_chainerx_cpu(self):
-        inputs = [backend.to_chx(_) for _ in [self.x, self.W, self.b]]
-        grad_outputs = [backend.to_chx(_) for _ in [self.gy]]
-        grad_grad_inputs = [backend.to_chx(_) for _
-                            in [self.ggx, self.ggW, self.ggb]]
-
-        self.check_double_backward(
-            inputs, grad_outputs, grad_grad_inputs, use_cudnn='never')
-
-    @attr.chainerx
-    @attr.gpu
-    @condition.retry(3)
-    def test_double_backward_chainerx_gpu(self):
-        inputs = [backend.to_chx(_).to_device('cuda')
-                  for _ in [self.x, self.W, self.b]]
-        grad_outputs = [backend.to_chx(_).to_device('cuda')
-                        for _ in [self.gy]]
-        grad_grad_inputs = [backend.to_chx(_).to_device('cuda')
-                            for _ in [self.ggx, self.ggW, self.ggb]]
-
-        self.check_double_backward(
-            inputs, grad_outputs, grad_grad_inputs, use_cudnn='never')
+            self.check_forward_consistency_regression(backend_config)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -49,8 +49,7 @@ from chainer.utils import type_check
     'autotune': [False],
 }))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward',
-     'test_consistency_regression_forward'],
+    None,
     # CPU tests
     [{}]
     # GPU tests


### PR DESCRIPTION
This PR modifies the `deconvolution` tests to follow the `testing.FunctionTest` approach.

This is the first step towards eliminating the flakyness of the convolution related tests.

Merge before #7864 