### PR TITLE
Fix numerical gradient precision in `F.squared_error` test

### DIFF
--- a/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py
@@ -58,6 +58,7 @@ class TestSquaredError(unittest.TestCase):
         gradient_check.check_backward(
             functions.squared_error,
             (x0_data, x1_data), y_grad, eps=1e-2,
+            dtype=numpy.float64,
             **self.check_backward_options)
 
     def test_backward_cpu(self):
@@ -73,6 +74,7 @@ class TestSquaredError(unittest.TestCase):
         gradient_check.check_double_backward(
             functions.squared_error,
             (x0_data, x1_data), y_grad, (ggx0_data, ggx1_data), eps=1e-2,
+            dtype=numpy.float64,
             **self.check_double_backward_options)
 
     def test_double_backward_cpu(self):


### PR DESCRIPTION
Fixes #8008

Confirmed to pass 100000 times in a row, both in backward and double-backward tests:

`pytest tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py -k 'float16 and test_backward_cpu and _param_1_'`

`pytest tests/chainer_tests/functions_tests/loss_tests/test_squared_error.py -k 'float16 and test_double_backward_cpu and _param_1_'`