### PR TITLE
Relax tolerances in old cuDNN convolution tests

### DIFF
--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_2d.py
@@ -95,7 +95,7 @@ class TestConvolution2DFunction(testing.FunctionTestCase):
             self.check_backward_options.update({
                 'atol': 1e-3, 'rtol': 1e-3})
             self.check_double_backward_options.update({
-                'atol': 1e-3, 'rtol': 1e-3})
+                'atol': 1e-2, 'rtol': 1e-2})
 
     def generate_inputs(self):
         W = numpy.random.normal(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_convolution_nd.py
@@ -94,7 +94,7 @@ class TestConvolutionND(testing.FunctionTestCase):
             self.check_backward_options.update({
                 'atol': 1e-3, 'rtol': 1e-3})
             self.check_double_backward_options.update({
-                'atol': 1e-3, 'rtol': 1e-3})
+                'atol': 1e-2, 'rtol': 1e-2})
 
     def generate_inputs(self):
         W = numpy.random.normal(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -105,7 +105,7 @@ class TestDeconvolution2DFunction(testing.FunctionTestCase):
             self.check_backward_options.update({
                 'atol': 1e-3, 'rtol': 1e-3})
             self.check_double_backward_options.update({
-                'atol': 1e-3, 'rtol': 1e-3})
+                'atol': 1e-2, 'rtol': 1e-2})
 
     def generate_inputs(self):
         W = numpy.random.normal(

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_nd.py
@@ -113,7 +113,7 @@ class TestDeconvolutionND(testing.FunctionTestCase):
             self.check_backward_options.update({
                 'atol': 1e-3, 'rtol': 1e-3})
             self.check_double_backward_options.update({
-                'atol': 1e-3, 'rtol': 1e-3})
+                'atol': 1e-2, 'rtol': 1e-2})
 
     def generate_inputs(self):
         W = numpy.random.normal(


### PR DESCRIPTION
Aims to fix #7695 

Double backward test was failing [Jenkins](https://jenkins.preferred.jp/job/chainer/job/chainer_pr/1828/testReport/)