### PR TITLE
Refactor `F.batch_normalization` and ChainerMN backend implementations

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -26,7 +26,7 @@ class _BatchNormalizationBackend:
         raise NotImplementedError()
 
 
-class _GeneralBatchNormalizationBackend(_BatchNormalizationBackend):
+class GeneralBatchNormalizationBackend(_BatchNormalizationBackend):
 
     def __init__(self):
         self.mean = None
@@ -133,7 +133,7 @@ class _GeneralBatchNormalizationBackend(_BatchNormalizationBackend):
         return gx, ggamma, gbeta
 
 
-class _IDeepBatchNormalizationBackend(_GeneralBatchNormalizationBackend):
+class _IDeepBatchNormalizationBackend(GeneralBatchNormalizationBackend):
     def forward(self, axis, gamma, x, xp, expander,
                 beta, eps, decay, running_mean, running_var):
         self.running_mean = running_mean
@@ -205,7 +205,7 @@ class _IDeepBatchNormalizationBackend(_GeneralBatchNormalizationBackend):
         return gx, ggamma, gbeta
 
 
-class _CudnnBatchNormalizationBackend(_GeneralBatchNormalizationBackend):
+class _CudnnBatchNormalizationBackend(GeneralBatchNormalizationBackend):
     def __init__(self, is_for_conv2d, cudnn_mode):
         self.is_for_conv2d = is_for_conv2d
         self.cudnn_mode = cudnn_mode
@@ -271,7 +271,7 @@ def _bn_backend_selector(xp, mode):
         return _CudnnBatchNormalizationBackend(mode.is_for_conv2d,
                                                mode.get_cudnn_mode())
     else:
-        return _GeneralBatchNormalizationBackend()
+        return GeneralBatchNormalizationBackend()
 
 
 class BatchNormalization(function_node.FunctionNode):

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -3,8 +3,6 @@ import warnings
 import numpy
 import six
 
-from abc import abstractmethod
-from abc import ABCMeta
 import chainer
 from chainer import backend
 from chainer.backends import cuda
@@ -17,14 +15,12 @@ from chainer.utils import type_check
 import chainerx
 
 
-class _BatchNormalizationBackend(six.with_metaclass(ABCMeta)):
+class _BatchNormalizationBackend:
 
-    @abstractmethod
     def forward(self, axis, gamma, x, xp, expander,
                 beta, eps, decay, running_mean, running_var):
         raise NotImplementedError()
 
-    @abstractmethod
     def backward(self, axis, gamma, gy, x, xp,
                  expander, mean, inv_std, eps, var, mode):
         raise NotImplementedError()

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -261,10 +261,10 @@ def _compute_key_axis(x_ndim, gamma_ndim=1, axis=None):
     return key_axis
 
 
-def _bn_backend_selector(batch_norm_obj, inputs):
+def _bn_backend_selector(batch_norm_func, inputs):
     x, gamma, _ = inputs
     xp = backend.get_array_module(x)
-    mode = _BNMode(x, gamma, batch_norm_obj.key_axis)
+    mode = _BNMode(x, gamma, batch_norm_func.key_axis)
     use_cudnn = mode.can_use_cudnn(xp)
     use_ideep = mode.can_use_ideep()
 

--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -44,8 +44,8 @@ class GeneralBatchNormalizationBackend(_BatchNormalizationBackend):
 
         gamma = gamma[expander].astype(interm_dtype, copy=False)
         beta = beta[expander].astype(interm_dtype, copy=False)
-        self.mean, var = self._get_mean_and_var(axis, gamma,
-                                                x, xp, interm_dtype)
+        self.mean, var = self.get_mean_and_var(axis, gamma,
+                                               x, xp, interm_dtype)
         if xp is numpy:
             self.inv_std = numpy.reciprocal(numpy.sqrt(
                 var + eps, dtype=interm_dtype))
@@ -90,12 +90,12 @@ class GeneralBatchNormalizationBackend(_BatchNormalizationBackend):
 
         return y,
 
