### PR TITLE
Remove default value of `groups` of decorrelated batch normalization

### DIFF
--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -311,8 +311,9 @@ eps=2e-5, running_mean=None, running_projection=None, decay=0.9)
 
     Args:
         x (:class:`~chainer.Variable`): Input variable.
-        groups (int): Number of groups to use for group whitening.
-        group_size (int): Size of each group to use for group whitening.
+        groups (int or None): Number of groups to use for group whitening.
+        group_size (int or None): Size of each group to use for group
+            whitening.
         eps (float): Epsilon value for numerical stability.
         running_mean (:ref:`ndarray`): Expected value of the mean. This is a
             running average of the mean over several mini-batches using
@@ -364,8 +365,9 @@ def fixed_decorrelated_batch_normalization(
             Shifting parameter of input.
         projection (:class:`~chainer.Variable` or :ref:`ndarray`):
             Projection matrix for decorrelation of input.
-        groups (int): Number of groups to use for group whitening.
-        group_size (int): Size of each group to use for group whitening.
+        groups (int or None): Number of groups to use for group whitening.
+        group_size (int or None): Size of each group to use for group
+            whitening.
 
     Returns:
         ~chainer.Variable: The output variable which has the same shape as

--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -301,7 +301,7 @@ class FixedDecorrelatedBatchNormalizationGrad(function_node.FunctionNode):
 
 
 def decorrelated_batch_normalization(x, **kwargs):
-    """decorrelated_batch_normalization(x, *, groups=16, group_size=None, \
+    """decorrelated_batch_normalization(x, *, groups=None, group_size=None, \
 eps=2e-5, running_mean=None, running_projection=None, decay=0.9)
 
     Decorrelated batch normalization function.
@@ -313,7 +313,7 @@ eps=2e-5, running_mean=None, running_projection=None, decay=0.9)
         x (:class:`~chainer.Variable`): Input variable.
         groups (int or None): Number of groups to use for group whitening.
         group_size (int or None): Size of each group to use for group
-            whitening.
+            whitening.  The default value is ``16`` unless ``groups`` is set.
         eps (float): Epsilon value for numerical stability.
         running_mean (:ref:`ndarray`): Expected value of the mean. This is a
             running average of the mean over several mini-batches using
