### PR TITLE
[backport] Fix precision in `F.max_pooling_2d`

### DIFF
--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -102,7 +102,7 @@ class MaxPooling2D(pooling_2d.Pooling2D):
                for (int y = in_y_0; y < in_y_1; ++y) {
                  int offset_y = w * (y + h * c0);
                  for (int x = in_x_0; x < in_x_1; ++x) {
-                   float v = in[x + offset_y];
+                   T v = in[x + offset_y];
                    if (maxval < v) {
                      maxval   = v;
                      argmax_y = y;


### PR DESCRIPTION
Backport of #7922