### PR TITLE
Support CuPy/ChainerX arrays when initializing `variable.Parameter` objects

### DIFF
--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -73,8 +73,8 @@ def _get_initializer(initializer):
 
     if initializer is None:
         return LeCunNormal()
-    if (isinstance(initializer, chainer.get_array_types()) or
-            numpy.isscalar(initializer)):
+    if (isinstance(initializer, chainer.get_array_types())
+            or numpy.isscalar(initializer)):
         return Constant(initializer)
 
     if not callable(initializer):

--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -62,7 +62,6 @@ def generate_array(initializer, shape, xp, dtype=None, device=None):
         backend_device = chainer.get_device(device)
         if xp != backend_device.xp:
             raise ValueError('xp and device arguments are inconsistent.')
-
     with chainer.using_device(backend_device):
         array = xp.empty(shape, dtype=dtype)
         initializer(array)
@@ -74,9 +73,8 @@ def _get_initializer(initializer):
 
     if initializer is None:
         return LeCunNormal()
-    if numpy.isscalar(initializer):
-        return Constant(initializer)
-    if isinstance(initializer, numpy.ndarray):
+    if (isinstance(initializer, chainer.get_array_types()) or
+            numpy.isscalar(initializer)):
         return Constant(initializer)
 
     if not callable(initializer):

--- a/chainer/initializers/constant.py
+++ b/chainer/initializers/constant.py
@@ -46,6 +46,8 @@ class _Constant(initializer.Initializer):
                 'fill_value must be either scalar, numpy.ndarray, '
                 'cupy.ndarray or chainerx.ndarray.')
         super(_Constant, self).__init__(dtype)
+        # Array might be residing on a specific device
+        self.device = backend.get_device_from_array(self.fill_value)
 
     def __call__(self, array):
         if self.dtype is not None:

--- a/chainer/initializers/constant.py
+++ b/chainer/initializers/constant.py
@@ -40,8 +40,8 @@ class _Constant(initializer.Initializer):
     fill_value = None  # type: types.ScalarValue
 
     def __init__(self, dtype=None):
-        if not (isinstance(self.fill_value, chainer.get_array_types()) or
-                numpy.isscalar(self.fill_value)):
+        if not (isinstance(self.fill_value, chainer.get_array_types())
+                or numpy.isscalar(self.fill_value)):
             raise ValueError(
                 'fill_value must be either scalar, numpy.ndarray, '
                 'cupy.ndarray or chainerx.ndarray.')

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -1663,6 +1663,7 @@ class Parameter(Variable):
     def __init__(self, initializer=None, shape=None, name=None):
         # type: (tp.Optional[types.InitializerSpec], tp.Optional[types.ShapeSpec], tp.Optional[str]) -> None # NOQA
 
+        device = backend.CpuDevice()
         if initializer is None:
             initializer = constant.NaN()
         elif numpy.isscalar(initializer):
@@ -1671,23 +1672,27 @@ class Parameter(Variable):
             if isinstance(initializer, chainer.get_array_types()):
                 # parameter initialized by the initial array
                 super(Parameter, self).__init__(initializer, name=name)
+                device = backend.get_device_from_array(initializer)
+                self._initial_device = device
+                # Data is already initialized
+                initializer = None
             else:
                 # uninitialized parameter
                 super(Parameter, self).__init__(name=name, _grad_valid=False)
                 dtype = getattr(initializer, 'dtype', None)
+                device = getattr(initializer, 'device', device)
                 self._grad_initializer = constant.NaN(dtype)
         else:
             # parameter initialized with a given shape
             if isinstance(initializer, chainer.get_array_types()):
-                xp = backend.get_array_module(initializer)
                 initializer = constant.Constant(initializer)
-            else:
-                xp = numpy
+            device = getattr(initializer, 'device', device)
+            xp = device.xp
             data = initializers.generate_array(initializer, shape, xp)  # type: ignore # NOQA
             grad = xp.full_like(data, numpy.nan)
             super(Parameter, self).__init__(data, name=name, grad=grad)
-
-        self._initial_device = backend.CpuDevice()
+        self._initial_device = device
+        self._has_chainerx_array = device.xp is chainerx
         self.update_rule = None
         self.initializer = initializer
 
@@ -1793,14 +1798,15 @@ class Parameter(Variable):
         device = self._initial_device
         assert device is not None
         xp = device.xp
+        if self.initializer is not None:
+            data = initializers.generate_array(
+                self.initializer, shape, xp, device=device)
+            self.array = data
 
-        data = initializers.generate_array(
-            self.initializer, shape, xp, device=device)
         ginit = self._grad_initializer
         grad = None if ginit is None else initializers.generate_array(
             ginit, shape, xp, device=device)
 
-        self.array = data
         self.grad = grad
 
         # Convert the array for iDeep.

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1855,8 +1855,9 @@ class TestUninitializedParameterWithDevices(unittest.TestCase):
     def test_initialize_with_device(self, backend_config):
         a = backend_config.get_array(self.a)
         x = chainer.Parameter(initializer=initializers.Constant(a))
+        # Parameters arrays are always initialized in numpy side
         self.check_constant_initialization(
-            x, self.a, backend_config.xp, backend_config.device)
+            x, self.a, np, _numpy_device)
 
     def check_zerograd(self, x, xp):
         assert isinstance(x.grad, xp.ndarray)


### PR DESCRIPTION
Merge before #7525

When trying to create a `variable.Parameter` with an `initializer.Constant` that uses an array other than NumPy, the call to the `initialize` method will faill when trying to generate the array, as the `variable.Parameter` class expects the initializer to be internally using a `numpy.ndarray` if its `initializer.Constant`.

When the `initializers.Constant` tries to copy an array to an array residing on another backend it explicitly moves its fill_value to the target device. This allows to have the `Parameter` initialized with numpy arrays as the  convention requires.