### PR TITLE
Relax tolerances in convolution link tests when using old cuDNN

### DIFF
--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -5,11 +5,9 @@ import six.moves.cPickle as pickle
 
 import chainer
 from chainer.backends import cuda
-from chainer import gradient_check
 from chainer import links
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
 from chainer.utils import conv
 
 
@@ -17,22 +15,96 @@ from chainer.utils import conv
     'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
     'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
-class TestConvolution2D(unittest.TestCase):
+@testing.inject_backend_tests(
+    ['test_forward', 'test_backward', 'test_double_backward',
+     'test_pickling'],
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestConvolution2D(testing.LinkTestCase):
+
+    param_names = ('W', 'b')
 
     def setUp(self):
-        self.link = links.Convolution2D(
-            3, 2, 3, stride=2, pad=1,
-            initialW=chainer.initializers.Normal(1, self.W_dtype),
-            initial_bias=chainer.initializers.Normal(1, self.x_dtype))
-        self.link.cleargrads()
+        self.check_backward_options.update({
+            'atol': 5e-4, 'rtol': 5e-3
+        })
+        if self.x_dtype == numpy.float16 or self.W_dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 5e-3, 'rtol': 5e-2})
+            self.check_backward_options.update({
+                'atol': 1e-3, 'rtol': 1e-3
+            })
 
+    def generate_params(self):
+        initialW = chainer.initializers.Normal(1, self.W_dtype)
+        initial_bias = chainer.initializers.Normal(1, self.x_dtype)
+        return initialW, initial_bias
+
+    def create_link(self, initializers):
+        initialW, initial_bias = initializers
+
+        link = links.Convolution2D(
+            3, 2, 3, stride=2, pad=1,
+            initialW=initialW,
+            initial_bias=initial_bias)
+
+        return link
+
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1,
+                                 (2, 3, 4, 3)).astype(self.x_dtype)
+        return x,
+
+    def forward_expected(self, link, inputs):
+        x, = inputs
+        y = link(x).array
+        return y,
+
+    def test_pickling(self, backend_config):
+        with backend_config:
+            x_data, = self.generate_inputs()
+
+            link = self.create_link(self.generate_params())
+            link.to_device(backend_config.device)
+
+            x = chainer.Variable(x_data)
+            x.to_device(backend_config.device)
+
+            y = link(x)
+            y_data1 = y.data
+            del x, y
+            pickled = pickle.dumps(link, -1)
+            del link
+            link = pickle.loads(pickled)
+            x = chainer.Variable(x_data)
+            x.to_device(backend_config.device)
+            y = link(x)
+            y_data2 = y.data
+
+        testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
+
+
+@testing.parameterize(*testing.product({
+    'x_dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestConvolution2DIm2ColConsistency(unittest.TestCase):
+
+    def setUp(self):
         self.x = numpy.random.uniform(-1, 1,
                                       (2, 3, 4, 3)).astype(self.x_dtype)
-        self.gy = numpy.random.uniform(-1, 1,
-                                       (2, 2, 2, 2)).astype(self.x_dtype)
-        self.check_backward_options = {}
-        if self.x_dtype == numpy.float16 or self.W_dtype == numpy.float16:
-            self.check_backward_options = {'atol': 3e-2, 'rtol': 5e-2}
 
     @attr.gpu
     def test_im2col_consistency(self):
@@ -47,178 +119,78 @@ class TestConvolution2D(unittest.TestCase):
         im_cpu = conv.col2im_cpu(col, 2, 2, 1, 1, h, w)
         im_gpu = conv.col2im_gpu(cuda.to_gpu(col), 2, 2, 1, 1, h, w)
         testing.assert_allclose(im_cpu, im_gpu.get())
-
-    def check_forward_consistency(self):
-        x_cpu = chainer.Variable(self.x)
-        y_cpu = self.link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, self.x_dtype)
-
-        self.link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        y_gpu = self.link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, self.x_dtype)
-
-        testing.assert_allclose(y_cpu.data, y_gpu.data.get())
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_consistency(self):
-        self.check_forward_consistency()
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', 'never'):
-            self.check_forward_consistency()
-
-    def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(
-            self.link, x_data, y_grad, (self.link.W, self.link.b), eps=2 ** -3,
-            **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu_im2col(self):
-        self.link.to_gpu()
-        with chainer.using_config('use_cudnn', 'never'):
-            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_pickling(self, x_data):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y_data1 = y.data
-
-        del x, y
-
-        pickled = pickle.dumps(self.link, -1)
-        del self.link
-        self.link = pickle.loads(pickled)
-
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y_data2 = y.data
-
-        testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
-
-    def test_pickling_cpu(self):
-        self.check_pickling(self.x)
-
-    @attr.gpu
-    def test_pickling_gpu(self):
-        self.link.to_gpu()
-        self.check_pickling(cuda.to_gpu(self.x))
 
 
 @testing.parameterize(*testing.product({
     'conv_args': [((None, 2, 3, 2, 1), {}),
                   ((2, 3), {'stride': 2, 'pad': 1})],
 }))
-class TestConvolution2DParameterShapePlaceholder(unittest.TestCase):
+@testing.inject_backend_tests(
+    ['test_forward', 'test_backward', 'test_double_backward',
+     'test_pickling'],
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestConvolution2DParameterShapePlaceholder(testing.LinkTestCase):
 
-    def setUp(self):
+    param_names = ('W', 'b')
+
+    def generate_params(self):
+        return ()
+
+    def create_link(self, initializers):
+
         args, kwargs = self.conv_args
-        self.link = links.Convolution2D(*args, **kwargs)
-        self.x = numpy.random.uniform(-1, 1,
-                                      (2, 3, 4, 3)).astype(numpy.float32)
-        self.link(chainer.Variable(self.x))
-        b = self.link.b.data
+        link = links.Convolution2D(*args, **kwargs)
+        b = link.b.data
         b[...] = numpy.random.uniform(-1, 1, b.shape)
-        self.link.cleargrads()
-        self.gy = numpy.random.uniform(-1, 1,
-                                       (2, 2, 2, 2)).astype(numpy.float32)
 
-    @attr.gpu
-    def test_im2col_consistency(self):
-        col_cpu = conv.im2col_cpu(self.x, 3, 3, 2, 2, 1, 1)
-        col_gpu = conv.im2col_gpu(cuda.to_gpu(self.x), 3, 3, 2, 2, 1, 1)
-        testing.assert_allclose(col_cpu, col_gpu.get(), atol=0, rtol=0)
+        return link
 
-    @attr.gpu
-    def test_col2im_consistency(self):
-        col = conv.im2col_cpu(self.x, 3, 3, 2, 2, 1, 1)
-        h, w = self.x.shape[2:]
-        im_cpu = conv.col2im_cpu(col, 2, 2, 1, 1, h, w)
-        im_gpu = conv.col2im_gpu(cuda.to_gpu(col), 2, 2, 1, 1, h, w)
-        testing.assert_allclose(im_cpu, im_gpu.get())
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1,
+                                 (2, 3, 4, 3)).astype(numpy.float32)
+        return x,
 
-    def check_forward_consistency(self):
-        x_cpu = chainer.Variable(self.x)
-        y_cpu = self.link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, numpy.float32)
+    def forward_expected(self, link, inputs):
+        x, = inputs
+        y = link(x).array
+        return y,
 
-        self.link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        y_gpu = self.link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, numpy.float32)
+    def test_pickling(self, backend_config):
+        with backend_config:
+            x_data, = self.generate_inputs()
 
