### PR TITLE
Replace n_layer with n_layers for consistency

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -531,6 +531,9 @@ class BuildingBlock(link.Chain):
     """A building block that consists of several Bottleneck layers.
 
     Args:
+        n_layer (int): *(deprecated since v7.0.0)*
+            `n_layer` is now deprecated for consistency of naming choice.
+            Please use `n_layers` instead.
         n_layers (int): Number of layers used in the building block.
         in_channels (int): Number of channels of input arrays.
         mid_channels (int): Number of channels of intermediate arrays.
@@ -544,10 +547,6 @@ class BuildingBlock(link.Chain):
             If this argument is specified as ``True``, it performs downsampling
             by placing stride 2 on the 3x3 convolutional layers
             (Facebook ResNet).
-
-    .. note::
-       `n_layers` is replaced with `n_layer`.
-       `n_layer` is now deprecated for consistency of naming choice.
 
     """
 

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -545,8 +545,9 @@ class BuildingBlock(link.Chain):
             (Facebook ResNet).
     """
 
-    def __init__(self, n_layers, in_channels, mid_channels,
-                 out_channels, stride, initialW=None, downsample_fb=False):
+    def __init__(self, n_layers=None, in_channels=None, mid_channels=None,
+                 out_channels=None, stride=None, initialW=None,
+                 downsample_fb=None, n_layer=None):
         super(BuildingBlock, self).__init__()
         with self.init_scope():
             self.a = BottleneckA(

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -530,7 +530,7 @@ class BuildingBlock(link.Chain):
     """A building block that consists of several Bottleneck layers.
 
     Args:
-        n_layer (int): Number of layers used in the building block.
+        n_layers (int): Number of layers used in the building block.
         in_channels (int): Number of channels of input arrays.
         mid_channels (int): Number of channels of intermediate arrays.
         out_channels (int): Number of channels of output arrays.
@@ -545,7 +545,7 @@ class BuildingBlock(link.Chain):
             (Facebook ResNet).
     """
 
-    def __init__(self, n_layer, in_channels, mid_channels,
+    def __init__(self, n_layers, in_channels, mid_channels,
                  out_channels, stride, initialW=None, downsample_fb=False):
         super(BuildingBlock, self).__init__()
         with self.init_scope():
@@ -553,7 +553,7 @@ class BuildingBlock(link.Chain):
                 in_channels, mid_channels, out_channels, stride,
                 initialW, downsample_fb)
             self._forward = ['a']
-            for i in range(n_layer - 1):
+            for i in range(n_layers - 1):
                 name = 'b{}'.format(i + 1)
                 bottleneck = BottleneckB(out_channels, mid_channels, initialW)
                 setattr(self, name, bottleneck)

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import sys
+import warnings
 
 import numpy
 try:
@@ -549,6 +550,12 @@ class BuildingBlock(link.Chain):
                  out_channels=None, stride=None, initialW=None,
                  downsample_fb=None, n_layer=None):
         super(BuildingBlock, self).__init__()
+
+        if n_layer is not None:
+            warnings.warn('Argument `n_layer` is deprecated. '
+                          'Please use `n_layers` instead')
+            n_layers = n_layer
+
         with self.init_scope():
             self.a = BottleneckA(
                 in_channels, mid_channels, out_channels, stride,

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -544,6 +544,11 @@ class BuildingBlock(link.Chain):
             If this argument is specified as ``True``, it performs downsampling
             by placing stride 2 on the 3x3 convolutional layers
             (Facebook ResNet).
+
+    .. note::
+       `n_layers` is replaced with `n_layer`.
+       `n_layer` is now deprecated for consistency of naming choice.
+
     """
 
     def __init__(self, n_layers=None, in_channels=None, mid_channels=None,

--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -548,13 +548,14 @@ class BuildingBlock(link.Chain):
 
     def __init__(self, n_layers=None, in_channels=None, mid_channels=None,
                  out_channels=None, stride=None, initialW=None,
-                 downsample_fb=None, n_layer=None):
+                 downsample_fb=None, **kwargs):
         super(BuildingBlock, self).__init__()
 
