### PR TITLE
Relax float16 tolerances in ChainerX binary math tests

### DIFF
--- a/tests/chainerx_tests/math_utils.py
+++ b/tests/chainerx_tests/math_utils.py
@@ -77,9 +77,9 @@ class BinaryMathTestBase(object):
 
         if in_dtype1 == 'float16' or in_dtype2 == 'float16':
             self.check_forward_options.update({'rtol': 1e-3, 'atol': 1e-3})
-            self.check_backward_options.update({'rtol': 1e-3, 'atol': 1e-3})
+            self.check_backward_options.update({'rtol': 1e-2, 'atol': 3e-3})
             self.check_double_backward_options.update(
-                {'rtol': 1e-3, 'atol': 1e-3})
+                {'rtol': 1e-2, 'atol': 3e-3})
 
     def generate_inputs(self):
         in_dtype1, in_dtype2 = self.in_dtypes


### PR DESCRIPTION
Fixes #7845

```
pytest --count 1000  -s -v -rfEX --tb=short tests/chainerx_tests/unit_tests/routines_tests/test_arithmetic.py -k '_Sub_ and float16 and cuda'
```

Before: `7 failed, 59993 passed, 26690000 deselected in 4267.15 seconds`
After fix: `60000 passed, 26690000 deselected in 4166.01 seconds`
