### PR TITLE
Remove obsolete note about `chainerx.take` indices dtype

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -497,9 +497,6 @@ Returns:
     :func:`~chainerx.ndarray`: Output array.
 
 Note:
-    This function currently only supports indices of int64 array.
-
-Note:
     This function currently does not support ``axis=None``
 
 Note:


### PR DESCRIPTION
It seems other integer dtypes including `uint8` are supported.