-    def _get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
+    def get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
         mean = x.mean(axis=axis, dtype=interm_dtype)
         var = x.var(axis=axis, dtype=interm_dtype)
         return mean, var
 
-    def _get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
+    def get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
         gbeta = gy.sum(axis=axis, dtype=gamma.dtype)
         ggamma = (gy * x_hat).sum(axis=axis, dtype=gamma.dtype)
 
@@ -109,7 +109,7 @@ class GeneralBatchNormalizationBackend(_BatchNormalizationBackend):
             gy = numpy.asarray(gy)
 
         x_hat = _x_hat(x, mean[expander], inv_std[expander])
-        gbeta, ggamma = self._get_ggamma_and_gbeta(axis, gamma, gy, x_hat, xp)
+        gbeta, ggamma = self.get_ggamma_and_gbeta(axis, gamma, gy, x_hat, xp)
 
         inv_m = gamma.dtype.type(1. / (x.size // gamma.size))
         if xp is numpy:

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -124,7 +124,7 @@ class multinode_bn_backend_selector:
         self.comm = comm
         self.communication_backend_name = communication_backend_name
 
-    def __call__(self, xp, mode):
+    def __call__(self, batch_norm_obj, inputs):
         if self.communication_backend_name == 'nccl':
             return _NcclBackend(self.comm)
         else:

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -5,10 +5,10 @@ import chainer
 from chainer import cuda
 import chainer.utils
 from chainer.functions.normalization.batch_normalization \
-    import GeneralBatchNormalizationBackend
+    import GeneralBatchNormalizationImpl
 
 
-class _MpiBackend(GeneralBatchNormalizationBackend):
+class _MpiImpl(GeneralBatchNormalizationImpl):
     def __init__(self, comm):
         self.comm = comm
 
@@ -36,7 +36,7 @@ class _MpiBackend(GeneralBatchNormalizationBackend):
         return gbeta, ggamma
 
 
-class _NcclBackend(GeneralBatchNormalizationBackend):
+class _NcclImpl(GeneralBatchNormalizationImpl):
 
     def __init__(self, comm):
         self.comm = comm
@@ -119,13 +119,13 @@ def get_communication_backend(comm, communication_backend='auto'):
     return selected_communication_backend
 
 
-class MultiNodeBNBackendSelector:
+class MultiNodeBNImplSelector:
     def __init__(self, comm, communication_backend_name):
         self.comm = comm
         self.communication_backend_name = communication_backend_name
 
     def __call__(self, batch_norm_func, inputs):
         if self.communication_backend_name == 'nccl':
-            return _NcclBackend(self.comm)
+            return _NcclImpl(self.comm)
         else:
-            return _MpiBackend(self.comm)
+            return _MpiImpl(self.comm)

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -136,19 +136,7 @@ class MultiNodeBatchNormalizationFunction(BatchNormalization):
         self.comm = comm
         self.communication_backend = communication_backend
 
-    def _bn_backend_selector(self, x, xp, gamma):
-        head_ndim = gamma.ndim + 1
-        # cuDNN only supports these tensor dimensions because they are
-        # the most commonly used. If there is a need to support other
-        # dimensions with cuDNN, we could consider reshaping the input
-        # into a 2-dim array with channels as second dim and m=<product
-        # of all dimensions except the 2nd dimension> as the first
-        # dimension.
-        cudnn_dim_ok = x.ndim == 2 or (x.ndim == 4 and head_ndim == 2)
-        # TODO(bkvogel): Check for float16 support again in next cuDNN version.
-        # cuDNN v5 batch normalization does not seem to support float16.
-        self.use_cudnn = cudnn_dim_ok and x[0].dtype != numpy.float16
-
+    def _bn_backend_selector(self, xp):
         if self.communication_backend == 'nccl':
             return _NcclBackend(self.comm)
         else:

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -11,16 +11,9 @@ from chainer.functions.normalization.batch_normalization \
     import BatchNormalization
 
 
-class _MultiNodeBatchNormalizationBackend(_GeneralBatchNormalizationBackend):
+class _MpiBackend(_GeneralBatchNormalizationBackend):
     def __init__(self, comm):
-        super(_MultiNodeBatchNormalizationBackend, self).__init__()
         self.comm = comm
-        self.std = None
-
-
-class _MpiBackend(_MultiNodeBatchNormalizationBackend):
-    def __init__(self, comm):
-        super(_MpiBackend, self).__init__(comm)
 
     def _get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
         tmp = xp.empty(gamma.size * 2, dtype=gamma.dtype)
@@ -46,10 +39,10 @@ class _MpiBackend(_MultiNodeBatchNormalizationBackend):
         return gbeta, ggamma
 
 
-class _NcclBackend(_MultiNodeBatchNormalizationBackend):
+class _NcclBackend(_GeneralBatchNormalizationBackend):
 
     def __init__(self, comm):
-        super(_NcclBackend, self).__init__(comm)
+        self.comm = comm
 
         # We need to delay importing MPI4py (and momdules that import MPI4py)
         import chainermn.communicators._memory_utility as memory_utility_module

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -12,7 +12,7 @@ class _MpiBackend(GeneralBatchNormalizationBackend):
     def __init__(self, comm):
         self.comm = comm
 
-    def _get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
+    def get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
         tmp = xp.empty(gamma.size * 2, dtype=gamma.dtype)
         x.mean(axis=axis, out=tmp[:gamma.size], dtype=gamma.dtype)
         xp.square(x).mean(axis=axis, out=tmp[gamma.size:], dtype=gamma.dtype)
@@ -24,7 +24,7 @@ class _MpiBackend(GeneralBatchNormalizationBackend):
         var = sqmean - xp.square(mean)
         return mean, var
 
-    def _get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
+    def get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
         tmp = xp.empty(gamma.size * 2, dtype=gamma.dtype)
         gy.sum(axis=axis, out=tmp[:gamma.size], dtype=gamma.dtype)
         (gy * x_hat).sum(axis=axis, out=tmp[gamma.size:], dtype=gamma.dtype)
@@ -45,7 +45,7 @@ class _NcclBackend(GeneralBatchNormalizationBackend):
         import chainermn.communicators._memory_utility as memory_utility_module
         self.memory_utility_module = memory_utility_module
 
-    def _get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
+    def get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
         gpu_buffer_n_elems = gamma.size * 2
         gpu_buffer_size = gamma.dtype.itemsize * gpu_buffer_n_elems
         gpu_buffer_a = self.memory_utility_module.DeviceMemory()
@@ -71,7 +71,7 @@ class _NcclBackend(GeneralBatchNormalizationBackend):
         var = sqmean - xp.square(mean)
         return mean, var
 
-    def _get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
+    def get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
         gpu_buffer_n_elems = gamma.size * 2
         gpu_buffer_size = gamma.dtype.itemsize * gpu_buffer_n_elems
         gpu_buffer_a = self.memory_utility_module.DeviceMemory()

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -119,12 +119,12 @@ def get_communication_backend(comm, communication_backend='auto'):
     return selected_communication_backend
 
 
-class multinode_bn_backend_selector:
+class MultiNodeBNBackendSelector:
     def __init__(self, comm, communication_backend_name):
         self.comm = comm
         self.communication_backend_name = communication_backend_name
 
-    def __call__(self, batch_norm_obj, inputs):
+    def __call__(self, batch_norm_func, inputs):
         if self.communication_backend_name == 'nccl':
             return _NcclBackend(self.comm)
         else:

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -4,7 +4,6 @@
 import chainer
 from chainer import cuda
 import chainer.utils
-import numpy
 from chainer.functions.normalization.batch_normalization \
     import _GeneralBatchNormalizationBackend
 from chainer.functions.normalization.batch_normalization \

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -1,41 +1,28 @@
 # This file is heavily based on Chainer's batch normalization implementation.
 # See: chainer/functions/normalization/batch_normalization.py (dbb650)
 
-from abc import ABCMeta
-from abc import abstractmethod
 import chainer
-from chainer import backend
 from chainer import cuda
-from chainer import function
 import chainer.utils
-from chainer.utils import type_check
 import numpy
-import six
+from chainer.functions.normalization.batch_normalization \
+    import _GeneralBatchNormalizationBackend
+from chainer.functions.normalization.batch_normalization \
+    import BatchNormalization
 
 
-def _xhat(x, mean, std, expander):
-    x_mu = x - mean[expander]
-    x_mu /= std[expander]
-    return x_mu
-
-
-class _MultiNodeBatchNormalizationBackend(six.with_metaclass(ABCMeta)):
-
-    @abstractmethod
-    def forward(self, axis, gamma, x, xp):
-        raise NotImplementedError()
-
-    @abstractmethod
-    def backward(self, axis, gamma, gy, x_hat, x, xp):
-        raise NotImplementedError()
+class _MultiNodeBatchNormalizationBackend(_GeneralBatchNormalizationBackend):
+    def __init__(self, comm):
+        super(_MultiNodeBatchNormalizationBackend, self).__init__()
+        self.comm = comm
+        self.std = None
 
 
 class _MpiBackend(_MultiNodeBatchNormalizationBackend):
-
     def __init__(self, comm):
-        self.comm = comm
+        super(_MpiBackend, self).__init__(comm)
 
-    def forward(self, axis, gamma, x, xp):
+    def _get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
         tmp = xp.empty(gamma.size * 2, dtype=gamma.dtype)
         x.mean(axis=axis, out=tmp[:gamma.size], dtype=gamma.dtype)
         xp.square(x).mean(axis=axis, out=tmp[gamma.size:], dtype=gamma.dtype)
@@ -47,7 +34,7 @@ class _MpiBackend(_MultiNodeBatchNormalizationBackend):
         var = sqmean - xp.square(mean)
         return mean, var
 
-    def backward(self, axis, gamma, gy, x_hat, x, xp):
+    def _get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
         tmp = xp.empty(gamma.size * 2, dtype=gamma.dtype)
         gy.sum(axis=axis, out=tmp[:gamma.size], dtype=gamma.dtype)
         (gy * x_hat).sum(axis=axis, out=tmp[gamma.size:], dtype=gamma.dtype)
@@ -62,13 +49,13 @@ class _MpiBackend(_MultiNodeBatchNormalizationBackend):
 class _NcclBackend(_MultiNodeBatchNormalizationBackend):
 
     def __init__(self, comm):
-        self.comm = comm
+        super(_NcclBackend, self).__init__(comm)
 
         # We need to delay importing MPI4py (and momdules that import MPI4py)
         import chainermn.communicators._memory_utility as memory_utility_module
         self.memory_utility_module = memory_utility_module
 
-    def forward(self, axis, gamma, x, xp):
+    def _get_mean_and_var(self, axis, gamma, x, xp, interm_dtype):
         gpu_buffer_n_elems = gamma.size * 2
         gpu_buffer_size = gamma.dtype.itemsize * gpu_buffer_n_elems
         gpu_buffer_a = self.memory_utility_module.DeviceMemory()
@@ -94,7 +81,7 @@ class _NcclBackend(_MultiNodeBatchNormalizationBackend):
         var = sqmean - xp.square(mean)
         return mean, var
 
-    def backward(self, axis, gamma, gy, x_hat, x, xp):
+    def _get_ggamma_and_gbeta(self, axis, gamma, gy, x_hat, xp):
         gpu_buffer_n_elems = gamma.size * 2
         gpu_buffer_size = gamma.dtype.itemsize * gpu_buffer_n_elems
         gpu_buffer_a = self.memory_utility_module.DeviceMemory()
@@ -120,103 +107,15 @@ class _NcclBackend(_MultiNodeBatchNormalizationBackend):
         return gbeta, ggamma
 
 
-def get_communication_backend(comm, communication_backend='auto'):
-    if communication_backend not in ['mpi', 'nccl', 'auto']:
-        raise ValueError('MultiNodeBatchNormalization does not support '
-                         '{}.'.format(communication_backend))
-    from chainermn.communicators.pure_nccl_communicator \
-        import PureNcclCommunicator
-    if communication_backend != 'auto':
-        if 'nccl' == communication_backend:
-            if not isinstance(comm, PureNcclCommunicator):
-                raise ValueError('{} is not supported in '
-                                 'MultiNodeBatchNormalization when using '
-                                 '{}.'.format(communication_backend,
-                                              type(comm)))
-        selected_communication_backend = communication_backend
-    else:
-        if isinstance(comm, PureNcclCommunicator):
-            selected_communication_backend = 'nccl'
-        else:
-            selected_communication_backend = 'mpi'
-    return selected_communication_backend
-
-
-class MultiNodeBatchNormalizationFunction(function.Function):
-
+class MultiNodeBatchNormalizationFunction(BatchNormalization):
     def __init__(self, comm, eps=2e-5, mean=None, var=None, decay=0.9,
                  communication_backend='auto'):
-        chainer.utils.experimental(
-            'chainermn.functions.MultiNodeBatchNormalizationFunction')
-
+        super().__init__(eps, mean, var, decay)
         self.comm = comm
-        self.running_mean = mean
-        self.running_var = var
+        self.communication_backend = communication_backend
 
-        # Note: cuDNN v5 requires that eps be greater than 1e-5. Otherwise, an
-        # error will occur.
-        # See CUDNN_BN_MIN_EPSILON value in cudnn.h to verify minimum allowable
-        # value.
-        self.eps = eps
-        if chainer.should_use_cudnn('>=auto'):
-            if eps < 1e-5:
-                msg = 'cuDNN does not allow an eps value less than 1e-5.'
-                raise RuntimeError(msg)
-        self.mean_cache = None
-        self.decay = decay
-
-        selected_communication_backend = \
-            get_communication_backend(comm, communication_backend)
-
-        if selected_communication_backend == 'nccl':
-            self._backend = _NcclBackend(comm)
-        else:
-            self._backend = _MpiBackend(comm)
-
-    def check_type_forward(self, in_types):
-        n_in = type_check.eval(in_types.size())
-        if n_in != 3 and n_in != 5:
-            raise type_check.InvalidType(
-                '%s or %s' % (in_types.size() == 3, in_types.size() == 5),
-                '%s == %s' % (in_types.size(), n_in))
-        x_type, gamma_type, beta_type = in_types[:3]
-        M = type_check.eval(gamma_type.ndim)
-        type_check.expect(
-            x_type.dtype.kind == 'f',
-            x_type.ndim >= gamma_type.ndim + 1,
-            x_type.shape[1:1 + M] == gamma_type.shape,
-            gamma_type.dtype.kind == 'f',
-            gamma_type.dtype == beta_type.dtype,
-            gamma_type.shape == beta_type.shape,
-        )
-        if len(in_types) == 5:
-            mean_type, var_type = in_types[3:]
-            type_check.expect(
-                mean_type.dtype == x_type.dtype,
-                mean_type.shape == gamma_type.shape,
-                var_type.dtype == x_type.dtype,
-                var_type.shape == gamma_type.shape,
-            )
-
-    def forward(self, inputs):
-        xp = backend.get_array_module(*inputs)
-        x, gamma, beta = inputs[:3]
-        if chainer.configuration.config.train:
-            if self.running_mean is None:
-                self.running_mean = xp.zeros_like(gamma, dtype=x.dtype)
-                self.running_var = xp.zeros_like(gamma, dtype=x.dtype)
-            else:
-                self.running_mean = xp.array(self.running_mean)
-                self.running_var = xp.array(self.running_var)
-        elif len(inputs) == 5:
-            self.fixed_mean = inputs[3]
-            self.fixed_var = inputs[4]
-
+    def _bn_backend_selector(self, x, xp, gamma):
         head_ndim = gamma.ndim + 1
-        expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
-        gamma = gamma[expander]
-        beta = beta[expander]
-
         # cuDNN only supports these tensor dimensions because they are
         # the most commonly used. If there is a need to support other
         # dimensions with cuDNN, we could consider reshaping the input
@@ -226,108 +125,43 @@ class MultiNodeBatchNormalizationFunction(function.Function):
         cudnn_dim_ok = x.ndim == 2 or (x.ndim == 4 and head_ndim == 2)
         # TODO(bkvogel): Check for float16 support again in next cuDNN version.
         # cuDNN v5 batch normalization does not seem to support float16.
-        self._can_use_cudnn = cudnn_dim_ok and x[0].dtype != numpy.float16
+        self.use_cudnn = cudnn_dim_ok and x[0].dtype != numpy.float16
 
-        cudnn_updated_running_stats = False
-
-        if chainer.configuration.config.train:
-            axis = (0,) + tuple(range(head_ndim, x.ndim))
-            mean, var = self._backend.forward(axis, gamma, x, xp)
-            var += self.eps
+        if self.communication_backend not in ['mpi', 'nccl', 'auto']:
+            raise ValueError('MultiNodeBatchNormalization does not support '
+                             '{}.'.format(self.communication_backend))
+        from chainermn.communicators.pure_nccl_communicator \
+            import PureNcclCommunicator
+        if self.communication_backend != 'auto':
+            if 'nccl' == self.communication_backend:
+                if not isinstance(self.comm, PureNcclCommunicator):
+                    raise ValueError('{} is not supported in '
+                                     'MultiNodeBatchNormalization when using '
+                                     '{}.'.format(self.communication_backend,
+                                                  type(self.comm)))
+            selected_communication_backend = self.communication_backend
         else:
-            mean = self.fixed_mean
-            var = self.fixed_var + self.eps
-        self.std = xp.sqrt(var, dtype=var.dtype)
-        if xp is numpy:
-            self.x_hat = _xhat(x, mean, self.std, expander)
-            y = gamma * self.x_hat
-            y += beta
-            y = y.astype(x.dtype)
-        else:
-            self.x_hat, y = cuda.elementwise(
-                'T x, U mean, U std, U gamma, U beta', 'T x_hat, T y',
-                '''
-                x_hat = (x - mean) / std;
-                y = gamma * x_hat + beta;
-                ''',
-                'bn_fwd')(x, mean[expander], self.std[expander], gamma,
-                          beta)
-
-        if chainer.configuration.config.train and \
-                (not cudnn_updated_running_stats):
-            # Note: If in training mode, the cuDNN forward training function
-            # will do this for us, so
-            # only run following code if cuDNN was not used.
-            # Update running statistics:
-            m = x.size // gamma.size
-            adjust = m / max(m - 1., 1.)  # unbiased estimation
-            if xp is numpy:
-                self.running_mean *= self.decay
-                temp_ar = xp.array(mean)
-                temp_ar *= (1 - self.decay)
-                self.running_mean += temp_ar
-                del temp_ar
-                self.running_var *= self.decay
-                temp_ar = xp.array(var)
-                temp_ar *= (1 - self.decay) * adjust
-                self.running_var += temp_ar
-                del temp_ar
+            if isinstance(self.comm, PureNcclCommunicator):
+                selected_communication_backend = 'nccl'
             else:
-                cuda.elementwise(
-                    'U mean, U var, U decay, U adjust',
-                    'U r_mean, U r_var',
-                    '''
-                    r_mean = r_mean * decay + mean * (1 - decay);
-                    r_var = r_var * decay + var * (1 - decay) * adjust;
-                    ''',
-                    'update_mean_var')(mean, var, self.decay, adjust,
-                                       self.running_mean, self.running_var)
+                selected_communication_backend = 'mpi'
 
-        return y,
-
-    def backward(self, inputs, grad_outputs):
-        x, gamma = inputs[:2]
-        gy = grad_outputs[0]
-        head_ndim = gamma.ndim + 1
-        expander = (None, Ellipsis) + (None,) * (x.ndim - head_ndim)
-        m = gamma.dtype.type(x.size // gamma.size)
-        axis = (0,) + tuple(range(head_ndim, x.ndim))
-        xp = backend.get_array_module(x)
-        if len(inputs) == 5:
-            # This case is unlikely to be used in practice and so does not
-            # need to be optimized for performance.
-            mean = inputs[3]
-            var = inputs[4]
-            std = xp.sqrt(var, dtype=var.dtype)
-            gs = gamma / std
-            gbeta = gy.sum(axis=axis)
-            x_hat = _xhat(x, mean, std, expander)
-            ggamma = (gy * x_hat).sum(axis=axis)
-            gmean = -gs * gbeta
-            gvar = -0.5 * gamma / var * ggamma
-            gx = gs[expander] * gy
-            gx = gx.astype(x.dtype, copy=False)
-            return gx, ggamma, gbeta, gmean, gvar
-
-        # Note: If length of inputs is not 5, we must be in train mode.
-        assert chainer.configuration.config.train
-        gbeta, ggamma = self._backend.backward(axis, gamma, gy,
-                                               self.x_hat, x, xp)
-
-        if xp is numpy:
-            gx = (gamma / self.std)[expander] * (
-                gy - (self.x_hat * ggamma[expander] + gbeta[expander]) / m)
-            gx = gx.astype(x.dtype, copy=False)
+        if selected_communication_backend == 'nccl':
+            return _NcclBackend(self.comm)
         else:
-            inv_m = numpy.float32(1) / m
-            gx = cuda.elementwise(
-                'T gy, T x_hat, U gamma, U std, U ggamma, U gbeta, \
-                U inv_m',
-                'T gx',
-                'gx = (gamma / std) * (gy - (x_hat * ggamma + gbeta) * \
-                inv_m)',
-                'bn_bwd')(gy, self.x_hat, gamma[expander],
-                          self.std[expander], ggamma[expander],
-                          gbeta[expander], inv_m)
+            return _MpiBackend(self.comm)
 
-        return gx, ggamma, gbeta
+    def copy(self, mode='share'):
+        to_be_preserved = ['bn_backend', 'comm']
+        preserved = {}
+        for name in to_be_preserved:
+            preserved[name] = getattr(self, name)
+            setattr(self, name, None)
+
+        ret = super(BatchNormalization, self).copy(mode)
+
+        for name in to_be_preserved:
+            setattr(self, name, preserved[name])
+            setattr(ret, name, preserved[name])
+
+        return ret

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -5,10 +5,10 @@ import chainer
 from chainer import cuda
 import chainer.utils
 from chainer.functions.normalization.batch_normalization \
-    import _GeneralBatchNormalizationBackend
+    import GeneralBatchNormalizationBackend
 
 
-class _MpiBackend(_GeneralBatchNormalizationBackend):
+class _MpiBackend(GeneralBatchNormalizationBackend):
     def __init__(self, comm):
         self.comm = comm
 
@@ -36,7 +36,7 @@ class _MpiBackend(_GeneralBatchNormalizationBackend):
         return gbeta, ggamma
 
 
-class _NcclBackend(_GeneralBatchNormalizationBackend):
+class _NcclBackend(GeneralBatchNormalizationBackend):
 
     def __init__(self, comm):
         self.comm = comm

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -6,8 +6,6 @@ from chainer import cuda
 import chainer.utils
 from chainer.functions.normalization.batch_normalization \
     import _GeneralBatchNormalizationBackend
-from chainer.functions.normalization.batch_normalization \
-    import BatchNormalization
 
 
 class _MpiBackend(_GeneralBatchNormalizationBackend):

--- a/chainermn/functions/batch_normalization.py
+++ b/chainermn/functions/batch_normalization.py
@@ -1,6 +1,3 @@
-# This file is heavily based on Chainer's batch normalization implementation.
-# See: chainer/functions/normalization/batch_normalization.py (dbb650)
-
 import chainer
 from chainer import cuda
 import chainer.utils

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -10,7 +10,9 @@ import numpy
 from chainermn.functions.batch_normalization import \
     get_communication_backend
 from chainermn.functions.batch_normalization import \
-    MultiNodeBatchNormalizationFunction
+    multinode_bn_backend_selector
+from chainer.functions.normalization.batch_normalization \
+    import BatchNormalization
 
 
 class MultiNodeBatchNormalization(link.Link):
@@ -103,9 +105,10 @@ class MultiNodeBatchNormalization(link.Link):
             else:
                 decay = self.decay
 
-            func = MultiNodeBatchNormalizationFunction(
-                self.comm, self.eps, self.avg_mean, self.avg_var, decay=decay,
-                communication_backend=self._communication_backend)
+            func = BatchNormalization(
+                self.eps, self.avg_mean, self.avg_var, decay,
+                backend_selector=multinode_bn_backend_selector(
+                    self.comm, self._communication_backend))
 
             ret = func.apply((x, gamma, beta))[0]
 

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -10,9 +10,7 @@ import numpy
 from chainermn.functions.batch_normalization import \
     get_communication_backend
 from chainermn.functions.batch_normalization import \
-    multinode_bn_backend_selector
-from chainer.functions.normalization.batch_normalization \
-    import BatchNormalization
+    MultiNodeBNBackendSelector
 
 
 class MultiNodeBatchNormalization(link.Link):
@@ -105,9 +103,9 @@ class MultiNodeBatchNormalization(link.Link):
             else:
                 decay = self.decay
 
-            func = BatchNormalization(
+            func = batch_normalization.BatchNormalization(
                 self.eps, self.avg_mean, self.avg_var, decay,
-                backend_selector=multinode_bn_backend_selector(
+                backend_selector=MultiNodeBNBackendSelector(
                     self.comm, self._communication_backend))
 
             ret = func.apply((x, gamma, beta))[0]

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -10,7 +10,7 @@ import numpy
 from chainermn.functions.batch_normalization import \
     get_communication_backend
 from chainermn.functions.batch_normalization import \
-    MultiNodeBNBackendSelector
+    MultiNodeBNImplSelector
 
 
 class MultiNodeBatchNormalization(link.Link):
@@ -105,7 +105,7 @@ class MultiNodeBatchNormalization(link.Link):
 
             func = batch_normalization.BatchNormalization(
                 self.eps, self.avg_mean, self.avg_var, decay,
-                backend_selector=MultiNodeBNBackendSelector(
+                impl_selector=MultiNodeBNImplSelector(
                     self.comm, self._communication_backend))
 
             ret = func.apply((x, gamma, beta))[0]

--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -8,6 +8,8 @@ from chainer import variable
 import numpy
 
 from chainermn.functions.batch_normalization import \
+    get_communication_backend
+from chainermn.functions.batch_normalization import \
     MultiNodeBatchNormalizationFunction
 
 
@@ -63,7 +65,8 @@ class MultiNodeBatchNormalization(link.Link):
         self.decay = decay
         self.eps = eps
 
-        self._communication_backend = communication_backend
+        self._communication_backend = \
+            get_communication_backend(comm, communication_backend)
 
         with self.init_scope():
             if use_gamma:


### PR DESCRIPTION
This PR refactors the `batch_normalization` in `chainermn`.
The motivation is to merge the `batch_normalization` code in `chainermn` into the `batch_normalization` in `chainer`, which can reduce the code redundancy, and enables features in `batch_normalization` in `chainer` into `chainermn`.

This PR resolves #6533