### PR TITLE
Relax tolerances in convolution function tests when using old cuDNN

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -86,6 +86,17 @@ class TestConvolution2DFunction(testing.FunctionTestCase):
                 'atol': 1e-3, 'rtol': 1e-3
             })
 
+    def before_test(self, test_name):
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
+            self.check_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
+            self.check_double_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
+
     def generate_inputs(self):
         W = numpy.random.normal(
             0, numpy.sqrt(1. / (self.kh * self.kw * self.in_channels_a_group)),

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -82,7 +82,19 @@ class TestConvolutionND(testing.FunctionTestCase):
                 'atol': 2 ** -4, 'rtol': 2 ** -4})
 
     def before_test(self, test_name):
+        # Some of the test configurations do not
+        # support autotune so this hack is necessary
+        # for the CI to work
         self.backend_config.autotune = self.autotune
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
+            self.check_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
+            self.check_double_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
 
     def generate_inputs(self):
         W = numpy.random.normal(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -96,6 +96,17 @@ class TestDeconvolution2DFunction(testing.FunctionTestCase):
             self.check_backward_options.update(atol=5e-3, rtol=5e-2)
             self.check_double_backward_options.update(atol=5e-3, rtol=5e-2)
 
+    def before_test(self, test_name):
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
+            self.check_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
+            self.check_double_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
+
     def generate_inputs(self):
         W = numpy.random.normal(
             0, numpy.sqrt(1. / (self.kh * self.kw * self.in_channels_a_group)),

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -104,6 +104,17 @@ class TestDeconvolutionND(testing.FunctionTestCase):
             self.check_double_backward_options.update({
                 'atol': 2 ** -4, 'rtol': 2 ** -4})
 
+    def before_test(self, test_name):
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
+            self.check_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
+            self.check_double_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3})
+
     def generate_inputs(self):
         W = numpy.random.normal(
             0, self.W_scale, self.W_shape).astype(self.W_dtype)


### PR DESCRIPTION
Depends #7863 #7868  Merge after #7863 #7868 
Fixes #7693 and #7695 

When using cudnn 5.x convolution tests often suffer from precision related issues.
This PR relax the tolerance requirements when using cudnn <6.

1000 runs of test_backward for ConvolutionND

cudnn 5.2 - 45 failures (4.5%)
cudnn 7 - 0 failures
cudnn 5.2 with higher tolerance - 0 failures