### PR TITLE
Suppress number of combinations of in_out_dtype

### DIFF
--- a/tests/chainerx_tests/dtype_utils.py
+++ b/tests/chainerx_tests/dtype_utils.py
@@ -15,38 +15,42 @@ def _permutate_dtype_mapping(dtype_mapping_list):
 
 
 # Used for e.g. testing power.
-result_numeric_dtypes_two_arrays = _permutate_dtype_mapping([
+result_numeric_dtypes_two_arrays = [
     # Floats.
     (('float16', 'float16'), 'float16'),
     (('float32', 'float32'), 'float32'),
     (('float64', 'float64'), 'float64'),
-    (('float32', 'float16'), 'float32'),
+    (('float16', 'float32'), 'float32'),
+    (('float32', 'float64'), 'float64'),
     (('float64', 'float16'), 'float64'),
-    (('float64', 'float32'), 'float64'),
+
     # Signed ints.
     (('int8', 'int8'), 'int8'),
-    (('int8', 'int16'), 'int16'),
-    (('int8', 'int32'), 'int32'),
-    (('int8', 'int64'), 'int64'),
     (('int16', 'int16'), 'int16'),
     (('int32', 'int32'), 'int32'),
     (('int64', 'int64'), 'int64'),
+    (('int8', 'int16'), 'int16'),
+    (('int8', 'int64'), 'int64'),
     (('int16', 'int32'), 'int32'),
-    (('int16', 'int64'), 'int64'),
+    (('int32', 'int8'), 'int32'),
     (('int32', 'int64'), 'int64'),
+    (('int64', 'int16'), 'int64'),
     # Unsigned ints.
     (('uint8', 'uint8'), 'uint8'),
     # Signed int and unsigned int.
     (('uint8', 'int8'), 'int16'),
     (('uint8', 'int16'), 'int16'),
-    (('uint8', 'int32'), 'int32'),
-    # Int and float.
+    (('int32', 'uint8'), 'int32'),
+    # Signed int and float.
     (('int8', 'float16'), 'float16'),
-    (('uint8', 'float16'), 'float16'),
-    (('int16', 'float32'), 'float32'),
-    (('int32', 'float32'), 'float32'),
+    (('int16', 'float64'), 'float64'),
     (('int64', 'float32'), 'float32'),
-])
+    (('float16', 'int64'), 'float16'),
+    (('float32', 'int32'), 'float32'),
+    # Unsigned int and float.
+    (('uint8', 'float16'), 'float16'),
+    (('float16', 'uint8'), 'float16'),
+]
 
 
 result_comparable_dtypes_two_arrays = [

--- a/tests/chainerx_tests/math_utils.py
+++ b/tests/chainerx_tests/math_utils.py
@@ -244,36 +244,42 @@ in_out_dtypes_math_functions = in_out_float_dtypes_math_functions + [
 ]
 
 
-in_out_dtypes_math_binary_functions = dtype_utils._permutate_dtype_mapping([
+in_out_dtypes_math_binary_functions = [
     # integer mixed
     (('int8', 'int16'), 'float32'),
-    (('int8', 'int32'), 'float32'),
     (('int8', 'int64'), 'float32'),
     (('int8', 'uint8'), 'float32'),
     (('int16', 'int32'), 'float32'),
     (('int16', 'int64'), 'float32'),
-    (('int16', 'uint8'), 'float32'),
-    (('int32', 'int64'), 'float32'),
     (('int32', 'uint8'), 'float32'),
+    (('int32', 'int8'), 'float32'),
+    (('int64', 'int32'), 'float32'),
     (('int64', 'uint8'), 'float32'),
+    (('uint8', 'int16'), 'float32'),
     # integer float mixed
     (('int8', 'float16'), 'float16'),
-    (('int8', 'float32'), 'float32'),
     (('int8', 'float64'), 'float64'),
     (('int16', 'float16'), 'float16'),
     (('int16', 'float32'), 'float32'),
-    (('int16', 'float64'), 'float64'),
-    (('int32', 'float16'), 'float16'),
     (('int32', 'float32'), 'float32'),
     (('int32', 'float64'), 'float64'),
     (('int64', 'float16'), 'float16'),
-    (('int64', 'float32'), 'float32'),
     (('int64', 'float64'), 'float64'),
     (('uint8', 'float16'), 'float16'),
     (('uint8', 'float32'), 'float32'),
-    (('uint8', 'float64'), 'float64'),
+    (('float32', 'int8'), 'float32'),
+    (('float64', 'int16'), 'float64'),
+    (('float16', 'int32'), 'float16'),
+    (('float32', 'int64'), 'float32'),
+    (('float64', 'uint8'), 'float64'),
     # float mixed
+    (('float16', 'float16'), 'float16'),
     (('float16', 'float32'), 'float32'),
     (('float16', 'float64'), 'float64'),
+    (('float32', 'float16'), 'float32'),
+    (('float32', 'float32'), 'float32'),
     (('float32', 'float64'), 'float64'),
-])
+    (('float64', 'float16'), 'float64'),
+    (('float64', 'float32'), 'float64'),
+    (('float64', 'float64'), 'float64'),
+]


### PR DESCRIPTION
This PR suppresses the number of combinations of `in_out_dtypes` to reduce test execution time.

`python -m pytest tests/chainerx_tests/unit_tests/routines_tests/`
- `8c8025e`: 167127 items
- `d51b93b`: 158359 items