### PR TITLE
Avoid unnecessary test condition in `F.max_pooling_2d` test

### DIFF
--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -11,14 +11,8 @@ from chainer.testing import attr
 from chainer.testing import backend
 
 
-@testing.parameterize(*testing.product({
-    'cover_all': [True, False],
-    'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'contiguous': [None, 'C'],
-}))
-@backend.inject_backend_tests(
-    ['test_forward', 'test_backward', 'test_double_backward',
-     'test_forward_cpu_wide', 'test_forward_output_size_zero'],
+_inject_backend_tests = backend.inject_backend_tests(
+    None,
     # CPU tests
     testing.product({
         'use_cuda': [False],
@@ -35,6 +29,14 @@ from chainer.testing import backend
         'chainerx_device': ['native:0', 'cuda:0'],
     })
 )
+
+
+@_inject_backend_tests
+@testing.parameterize(*testing.product({
+    'cover_all': [True, False],
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+    'contiguous': [None, 'C'],
+}))
 class TestMaxPooling2D(testing.FunctionTestCase):
 
     def setUp(self):
@@ -83,7 +85,14 @@ class TestMaxPooling2D(testing.FunctionTestCase):
                                      cover_all=self.cover_all)
         return y,
 
-    def test_forward_cpu_wide(self, backend_config):  # see #120
+
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32, numpy.float64],
+}))
+class TestMaxPooling2DForwardCpuWide(unittest.TestCase):
+    # see #120
+
+    def test_forward_cpu_wide(self):
         x_data = numpy.random.rand(2, 3, 15, 15).astype(self.dtype)
         x = chainer.Variable(x_data)
         functions.max_pooling_2d(x, 6, stride=6, pad=0)


### PR DESCRIPTION
Some parameterizations were simply ignored.