-        testing.assert_allclose(y_cpu.data, y_gpu.data.get())
+            link = self.create_link(self.generate_params())
+            link.to_device(backend_config.device)
 
-    @attr.cudnn
-    @condition.retry(3)
-    def test_forward_consistency(self):
-        self.check_forward_consistency()
+            x = chainer.Variable(x_data)
+            x.to_device(backend_config.device)
 
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', 'never'):
-            self.check_forward_consistency()
-
-    def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(
-            self.link, x_data, y_grad, (self.link.W, self.link.b), eps=1e-2)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu_im2col(self):
-        self.link.to_gpu()
-        with chainer.using_config('use_cudnn', 'never'):
-            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_pickling(self, x_data):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y_data1 = y.data
-
-        del x, y
-
-        pickled = pickle.dumps(self.link, -1)
-        del self.link
-        self.link = pickle.loads(pickled)
-
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y_data2 = y.data
+            y = link(x)
+            y_data1 = y.data
+            del x, y
+            pickled = pickle.dumps(link, -1)
+            del link
+            link = pickle.loads(pickled)
+            x = chainer.Variable(x_data)
+            x.to_device(backend_config.device)
+            y = link(x)
+            y_data2 = y.data
 
         testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
-
-    def test_pickling_cpu(self):
-        self.check_pickling(self.x)
-
-    @attr.gpu
-    def test_pickling_gpu(self):
-        self.link.to_gpu()
-        self.check_pickling(cuda.to_gpu(self.x))
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -49,8 +49,8 @@ class TestConvolution2D(testing.LinkTestCase):
 
     def before_test(self, test_name):
         # cuDNN 5 and 5.1 results suffer from precision issues
-        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
-                           self.backend_config.use_cudnn == 'always'
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
                            and cuda.cuda.cudnn.getVersion() < 6000)
         if using_old_cudnn:
             self.check_backward_options.update({'atol': 3e-2, 'rtol': 5e-2})
@@ -162,8 +162,8 @@ class TestConvolution2DParameterShapePlaceholder(testing.LinkTestCase):
 
     def before_test(self, test_name):
         # cuDNN 5 and 5.1 results suffer from precision issues
-        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
-                           self.backend_config.use_cudnn == 'always'
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
                            and cuda.cuda.cudnn.getVersion() < 6000)
         if using_old_cudnn:
             self.check_backward_options.update({'atol': 3e-2, 'rtol': 5e-2})

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -16,12 +16,9 @@ from chainer.utils import conv
     'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward',
-     'test_pickling'],
+    None,
     # CPU tests
-    [
-        {},
-    ]
+    [{}]
     # GPU tests
     + testing.product({
         'use_cuda': [True],
@@ -68,25 +65,24 @@ class TestConvolution2D(testing.LinkTestCase):
         return y,
 
     def test_pickling(self, backend_config):
-        with backend_config:
-            x_data, = self.generate_inputs()
+        x_data, = self.generate_inputs()
 
-            link = self.create_link(self.generate_params())
-            link.to_device(backend_config.device)
+        link = self.create_link(self.generate_params())
+        link.to_device(backend_config.device)
 
-            x = chainer.Variable(x_data)
-            x.to_device(backend_config.device)
+        x = chainer.Variable(x_data)
+        x.to_device(backend_config.device)
 
-            y = link(x)
-            y_data1 = y.data
-            del x, y
-            pickled = pickle.dumps(link, -1)
-            del link
-            link = pickle.loads(pickled)
-            x = chainer.Variable(x_data)
-            x.to_device(backend_config.device)
-            y = link(x)
-            y_data2 = y.data
+        y = link(x)
+        y_data1 = y.data
+        del x, y
+        pickled = pickle.dumps(link, -1)
+        del link
+        link = pickle.loads(pickled)
+        x = chainer.Variable(x_data)
+        x.to_device(backend_config.device)
+        y = link(x)
+        y_data2 = y.data
 
         testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
 
@@ -121,12 +117,9 @@ class TestConvolution2DIm2ColConsistency(unittest.TestCase):
                   ((2, 3), {'stride': 2, 'pad': 1})],
 }))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward',
