### PR TITLE
Fix floating point exception in ChainerX inferred reshape

### DIFF
--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -133,6 +133,12 @@ Shape GetInferredShape(const Shape& shape, int64_t total_size) {
         }
         int64_t rest_size = std::accumulate(inferred_shape.begin(), it, int64_t{1}, std::multiplies<>()) *
                             std::accumulate(std::next(it), inferred_shape.end(), int64_t{1}, std::multiplies<>());
+        if (rest_size == 0) {
+            // We raise an error similar to NumPy. See https://github.com/numpy/numpy/issues/8972.
+            throw DimensionError{"Cannot reshape array of size ",
+                                 total_size,
+                                 " into a 0-sized shape with more than 1 dimensions that contains an unknown dimension"};
+        }
         *it = total_size / rest_size;
     }
 

--- a/chainerx_cc/chainerx/routines/manipulation.cc
+++ b/chainerx_cc/chainerx/routines/manipulation.cc
@@ -134,10 +134,7 @@ Shape GetInferredShape(const Shape& shape, int64_t total_size) {
         int64_t rest_size = std::accumulate(inferred_shape.begin(), it, int64_t{1}, std::multiplies<>()) *
                             std::accumulate(std::next(it), inferred_shape.end(), int64_t{1}, std::multiplies<>());
         if (rest_size == 0) {
-            // We raise an error similar to NumPy. See https://github.com/numpy/numpy/issues/8972.
-            throw DimensionError{"Cannot reshape array of size ",
-                                 total_size,
-                                 " into a 0-sized shape with more than 1 dimensions that contains an unknown dimension"};
+            throw DimensionError{"Cannot reshape array of size ", total_size, " into an ambiguous shape ", shape};
         }
         *it = total_size / rest_size;
     }

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -210,6 +210,9 @@ _reshape_shape = [
     ((2, 3, 4), (3, -1, 2)),
     ((2, 3, 4), (3, -3, 2)),  # -3 is treated as a -1 and is valid.
     ((2, 0, 3), (-1,)),  # Empty to inferred.
+    ((2, 0, 3), (-1, 4)),  # Empty to inferred.
+    ((2, 0, 3), (4, -1)),  # Empty to inferred.
+    ((2, 0, 3), (4, -1, 5)),  # Empty to inferred.
 ]
 
 
@@ -352,7 +355,9 @@ def test_reshape_invalid(shape1, shape2):
     ((2, 3, 4), (5, -1, 3)),  # Not divisible.
     ((2, 3, 4), (-1, -1, 3)),  # More than one dimension cannot be inferred.
     ((2, 3, 4), (-2, 4, -1)),
-    ((2, 0, 4), (-1, 0)),  # Empty to high-dimensional.
+    ((2, 0, 4), (-1, 0)),  # Empty to ambiguous.
+    ((2, 0, 4), (0, -1)),  # Empty to ambiguous.
+    ((2, 0, 4), (0, -1, 2)),  # Empty to ambiguous.
 ])
 def test_reshape_invalid_cannot_infer(shape1, shape2):
     a = array_utils.create_dummy_ndarray(chainerx, shape1, 'float32')

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_manipulation.py
@@ -209,6 +209,7 @@ _reshape_shape = [
     ((2, 3, 4), (3, 4, 2)),
     ((2, 3, 4), (3, -1, 2)),
     ((2, 3, 4), (3, -3, 2)),  # -3 is treated as a -1 and is valid.
+    ((2, 0, 3), (-1,)),  # Empty to inferred.
 ]
 
 
@@ -351,6 +352,7 @@ def test_reshape_invalid(shape1, shape2):
     ((2, 3, 4), (5, -1, 3)),  # Not divisible.
     ((2, 3, 4), (-1, -1, 3)),  # More than one dimension cannot be inferred.
     ((2, 3, 4), (-2, 4, -1)),
+    ((2, 0, 4), (-1, 0)),  # Empty to high-dimensional.
 ])
 def test_reshape_invalid_cannot_infer(shape1, shape2):
     a = array_utils.create_dummy_ndarray(chainerx, shape1, 'float32')


### PR DESCRIPTION
Fixes a floating point exception in reshape in ChainerX, raising an error similar to NumPy.

The changes are quite self-describing so please refer to them.