### PR TITLE
Loss scale support for chainerx 

### DIFF
--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -1022,7 +1022,7 @@ def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
         outputs_chx = [x._data[0] for x in outputs]
         inputs_chx = [x._data[0] for x in inputs]
         # pybind has issues when converting opt<int> -> opt<float>
-        if loss_scale:
+        if loss_scale is not None:
             loss_scale = float(loss_scale)
         grads = chainerx.grad(outputs_chx, inputs_chx,
                               backprop_id=None,

--- a/chainer/function_node.py
+++ b/chainer/function_node.py
@@ -1035,12 +1035,8 @@ def grad(outputs, inputs, grad_outputs=None, grad_inputs=None, set_grad=False,
         if grad_inputs:
             grads = [g+gi._data[0] for g, gi in zip(grads, grad_inputs)]
 
-        i_vars = [variable.Variable(g, requires_grad=g.is_backprop_required())
-                  for g in grads]
-        if loss_scale:
-            for var in i_vars:
-                var._loss_scale = loss_scale
-        return i_vars
+        return [variable.Variable(g, requires_grad=g.is_backprop_required())
+                for g in grads]
 
     elif n_chx_inputs > 0:
         raise TypeError(

--- a/chainer/optimizer.py
+++ b/chainer/optimizer.py
@@ -283,7 +283,8 @@ class UpdateRule(object):
             self._init_states(param_)
 
             # Apply loss scaling
-            if loss_scale is not None:
+            if (loss_scale is not None
+                    and not isinstance(param_.array, chainerx.ndarray)):
                 param_.grad /= loss_scale
 
         # Call update_core

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1433,13 +1433,14 @@ class Variable(object):
             if retain_grad:
                 raise RuntimeError(
                     'retain_grad is not supported for ChainerX array.')
-            if loss_scale is not None:
-                raise RuntimeError(
-                    'loss_scale is not supported for ChainerX array.')
             arr = self._data[0]
             assert isinstance(arr, chainerx.ndarray)
+            # pybind has issues when converting opt<int> -> opt<float>
+            if loss_scale:
+                loss_scale = float(loss_scale)
             chainerx.backward(
-                arr, enable_double_backprop=enable_double_backprop)
+                arr, enable_double_backprop=enable_double_backprop,
+                loss_scale=loss_scale)
             return
 
         # Initialize error by 1, if this is a loss variable

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1435,7 +1435,7 @@ class Variable(object):
                     'retain_grad is not supported for ChainerX array.')
             arr = self._data[0]
             assert isinstance(arr, chainerx.ndarray)
-            # pybind has issues when converting opt<int> -> opt<float>
+            # pybind has issues when converting int -> opt<float>
             if loss_scale:
                 loss_scale = float(loss_scale)
             chainerx.backward(

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -34,7 +34,8 @@ void SetGrad(absl::optional<Array>& target_grad, Array grad, const Shape& shape,
 void Backward(
         const Array& output,
         const absl::optional<BackpropId>& backprop_id = absl::nullopt,
-        DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
+        DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable,
+        const absl::optional<float>& loss_scale = absl::nullopt);
 
 // Updates the gradients held by the input arrays using backpropagation.
 //
@@ -42,7 +43,8 @@ void Backward(
 void Backward(
         const std::vector<ConstArrayRef>& outputs,
         const absl::optional<BackpropId>& backprop_id = absl::nullopt,
-        DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable);
+        DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable,
+        const absl::optional<float>& loss_scale = absl::nullopt);
 
 // Returns gradient arrays for all inputs.
 std::vector<absl::optional<Array>> Grad(
@@ -52,6 +54,7 @@ std::vector<absl::optional<Array>> Grad(
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable,
         bool set_grad = false,
         bool retain_grad = false,
-        const std::vector<ConstArrayRef>& grad_outputs = {});
+        const std::vector<ConstArrayRef>& grad_outputs = {},
+        const absl::optional<float>& loss_scale = absl::nullopt);
 
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/python/array.cc
+++ b/chainerx_cc/chainerx/python/array.cc
@@ -604,12 +604,16 @@ void InitChainerxArraySpecial(pybind11::module& m, py::class_<ArrayBody, ArrayBo
           "grad"_a,
           "backprop_id"_a = nullptr);
     c.def("backward",
-          [](const ArrayBodyPtr& self, const absl::optional<BackpropId>& backprop_id, bool enable_double_backprop) {
+          [](const ArrayBodyPtr& self,
+             const absl::optional<BackpropId>& backprop_id,
+             bool enable_double_backprop,
+             const absl::optional<float>& loss_scale) {
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
-              Backward(Array{self}, backprop_id, double_backprop);
+              Backward(Array{self}, backprop_id, double_backprop, loss_scale);
           },
           "backprop_id"_a = nullptr,
-          "enable_double_backprop"_a = false);
+          "enable_double_backprop"_a = false,
+          "loss_scale"_a = nullptr);
     c.def("_debug_dump_computational_graph",
           [](const ArrayBodyPtr& self, const absl::optional<BackpropId>& backprop_id) {
               DebugDumpComputationalGraph(std::cout, Array{self}, backprop_id);

--- a/chainerx_cc/chainerx/python/backward.cc
+++ b/chainerx_cc/chainerx/python/backward.cc
@@ -39,24 +39,26 @@ std::vector<Array> ConvertToArrays(const std::vector<ArrayBodyPtr>& array_body_p
 
 void InitChainerxBackward(pybind11::module& m) {
     m.def("backward",
-          [](const ArrayBodyPtr& body, const absl::optional<BackpropId>& backprop_id, bool enable_double_backprop) {
+          [](const ArrayBodyPtr& body, const absl::optional<BackpropId>& backprop_id, bool enable_double_backprop, const absl::optional<float>& loss_scale) {
               Array array{body};
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
-              Backward(array, backprop_id, double_backprop);
+              Backward(array, backprop_id, double_backprop, loss_scale);
           },
           py::arg(),
           "backprop_id"_a = nullptr,
-          "enable_double_backprop"_a = false);
+          "enable_double_backprop"_a = false,
+          "loss_scale"_a = nullptr);
 
     m.def("backward",
-          [](const std::vector<ArrayBodyPtr>& outputs, const absl::optional<BackpropId>& backprop_id, bool enable_double_backprop) {
+          [](const std::vector<ArrayBodyPtr>& outputs, const absl::optional<BackpropId>& backprop_id, bool enable_double_backprop, const absl::optional<float>& loss_scale) {
               std::vector<Array> arrays = ConvertToArrays(outputs);
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
-              Backward({arrays.begin(), arrays.end()}, backprop_id, double_backprop);
+              Backward({arrays.begin(), arrays.end()}, backprop_id, double_backprop, loss_scale);
           },
           py::arg(),
           "backprop_id"_a = nullptr,
-          "enable_double_backprop"_a = false);
+          "enable_double_backprop"_a = false,
+          "loss_scale"_a = nullptr);
 
     m.def("grad",
           [](const std::vector<ArrayBodyPtr>& outputs,
@@ -65,7 +67,8 @@ void InitChainerxBackward(pybind11::module& m) {
              bool enable_double_backprop,
              bool set_grad,
              bool retain_grad,
-             const std::vector<ArrayBodyPtr>& grad_outputs) {
+             const std::vector<ArrayBodyPtr>& grad_outputs,
+             const absl::optional<float>& loss_scale) {
               std::vector<Array> output_arrays = ConvertToArrays(outputs);
               std::vector<Array> input_arrays = ConvertToArrays(inputs);
 
@@ -79,7 +82,8 @@ void InitChainerxBackward(pybind11::module& m) {
                            double_backprop,
                            set_grad,
                            retain_grad,
-                           std::vector<ConstArrayRef>{grad_output_arrays.begin(), grad_output_arrays.end()});
+                           std::vector<ConstArrayRef>{grad_output_arrays.begin(), grad_output_arrays.end()},
+                           loss_scale);
               return internal::MoveArrayBodies(std::move(grads));
           },
           py::arg(),  // outputs
@@ -88,7 +92,8 @@ void InitChainerxBackward(pybind11::module& m) {
           "enable_double_backprop"_a = false,
           "set_grad"_a = false,
           "retain_grad"_a = false,
-          "grad_outputs"_a = std::vector<ArrayBodyPtr>{});
+          "grad_outputs"_a = std::vector<ArrayBodyPtr>{},
+          "loss_scale"_a = nullptr);
 }
 
 }  // namespace python_internal

--- a/chainerx_cc/chainerx/python/backward.cc
+++ b/chainerx_cc/chainerx/python/backward.cc
@@ -39,7 +39,10 @@ std::vector<Array> ConvertToArrays(const std::vector<ArrayBodyPtr>& array_body_p
 
 void InitChainerxBackward(pybind11::module& m) {
     m.def("backward",
-          [](const ArrayBodyPtr& body, const absl::optional<BackpropId>& backprop_id, bool enable_double_backprop, const absl::optional<float>& loss_scale) {
+          [](const ArrayBodyPtr& body,
+             const absl::optional<BackpropId>& backprop_id,
+             bool enable_double_backprop,
+             const absl::optional<float>& loss_scale) {
               Array array{body};
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
               Backward(array, backprop_id, double_backprop, loss_scale);
@@ -50,7 +53,10 @@ void InitChainerxBackward(pybind11::module& m) {
           "loss_scale"_a = nullptr);
 
     m.def("backward",
-          [](const std::vector<ArrayBodyPtr>& outputs, const absl::optional<BackpropId>& backprop_id, bool enable_double_backprop, const absl::optional<float>& loss_scale) {
+          [](const std::vector<ArrayBodyPtr>& outputs,
+             const absl::optional<BackpropId>& backprop_id,
+             bool enable_double_backprop,
+             const absl::optional<float>& loss_scale) {
               std::vector<Array> arrays = ConvertToArrays(outputs);
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
               Backward({arrays.begin(), arrays.end()}, backprop_id, double_backprop, loss_scale);

--- a/tests/chainer_tests/optimizer_hooks_tests/test_weight_decay.py
+++ b/tests/chainer_tests/optimizer_hooks_tests/test_weight_decay.py
@@ -71,6 +71,11 @@ class TestWeightDecay(unittest.TestCase):
     + testing.product({
         'use_cuda': [True],
     })
+    + [
+        # ChainerX
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'}
+    ]
 )
 class TestWeightDecayLossScale(unittest.TestCase):
 

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -964,8 +964,6 @@ class GradTestBase(object):
             raise
 
     def test_grad(self, backend_config):
-        if self.loss_scale and backend_config.xp is chainerx:
-            pytest.skip('chainerx.grad does not support loss_scale')
         self.use_device(backend_config.device)
         self.check_grad()
 
@@ -991,8 +989,6 @@ class GradTestBase(object):
             raise
 
     def test_double_grad(self, backend_config):
-        if self.loss_scale and backend_config.xp is chainerx:
-            pytest.skip('chainerx.grad does not support loss_scale')
         self.use_device(backend_config.device)
         self.check_double_grad()
 

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -1003,9 +1003,6 @@ class GradTestBase(object):
         {'use_ideep': 'always'},
         {'use_cuda': True, 'cuda_device': 0},
         {'use_cuda': True, 'cuda_device': 1},
-        {'use_chainerx': True, 'chainerx_device': 'native:0'},
-        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
-        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
     ]
 )
 class TestGradSimple(GradTestBase, unittest.TestCase):
@@ -1026,6 +1023,34 @@ class TestGradSimple(GradTestBase, unittest.TestCase):
         ggrad = 2 * self.gy
         if self.loss_scale is not None:
             ggrad *= self.loss_scale
+        return [ggrad]
+
+
+@testing.parameterize(*testing.product({
+    'loss_scale': [None, 1, 10],
+}))
+@testing.backend.inject_backend_tests(
+    None,
+    [
+        {'use_chainerx': True, 'chainerx_device': 'native:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:0'},
+        {'use_chainerx': True, 'chainerx_device': 'cuda:1'},
+    ]
+)
+class TestGradSimpleChainerX(GradTestBase, unittest.TestCase):
+
+    x_names = 'x',
+    y_names = 'y',
+
+    def forward(self):
+        self.y = self.x * self.x
+
+    def expected_grad(self):
+        grad = 2 * self.x * self.gy
+        return [grad]
+
+    def expected_double_grad(self):
+        ggrad = 2 * self.gy
         return [ggrad]
 
 

--- a/tests/chainer_tests/test_function_node.py
+++ b/tests/chainer_tests/test_function_node.py
@@ -1027,7 +1027,7 @@ class TestGradSimple(GradTestBase, unittest.TestCase):
 
 
 @testing.parameterize(*testing.product({
-    'loss_scale': [None, 1, 10],
+    'loss_scale': [None, 1, 1.5, 2.5, 10],
 }))
 @testing.backend.inject_backend_tests(
     None,

--- a/tests/chainer_tests/test_optimizer.py
+++ b/tests/chainer_tests/test_optimizer.py
@@ -635,6 +635,12 @@ class TestGradientMethodLossScale(unittest.TestCase):
         self.optimizer = chainer.optimizers.SGD(lr)
 
     def test_update(self, backend_config):
+        if backend_config.xp is chainerx:
+            # ChainerX performs the loss scaling on its own backward
+            # method, the optimizer should not divide back the parameters
+            # This test is not actually creating a ChainerX
+            # computation graph so no actual loss scale is being done
+            self.optimizer.lr = 1.0
         target = self.target
         optimizer = self.optimizer
         target.to_device(backend_config.device)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -2824,13 +2824,14 @@ class TestLossScale(unittest.TestCase):
         self.x = np.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
         self.y = np.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
 
-    def check_loss_scale(self, x_data, y_data):
+    def check_loss_scale(self, x_data, y_data, chainerx=False):
         x = chainer.Variable(x_data)
         y = chainer.Variable(y_data)
         z = x * y
         loss = F.sum(z)
         loss.backward(loss_scale=self.loss_scale)
-        if self.loss_scale is not None:
+        # ChainerX scales back gradients on the backward method
+        if not chainerx and self.loss_scale is not None:
             x.grad /= self.loss_scale
             y.grad /= self.loss_scale
         rtol, atol = 1e-4, 1e-5
@@ -2847,10 +2848,17 @@ class TestLossScale(unittest.TestCase):
         self.check_loss_scale(cuda.to_gpu(self.x), cuda.to_gpu(self.y))
 
     @attr.chainerx
-    def test_loss_chainerx_cpu(self):
-        x = chainerx.array(self.x)
-        y = chainerx.array(self.y)
-        self.check_loss_scale(x, y)
+    def test_loss_scale_chainerx_cpu(self):
+        x = chainerx.array(self.x, device='native:0')
+        y = chainerx.array(self.y, device='native:0')
+        self.check_loss_scale(x, y, chainerx=True)
+
+    @attr.gpu
+    @attr.chainerx
+    def test_loss_scale_chainerx_gpu(self):
+        x = chainerx.array(self.x, device='cuda:0')
+        y = chainerx.array(self.y, device='cuda:0')
+        self.check_loss_scale(x, y, chainerx=True)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -2824,14 +2824,14 @@ class TestLossScale(unittest.TestCase):
         self.x = np.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
         self.y = np.random.uniform(-1, 1, self.in_shape).astype(self.dtype)
 
-    def check_loss_scale(self, x_data, y_data, chainerx=False):
+    def check_loss_scale(self, xp, x_data, y_data):
         x = chainer.Variable(x_data)
         y = chainer.Variable(y_data)
         z = x * y
         loss = F.sum(z)
         loss.backward(loss_scale=self.loss_scale)
         # ChainerX scales back gradients on the backward method
-        if not chainerx and self.loss_scale is not None:
+        if xp is not chainerx and self.loss_scale is not None:
             x.grad /= self.loss_scale
             y.grad /= self.loss_scale
         rtol, atol = 1e-4, 1e-5
@@ -2841,24 +2841,24 @@ class TestLossScale(unittest.TestCase):
         testing.assert_allclose(y.data, x.grad, rtol=rtol, atol=atol)
 
     def test_loss_scale_cpu(self):
-        self.check_loss_scale(self.x, self.y)
+        self.check_loss_scale(np, self.x, self.y)
 
     @attr.gpu
     def test_loss_scale_gpu(self):
-        self.check_loss_scale(cuda.to_gpu(self.x), cuda.to_gpu(self.y))
+        self.check_loss_scale(cuda, cuda.to_gpu(self.x), cuda.to_gpu(self.y))
 
     @attr.chainerx
     def test_loss_scale_chainerx_cpu(self):
         x = chainerx.array(self.x, device='native:0')
         y = chainerx.array(self.y, device='native:0')
-        self.check_loss_scale(x, y, chainerx=True)
+        self.check_loss_scale(chainerx, x, y)
 
     @attr.gpu
     @attr.chainerx
     def test_loss_scale_chainerx_gpu(self):
         x = chainerx.array(self.x, device='cuda:0')
         y = chainerx.array(self.y, device='cuda:0')
-        self.check_loss_scale(x, y, chainerx=True)
+        self.check_loss_scale(chainerx, x, y)
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -2846,6 +2846,12 @@ class TestLossScale(unittest.TestCase):
     def test_loss_scale_gpu(self):
         self.check_loss_scale(cuda.to_gpu(self.x), cuda.to_gpu(self.y))
 
+    @attr.chainerx
+    def test_loss_chainerx_cpu(self):
+        x = chainerx.array(self.x)
+        y = chainerx.array(self.y)
+        self.check_loss_scale(x, y)
+
 
 @testing.parameterize(*testing.product({
     # ideep2.0.0 not support shape 0


### PR DESCRIPTION
Reworks #7763
Closes #7756

Instead of exposing a `loss_scale` attribute on Chainerx arrays. 
We do the loss scaling on the arrays that belong to input variables, parameters or must be explicitly retained at the end of the ChainerX backward pass.

