### PR TITLE
Make `weights` and `keepdims` arguments in `Variable.mean` keyword-only

### DIFF
--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1480,7 +1480,7 @@ class Variable(object):
         """
         return self.array.item()
 
-    def mean(self, axis=None, weights=None, keepdims=False):
+    def mean(self, axis=None, *, weights=None, keepdims=False):
         """Calculate weighted average of array elements over a given axis.
 
         .. seealso::


### PR DESCRIPTION
Following [the policy](https://github.com/chainer/chainer/wiki/Development-policies/5acfc284fa9fecbea4998e95f7c127752476bc05#api)

Introduced in #7670

`axis` is left because it's common to give the corresponding argument in `numpy.mean` as positional.