### PR TITLE
More efficient multi-node snapshot

### DIFF
--- a/chainermn/extensions/__init__.py
+++ b/chainermn/extensions/__init__.py
@@ -1,5 +1,6 @@
 from chainermn.extensions.allreduce_persistent import AllreducePersistent  # NOQA
 from chainermn.extensions.checkpoint import create_multi_node_checkpointer  # NOQA
 from chainermn.extensions.multi_node_evaluator import create_multi_node_evaluator  # NOQA
+from chainermn.extensions._multi_node_snapshot import multi_node_snapshot  # NOQA
 from chainermn.extensions.observation_aggregator import ObservationAggregator  # NOQA
 from chainermn.extensions.multi_node_early_stopping_trigger import MultiNodeEarlyStoppingTrigger  # NOQA

--- a/chainermn/extensions/_multi_node_snapshot.py
+++ b/chainermn/extensions/_multi_node_snapshot.py
@@ -1,0 +1,212 @@
+import io
+
+from chainer.serializers import load_npz
+from chainer.serializers import save_npz
+from chainer.training.extension import Extension
+from chainer.training.extensions._snapshot import _find_latest_snapshot
+
+
+def multi_node_snapshot(comm, snapshot, replica_sets):
+    '''Create trainer extension for multi-node snapshots
+
+    Provides generis multi-node snapshot saving and auto-load feature
+    at multi-node environment, leveraging power of single-node
+    snapshot.
+
+    In many cases snapshot target may differ, e.g. only trainer of
+    rank 0 process often has extensions such as ``LogReport`` and so
+    on, to not confuse terminal output. Just loading at one process
+    and broadcasting it to other processes does not work in that case.
+
+    This wrapper addresses that issue by defining sets of replicas
+    where within the set the target object is replicated and supposed
+    to be same among processes. For example, a trainer example, only
+    the trainer at rank ``0`` has special extensions and others
+    doesn't::
+
+        trainer = Trainer(updater)
+        if comm.rank == 0:
+            trainer.extend(extensions.DumpGraph('main/loss'))
+            trainer.extend(extensions.LogReport())
+            trainer.extend(extensions.PrintReport(
+                ['epoch', 'main/loss', 'validation/main/loss',
+                 'main/accuracy', 'validation/main/accuracy', 'elapsed_time']))
+            trainer.extend(extensions.ProgressBar())
+
+    This case can be described with two replica sets, where each set
+    can be represented as single integer that indicates rank number,
+    or iterable set/list/generator of integers like this::
+
+        replica_sets = [[0], range(1, comm.size)]
+
+    Here the first replica set is described as ``[0]``, or simply in
+    short just ``0``, and the second replica set is ``range(1,
+    comm.size)``, representing rest of processes other than ``0``. The
+    remaining list can be ommited. Thus in that case, it can be
+    simplified more::
+
+        replica_sets = [0,]
+
+    In this case, the snapshot will be saved at rank ``0`` process and
+    at rank ``1`` process. The latter represents the replica set of
+    ``range(1, comm.size)`` . In this case autoloading at
+    initialization of snapshot extension works after the restart
+    cleanly, even though the size of the communicator differs.
+
+    Once the replica sets are defined, it can be easily extended::
+
+        replica_sets = [0,]
+        snapshot = multi_node_snapshot(comm, extensions.snapshot(),
+                                       replica_sets)
+        trainer.extend(snapshot, trigger=(1, 'epoch'))
+
+
+    More example tuples of replica set representation follows:
+
+    ===================== ===== ==============================================
+    code                  nproc actual sets
+    ===================== ===== ==============================================
+    ``[0]``               ``4`` ``[{0}, {1, 2, 3}]``
+    ``[0, 1]``            ``4`` ``[{0}, {1}, {2, 3}]``
+    ``[0, 1], [2, 3]]``   ``4`` ``[{0, 1}, {2, 3}]``
+    ``[]``                ``4`` ``[{0, 1, 2, 3}]``
+    ``[range(0, 8, 2)]``  ``8`` ``[set(range(0, 8, 2)), set(range(1, 8, 2))]``
+    ===================== ===== ==============================================
+
+    Args:
+        comm (ChainerMN communicator): communicater object
+        snapshot: Snapshot extension object obtained via
+              :meth:`~chainer.training.extensions.snapshot` .
+        replica_sets: list of replica set definition, where
+              a replica set can be defined by single integer
+              as rank number, or iterable integers.
+
+    Returns:
+        Trainer extension that wraps ``snapshot`` and properly
+        controles number of snapshots.
+
+    '''
+    return _MultiNodeSnapshot(comm, snapshot, replica_sets)
+
+
+def _parse_replica_sets(replica_sets, size):
+    sets = []
+
+    for replica_set in replica_sets:
+        if isinstance(replica_set, int):
+            assert replica_set >= 0
+            assert replica_set < size
+            sets.append({replica_set})
+        else:
+            # Must be iterable
+            for i in replica_set:
+                assert i >= 0
+                assert i < size
+            sets.append(set(replica_set))
+
+    if size > sum(len(s) for s in sets):
+        all_ranks = set(range(size))
+        all_exp = set()
+        for s in sets:
+            all_exp |= s
+        rest = all_ranks - all_exp
+        if rest:
+            sets.append(rest)
+
+    # Must guarantee: no lack allowed
+    assert size == sum(len(s) for s in sets)
+
+    # Must guarantee: no two sets must have intersection.
+    all_sum = set()
+    for s in sets:
+        all_sum |= s
+    assert size == len(all_sum)
+    return sets
+
+
+class _MultiNodeSnapshot(Extension):
+    def __init__(self, comm, snapshot, replica_sets=[]):
+        assert comm is not None
+        assert snapshot is not None
+        self.comm = comm
+        self.snapshot = snapshot
+
+        # Append rank number to snapshot filename format/function
+        if callable(snapshot.filename):
+            filename_fun = snapshot.filename
+
+            def append_rank(trainer):
+                filename = filename_fun(trainer)
+                return '{}.{}'.format(filename, comm.rank)
+            snapshot.filename = append_rank
+
+        else:
+            filename = '{}.{}'.format(snapshot.filename, comm.rank)
+            snapshot.filename = filename
+
+        sets = _parse_replica_sets(replica_sets, comm.size)
+
+        self.master = None
+        self.replica_set = []
+        for s in sets:
+            if self.comm.rank in s:
+                self.master = min(s)
+                self.replica_set = s
+                break
+        assert self.master is not None
+        assert self.comm.rank in self.replica_set
+
+    @property
+    def is_master(self):
+        return self.master == self.comm.rank
+
+    def initialize(self, trainer):
+        if self.is_master:
+            self.snapshot.initialize(trainer)
+
+        # If autoload is off, no need to re-init this extension.
+        if not self.snapshot.autoload:
+            return
+
+        if self.snapshot._target is None:
+            target = trainer
+        else:
+            target = self.snapshot._target
+
+        # "Broadcast" the target here
+        if self.is_master:
+            # Find snapshot again
+            # TODO(kuenishi): replace with cleaner way to know whether
+            # a snapshot is autoloaded or not
+            filename = _find_latest_snapshot(self.snapshot.filename,
+                                             trainer.out)
+            if filename is None:
+                data = None
+            else:
+                buf = io.BytesIO()
+                save_npz(buf, target)
+                data = buf.getvalue()
+
+            for rank in self.replica_set:
+                if rank == self.comm.rank:
+                    continue
+                self.comm.send_obj(data, rank)
+
+        # Get the loaded target from master
+        else:
+            data = self.comm.recv_obj(self.master)
+            if data is None:
+                return
+            load_npz(io.BytesIO(data), target)
+
+    def on_error(self, trainer, e, t):
+        if self.is_master:
+            self.snapshot.on_error(trainer, e, t)
+
+    def __call__(self, trainer):
+        if self.is_master:
+            self.snapshot(trainer)
+
+    def finalize(self):
+        if self.is_master:
+            self.snapshot.finalize()

