### PR TITLE
Improve error message of `Variable.backward` with grad unset

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1429,6 +1429,10 @@ class Variable(object):
                 parameters are divided by the factor just before the parameters
                 are to be updated.
         """
+        if self.shape != () and self.grad is None:
+            raise RuntimeError(
+                'Variable.backward() can only be called if either the shape '
+                'of the variable is () or its gradient is manually set.')
         if self._has_chainerx_array:
             if retain_grad:
                 raise RuntimeError(

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1454,6 +1454,18 @@ class TestVariableDataAssign(unittest.TestCase):
         assert x.data is x.node.data
 
 
+class TestVariableBackwardWithoutGrad(unittest.TestCase):
+    # If one forgets to set a grad, the error from backward() should be
+    # informative.
+
+    def test_variable_backward_without_grad(self):
+        x_np = np.ones((3, 2), np.float32)
+        x = chainer.Variable(x_np)
+        y = x ** 2
+        with pytest.raises(RuntimeError, match=r'backward.*gradient'):
+            y.backward()
+
+
 class TestParameter(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes #3435 and fixes #6260