### PR TITLE
Fix MPI installation for macOS

### DIFF
--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -68,7 +68,7 @@ step_before_install_chainermn_test_deps() {
             sudo apt-get install -y "${pkgs[@]}"
             ;;
         osx)
-            brew install open-mpi
+            brew install open-mpi hwloc
             ;;
         *)
             false


### PR DESCRIPTION
TravisCI is failing after the homebrew formula updates to `open-mpi-4.0.1_2`.