@@ -338,7 +338,7 @@ eps=2e-5, running_mean=None, running_projection=None, decay=0.9)
     """
     groups, group_size, eps, running_mean, running_projection, decay = \
         argument.parse_kwargs(
-            kwargs, ('groups', 16), ('group_size', None), ('eps', 2e-5),
+            kwargs, ('groups', None), ('group_size', None), ('eps', 2e-5),
             ('running_mean', None), ('running_projection', None),
             ('decay', 0.9))
 
@@ -348,9 +348,9 @@ eps=2e-5, running_mean=None, running_projection=None, decay=0.9)
 
 
 def fixed_decorrelated_batch_normalization(
-        x, mean, projection, groups=16, **kwargs):
-    """fixed_decorrelated_batch_normalization(x, mean, projection, groups=16, \
-*, group_size=None):
+        x, mean, projection, groups=None, **kwargs):
+    """fixed_decorrelated_batch_normalization(x, mean, projection, \
+groups=None, *, group_size=None):
 
     Decorrelated batch normalization function with fixed statistics.
 
@@ -367,7 +367,7 @@ def fixed_decorrelated_batch_normalization(
             Projection matrix for decorrelation of input.
         groups (int or None): Number of groups to use for group whitening.
         group_size (int or None): Size of each group to use for group
-            whitening.
+            whitening.  The default value is ``16`` unless ``groups`` is set.
 
     Returns:
         ~chainer.Variable: The output variable which has the same shape as

--- a/chainer/functions/normalization/decorrelated_batch_normalization.py
+++ b/chainer/functions/normalization/decorrelated_batch_normalization.py
@@ -312,6 +312,7 @@ eps=2e-5, running_mean=None, running_projection=None, decay=0.9)
     Args:
         x (:class:`~chainer.Variable`): Input variable.
         groups (int): Number of groups to use for group whitening.
+        group_size (int): Size of each group to use for group whitening.
         eps (float): Epsilon value for numerical stability.
         running_mean (:ref:`ndarray`): Expected value of the mean. This is a
             running average of the mean over several mini-batches using
@@ -364,6 +365,7 @@ def fixed_decorrelated_batch_normalization(
         projection (:class:`~chainer.Variable` or :ref:`ndarray`):
             Projection matrix for decorrelation of input.
         groups (int): Number of groups to use for group whitening.
+        group_size (int): Size of each group to use for group whitening.
 
     Returns:
         ~chainer.Variable: The output variable which has the same shape as

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -23,7 +23,10 @@ def _check_and_compute_group_shape(size, groups, group_size):
 
 class DecorrelatedBatchNormalization(link.Link):
 
-    """Decorrelated batch normalization layer.
+    """__init__(self, size, groups=16, decay=0.9, eps=2e-5, \
+dtype=numpy.float32, *, group_size=None)
+
+    Decorrelated batch normalization layer.
 
     This link wraps the
     :func:`~chainer.functions.decorrelated_batch_normalization` and
@@ -54,6 +57,7 @@ class DecorrelatedBatchNormalization(link.Link):
             which is used during training.
         eps (float): Epsilon value for numerical stability.
         dtype (numpy.dtype): Type to use in computing.
+        group_size (int): Size of each group to use for group whitening.
 
     See: `Decorrelated Batch Normalization <https://arxiv.org/abs/1804.08450>`_
 

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -50,14 +50,14 @@ dtype=numpy.float32, *, group_size=None)
     fine-tuning mode.
 
     Args:
-        size (int or tuple of ints): Size (or shape) of channel
-            dimensions.
-        groups (int): Number of groups to use for group whitening.
+        size (int): Size of channel dimension.
+        groups (int or None): Number of groups to use for group whitening.
         decay (float): Decay rate of moving average
             which is used during training.
         eps (float): Epsilon value for numerical stability.
         dtype (numpy.dtype): Type to use in computing.
-        group_size (int): Size of each group to use for group whitening.
+        group_size (int or None): Size of each group to use for group
+            whitening.
 
     See: `Decorrelated Batch Normalization <https://arxiv.org/abs/1804.08450>`_
 

--- a/chainer/links/normalization/decorrelated_batch_normalization.py
+++ b/chainer/links/normalization/decorrelated_batch_normalization.py
@@ -57,7 +57,7 @@ dtype=numpy.float32, *, group_size=None)
         eps (float): Epsilon value for numerical stability.
         dtype (numpy.dtype): Type to use in computing.
         group_size (int or None): Size of each group to use for group
-            whitening.
+            whitening.  The default value is ``16`` unless ``groups`` is set.
 
     See: `Decorrelated Batch Normalization <https://arxiv.org/abs/1804.08450>`_
 

--- a/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -56,7 +56,7 @@ def _calc_mean(x, groups):
     return x.mean(axis=axis).reshape(groups, -1)
 
 
-def _parse_group_kwargs(n_channels, groups, group_size=None):
+def _parse_group_kwargs(n_channels, groups=None, group_size=None):
     if group_size is None:
         if groups is None:
             group_size = 16
@@ -73,7 +73,7 @@ def _parse_group_kwargs(n_channels, groups, group_size=None):
     'group_kwargs': [
         {'groups': 1, 'group_size': 8},
         {'groups': 2},
-        {'groups': None, 'group_size': 2},
+        {'group_size': 2},
     ],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float32],
@@ -84,7 +84,7 @@ def _parse_group_kwargs(n_channels, groups, group_size=None):
     'group_kwargs': [
         {'groups': 1, 'group_size': 8},
         {'groups': 2},
-        {'groups': None, 'group_size': 2},
+        {'group_size': 2},
     ],
     'eps': [2e-5, 5e-1],
     # NOTE(crcrpar): np.linalg.eigh does not support float16
@@ -147,7 +147,7 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
     'group_kwargs': [
         {'groups': 1, 'group_size': 8},
         {'groups': 2},
-        {'groups': None, 'group_size': 2},
+        {'group_size': 2},
     ],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float32],
@@ -158,7 +158,7 @@ class TestDecorrelatedBatchNormalization(testing.FunctionTestCase):
     'group_kwargs': [
         {'groups': 1, 'group_size': 8},
         {'groups': 2},
-        {'groups': None, 'group_size': 2},
+        {'group_size': 2},
     ],
     'eps': [2e-5, 5e-1],
     'dtype': [numpy.float16, numpy.float32, numpy.float64],

--- a/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_decorrelated_batch_normalization.py
@@ -65,7 +65,7 @@ def _calc_mean(x, groups):
     return x.mean(axis=axis).reshape(groups, -1)
 
 
-def _parse_group_kwargs(n_channels, groups, group_size=None):
+def _parse_group_kwargs(n_channels, groups=None, group_size=None):
     if group_size is None:
         if groups is None:
             group_size = 16
@@ -81,7 +81,7 @@ def _parse_group_kwargs(n_channels, groups, group_size=None):
     'group_kwargs': [
         {'groups': 1, 'group_size': 8},
         {'groups': 2},
-        {'groups': None, 'group_size': 2},
+        {'group_size': 2},
     ],
     'test': [True, False],
     'ndim': [0, 2],


### PR DESCRIPTION
Merge #7906 first.

Close #7905.