### PR TITLE
Add DeprecationWarning to initializer of BuildingBlock

### DIFF
--- a/chainer/links/model/vision/resnet.py
+++ b/chainer/links/model/vision/resnet.py
@@ -558,7 +558,8 @@ class BuildingBlock(link.Chain):
         if 'n_layer' in kwargs:
             warnings.warn(
                 'Argument `n_layer` is deprecated. '
-                'Please use `n_layers` instead')
+                'Please use `n_layers` instead',
+                DeprecationWarning)
             n_layers = kwargs['n_layer']
 
         with self.init_scope():


### PR DESCRIPTION
Related to https://github.com/chainer/chainer/pull/7871.
I apologize that I forgot adding `DeprecationWarning` in `warnings.warn`.

FIY. @emcastillo