-     'test_pickling'],
+    None,
     # CPU tests
-    [
-        {},
-    ]
+    [{}]
     # GPU tests
     + testing.product({
         'use_cuda': [True],
@@ -165,25 +158,24 @@ class TestConvolution2DParameterShapePlaceholder(testing.LinkTestCase):
         return y,
 
     def test_pickling(self, backend_config):
-        with backend_config:
-            x_data, = self.generate_inputs()
+        x_data, = self.generate_inputs()
 
-            link = self.create_link(self.generate_params())
-            link.to_device(backend_config.device)
+        link = self.create_link(self.generate_params())
+        link.to_device(backend_config.device)
 
-            x = chainer.Variable(x_data)
-            x.to_device(backend_config.device)
+        x = chainer.Variable(x_data)
+        x.to_device(backend_config.device)
 
-            y = link(x)
-            y_data1 = y.data
-            del x, y
-            pickled = pickle.dumps(link, -1)
-            del link
-            link = pickle.loads(pickled)
-            x = chainer.Variable(x_data)
-            x.to_device(backend_config.device)
-            y = link(x)
-            y_data2 = y.data
+        y = link(x)
+        y_data1 = y.data
+        del x, y
+        pickled = pickle.dumps(link, -1)
+        del link
+        link = pickle.loads(pickled)
+        x = chainer.Variable(x_data)
+        x.to_device(backend_config.device)
+        y = link(x)
+        y_data2 = y.data
 
         testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -17,8 +17,7 @@ from chainer.utils import conv
     'W_dtype': [numpy.float16, numpy.float32, numpy.float64],
 }))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward',
-     'test_pickling'],
+    None,
     # CPU tests
     [{}]
     # GPU tests
@@ -35,6 +34,8 @@ from chainer.utils import conv
 class TestConvolution2D(testing.LinkTestCase):
 
     param_names = ('W', 'b')
+
+    skip_double_backward_test = True
 
     def setUp(self):
         self.N = 2
@@ -141,8 +142,7 @@ class TestConvolution2DIm2ColConsistency(unittest.TestCase):
                   ((2, 3), {'stride': 2, 'pad': 1})],
 }))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward',
-     'test_pickling'],
+    None,
     # CPU tests
     [{}]
     # GPU tests
@@ -159,6 +159,8 @@ class TestConvolution2DIm2ColConsistency(unittest.TestCase):
 class TestConvolution2DParameterShapePlaceholder(testing.LinkTestCase):
 
     param_names = ('W', 'b')
+
+    skip_double_backward_test = True
 
     def before_test(self, test_name):
         # cuDNN 5 and 5.1 results suffer from precision issues

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -38,14 +38,9 @@ class TestConvolution2D(testing.LinkTestCase):
     param_names = ('W', 'b')
 
     def setUp(self):
-        self.check_backward_options.update({
-            'atol': 5e-4, 'rtol': 5e-3
-        })
         if self.x_dtype == numpy.float16 or self.W_dtype == numpy.float16:
             self.check_forward_options.update({'atol': 5e-3, 'rtol': 5e-2})
-            self.check_backward_options.update({
-                'atol': 1e-3, 'rtol': 1e-3
-            })
+            self.check_backward_options = {'atol': 3e-2, 'rtol': 5e-2}
 
     def generate_params(self):
         initialW = chainer.initializers.Normal(1, self.W_dtype)

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -5,6 +5,7 @@ import six.moves.cPickle as pickle
 
 import chainer
 from chainer.backends import cuda
+from chainer import functions as F
 from chainer import initializers
 from chainer.links.connection import convolution_nd
 from chainer import testing
@@ -82,8 +83,14 @@ class TestConvolutionND(testing.LinkTestCase):
 
     def forward_expected(self, link, inputs):
         x, = inputs
-        y = link(x).array
-        return y.astype(self.dtype),
+        W = link.W
+        b = link.b
+        y = F.convolution_nd(
+            x, W, b,
+            pad=self.pad,
+            groups=self.groups,
+            stride=self.stride)
+        return y.array,
 
     def test_pickling(self, backend_config):
         x_data, = self.generate_inputs()

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -55,6 +55,7 @@ class TestConvolutionND(testing.LinkTestCase):
         self.check_backward_options.update({'eps': 1e-2,
                                             'atol': 1e-3, 'rtol': 1e-3})
         if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 5e-4, 'rtol': 5e-3})
             self.check_backward_options.update({
                 'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4})
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -60,8 +60,8 @@ class TestConvolutionND(testing.LinkTestCase):
 
     def before_test(self, test_name):
         # cuDNN 5 and 5.1 results suffer from precision issues
-        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
-                           self.backend_config.use_cudnn == 'always'
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
                            and cuda.cuda.cudnn.getVersion() < 6000)
         if using_old_cudnn:
             self.check_backward_options.update({

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -55,7 +55,7 @@ class TestConvolutionND(testing.LinkTestCase):
         self.check_backward_options.update({'eps': 1e-2,
                                             'atol': 1e-3, 'rtol': 1e-3})
         if self.dtype == numpy.float16:
-            self.check_forward_options.update({'atol': 5e-4, 'rtol': 5e-3})
+            self.check_forward_options.update({'atol': 5e-3, 'rtol': 5e-2})
             self.check_backward_options.update({
                 'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4})
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -24,12 +24,9 @@ from chainer.utils import conv_nd
     'groups': [1, 2],
 })))
 @testing.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward',
-     'test_pickling'],
+    None,
     # CPU tests
