### PR TITLE
Make arguments of `WeightStandardization` keyword-only

### DIFF
--- a/chainer/link_hooks/weight_standardization.py
+++ b/chainer/link_hooks/weight_standardization.py
@@ -34,7 +34,7 @@ class WeightStandardization(link_hook.LinkHook):
 
     name = 'WeightStandardization'
 
-    def __init__(self, eps=1e-5, weight_name='W', name=None):
+    def __init__(self, *, eps=1e-5, weight_name='W', name=None):
         self.eps = eps
         self.weight_name = weight_name
         self._initialized = False


### PR DESCRIPTION
Following [the policy](https://github.com/chainer/chainer/wiki/Development-policies/5acfc284fa9fecbea4998e95f7c127752476bc05#api)

Introduced in #6678
