### PR TITLE
Fix NumPy version in Dockerfile

### DIFF
--- a/docker/intel/python2/Dockerfile
+++ b/docker/intel/python2/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip install --no-cache-dir 'ideep4py<2.1' chainer==7.0.0b3
+RUN pip install --no-cache-dir 'numpy<1.17' 'ideep4py<2.1' chainer==7.0.0b3

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update -y && \
     python-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN pip install --no-cache-dir cupy-cuda92==7.0.0b3 chainer==7.0.0b3
+RUN pip install --no-cache-dir 'numpy<1.17' cupy-cuda92==7.0.0b3 chainer==7.0.0b3


### PR DESCRIPTION
This PR fixes the docker build failure.
(Python 2 is no longer supported in NumPy 1.17)

Although Py2 is no longer supported in master branch, I'd like to fix in master branch as we need to re-release the docker image for v7.0.0b3 (and v6.3.0) using these Dockerfiles.