-        if n_layer is not None:
-            warnings.warn('Argument `n_layer` is deprecated. '
-                          'Please use `n_layers` instead')
-            n_layers = n_layer
+        if 'n_layer' in kwargs:
+            warnings.warn(
+                'Argument `n_layer` is deprecated. '
+                'Please use `n_layers` instead')
+            n_layers = kwargs['n_layer']
 
         with self.init_scope():
             self.a = BottleneckA(

--- a/tests/chainer_tests/links_tests/rnn_tests/test_link_n_step_gru.py
+++ b/tests/chainer_tests/links_tests/rnn_tests/test_link_n_step_gru.py
@@ -20,13 +20,13 @@ def sigmoid(x):
 class TestNStepGRU(unittest.TestCase):
 
     lengths = [3, 1, 2]
-    n_layer = 2
+    n_layers = 2
     in_size = 3
     out_size = 2
     dropout = 0.0
 
     def setUp(self):
-        shape = (self.n_layer, len(self.lengths), self.out_size)
+        shape = (self.n_layers, len(self.lengths), self.out_size)
         if self.hidden_none:
             self.h = numpy.zeros(shape, 'f')
         else:
@@ -40,7 +40,7 @@ class TestNStepGRU(unittest.TestCase):
             numpy.random.uniform(-1, 1, (l, self.out_size)).astype('f')
             for l in self.lengths]
         self.rnn = links.NStepGRU(
-            self.n_layer, self.in_size, self.out_size, self.dropout)
+            self.n_layers, self.in_size, self.out_size, self.dropout)
 
         for layer in self.rnn:
             for p in layer.params():
@@ -64,7 +64,7 @@ class TestNStepGRU(unittest.TestCase):
         self.rnn.to_cpu()
 
         for batch, seq in enumerate(self.xs):
-            for layer in range(self.n_layer):
+            for layer in range(self.n_layers):
                 p = self.rnn[layer]
                 h_prev = self.h[layer, batch]
                 hs = []
@@ -199,13 +199,13 @@ class TestNStepGRU(unittest.TestCase):
 class TestNStepBiGRU(unittest.TestCase):
 
     lengths = [3, 1, 2]
-    n_layer = 2
+    n_layers = 2
     in_size = 3
     out_size = 2
     dropout = 0.0
 
     def setUp(self):
-        shape = (self.n_layer * 2, len(self.lengths), self.out_size)
+        shape = (self.n_layers * 2, len(self.lengths), self.out_size)
         if self.hidden_none:
             self.h = numpy.zeros(shape, 'f')
         else:
@@ -219,7 +219,7 @@ class TestNStepBiGRU(unittest.TestCase):
             numpy.random.uniform(-1, 1, (l, self.out_size * 2)).astype('f')
             for l in self.lengths]
         self.rnn = links.NStepBiGRU(
-            self.n_layer, self.in_size, self.out_size, self.dropout)
+            self.n_layers, self.in_size, self.out_size, self.dropout)
 
         for layer in self.rnn:
             for p in layer.params():
@@ -243,7 +243,7 @@ class TestNStepBiGRU(unittest.TestCase):
         self.rnn.to_cpu()
 
         for batch, seq in enumerate(self.xs):
-            for layer in range(self.n_layer):
+            for layer in range(self.n_layers):
                 # forward
                 di = 0
                 layer_idx = layer * 2 + di

--- a/tests/chainer_tests/links_tests/rnn_tests/test_link_n_step_lstm.py
+++ b/tests/chainer_tests/links_tests/rnn_tests/test_link_n_step_lstm.py
@@ -20,13 +20,13 @@ def sigmoid(x):
 class TestNStepLSTM(unittest.TestCase):
 
     lengths = [3, 1, 2]
-    n_layer = 2
+    n_layers = 2
     in_size = 3
     out_size = 2
     dropout = 0.0
 
     def setUp(self):
-        shape = (self.n_layer, len(self.lengths), self.out_size)
+        shape = (self.n_layers, len(self.lengths), self.out_size)
         if self.hidden_none:
             self.h = self.c = numpy.zeros(shape, 'f')
         else:
@@ -42,7 +42,7 @@ class TestNStepLSTM(unittest.TestCase):
             numpy.random.uniform(-1, 1, (l, self.out_size)).astype('f')
             for l in self.lengths]
         self.rnn = links.NStepLSTM(
-            self.n_layer, self.in_size, self.out_size, self.dropout)
+            self.n_layers, self.in_size, self.out_size, self.dropout)
 
         for layer in self.rnn:
             for p in layer.params():
@@ -68,7 +68,7 @@ class TestNStepLSTM(unittest.TestCase):
         self.rnn.to_cpu()
 
         for batch, seq in enumerate(self.xs):
-            for layer in range(self.n_layer):
+            for layer in range(self.n_layers):
                 p = self.rnn[layer]
                 h_prev = self.h[layer, batch]
                 c_prev = self.c[layer, batch]
@@ -227,13 +227,13 @@ class TestNStepLSTM(unittest.TestCase):
 class TestNStepBiLSTM(unittest.TestCase):
 
     lengths = [3, 1, 2]
-    n_layer = 2
+    n_layers = 2
     in_size = 3
     out_size = 2
     dropout = 0.0
 
     def setUp(self):
-        shape = (self.n_layer * 2, len(self.lengths), self.out_size)
+        shape = (self.n_layers * 2, len(self.lengths), self.out_size)
         if self.hidden_none:
             self.h = self.c = numpy.zeros(shape, 'f')
         else:
