### PR TITLE
Fix LSTM for omitted upstream gradients

### DIFF
--- a/chainer/functions/rnn/lstm.py
+++ b/chainer/functions/rnn/lstm.py
@@ -190,18 +190,20 @@ class LSTMGrad(function.Function):
         ggc_prev, ggx = grads
         batch = len(x)
 
-        if gc is None:
-            gc = xp.zeros_like(c)
-        if gh is None:
-            gh = xp.zeros_like(c[:batch])
+        gc_is_none = gc is None
+        gh_is_none = gh is None
+        if gc_is_none:
+            gc = 0
+        if gh_is_none:
+            gh = 0
         if ggc_prev is None:
-            ggc_prev = xp.zeros_like(c_prev)
+            ggc_prev = 0
 
         gc_prev = xp.empty_like(c_prev)
         gx = xp.empty_like(x)
         gc_next = xp.empty_like(c)
-        ggc = xp.empty_like(ggc_prev)
-        ggh = xp.empty_like(gh)
+        ggc = xp.empty_like(c_prev)
+        ggh = xp.empty_like(c[:batch])
 
         gc_prev[batch:] = 0
         gc_next[batch:] = 0
@@ -210,7 +212,8 @@ class LSTMGrad(function.Function):
 
         c_prev = c_prev[:batch]
         c = c[:batch]
-        gc = gc[:batch]
+        if not gc_is_none:
+            gc = gc[:batch]
         ggc_prev = ggc_prev[:batch]
         ggx = ggx[:batch]
 
@@ -222,6 +225,12 @@ class LSTMGrad(function.Function):
             c_prev, a, i, f, o, c, gc, gh, ggc_prev, gga, ggi, ggf, ggo,
             gc_prev[:batch], ga[:], gi[:], gf[:], go[:], gc_next[:batch],
             ggc[:batch], ggh[:batch])
+
+        if gc_is_none:
+            ggc = None
+        if gh_is_none:
+            ggh = None
+
         return gc_prev, gx, gc_next, ggc, ggh
 
 

--- a/tests/chainer_tests/functions_tests/rnn_tests/test_function_lstm.py
+++ b/tests/chainer_tests/functions_tests/rnn_tests/test_function_lstm.py
@@ -87,8 +87,6 @@ class TestLSTM(testing.FunctionTestCase):
             self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-2}
             self.check_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
             self.check_double_backward_options = {'atol': 5e-3, 'rtol': 5e-2}
-        if self.grad_outputs[0] is False or self.grad_outputs[1] is False:
-            self.skip_double_backward_test = True
 
     def generate_inputs(self):
         c = _shaped_random(self.c_shape, self.dtype)


### PR DESCRIPTION
Same fix as https://github.com/chainer/chainer/pull/7891 but for LSTM, instead of SLSTM.

The double backward implementation can be further optimized by the way, but that should be done in a different PR and my understanding is that this omitted gradient is a rather rare case in practice.