-    [
-        {},
-    ]
+    [{}]
     # GPU tests
     + testing.product({
         'use_cuda': [True],
@@ -89,25 +86,24 @@ class TestConvolutionND(testing.LinkTestCase):
         return y.astype(self.dtype),
 
     def test_pickling(self, backend_config):
-        with backend_config:
-            x_data, = self.generate_inputs()
+        x_data, = self.generate_inputs()
 
-            link = self.create_link(self.generate_params())
-            link.to_device(backend_config.device)
+        link = self.create_link(self.generate_params())
+        link.to_device(backend_config.device)
 
-            x = chainer.Variable(x_data)
-            x.to_device(backend_config.device)
+        x = chainer.Variable(x_data)
+        x.to_device(backend_config.device)
 
-            y = link(x)
-            y_data1 = y.data
-            del x, y
-            pickled = pickle.dumps(link, -1)
-            del link
-            link = pickle.loads(pickled)
-            x = chainer.Variable(x_data)
-            x.to_device(backend_config.device)
-            y = link(x)
-            y_data2 = y.data
+        y = link(x)
+        y_data1 = y.data
+        del x, y
+        pickled = pickle.dumps(link, -1)
+        del link
+        link = pickle.loads(pickled)
+        x = chainer.Variable(x_data)
+        x.to_device(backend_config.device)
+        y = link(x)
+        y_data2 = y.data
 
         testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -5,13 +5,10 @@ import six.moves.cPickle as pickle
 
 import chainer
 from chainer.backends import cuda
-from chainer import gradient_check
 from chainer import initializers
 from chainer.links.connection import convolution_nd
 from chainer import testing
 from chainer.testing import attr
-from chainer.testing import condition
-from chainer.utils import conv
 from chainer.utils import conv_nd
 
 
@@ -26,37 +23,112 @@ from chainer.utils import conv_nd
     'in_channels': [4, None, 'omit'],
     'groups': [1, 2],
 })))
