### PR TITLE
Remove stable version section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ It provides automatic differentiation APIs based on the **define-by-run** approa
 It also supports CUDA/cuDNN using [CuPy](https://github.com/cupy/cupy) for high performance training and inference.
 For more details about Chainer, see the documents and resources listed above and join the community in Forum, Slack, and Twitter.
 
-## Stable version
-
-The stable version of current Chainer is separated in here: [v6](https://github.com/chainer/chainer/tree/v6).
-
 ## Installation
 
 To install Chainer, use `pip`.


### PR DESCRIPTION
Related: #7948

I don't know how this section would be useful.