### PR TITLE
Fixed a bug for 0-sized input for dot product in ChainerX

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/dot.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/dot.cu
@@ -82,6 +82,7 @@ public:
         int64_t m = a.shape()[0];
         int64_t k = a.shape()[1];
         int64_t n = b.shape()[1];
+        int64_t ld_out = std::max(int64_t{1}, n);
         CHAINERX_ASSERT(b.shape()[0] == k);
         CHAINERX_ASSERT(out.shape()[0] == m);
         CHAINERX_ASSERT(out.shape()[1] == n);
@@ -140,7 +141,7 @@ public:
                     &zero,
                     internal::GetRawOffsetData(out_contiguous),
                     data_type,
-                    n,
+                    ld_out,
                     compute_type,
                     CUBLAS_GEMM_DEFAULT_TENSOR_OP);
         };

--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -85,6 +85,7 @@ void Gemm(const Array& a, const Array& b, const Array& out) {
     int64_t m = a.shape()[0];
     int64_t k = a.shape()[1];
     int64_t n = b.shape()[1];
+    int64_t ld_out = std::max(int64_t{1}, n);
     CHAINERX_ASSERT(b.shape()[0] == k);
     CHAINERX_ASSERT(out.shape()[0] == m);
     CHAINERX_ASSERT(out.shape()[1] == n);
@@ -106,7 +107,7 @@ void Gemm(const Array& a, const Array& b, const Array& out) {
         const T* b_ptr = static_cast<const T*>(internal::GetRawOffsetData(b_config));
         T* out_ptr = static_cast<T*>(internal::GetRawOffsetData(out_contiguous));
         GemmImpl<T>{}(
-                CblasRowMajor, a_layout.trans, b_layout.trans, m, n, k, one, a_ptr, a_layout.ld, b_ptr, b_layout.ld, zero, out_ptr, n);
+                CblasRowMajor, a_layout.trans, b_layout.trans, m, n, k, one, a_ptr, a_layout.ld, b_ptr, b_layout.ld, zero, out_ptr, ld_out);
     };
 
     if (a.dtype() == Dtype::kFloat32) {

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
@@ -14,6 +14,7 @@ from chainerx_tests import op_utils
 @chainer.testing.parameterize_pytest('a_shape,b_shape', [
     ((), ()),
     ((), (2, 3)),
+    ((0, 2), (2, 0)),
     ((2, 0), (0, 3)),
     ((0, 0), (0, 0)),
     ((2, 3), (3, 4)),


### PR DESCRIPTION
Leading dimension arguments when calling CBLAS or cuBLAS should not be less than 1.
With proposed change tests for shapes `((0, 2), (2, 0))` pass.