-class TestConvolutionND(unittest.TestCase):
+@testing.inject_backend_tests(
+    ['test_forward', 'test_backward', 'test_double_backward',
+     'test_pickling'],
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX tests
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestConvolutionND(testing.LinkTestCase):
+
+    param_names = ('W', 'b')
 
     def setUp(self):
-        ndim = len(self.dims)
-        self.ksize = (3,) * ndim
-        self.stride = (2,) * ndim
-        self.pad = (1,) * ndim
+        self.ndim = len(self.dims)
+        self.ksize = (3,) * self.ndim
+        self.stride = (2,) * self.ndim
+        self.pad = (1,) * self.ndim
 
-        if self.in_channels == 'omit':
-            self.link = convolution_nd.ConvolutionND(
-                ndim, 2, self.ksize, stride=self.stride,
-                pad=self.pad, groups=self.groups,
-                initial_bias=initializers.Uniform(scale=1., dtype=self.dtype))
-        else:
-            self.link = convolution_nd.ConvolutionND(
-                ndim, self.in_channels, 2, self.ksize, stride=self.stride,
-                pad=self.pad, groups=self.groups,
-                initial_bias=initializers.Uniform(scale=1., dtype=self.dtype))
-        self.link.cleargrads()
-
-        x_shape = (2, 4) + self.dims
-        self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-        gy_shape = (2, 2) + tuple(
-            conv.get_conv_outsize(d, k, s, p) for (d, k, s, p) in zip(
-                self.dims, self.ksize, self.stride, self.pad))
-        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
+        self.x_shape = (2, 4) + self.dims
 
         self.check_backward_options = {'eps': 1e-2, 'atol': 1e-3, 'rtol': 1e-3}
         if self.dtype == numpy.float16:
             self.check_backward_options = {
                 'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+
+    def generate_params(self):
+        initial_bias = initializers.Uniform(scale=1., dtype=self.dtype)
+        return initial_bias,
+
+    def create_link(self, initializers):
+        initial_bias, = initializers
+
+        if self.in_channels == 'omit':
+            link = convolution_nd.ConvolutionND(
+                self.ndim, 2, self.ksize, stride=self.stride,
+                pad=self.pad, groups=self.groups,
+                initial_bias=initial_bias)
+        else:
+            link = convolution_nd.ConvolutionND(
+                self.ndim, self.in_channels, 2, self.ksize, stride=self.stride,
+                pad=self.pad, groups=self.groups,
+                initial_bias=initial_bias)
+
+        return link
+
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, self.x_shape).astype(self.dtype)
+        return x,
+
+    def forward_expected(self, link, inputs):
+        x, = inputs
+        y = link(x).array
+        return y.astype(self.dtype),
+
+    def test_pickling(self, backend_config):
+        with backend_config:
+            x_data, = self.generate_inputs()
+
+            link = self.create_link(self.generate_params())
+            link.to_device(backend_config.device)
+
+            x = chainer.Variable(x_data)
+            x.to_device(backend_config.device)
+
+            y = link(x)
+            y_data1 = y.data
+            del x, y
+            pickled = pickle.dumps(link, -1)
+            del link
+            link = pickle.loads(pickled)
+            x = chainer.Variable(x_data)
+            x.to_device(backend_config.device)
+            y = link(x)
+            y_data2 = y.data
+
+        testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
+
+
+@testing.parameterize(*(testing.product({
+    'dims': [(3, 4), (3, 4, 3)],
+    'dtype': [numpy.float32],
+}) + testing.product({
+    'dims': [(5,)],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+})))
+class TestConvolutionNDIm2ColConsistency(unittest.TestCase):
+
+    def setUp(self):
+        self.ndim = len(self.dims)
+        self.ksize = (3,) * self.ndim
+        self.stride = (2,) * self.ndim
+        self.pad = (1,) * self.ndim
+
+        self.x_shape = (2, 4) + self.dims
+        self.x = numpy.random.uniform(-1, 1, self.x_shape).astype(self.dtype)
 
     @attr.gpu
     def test_im2col_consistency(self):
@@ -73,76 +145,6 @@ class TestConvolutionND(unittest.TestCase):
         im_gpu = conv_nd.col2im_nd_gpu(
             cuda.to_gpu(col), self.stride, self.pad, self.dims)
         testing.assert_allclose(im_cpu, im_gpu.get())
-
-    def check_forward_consistency(self):
-        x_cpu = chainer.Variable(self.x)
-        y_cpu = self.link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, self.dtype)
-
-        self.link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        y_gpu = self.link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, self.dtype)
-
-        testing.assert_allclose(y_cpu.data, y_gpu.data.get())
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_forward_consistency(self):
-        self.check_forward_consistency()
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_consistency_im2col(self):
-        with chainer.using_config('use_cudnn', 'never'):
-            self.check_forward_consistency()
-
-    def check_backward(self, x_data, y_grad):
-        gradient_check.check_backward(
-            self.link, x_data, y_grad, (self.link.W, self.link.b),
-            **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.cudnn
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.link.to_gpu()
-        self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu_im2col(self):
-        self.link.to_gpu()
-        with chainer.using_config('use_cudnn', 'never'):
-            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
-
-    def check_pickling(self, x_data):
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y_data1 = y.data
-
-        del x, y
-
-        pickled = pickle.dumps(self.link, -1)
-        del self.link
-        self.link = pickle.loads(pickled)
-
-        x = chainer.Variable(x_data)
-        y = self.link(x)
-        y_data2 = y.data
-
-        testing.assert_allclose(y_data1, y_data2, atol=0, rtol=0)
-
-    def test_pickling_cpu(self):
-        self.check_pickling(self.x)
-
-    @attr.gpu
-    def test_pickling_gpu(self):
-        self.link.to_gpu()
-        self.check_pickling(cuda.to_gpu(self.x))
 
 
 class TestConvolutionNDNoInitialBias(unittest.TestCase):

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_nd.py
@@ -52,10 +52,20 @@ class TestConvolutionND(testing.LinkTestCase):
 
         self.x_shape = (2, 4) + self.dims
 
-        self.check_backward_options = {'eps': 1e-2, 'atol': 1e-3, 'rtol': 1e-3}
+        self.check_backward_options.update({'eps': 1e-2,
+                                            'atol': 1e-3, 'rtol': 1e-3})
         if self.dtype == numpy.float16:
-            self.check_backward_options = {
-                'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4}
+            self.check_backward_options.update({
+                'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4})
+
+    def before_test(self, test_name):
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
+                           self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
+            self.check_backward_options.update({
+                'eps': 2 ** -4, 'atol': 2 ** -4, 'rtol': 2 ** -4})
 
     def generate_params(self):
         initial_bias = initializers.Uniform(scale=1., dtype=self.dtype)

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -52,8 +52,7 @@ class TestDeconvolution2D(testing.LinkTestCase):
         else:
             TestDeconvolution2D.param_names = ('W', 'b')
 
-        self.check_backward_options.update({
-            'atol': 1e-3, 'rtol': 1e-2})
+        self.check_backward_options.update({'atol': 1e-3, 'rtol': 1e-2})
 
     def generate_inputs(self):
         N = 2
@@ -126,6 +125,7 @@ class TestDeconvolution2DParameterShapePlaceholder(testing.LinkTestCase):
             self.param_names = ('W',)
         else:
             self.param_names = ('W', 'b')
+        self.check_backward_options.update({'atol': 1e-4, 'rtol': 1e-3})
 
     def generate_inputs(self):
         N = 2

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -58,8 +58,8 @@ class TestDeconvolution2D(testing.LinkTestCase):
 
     def before_test(self, test_name):
         # cuDNN 5 and 5.1 results suffer from precision issues
-        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
-                           self.backend_config.use_cudnn == 'always'
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
                            and cuda.cuda.cudnn.getVersion() < 6000)
         if using_old_cudnn:
             self.check_backward_options.update({'atol': 3e-2, 'rtol': 5e-2})
@@ -150,8 +150,8 @@ class TestDeconvolution2DParameterShapePlaceholder(testing.LinkTestCase):
 
     def before_test(self, test_name):
         # cuDNN 5 and 5.1 results suffer from precision issues
-        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
-                           self.backend_config.use_cudnn == 'always'
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
                            and cuda.cuda.cudnn.getVersion() < 6000)
         if using_old_cudnn:
             self.check_backward_options.update({'atol': 3e-2, 'rtol': 5e-2})

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -1,15 +1,9 @@
-import unittest
-
 import numpy
 
 import chainer
-from chainer.backends import cuda
-from chainer import gradient_check
 from chainer import links as L
 from chainer import testing
-from chainer.testing import attr
 from chainer.testing import parameterize
-from chainer.utils import conv
 
 
 def _pair(x):
@@ -21,74 +15,81 @@ def _pair(x):
 @parameterize(
     *testing.product({
         'nobias': [True, False],
-        'use_cudnn': ['always', 'never'],
         'dilate': [1, 2],
         'groups': [1, 3],
+        'x_dtype': [numpy.float32],
+        'W_dtype': [numpy.float32],
     })
 )
-class TestDeconvolution2D(unittest.TestCase):
+@testing.inject_backend_tests(
+    ['test_forward', 'test_backward'],
+    # CPU tests
+    [
+        {},
+        {'use_ideep': 'always'},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestDeconvolution2D(testing.LinkTestCase):
 
     def setUp(self):
-        in_channels = 3
-        out_channels = 6
-        ksize = 3
-        stride = 2
-        pad = 1
-        self.link = L.Deconvolution2D(
-            in_channels, out_channels, ksize, stride=stride, pad=pad,
-            nobias=self.nobias, dilate=self.dilate, groups=self.groups)
-        self.link.W.data[...] = numpy.random.uniform(
-            -1, 1, self.link.W.data.shape).astype(numpy.float32)
-        if not self.nobias:
-            self.link.b.data[...] = numpy.random.uniform(
-                -1, 1, self.link.b.data.shape).astype(numpy.float32)
+        self.in_channels = 3
+        self.out_channels = 6
+        self.ksize = 3
+        self.stride = 2
+        self.pad = 1
+        if self.nobias:
+            TestDeconvolution2D.param_names = ('W',)
+        else:
+            TestDeconvolution2D.param_names = ('W', 'b')
 
-        self.link.cleargrads()
+        self.check_backward_options.update({
+            'atol': 1e-3, 'rtol': 1e-2})
 
+    def generate_inputs(self):
         N = 2
         h, w = 3, 2
-        kh, kw = _pair(ksize)
-        out_h = conv.get_deconv_outsize(h, kh, stride, pad, d=self.dilate)
-        out_w = conv.get_deconv_outsize(w, kw, stride, pad, d=self.dilate)
-        self.gy = numpy.random.uniform(
-            -1, 1, (N, out_channels, out_h, out_w)).astype(numpy.float32)
-        self.x = numpy.random.uniform(
-            -1, 1, (N, in_channels, h, w)).astype(numpy.float32)
+        x = numpy.random.uniform(
+            -1, 1, (N, self.in_channels, h, w)).astype(self.x_dtype)
+        return x,
 
-    def check_forward_consistency(self):
-        x_cpu = chainer.Variable(self.x)
-        y_cpu = self.link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, numpy.float32)
+    def generate_params(self):
+        initialW = chainer.initializers.Normal(1, self.W_dtype)
+        initial_bias = chainer.initializers.Normal(1, self.x_dtype)
+        return initialW, initial_bias
 
-        self.link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        y_gpu = self.link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, numpy.float32)
+    def create_link(self, initializers):
+        initialW, initial_bias = initializers
 
-        testing.assert_allclose(y_cpu.data, y_gpu.data.get())
+        if self.nobias:
+            link = L.Deconvolution2D(
+                self.in_channels, self.out_channels, self.ksize,
+                stride=self.stride, pad=self.pad, nobias=self.nobias,
+                dilate=self.dilate, groups=self.groups,
+                initialW=initialW)
+        else:
+            link = L.Deconvolution2D(
+                self.in_channels, self.out_channels, self.ksize,
+                stride=self.stride, pad=self.pad, nobias=self.nobias,
+                dilate=self.dilate, groups=self.groups,
+                initialW=initialW,
+                initial_bias=initial_bias)
 
-    @attr.gpu
-    def test_forward_consistency(self):
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            self.check_forward_consistency()
+        return link
 
-    def check_backward(self, x_data, y_grad):
-        params = [self.link.W]
-        if not self.nobias:
-            params.append(self.link.b)
-
-        gradient_check.check_backward(
-            self.link, x_data, y_grad, params, dtype=numpy.float64,
-            atol=1e-3, rtol=1e-2)
-
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.link.to_gpu()
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+    def forward_expected(self, link, inputs):
+        x, = inputs
+        y = link(x).array
+        return y,
 
 
 @parameterize(
@@ -100,65 +101,57 @@ class TestDeconvolution2D(unittest.TestCase):
                         ((None, 2, 3, 2, 1), {})]
     })
 )
