### PR TITLE
Fix tolerance in `L.CRF1d` test

### DIFF
--- a/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
+++ b/tests/chainer_tests/links_tests/loss_tests/test_crf1d.py
@@ -55,7 +55,7 @@ class TestCRF1d(unittest.TestCase):
         self.cost_shape = (self.n_label, self.n_label)
 
         if self.dtype == numpy.float16:
-            self.check_forward_options = {'atol': 5e-3}
+            self.check_forward_options = {'rtol': 5e-3, 'atol': 1e-2}
         else:
             self.check_forward_options = {'atol': 1e-4}
 


### PR DESCRIPTION
Fixes #7925 

Tested 100000 trials without any error:

`pytest -v -rfEX --tb=short tests/chainer_tests/links_tests/loss_tests/test_crf1d.py  -k 'test_forward_cpu and float16 and param_1_'`