### PR TITLE
Fix precision in `F.max_pooling_2d`

### DIFF
--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -106,7 +106,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
                for (int y = in_y_0; y < in_y_1; ++y) {
                  int offset_y = w * (y + h * c0);
                  for (int x = in_x_0; x < in_x_1; ++x) {
-                   float v = in[x + offset_y];
+                   T v = in[x + offset_y];
                    if (maxval < v) {
                      maxval   = v;
                      argmax_y = y;


### PR DESCRIPTION
The precision of `F.max_pooling_2d` was degraded when `dtype = float64` (to `float32`).

Fixes #7911: It seems the precision is not enough in numeric gradient when `dtype = float32`.

Tested with
`pytest -x -m 'not chainerx and gpu and not cudnn' -v -rfEX --tb=short tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py -k 'test_backward and float32 and param_1_'`
for 100000 trials without any error (without this fix, the first failure was around ~1000th).