-class TestDeconvolution2DParameterShapePlaceholder(unittest.TestCase):
+@testing.inject_backend_tests(
+    ['test_forward', 'test_backward'],
+    # CPU tests
+    [
+        {},
+        {'use_ideep': 'always'},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    + [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ])
+class TestDeconvolution2DParameterShapePlaceholder(testing.LinkTestCase):
 
     def setUp(self):
-        args, kwargs = self.deconv_args
-        kwargs['nobias'] = self.nobias
-        self.link = L.Deconvolution2D(*args, **kwargs)
-        if not self.nobias:
-            self.link.b.data[...] = numpy.random.uniform(
-                -1, 1, self.link.b.data.shape).astype(numpy.float32)
-        out_channels = self.link.out_channels
-        ksize = self.link.ksize
-        stride = self.link.stride[0]
-        pad = self.link.pad[0]
+        if self.nobias:
+            self.param_names = ('W',)
+        else:
+            self.param_names = ('W', 'b')
+
+    def generate_inputs(self):
         N = 2
         h, w = 3, 2
-        kh, kw = _pair(ksize)
-        out_h = conv.get_deconv_outsize(h, kh, stride, pad)
-        out_w = conv.get_deconv_outsize(w, kw, stride, pad)
-        self.gy = numpy.random.uniform(
-            -1, 1, (N, out_channels, out_h, out_w)).astype(numpy.float32)
-        self.x = numpy.random.uniform(
+        x = numpy.random.uniform(
             -1, 1, (N, 3, h, w)).astype(numpy.float32)
-        self.link(chainer.Variable(self.x))
-        self.link.cleargrads()
+        return x,
 
-    def check_forward_consistency(self):
-        x_cpu = chainer.Variable(self.x)
-        y_cpu = self.link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, numpy.float32)
+    def generate_params(self):
+        return []
 
-        self.link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(self.x))
-        y_gpu = self.link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, numpy.float32)
+    def create_link(self, initializers):
 
-        testing.assert_allclose(y_cpu.data, y_gpu.data.get())
-
-    @attr.gpu
-    def test_forward_consistency(self):
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            self.check_forward_consistency()
-
-    def check_backward(self, x_data, y_grad):
-        params = [self.link.W]
+        args, kwargs = self.deconv_args
+        kwargs['nobias'] = self.nobias
+        link = L.Deconvolution2D(*args, **kwargs)
         if not self.nobias:
-            params.append(self.link.b)
+            link.b.data[...] = numpy.random.uniform(
+                -1, 1, link.b.data.shape).astype(numpy.float32)
 
-        gradient_check.check_backward(
-            self.link, x_data, y_grad, params, dtype=numpy.float64,
-            atol=1e-4, rtol=1e-3)
+        return link
 