--- a/chainermn/extensions/_multi_node_snapshot.py
+++ b/chainermn/extensions/_multi_node_snapshot.py
@@ -125,7 +125,7 @@ def _parse_replica_sets(replica_sets, size):
 
 
 class _MultiNodeSnapshot(Extension):
-    def __init__(self, comm, snapshot, replica_sets=[]):
+    def __init__(self, comm, snapshot, replica_sets):
         assert comm is not None
         assert snapshot is not None
         self.comm = comm

--- a/docs/source/chainermn/reference/index.rst
+++ b/docs/source/chainermn/reference/index.rst
@@ -64,6 +64,7 @@ Trainer extensions
 ~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: chainermn.extensions.AllreducePersistent
+.. autofunction:: chainermn.extensions.multi_node_snapshot
 .. autofunction:: chainermn.create_multi_node_checkpointer
 
 Configurations

--- a/tests/chainermn_tests/extensions_tests/test_multi_node_snapshot.py
+++ b/tests/chainermn_tests/extensions_tests/test_multi_node_snapshot.py
@@ -1,0 +1,171 @@
+import mock
+import tempfile
+
+import pytest
+
+import chainer
+import chainer.links as L
+import chainer.functions as F
+from chainer.training import extensions
+from chainer.training import StandardUpdater
+from chainer.training import Trainer
+import chainermn
+from chainermn import create_communicator
+from chainermn.extensions import multi_node_snapshot
+from chainermn.extensions import _multi_node_snapshot
+
+
+@pytest.mark.parametrize('rs,size,expected', [
+    ([0], 4, [{0}, {1, 2, 3}]),
+    ([0, 1], 4, [{0}, {1}, {2, 3}]),
+    ([[0, 1], [2, 3]], 4, [{0, 1}, {2, 3}]),
+    ([], 4, [{0, 1, 2, 3}]),
+    ([range(0, 16, 2), range(1, 16, 2)], 16,
+     [set(range(0, 16, 2)), set(range(1, 16, 2))]),
+    ([range(0, 16, 2)], 16, [set(range(0, 16, 2)), set(range(1, 16, 2))]),
+    ([], 8, [set(range(8))]),
+])
+def test_parser(rs, size, expected):
+    sets = _multi_node_snapshot._parse_replica_sets(rs, size)
+    assert expected == sets
+
+
+def test_smoke_wrapper():
+    rs = [[0, 1], ]
+    comm = create_communicator('naive')
+    if comm.size < 2:
+        pytest.skip()
+
+    snapshot = extensions.snapshot()
+    filename = '{}.{}'.format(snapshot.filename, comm.rank)
+
+    replica_sets = rs
+    mn_snapshot = multi_node_snapshot(comm, snapshot, replica_sets)
+    if comm.rank == 0:
+        assert mn_snapshot.is_master
+        assert filename == mn_snapshot.snapshot.filename
+    elif comm.rank == 1:
+        assert not mn_snapshot.is_master
+    elif comm.rank == 2:
+        assert mn_snapshot.is_master
+        assert filename == mn_snapshot.snapshot.filename
+    else:
+        assert not mn_snapshot.is_master
+
+    comm.finalize()
+
+
+def test_callable_filename():
+    rs = [[0, 1], ]
+    comm = create_communicator('naive')
+    if comm.size < 2:
+        pytest.skip()
+
+    def filename_fun(t):
+        return 'deadbeef-{.updater.iteration}'.format(t)
+
+    snapshot = extensions.snapshot(filename=filename_fun)
+
+    trainer = mock.MagicMock()
+    filename = '{}.{}'.format(filename_fun(trainer), comm.rank)
+
+    replica_sets = rs
+    mn_snapshot = multi_node_snapshot(comm, snapshot, replica_sets)
+    if comm.rank == 0:
+        assert mn_snapshot.is_master
+        assert filename == mn_snapshot.snapshot.filename(trainer)
+    elif comm.rank == 1:
+        assert not mn_snapshot.is_master
+    elif comm.rank == 2:
+        assert mn_snapshot.is_master
+        assert filename == mn_snapshot.snapshot.filename(trainer)
+    else:
+        assert not mn_snapshot.is_master
+
+    comm.finalize()
+
+
+def test_smoke_multinode_snapshot():
+    t = mock.MagicMock()
+    c = mock.MagicMock(side_effect=[True, False])
+    w = mock.MagicMock()
+    snapshot = extensions.snapshot(target=t, condition=c, writer=w)
+    trainer = mock.MagicMock()
+
+    comm = create_communicator('naive')
+    replica_sets = []
+    mn_snapshot = multi_node_snapshot(comm, snapshot, replica_sets)
+
+    mn_snapshot.initialize(trainer)
+    mn_snapshot(trainer)
+    mn_snapshot(trainer)
+    mn_snapshot.finalize()
+
+    if comm.rank == 0:
+        assert mn_snapshot.is_master
+        assert c.call_count == 2
+        assert w.call_count == 1
+    else:
+        assert not mn_snapshot.is_master
+        assert c.call_count == 0
+        assert w.call_count == 0
+
+    comm.finalize()
+
+
+class MLP(chainer.Chain):
+    def __init__(self, n_units, n_out):
+        super(MLP, self).__init__()
+        with self.init_scope():
+            self.l1 = L.Linear(784, n_units)
+            self.l2 = L.Linear(n_units, n_units)
+            self.l3 = L.Linear(n_units, n_out)
+
+    def __call__(self, x):
+        h1 = F.relu(self.l1(x))
+        h2 = F.relu(self.l2(h1))
+        return self.l3(h2)
+
+
+def _prepare_multinode_snapshot(n, result):
+    n_units = 100
+    batchsize = 10
+    comm = create_communicator('naive')
+    model = L.Classifier(MLP(n_units, 10))
+    optimizer = chainermn.create_multi_node_optimizer(
+        chainer.optimizers.Adam(), comm)
+    optimizer.setup(model)
+
+    if comm.rank == 0:
+        train, _ = chainer.datasets.get_mnist()
+    else:
+        train, _ = None, None
+
+    train = chainermn.scatter_dataset(train, comm, shuffle=True)
+    train_iter = chainer.iterators.SerialIterator(train, batchsize)
+
+    updater = StandardUpdater(train_iter, optimizer)
+    trainer = Trainer(updater, out=result)
+
+    snapshot = extensions.snapshot(target=updater, autoload=True)
+    replica_sets = []
+    mn_snapshot = multi_node_snapshot(comm, snapshot, replica_sets)
+    mn_snapshot.initialize(trainer)
+    for _ in range(n):
+        updater.update()
+
+    return updater, mn_snapshot, trainer
+
+
+def test_multinode_autoload():
+    n = 3
+    with tempfile.TemporaryDirectory() as tempd:
+        result = tempd
+        updater0, snapshot, trainer0 = _prepare_multinode_snapshot(n, result)
+
+        assert n == updater0.iteration
+        snapshot(trainer0)
+
+        updater, _, _ = _prepare_multinode_snapshot(0, result)
+
+        assert n == updater.iteration


### PR DESCRIPTION
Addresses https://github.com/chainer/chainer/issues/7947 . We'll deprecate multi-node checkpointer we already have, once this PR is merged.

Basic design is to let users define replica sets, which is supposed to be same, typically models or trainers in data-paralellism. But we often define rank 0 process' trainer as special trainer to inject observability extensions such as LogReport, PrintReport - which makes the trainer a bit different from those in other ranks. In that case, the most typical use case, the replica sets are defined as `[0,]` mentioning `0` as explicit replica set and the remaining `1..comm.size`as implicit replica set.

Then the wrapped snapshot object is only called at rank 0 and 1 (minimal number in the latter set), names suffixed with its rank numbers e.g. `snapshot_trainer_10.0` and `snapshot_trainer_10.1` and automatically resumed in case of program restarted, when `autoload=True`. 