### PR TITLE
Fix flaky tests of `chx.linalg.solve`

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
@@ -142,7 +142,9 @@ _numpy_does_not_support_0d_input116 = \
 class TestSolve(NumpyLinalgOpTest):
 
     def generate_inputs(self):
-        a = numpy.random.random(self.shape).astype(self.dtypes[0])
+        sv = numpy.random.uniform(1, 2, size=self.shape[0])
+        a = chainer.testing.generate_matrix(
+            self.shape, dtype=self.dtypes[0], singular_values=sv)
         b = numpy.random.random(
             (self.shape[0], *self.b_columns)).astype(self.dtypes[1])
         return a, b


### PR DESCRIPTION
Fix #7976.

~Note on the solution: the test case sometimes result in an output matrix with very large values, where the computational error exceeds the threshold by a large margin. Instead of increasing the threshold (which will make the most random cases meaningless), I changed the input generation to generate the output instead of input so that we can control the output scale.~

Update: following the comments from @asi1024, I understood that the problem is not solved essentially by the above method. I developed a tool to create a well-behaving matrix in #8077, and rewrote this PR using it.