-    def test_backward_cpu(self):
-        self.check_backward(self.x, self.gy)
-
-    @attr.gpu
-    def test_backward_gpu(self):
-        self.link.to_gpu()
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            self.check_backward(cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+    def forward_expected(self, link, inputs):
+        x, = inputs
+        y = link(x).array
+        return y,
 
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -1,6 +1,7 @@
 import numpy
 
 import chainer
+import chainer.functions as F
 from chainer import links as L
 from chainer import testing
 from chainer.testing import parameterize
@@ -87,8 +88,19 @@ class TestDeconvolution2D(testing.LinkTestCase):
 
     def forward_expected(self, link, inputs):
         x, = inputs
-        y = link(x).array
-        return y,
+        W = link.W
+        if self.nobias:
+            y = F.deconvolution_2d(
+                x, W,
+                stride=self.stride, pad=self.pad,
+                dilate=self.dilate, groups=self.groups)
+        else:
+            b = link.b
+            y = F.deconvolution_2d(
+                x, W, b,
+                stride=self.stride, pad=self.pad,
+                dilate=self.dilate, groups=self.groups)
+        return y.array,
 
 
 @parameterize(

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_2d.py
@@ -1,6 +1,7 @@
 import numpy
 
 import chainer
+from chainer.backends import cuda
 import chainer.functions as F
 from chainer import links as L
 from chainer import testing
@@ -54,6 +55,14 @@ class TestDeconvolution2D(testing.LinkTestCase):
             TestDeconvolution2D.param_names = ('W', 'b')
 
         self.check_backward_options.update({'atol': 1e-3, 'rtol': 1e-2})
+
+    def before_test(self, test_name):
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
+                           self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
+            self.check_backward_options.update({'atol': 3e-2, 'rtol': 5e-2})
 
     def generate_inputs(self):
         N = 2
@@ -138,6 +147,14 @@ class TestDeconvolution2DParameterShapePlaceholder(testing.LinkTestCase):
         else:
             self.param_names = ('W', 'b')
         self.check_backward_options.update({'atol': 1e-4, 'rtol': 1e-3})
+
+    def before_test(self, test_name):
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
+                           self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
+            self.check_backward_options.update({'atol': 3e-2, 'rtol': 5e-2})
 
     def generate_inputs(self):
         N = 2

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
@@ -84,8 +84,8 @@ class TestDeconvolutionND(testing.LinkTestCase):
 
     def before_test(self, test_name):
         # cuDNN 5 and 5.1 results suffer from precision issues
-        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
-                           self.backend_config.use_cudnn == 'always'
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy
+                           and self.backend_config.use_cudnn == 'always'
                            and cuda.cuda.cudnn.getVersion() < 6000)
         if using_old_cudnn:
             self.check_backward_options.update({

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+from chainer.backends import cuda
 import chainer.functions as F
 from chainer import initializers
 from chainer.links.connection import deconvolution_nd
@@ -78,6 +79,15 @@ class TestDeconvolutionND(testing.LinkTestCase):
             'eps': 1e-2, 'atol': 1e-4, 'rtol': 1e-3})
         if self.dtype == numpy.float16:
             self.check_forward_options.update({'atol': 5e-3, 'rtol': 5e-2})
+            self.check_backward_options.update({
+                'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1})
+
+    def before_test(self, test_name):
+        # cuDNN 5 and 5.1 results suffer from precision issues
+        using_old_cudnn = (self.backend_config.xp is cuda.cupy and
+                           self.backend_config.use_cudnn == 'always'
+                           and cuda.cuda.cudnn.getVersion() < 6000)
+        if using_old_cudnn:
             self.check_backward_options.update({
                 'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1})
 

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
@@ -2,14 +2,9 @@ import unittest
 
 import numpy
 
-import chainer
-from chainer.backends import cuda
-from chainer import gradient_check
 from chainer import initializers
 from chainer.links.connection import deconvolution_nd
 from chainer import testing
-from chainer.testing import attr
-from chainer.testing import condition
 from chainer.testing import parameterize
 from chainer.utils import conv
 
@@ -18,7 +13,6 @@ from chainer.utils import conv
     'dims': [(3, 2), (2,)],
     'nobias': [True, False],
     'dtype': [numpy.float32],
-    'use_cudnn': ['always', 'auto', 'never'],
     'used_outsize': ['case1', 'case2', 'None'],
     'in_channels': [4, None, 'omit'],
     'groups': [1, 2],
@@ -26,106 +20,95 @@ from chainer.utils import conv
     'dims': [(4, 3, 2)],
     'nobias': [False],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'use_cudnn': ['always'],
     'used_outsize': ['None'],
     'in_channels': [4, None, 'omit'],
     'groups': [1, 2],
 }))
-class TestDeconvolutionND(unittest.TestCase):
+@testing.inject_backend_tests(
+    ['test_forward', 'test_backward'],
+    # CPU tests
+    [
+        {},
+    ]
+    # GPU tests
+    + testing.product({
+        'use_cuda': [True],
+        'use_cudnn': ['never', 'always'],
+        'cuda_device': [0, 1],
+    })
+    # ChainerX is not supported
+    # TODO(ecastill)  chainerx support for case2
+)
+class TestDeconvolutionND(testing.LinkTestCase):
 
     def setUp(self):
-        N = 2
-        out_channels = 2
-        ndim = len(self.dims)
-        ksize = (3,) * ndim
-        stride = (2,) * ndim
-        pad = (1,) * ndim
+        self.N = 2
+        self.out_channels = 2
+        self.ndim = len(self.dims)
+        self.ksize = (3,) * self.ndim
+        self.stride = (2,) * self.ndim
+        self.pad = (1,) * self.ndim
+        if self.nobias:
+            self.param_names = ('W',)
+        else:
+            self.param_names = ('W', 'b')
 
         if self.used_outsize == 'case1' or self.used_outsize == 'None':
             # Use output size determined with get_deconv_outsize.
             outs = tuple(
                 conv.get_deconv_outsize(d, k, s, p)
-                for (d, k, s, p) in zip(self.dims, ksize, stride, pad))
+                for (d, k, s, p) in zip(self.dims, self.ksize,
+                                        self.stride, self.pad))
         elif self.used_outsize == 'case2':
             # Use possible output size other than the one determined with
             # get_deconv_outsize.
             outs = tuple(
                 conv.get_deconv_outsize(d, k, s, p) + 1
-                for (d, k, s, p) in zip(self.dims, ksize, stride, pad))
-
+                for (d, k, s, p) in zip(self.dims, self.ksize,
+                                        self.stride, self.pad))
         if self.used_outsize != 'None':
