### PR TITLE
Revert "Fix MPI installation for macOS"

### DIFF
--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -68,7 +68,7 @@ step_before_install_chainermn_test_deps() {
             sudo apt-get install -y "${pkgs[@]}"
             ;;
         osx)
-            brew install open-mpi hwloc
+            brew install open-mpi
             ;;
         *)
             false


### PR DESCRIPTION
Reverts chainer/chainer#7872

Homebrew/homebrew-core@52ae4857839ec471372014e03beec872477dc0f7 fixed the issue.