### PR TITLE
Make `mode` and `align_corners` arguments keyword-only

### DIFF
--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -299,7 +299,7 @@ class ResizeImagesGrad(function_node.FunctionNode):
             self.mode, self.align_corners).apply(grad_outputs)
 
 
-def resize_images(x, output_shape, mode='bilinear', align_corners=True):
+def resize_images(x, output_shape, *, mode='bilinear', align_corners=True):
     """Resize images to the given shape.
 
     This function resizes 2D data to :obj:`output_shape`.

--- a/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
+++ b/tests/chainer_tests/functions_tests/array_tests/test_resize_images.py
@@ -47,7 +47,8 @@ class TestResizeImagesForwardIdentity(testing.FunctionTestCase):
         x, = inputs
         output_shape = self.in_shape[2:]
         y = functions.resize_images(
-            x, output_shape, self.mode, align_corners=self.align_corners)
+            x, output_shape,
+            mode=self.mode, align_corners=self.align_corners)
         return y,
 
 
@@ -97,7 +98,8 @@ class TestResizeImagesForwardDownScale(testing.FunctionTestCase):
         x, = inputs
         output_shape = self.output_shape[2:]
         y = functions.resize_images(
-            x, output_shape, self.mode, self.align_corners)
+            x, output_shape,
+            mode=self.mode, align_corners=self.align_corners)
         return y,
 
 
@@ -197,7 +199,8 @@ class TestResizeImagesBackward(unittest.TestCase):
     def check_backward(self, x, output_shape, gy):
         def f(x):
             return functions.resize_images(
-                x, output_shape, self.mode, self.align_corners)
+                x, output_shape,
+                mode=self.mode, align_corners=self.align_corners)
 
         gradient_check.check_backward(
             f, x, gy, dtype='d', atol=1e-2, rtol=1e-3, eps=1e-5)
@@ -213,7 +216,8 @@ class TestResizeImagesBackward(unittest.TestCase):
     def check_double_backward(self, x, output_shape, gy, ggx):
         def f(x):
             return functions.resize_images(
-                x, output_shape, self.mode, self.align_corners)
+                x, output_shape,
+                mode=self.mode, align_corners=self.align_corners)
 
         gradient_check.check_double_backward(
             f, x, gy, ggx, atol=1e-2, rtol=1e-3)


### PR DESCRIPTION
Following [the policy](https://github.com/chainer/chainer/wiki/Development-policies/5acfc284fa9fecbea4998e95f7c127752476bc05#api)

Introduced in #7443
