### PR TITLE
Remove `backward` in `forward` hack of cudnn dropout

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -772,9 +772,16 @@ def should_use_cudnn_tensor_core(dtype):
 # cupy.cudnn utility
 # ------------------------------------------------------------------------------
 
-def get_cudnn_dropout_states():
+def get_cudnn_dropout_states(seed=None):
     if not cudnn_enabled:
         raise RuntimeError('cuDNN is not enabled.')
+
+    # Get a consistent state to always generate
+    # the same dropout masks, if a dropoutstates
+    # is memoized it will generate different values
+    # everytime and this can lead to inconsistencies
+    if seed is not None:
+        return seed, cudnn.DropoutStates(None, seed)
 
     thread_id = threading.current_thread().ident
     return get_cudnn_dropout_states_core(thread_id)
@@ -797,4 +804,4 @@ def get_cudnn_dropout_states_core(thread_id):
         seed = numpy.uint64(seed)
 
     seed += numpy.uint64(states_id)
-    return cudnn.DropoutStates(None, seed)
+    return seed, cudnn.DropoutStates(None, seed)

--- a/chainer/functions/noise/dropout.py
+++ b/chainer/functions/noise/dropout.py
@@ -25,6 +25,7 @@ class Dropout(function_node.FunctionNode):
         self._cudnn_states_seed = None
         if (mask is not None
                 and chainer.should_use_cudnn('>=auto', 5000)
+                and not return_mask
                 and numpy.isscalar(mask)):
             self._cudnn_states_seed = mask
             self._mask = None
@@ -56,8 +57,9 @@ class Dropout(function_node.FunctionNode):
 
     def forward_gpu(self, x):
         if (chainer.should_use_cudnn('>=auto', 5000)
+                and x[0].flags.c_contiguous
                 and self._mask is None
-                and x[0].flags.c_contiguous):
+                and not self.return_mask):
             self._use_cudnn = True
             # cuDNN doesnt support to provide a mask
             # so we save the random seed to ensure

--- a/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_dropout.py
@@ -87,12 +87,17 @@ class TestDropout(unittest.TestCase):
             inputs = cuda.to_gpu(inputs)
             grad_outputs = cuda.to_gpu(grad_outputs)
 
-        with backend_config:
-            _, out_mask = functions.dropout(inputs[0], self.ratio,
+        # if return_mask is set the cudnn version wont be used
+        mask = None
+        if backend_config.use_cudnn == "always":
+            mask = numpy.random.randint(numpy.iinfo(numpy.int32).max)
+        else:
+            with backend_config:
+                _, mask = functions.dropout(inputs[0], self.ratio,
                                             return_mask=True)
 
         def f(*inputs):
-            return functions.dropout(inputs[0], self.ratio, mask=out_mask)
+            return functions.dropout(inputs[0], self.ratio, mask=mask)
 
         with backend_config:
             gradient_check.check_backward(
@@ -108,12 +113,17 @@ class TestDropout(unittest.TestCase):
             grad_outputs = cuda.to_gpu(grad_outputs)
             grad_grad_inputs = cuda.to_gpu(grad_grad_inputs)
 
-        with backend_config:
-            _, out_mask = functions.dropout(inputs[0], self.ratio,
+        # if return_mask is set the cudnn version wont be used
+        mask = None
+        if backend_config.use_cudnn == "always":
+            mask = numpy.random.randint(numpy.iinfo(numpy.int32).max)
+        else:
+            with backend_config:
+                _, mask = functions.dropout(inputs[0], self.ratio,
                                             return_mask=True)
 
         def f(*inputs):
-            return functions.dropout(inputs[0], self.ratio, mask=out_mask)
+            return functions.dropout(inputs[0], self.ratio, mask=mask)
 
         with backend_config:
             gradient_check.check_double_backward(


### PR DESCRIPTION
Fixes #7813 

This PR allows to use the cudnn dropout `forward` in a deterministic way between calculations.
cudnn does not allow to specify dropout masks but we can generate random states with a predefined seed to return always the same values in the forward operation.

Tests are reworked but some of the code cant be more improved until an approach similar to #7798 
is taken.

This PR is a mostly complete draft but I will like to discuss my approach here as there are some tricky questions such as using the mask to hold a random seed or the actual array. I thought of adding a `DropoutMask` class to hide this ugliness but I would like to discuss a clean approach first.