@@ -249,7 +249,7 @@ class TestNStepBiLSTM(unittest.TestCase):
             numpy.random.uniform(-1, 1, (l, self.out_size * 2)).astype('f')
             for l in self.lengths]
         self.rnn = links.NStepBiLSTM(
-            self.n_layer, self.in_size, self.out_size, self.dropout)
+            self.n_layers, self.in_size, self.out_size, self.dropout)
 
         for layer in self.rnn:
             for p in layer.params():
@@ -275,7 +275,7 @@ class TestNStepBiLSTM(unittest.TestCase):
         self.rnn.to_cpu()
 
         for batch, seq in enumerate(self.xs):
-            for layer in range(self.n_layer):
+            for layer in range(self.n_layers):
                 # forward
                 di = 0
                 layer_idx = layer * 2 + di

--- a/tests/chainer_tests/links_tests/rnn_tests/test_link_n_step_rnn.py
+++ b/tests/chainer_tests/links_tests/rnn_tests/test_link_n_step_rnn.py
@@ -22,13 +22,13 @@ def relu(x):
 class TestNStepRNN(unittest.TestCase):
 
     lengths = [3, 1, 2]
-    n_layer = 2
+    n_layers = 2
     in_size = 3
     out_size = 2
     dropout = 0.0
 
     def setUp(self):
-        shape = (self.n_layer, len(self.lengths), self.out_size)
+        shape = (self.n_layers, len(self.lengths), self.out_size)
         if self.hidden_none:
             self.h = numpy.zeros(shape, 'f')
         else:
@@ -46,7 +46,7 @@ class TestNStepRNN(unittest.TestCase):
         elif self.activation == 'relu':
             rnn_link_class = links.NStepRNNReLU
         self.rnn = rnn_link_class(
-            self.n_layer, self.in_size, self.out_size, self.dropout)
+            self.n_layers, self.in_size, self.out_size, self.dropout)
 
         for layer in self.rnn:
             for p in layer.params():
@@ -70,7 +70,7 @@ class TestNStepRNN(unittest.TestCase):
         self.rnn.to_cpu()
 
         for batch, seq in enumerate(self.xs):
-            for layer in range(self.n_layer):
+            for layer in range(self.n_layers):
                 p = self.rnn[layer]
                 h_prev = self.h[layer, batch]
                 hs = []
@@ -205,13 +205,13 @@ class TestNStepRNN(unittest.TestCase):
 class TestNStepBiRNN(unittest.TestCase):
 
     lengths = [3, 1, 2]
-    n_layer = 2
+    n_layers = 2
     in_size = 3
     out_size = 2
     dropout = 0.0
 
     def setUp(self):
-        shape = (self.n_layer * 2, len(self.lengths), self.out_size)
+        shape = (self.n_layers * 2, len(self.lengths), self.out_size)
         if self.hidden_none:
             self.h = numpy.zeros(shape, 'f')
         else:
@@ -229,7 +229,7 @@ class TestNStepBiRNN(unittest.TestCase):
         elif self.activation == 'relu':
             rnn_link_class = links.NStepBiRNNReLU
         self.rnn = rnn_link_class(
-            self.n_layer, self.in_size, self.out_size, self.dropout)
+            self.n_layers, self.in_size, self.out_size, self.dropout)
 
         for layer in self.rnn:
             for p in layer.params():
@@ -253,7 +253,7 @@ class TestNStepBiRNN(unittest.TestCase):
         self.rnn.to_cpu()
 
         for batch, seq in enumerate(self.xs):
-            for layer in range(self.n_layer):
+            for layer in range(self.n_layers):
                 # forward
                 di = 0
                 layer_idx = layer * 2 + di

--- a/tests/chainermn_tests/links_tests/test_n_step_rnn.py
+++ b/tests/chainermn_tests/links_tests/test_n_step_rnn.py
@@ -12,14 +12,14 @@ import pytest
 
 class Model(chainer.Chain):
     def __init__(self, n_vocab, n_hid, communicator, rank_next, rank_prev):
-        n_layer = 1
+        n_layers = 1
         n_rnn_hid = 10
         super(Model, self).__init__()
         with self.init_scope():
             self.l1 = L.EmbedID(n_vocab, n_rnn_hid, ignore_label=-1)
             self.rnn = chainermn.links.create_multi_node_n_step_rnn(
                 L.NStepLSTM(
-                    n_layers=n_layer, in_size=n_rnn_hid, out_size=n_rnn_hid,
+                    n_layers=n_layers, in_size=n_rnn_hid, out_size=n_rnn_hid,
                     dropout=0.1),
                 communicator, rank_in=rank_prev, rank_out=rank_next,
             )


### PR DESCRIPTION
This PR replace variables/keywords `n_layer` with `n_layers`.

Although most changes do not break compatibility,
there is the breaking change in `BuildingBlock`.

https://github.com/chainer/chainer/compare/master...himkt:fix-var-name-n-layer?expand=1#diff-b27899a8e6e2ef04c4b64bb26c60669aR548