### PR TITLE
[backport] Avoid `ndarray.data` access and fix wrong test

### DIFF
--- a/chainer/function.py
+++ b/chainer/function.py
@@ -189,7 +189,7 @@ class FunctionAdapter(function_node.FunctionNode):
             in_data[i_in] = None if retained is None else retained.array
         in_data = tuple(in_data)
 
-        grad_out_data = tuple([None if grad is None else grad.data
+        grad_out_data = tuple([None if grad is None else grad.array
                                for grad in grad_outputs])
 
         is_chainerx_fallback_mode = self._is_chainerx_fallback_mode

--- a/tests/chainer_tests/test_function.py
+++ b/tests/chainer_tests/test_function.py
@@ -145,7 +145,9 @@ class TestFunction(unittest.TestCase):
         self.assertIsInstance(y.creator.outputs, tuple)
 
         if check_backward:
-            ys[0].creator_node.backward((0, 1), (self.gy1, self.gy2))
+            ys[0].creator_node.backward(
+                (0, 1),
+                (chainer.Variable(self.gy1), chainer.Variable(self.gy2)))
 
     def test_call_cpu(self):
         self.check_call()


### PR DESCRIPTION
Backport of #7890