### PR TITLE
Implement hooks for memory pool in ChainerX

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device_test.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device_test.cc
@@ -179,7 +179,7 @@ TEST(CudaDeviceTest, MemoryPoolHook) {
     CudaDevice& device = GetCudaDevice(ctx, 0);
     const std::shared_ptr<MemoryPool> memory_pool = device.device_memory_pool();
     bool called = false;
-    auto hook = [&called](size_t, MemoryPool&) { called = true; };
+    auto hook = [&called](MemoryPool&, size_t) { called = true; };
     memory_pool->SetMallocPreprocessHook(hook);
 
     EXPECT_FALSE(called);

--- a/chainerx_cc/chainerx/cuda/cuda_device_test.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device_test.cc
@@ -179,9 +179,7 @@ TEST(CudaDeviceTest, MemoryPoolHook) {
     CudaDevice& device = GetCudaDevice(ctx, 0);
     const std::shared_ptr<MemoryPool> memory_pool = device.device_memory_pool();
     bool called = false;
-    auto hook = [&called](size_t) {
-        called = true;
-    };
+    auto hook = [&called](size_t) { called = true; };
     memory_pool->SetMallocPreprocessHook(hook);
 
     EXPECT_FALSE(called);

--- a/chainerx_cc/chainerx/cuda/cuda_device_test.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device_test.cc
@@ -179,7 +179,7 @@ TEST(CudaDeviceTest, MemoryPoolHook) {
     CudaDevice& device = GetCudaDevice(ctx, 0);
     const std::shared_ptr<MemoryPool> memory_pool = device.device_memory_pool();
     bool called = false;
-    auto hook = [&called](size_t, const MemoryPool&) { called = true; };
+    auto hook = [&called](size_t, MemoryPool&) { called = true; };
     memory_pool->SetMallocPreprocessHook(hook);
 
     EXPECT_FALSE(called);

--- a/chainerx_cc/chainerx/cuda/cuda_device_test.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device_test.cc
@@ -179,7 +179,7 @@ TEST(CudaDeviceTest, MemoryPoolHook) {
     CudaDevice& device = GetCudaDevice(ctx, 0);
     const std::shared_ptr<MemoryPool> memory_pool = device.device_memory_pool();
     bool called = false;
-    auto hook = [&called](size_t) { called = true; };
+    auto hook = [&called](size_t, const MemoryPool&) { called = true; };
     memory_pool->SetMallocPreprocessHook(hook);
 
     EXPECT_FALSE(called);

--- a/chainerx_cc/chainerx/cuda/cuda_device_test.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device_test.cc
@@ -174,6 +174,21 @@ TEST(CudaDeviceTest, Synchronize) {
     device.Synchronize();  // no throw
 }
 
+TEST(CudaDeviceTest, MemoryPoolHook) {
+    Context ctx{};
+    CudaDevice& device = GetCudaDevice(ctx, 0);
+    const std::shared_ptr<MemoryPool> memory_pool = device.device_memory_pool();
+    bool called = false;
+    auto hook = [&called](size_t) {
+        called = true;
+    };
+    memory_pool->SetMallocPreprocessHook(hook);
+
+    EXPECT_FALSE(called);
+    device.Allocate(1);
+    EXPECT_TRUE(called);
+}
+
 }  // namespace
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -260,8 +260,8 @@ void* MemoryPool::Malloc(size_t bytesize) {
 }
 
 void MemoryPool::Free(void* ptr) {
-    if (free_preprocess_hook_) {
-        free_preprocess_hook_(*this, ptr);
+    if (free_hook_) {
+        free_hook_(*this, ptr);
     }
 
     if (ptr == nullptr) {
@@ -318,7 +318,7 @@ void MemoryPool::SetMallocPostprocessHook(std::function<void(MemoryPool&, size_t
     malloc_postprocess_hook_ = std::move(hook);
 }
 
-void MemoryPool::SetFreeHook(std::function<void(MemoryPool&, void*)> hook) { free_preprocess_hook_ = std::move(hook); }
+void MemoryPool::SetFreeHook(std::function<void(MemoryPool&, void*)> hook) { free_hook_ = std::move(hook); }
 
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -317,21 +317,13 @@ void MemoryPool::FreeNoExcept(void* ptr) noexcept {
     }
 }
 
-void MemoryPool::SetMallocPreprocessHook(std::function<void(size_t)> hook) {
-    malloc_preprocess_hook_ = hook;
-}
+void MemoryPool::SetMallocPreprocessHook(std::function<void(size_t)> hook) { malloc_preprocess_hook_ = hook; }
 
-void MemoryPool::SetMallocPostprocessHook(std::function<void(size_t, void*)> hook) {
-    malloc_postprocess_hook_ = hook;
-}
+void MemoryPool::SetMallocPostprocessHook(std::function<void(size_t, void*)> hook) { malloc_postprocess_hook_ = hook; }
 
-void MemoryPool::SetFreePreprocessHook(const std::function<void(void*)> hook) {
-    free_preprocess_hook_ = hook;
-}
+void MemoryPool::SetFreePreprocessHook(const std::function<void(void*)> hook) { free_preprocess_hook_ = hook; }
 
-void MemoryPool::SetFreePostprocessHook(const std::function<void(void*)> hook) {
-    free_postprocess_hook_ = hook;
-}
+void MemoryPool::SetFreePostprocessHook(const std::function<void(void*)> hook) { free_postprocess_hook_ = hook; }
 
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -314,7 +314,9 @@ void MemoryPool::FreeNoExcept(void* ptr) noexcept {
 
 void MemoryPool::SetMallocPreprocessHook(std::function<void(MemoryPool&, size_t)> hook) { malloc_preprocess_hook_ = std::move(hook); }
 
-void MemoryPool::SetMallocPostprocessHook(std::function<void(MemoryPool&, size_t, void*)> hook) { malloc_postprocess_hook_ = std::move(hook); }
+void MemoryPool::SetMallocPostprocessHook(std::function<void(MemoryPool&, size_t, void*)> hook) {
+    malloc_postprocess_hook_ = std::move(hook);
+}
 
 void MemoryPool::SetFreePreprocessHook(std::function<void(MemoryPool&, void*)> hook) { free_preprocess_hook_ = std::move(hook); }
 

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -317,13 +317,13 @@ void MemoryPool::FreeNoExcept(void* ptr) noexcept {
     }
 }
 
-void MemoryPool::SetMallocPreprocessHook(std::function<void(size_t, const MemoryPool&)> hook) { malloc_preprocess_hook_ = hook; }
+void MemoryPool::SetMallocPreprocessHook(std::function<void(size_t, MemoryPool&)> hook) { malloc_preprocess_hook_ = hook; }
 
-void MemoryPool::SetMallocPostprocessHook(std::function<void(size_t, void*, const MemoryPool&)> hook) { malloc_postprocess_hook_ = hook; }
+void MemoryPool::SetMallocPostprocessHook(std::function<void(size_t, void*, MemoryPool&)> hook) { malloc_postprocess_hook_ = hook; }
 
-void MemoryPool::SetFreePreprocessHook(const std::function<void(void*, const MemoryPool&)> hook) { free_preprocess_hook_ = hook; }
+void MemoryPool::SetFreePreprocessHook(const std::function<void(void*, MemoryPool&)> hook) { free_preprocess_hook_ = hook; }
 
-void MemoryPool::SetFreePostprocessHook(const std::function<void(void*, const MemoryPool&)> hook) { free_postprocess_hook_ = hook; }
+void MemoryPool::SetFreePostprocessHook(const std::function<void(void*, MemoryPool&)> hook) { free_postprocess_hook_ = hook; }
 
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -318,7 +318,7 @@ void MemoryPool::SetMallocPostprocessHook(std::function<void(MemoryPool&, size_t
     malloc_postprocess_hook_ = std::move(hook);
 }
 
-void MemoryPool::SetFreePreprocessHook(std::function<void(MemoryPool&, void*)> hook) { free_preprocess_hook_ = std::move(hook); }
+void MemoryPool::SetFreeHook(std::function<void(MemoryPool&, void*)> hook) { free_preprocess_hook_ = std::move(hook); }
 
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/memory_pool.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool.cc
@@ -204,7 +204,7 @@ void MemoryPool::FreeUnusedBlocks() {
 
 void* MemoryPool::Malloc(size_t bytesize) {
     if (malloc_preprocess_hook_) {
-        malloc_preprocess_hook_(bytesize);
+        malloc_preprocess_hook_(bytesize, *this);
     }
 
     if (bytesize == 0) {
@@ -253,7 +253,7 @@ void* MemoryPool::Malloc(size_t bytesize) {
     }
 
     if (malloc_postprocess_hook_) {
-        malloc_postprocess_hook_(bytesize, chunk_ptr);
+        malloc_postprocess_hook_(bytesize, chunk_ptr, *this);
     }
 
     return chunk_ptr;
@@ -261,7 +261,7 @@ void* MemoryPool::Malloc(size_t bytesize) {
 
 void MemoryPool::Free(void* ptr) {
     if (free_preprocess_hook_) {
-        free_preprocess_hook_(ptr);
+        free_preprocess_hook_(ptr, *this);
     }
 
     if (ptr == nullptr) {
@@ -305,7 +305,7 @@ void MemoryPool::Free(void* ptr) {
 
     if (free_postprocess_hook_) {
         // TODO(mkusumoto): Is this a valid call?
-        free_postprocess_hook_(ptr);
+        free_postprocess_hook_(ptr, *this);
     }
 }
 
@@ -317,13 +317,13 @@ void MemoryPool::FreeNoExcept(void* ptr) noexcept {
     }
 }
 
-void MemoryPool::SetMallocPreprocessHook(std::function<void(size_t)> hook) { malloc_preprocess_hook_ = hook; }
+void MemoryPool::SetMallocPreprocessHook(std::function<void(size_t, const MemoryPool&)> hook) { malloc_preprocess_hook_ = hook; }
 
-void MemoryPool::SetMallocPostprocessHook(std::function<void(size_t, void*)> hook) { malloc_postprocess_hook_ = hook; }
+void MemoryPool::SetMallocPostprocessHook(std::function<void(size_t, void*, const MemoryPool&)> hook) { malloc_postprocess_hook_ = hook; }
 
-void MemoryPool::SetFreePreprocessHook(const std::function<void(void*)> hook) { free_preprocess_hook_ = hook; }
+void MemoryPool::SetFreePreprocessHook(const std::function<void(void*, const MemoryPool&)> hook) { free_preprocess_hook_ = hook; }
 
-void MemoryPool::SetFreePostprocessHook(const std::function<void(void*)> hook) { free_postprocess_hook_ = hook; }
+void MemoryPool::SetFreePostprocessHook(const std::function<void(void*, const MemoryPool&)> hook) { free_postprocess_hook_ = hook; }
 
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/memory_pool.h
+++ b/chainerx_cc/chainerx/cuda/memory_pool.h
@@ -137,10 +137,10 @@ public:
 
     void FreeNoExcept(void* ptr) noexcept;
 
-    void SetMallocPreprocessHook(std::function<void(size_t)> hook);
-    void SetMallocPostprocessHook(std::function<void(size_t, void*)> hook);
-    void SetFreePreprocessHook(const std::function<void(void*)> hook);
-    void SetFreePostprocessHook(const std::function<void(void*)> hook);
+    void SetMallocPreprocessHook(std::function<void(size_t, const MemoryPool&)> hook);
+    void SetMallocPostprocessHook(std::function<void(size_t, void*, const MemoryPool&)> hook);
+    void SetFreePreprocessHook(const std::function<void(void*, const MemoryPool&)> hook);
+    void SetFreePostprocessHook(const std::function<void(void*, const MemoryPool&)> hook);
 
 private:
     friend class cuda_internal::MemoryPoolTest;  // for unit-tests
@@ -162,10 +162,10 @@ private:
     std::mutex in_use_mutex_;
     std::mutex free_bins_mutex_;
 
-    std::function<void(size_t)> malloc_preprocess_hook_;
-    std::function<void(size_t, void*)> malloc_postprocess_hook_;
-    std::function<void(void*)> free_preprocess_hook_;
-    std::function<void(void*)> free_postprocess_hook_;
+    std::function<void(size_t, const MemoryPool&)> malloc_preprocess_hook_;
+    std::function<void(size_t, void*, const MemoryPool&)> malloc_postprocess_hook_;
+    std::function<void(void*, const MemoryPool&)> free_preprocess_hook_;
+    std::function<void(void*, const MemoryPool&)> free_postprocess_hook_;
 };
 
 }  // namespace cuda

--- a/chainerx_cc/chainerx/cuda/memory_pool.h
+++ b/chainerx_cc/chainerx/cuda/memory_pool.h
@@ -137,10 +137,9 @@ public:
 
     void FreeNoExcept(void* ptr) noexcept;
 
-    void SetMallocPreprocessHook(std::function<void(size_t, MemoryPool&)> hook);
-    void SetMallocPostprocessHook(std::function<void(size_t, void*, MemoryPool&)> hook);
-    void SetFreePreprocessHook(const std::function<void(void*, MemoryPool&)> hook);
-    void SetFreePostprocessHook(const std::function<void(void*, MemoryPool&)> hook);
+    void SetMallocPreprocessHook(std::function<void(MemoryPool&, size_t)> hook);
+    void SetMallocPostprocessHook(std::function<void(MemoryPool&, size_t, void*)> hook);
+    void SetFreePreprocessHook(std::function<void(MemoryPool&, void*)> hook);
 
 private:
     friend class cuda_internal::MemoryPoolTest;  // for unit-tests
@@ -162,10 +161,9 @@ private:
     std::mutex in_use_mutex_;
     std::mutex free_bins_mutex_;
 
-    std::function<void(size_t, MemoryPool&)> malloc_preprocess_hook_;
-    std::function<void(size_t, void*, MemoryPool&)> malloc_postprocess_hook_;
-    std::function<void(void*, MemoryPool&)> free_preprocess_hook_;
-    std::function<void(void*, MemoryPool&)> free_postprocess_hook_;
+    std::function<void(MemoryPool&, size_t)> malloc_preprocess_hook_;
+    std::function<void(MemoryPool&, size_t, void*)> malloc_postprocess_hook_;
+    std::function<void(MemoryPool&, void*)> free_preprocess_hook_;
 };
 
 }  // namespace cuda

--- a/chainerx_cc/chainerx/cuda/memory_pool.h
+++ b/chainerx_cc/chainerx/cuda/memory_pool.h
@@ -163,7 +163,7 @@ private:
 
     std::function<void(MemoryPool&, size_t)> malloc_preprocess_hook_;
     std::function<void(MemoryPool&, size_t, void*)> malloc_postprocess_hook_;
-    std::function<void(MemoryPool&, void*)> free_preprocess_hook_;
+    std::function<void(MemoryPool&, void*)> free_hook_;
 };
 
 }  // namespace cuda

--- a/chainerx_cc/chainerx/cuda/memory_pool.h
+++ b/chainerx_cc/chainerx/cuda/memory_pool.h
@@ -137,10 +137,10 @@ public:
 
     void FreeNoExcept(void* ptr) noexcept;
 
-    void SetMallocPreprocessHook(std::function<void(size_t, const MemoryPool&)> hook);
-    void SetMallocPostprocessHook(std::function<void(size_t, void*, const MemoryPool&)> hook);
-    void SetFreePreprocessHook(const std::function<void(void*, const MemoryPool&)> hook);
-    void SetFreePostprocessHook(const std::function<void(void*, const MemoryPool&)> hook);
+    void SetMallocPreprocessHook(std::function<void(size_t, MemoryPool&)> hook);
+    void SetMallocPostprocessHook(std::function<void(size_t, void*, MemoryPool&)> hook);
+    void SetFreePreprocessHook(const std::function<void(void*, MemoryPool&)> hook);
+    void SetFreePostprocessHook(const std::function<void(void*, MemoryPool&)> hook);
 
 private:
     friend class cuda_internal::MemoryPoolTest;  // for unit-tests
@@ -162,10 +162,10 @@ private:
     std::mutex in_use_mutex_;
     std::mutex free_bins_mutex_;
 
-    std::function<void(size_t, const MemoryPool&)> malloc_preprocess_hook_;
-    std::function<void(size_t, void*, const MemoryPool&)> malloc_postprocess_hook_;
-    std::function<void(void*, const MemoryPool&)> free_preprocess_hook_;
-    std::function<void(void*, const MemoryPool&)> free_postprocess_hook_;
+    std::function<void(size_t, MemoryPool&)> malloc_preprocess_hook_;
+    std::function<void(size_t, void*, MemoryPool&)> malloc_postprocess_hook_;
+    std::function<void(void*, MemoryPool&)> free_preprocess_hook_;
+    std::function<void(void*, MemoryPool&)> free_postprocess_hook_;
 };
 
 }  // namespace cuda

--- a/chainerx_cc/chainerx/cuda/memory_pool.h
+++ b/chainerx_cc/chainerx/cuda/memory_pool.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/chainerx_cc/chainerx/cuda/memory_pool.h
+++ b/chainerx_cc/chainerx/cuda/memory_pool.h
@@ -139,7 +139,7 @@ public:
 
     void SetMallocPreprocessHook(std::function<void(MemoryPool&, size_t)> hook);
     void SetMallocPostprocessHook(std::function<void(MemoryPool&, size_t, void*)> hook);
-    void SetFreePreprocessHook(std::function<void(MemoryPool&, void*)> hook);
+    void SetFreeHook(std::function<void(MemoryPool&, void*)> hook);
 
 private:
     friend class cuda_internal::MemoryPoolTest;  // for unit-tests

--- a/chainerx_cc/chainerx/cuda/memory_pool.h
+++ b/chainerx_cc/chainerx/cuda/memory_pool.h
@@ -137,6 +137,11 @@ public:
 
     void FreeNoExcept(void* ptr) noexcept;
 
+    void SetMallocPreprocessHook(std::function<void(size_t)> hook);
+    void SetMallocPostprocessHook(std::function<void(size_t, void*)> hook);
+    void SetFreePreprocessHook(const std::function<void(void*)> hook);
+    void SetFreePostprocessHook(const std::function<void(void*)> hook);
+
 private:
     friend class cuda_internal::MemoryPoolTest;  // for unit-tests
 
@@ -156,6 +161,11 @@ private:
     cuda_internal::FreeBinsMap free_bins_;  // allocation size => cuda_internal::FreeList
     std::mutex in_use_mutex_;
     std::mutex free_bins_mutex_;
+
+    std::function<void(size_t)> malloc_preprocess_hook_;
+    std::function<void(size_t, void*)> malloc_postprocess_hook_;
+    std::function<void(void*)> free_preprocess_hook_;
+    std::function<void(void*)> free_postprocess_hook_;
 };
 
 }  // namespace cuda

--- a/chainerx_cc/chainerx/cuda/memory_pool_test.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool_test.cc
@@ -423,11 +423,11 @@ TEST(MemoryPoolTest, Hook) {
 
     size_t total_memory = 0;
     std::map<void*, size_t> memories;
-    auto malloc_postprocess_hook = [&total_memory, &memories](size_t bytesize, void* ptr, MemoryPool&) {
+    auto malloc_postprocess_hook = [&total_memory, &memories](MemoryPool&, size_t bytesize, void* ptr) {
         memories[ptr] += bytesize;
         total_memory += bytesize;
     };
-    auto free_preprocess_hook = [&total_memory, &memories](void* ptr, MemoryPool&) {
+    auto free_preprocess_hook = [&total_memory, &memories](MemoryPool&, void* ptr) {
         auto found = memories.find(ptr);
         ASSERT_TRUE(found != memories.end());
         const size_t bytesize = found->second;

--- a/chainerx_cc/chainerx/cuda/memory_pool_test.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool_test.cc
@@ -435,7 +435,7 @@ TEST(MemoryPoolTest, Hook) {
         total_memory -= bytesize;
     };
     memory_pool.SetMallocPostprocessHook(malloc_postprocess_hook);
-    memory_pool.SetFreePreprocessHook(free_preprocess_hook);
+    memory_pool.SetFreeHook(free_preprocess_hook);
 
     EXPECT_EQ(total_memory, 0);
     EXPECT_EQ(memories.size(), 0);

--- a/chainerx_cc/chainerx/cuda/memory_pool_test.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool_test.cc
@@ -418,7 +418,7 @@ TEST(MemoryPoolTest, MallocFreeThreadSafe) {
     });
 }
 
-TEST(MemoryPoolTest, HookTest) {
+TEST(MemoryPoolTest, Hook) {
     MemoryPool memory_pool{0, std::make_unique<FixedCapacityDummyAllocator>(0xffffffffU)};
 
     size_t total_memory = 0;

--- a/chainerx_cc/chainerx/cuda/memory_pool_test.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool_test.cc
@@ -423,11 +423,11 @@ TEST(MemoryPoolTest, Hook) {
 
     size_t total_memory = 0;
     std::map<void*, size_t> memories;
-    auto malloc_postprocess_hook = [&total_memory, &memories](size_t bytesize, void* ptr, const MemoryPool&) {
+    auto malloc_postprocess_hook = [&total_memory, &memories](size_t bytesize, void* ptr, MemoryPool&) {
         memories[ptr] += bytesize;
         total_memory += bytesize;
     };
-    auto free_preprocess_hook = [&total_memory, &memories](void* ptr, const MemoryPool&) {
+    auto free_preprocess_hook = [&total_memory, &memories](void* ptr, MemoryPool&) {
         auto found = memories.find(ptr);
         ASSERT_TRUE(found != memories.end());
         const size_t bytesize = found->second;

--- a/chainerx_cc/chainerx/cuda/memory_pool_test.cc
+++ b/chainerx_cc/chainerx/cuda/memory_pool_test.cc
@@ -423,16 +423,16 @@ TEST(MemoryPoolTest, Hook) {
 
     size_t total_memory = 0;
     std::map<void*, size_t> memories;
-    auto malloc_postprocess_hook = [&total_memory, &memories](size_t budget, void* ptr) {
-        memories[ptr] += budget;
-        total_memory += budget;
+    auto malloc_postprocess_hook = [&total_memory, &memories](size_t bytesize, void* ptr, const MemoryPool&) {
+        memories[ptr] += bytesize;
+        total_memory += bytesize;
     };
-    auto free_preprocess_hook = [&total_memory, &memories](void* ptr) {
+    auto free_preprocess_hook = [&total_memory, &memories](void* ptr, const MemoryPool&) {
         auto found = memories.find(ptr);
         ASSERT_TRUE(found != memories.end());
-        const size_t budget = found->second;
+        const size_t bytesize = found->second;
         memories.erase(found);
-        total_memory -= budget;
+        total_memory -= bytesize;
     };
     memory_pool.SetMallocPostprocessHook(malloc_postprocess_hook);
     memory_pool.SetFreePreprocessHook(free_preprocess_hook);


### PR DESCRIPTION
This PR implements hook functionality for MemoryPool objects.

To discuss:

* Is the interface of hooks sufficient? For example, hook functions don't have access to MemoryPool.
* FreePostprocessHook seems a little meaningless.
* ~~It might be better to add a test in CudaDeviceTest as well?~~