-            outsize = outs
+            self.outsize = outs
         else:
-            outsize = None
+            self.outsize = None
 
-        if not self.nobias:
-            initial_bias = initializers.Uniform(scale=1, dtype=self.dtype)
-        else:
-            initial_bias = None
+        self.x_shape = (self.N, 4) + self.dims
+
+        self.check_backward_options.update({
+            'eps': 1e-2, 'atol': 1e-4, 'rtol': 1e-3})
+        if self.dtype == numpy.float16:
+            self.check_forward_options.update({'atol': 5e-3, 'rtol': 5e-2})
+            self.check_backward_options.update({
+                'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1})
+
+    def generate_params(self):
+        initial_bias = initializers.Uniform(scale=1., dtype=self.dtype)
+        return initial_bias,
+
+    def create_link(self, initializers):
+        initial_bias, = initializers
 
         if self.in_channels == 'omit':
-            self.link = deconvolution_nd.DeconvolutionND(
-                ndim, out_channels, ksize, stride=stride, pad=pad,
-                outsize=outsize, initial_bias=initial_bias, nobias=self.nobias,
-                groups=self.groups)
-        else:
-            self.link = deconvolution_nd.DeconvolutionND(
-                ndim, self.in_channels, out_channels, ksize, stride=stride,
-                pad=pad, outsize=outsize, initial_bias=initial_bias,
+            link = deconvolution_nd.DeconvolutionND(
+                self.ndim, self.out_channels, self.ksize, stride=self.stride,
+                pad=self.pad, outsize=self.outsize, initial_bias=initial_bias,
                 nobias=self.nobias, groups=self.groups)
-        self.link.cleargrads()
+        else:
+            link = deconvolution_nd.DeconvolutionND(
+                self.ndim, self.in_channels, self.out_channels, self.ksize,
+                stride=self.stride, pad=self.pad, outsize=self.outsize,
+                initial_bias=initial_bias, nobias=self.nobias,
+                groups=self.groups)
 
-        x_shape = (N, 4) + self.dims
-        self.x = numpy.random.uniform(-1, 1, x_shape).astype(self.dtype)
-        gy_shape = (N, out_channels) + outs
-        self.gy = numpy.random.uniform(-1, 1, gy_shape).astype(self.dtype)
+        return link
 
-        self.check_forward_options = {}
-        self.check_backward_options = {
-            'eps': 1e-2, 'atol': 1e-4, 'rtol': 1e-3}
-        if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 5e-3, 'rtol': 5e-2}
-            self.check_backward_options = {
-                'eps': 2 ** -3, 'atol': 1e-2, 'rtol': 1e-1}
+    def generate_inputs(self):
+        x = numpy.random.uniform(-1, 1, self.x_shape).astype(self.dtype)
+        return x,
 
-    def check_forward_consistency(self, link, x_data):
-        x_cpu = chainer.Variable(x_data)
-        y_cpu = link(x_cpu)
-        self.assertEqual(y_cpu.data.dtype, x_data.dtype)
-
-        link.to_gpu()
-        x_gpu = chainer.Variable(cuda.to_gpu(x_data))
-        y_gpu = link(x_gpu)
-        self.assertEqual(y_gpu.data.dtype, x_data.dtype)
-
-        testing.assert_allclose(
-            y_cpu.data, y_gpu.data, **self.check_forward_options)
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_forward_consistency(self):
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            self.check_forward_consistency(self.link, self.x)
-
-    def check_backward(self, link, x_data, y_grad):
-        params = [link.W]
-        if not self.nobias:
-            params.append(link.b)
-
-        gradient_check.check_backward(
-            link, x_data, y_grad, params, **self.check_backward_options)
-
-    @condition.retry(3)
-    def test_backward_cpu(self):
-        self.check_backward(self.link, self.x, self.gy)
-
-    @attr.gpu
-    @condition.retry(3)
-    def test_backward_gpu(self):
-        self.link.to_gpu()
-        with chainer.using_config('use_cudnn', self.use_cudnn):
-            self.check_backward(
-                self.link, cuda.to_gpu(self.x), cuda.to_gpu(self.gy))
+    def forward_expected(self, link, inputs):
+        x, = inputs
+        y = link(x).array
+        return y,
 
 
 class TestDeconvolutionNDNoInitialBias(unittest.TestCase):

--- a/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_deconvolution_nd.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy
 
+import chainer.functions as F
 from chainer import initializers
 from chainer.links.connection import deconvolution_nd
 from chainer import testing
@@ -107,8 +108,13 @@ class TestDeconvolutionND(testing.LinkTestCase):
 
     def forward_expected(self, link, inputs):
         x, = inputs
-        y = link(x).array
-        return y,
+        W = link.W
+        b = link.b
+        y = F.deconvolution_nd(
+            x, W, b, outsize=self.outsize,
+            stride=self.stride, pad=self.pad,
+            groups=self.groups)
+        return y.array,
 
 
 class TestDeconvolutionNDNoInitialBias(unittest.TestCase):


### PR DESCRIPTION
Refactor links_tests convolution nd and 2d to use the backend injection and testing.LinksTestCase
format.

Merge before #7864 