### PR TITLE
Add test for `Parameter` initialization with device transfer and config dtype

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -65,7 +65,8 @@ def copyto(dst, src):
     elif isinstance(dst, cuda.ndarray):
         if isinstance(src, chainer.get_cpu_array_types()):
             src = numpy.asarray(src)
-            if dst.flags.c_contiguous or dst.flags.f_contiguous:
+            if (src.dtype == dst.dtype
+                    and (dst.flags.c_contiguous or dst.flags.f_contiguous)):
                 dst.set(src)
             else:
                 cuda.cupy.copyto(dst, cuda.to_gpu(src, device=dst.device))

--- a/tests/chainer_tests/test_backend.py
+++ b/tests/chainer_tests/test_backend.py
@@ -65,15 +65,21 @@ class _TestCopyToBase(object):
         numpy.testing.assert_array_equal(self._to_cpu(dst), self.src_data)
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32],
+}))
 class TestCopyToCPU(_TestCopyToBase, unittest.TestCase):
     def _get_dst(self):
-        return self.dst_data
+        return self.dst_data.astype(self.dtype, copy=False)
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32],
+}))
 @attr.gpu
 class TestCopyToGPU(_TestCopyToBase, unittest.TestCase):
     def _get_dst(self):
-        return cuda.cupy.array(self.dst_data)
+        return cuda.cupy.array(self.dst_data, self.dtype)
 
     @attr.multi_gpu(2)
     def test_gpu_to_another_gpu(self):
@@ -92,17 +98,23 @@ class TestCopyToIDeep(_TestCopyToBase, unittest.TestCase):
         return dst
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32],
+}))
 @attr.chainerx
 class TestCopyToChxNative(_TestCopyToBase, unittest.TestCase):
     def _get_dst(self):
-        return chainerx.array(self.dst_data, device='native')
+        return chainerx.array(self.dst_data, dtype=self.dtype, device='native')
 
 
+@testing.parameterize(*testing.product({
+    'dtype': [numpy.float16, numpy.float32],
+}))
 @attr.chainerx
 @attr.gpu
 class TestCopyToChxCuda(_TestCopyToBase, unittest.TestCase):
     def _get_dst(self):
-        return chainerx.array(self.dst_data, device='cuda:0')
+        return chainerx.array(self.dst_data, dtype=self.dtype, device='cuda:0')
 
 
 class TestCopyToError(unittest.TestCase):

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1837,10 +1837,13 @@ class TestUninitializedParameterWithDevices(unittest.TestCase):
         self.a = np.random.rand(3, 2).astype(np.float32)
         self.b = np.random.rand(*self.a.shape).astype(self.a.dtype)
 
-    def check_constant_initialization(self, x, a, xp, expected_device):
+    def check_constant_initialization(
+            self, x, a, xp, expected_dtype, expected_device):
         x.initialize(a.shape)
         assert isinstance(x.data, xp.ndarray)
         assert x._has_chainerx_array is (xp is chainerx)
+        assert x.dtype == expected_dtype
+        assert x.grad.dtype == expected_dtype
         xp.testing.assert_array_equal(x.data, xp.asarray(a))
         xp.testing.assert_array_equal(x.grad, np.float32('nan'))
         assert backend.get_device_from_array(x.data) == expected_device
@@ -1850,14 +1853,23 @@ class TestUninitializedParameterWithDevices(unittest.TestCase):
         x = chainer.Parameter(initializer=initializers.Constant(self.a))
         x.to_device(backend_config.device)
         self.check_constant_initialization(
-            x, self.a, backend_config.xp, backend_config.device)
+            x, self.a, backend_config.xp, self.a.dtype, backend_config.device)
+
+    def test_initialize_to_device_with_dtype(self, backend_config):
+        x = chainer.Parameter(initializer=initializers.Constant(
+            self.a, dtype=np.float64))
+        x.to_device(backend_config.device)
+        with chainer.using_config('dtype', np.float16):
+            self.check_constant_initialization(
+                x, self.a, backend_config.xp, np.float64,
+                backend_config.device)
 
     def test_initialize_with_device(self, backend_config):
         a = backend_config.get_array(self.a)
         x = chainer.Parameter(initializer=initializers.Constant(a))
         # Parameters arrays are always initialized in numpy side
         self.check_constant_initialization(
-            x, self.a, np, _numpy_device)
+            x, self.a, np, self.a.dtype, _numpy_device)
 
     def check_zerograd(self, x, xp):
         assert isinstance(x.grad, xp.ndarray)

--- a/tests/chainer_tests/test_variable.py
+++ b/tests/chainer_tests/test_variable.py
@@ -1837,13 +1837,11 @@ class TestUninitializedParameterWithDevices(unittest.TestCase):
         self.a = np.random.rand(3, 2).astype(np.float32)
         self.b = np.random.rand(*self.a.shape).astype(self.a.dtype)
 
-    def check_constant_initialization(
-            self, x, a, xp, expected_dtype, expected_device):
+    def check_constant_initialization(self, x, a, xp, expected_device):
         x.initialize(a.shape)
         assert isinstance(x.data, xp.ndarray)
         assert x._has_chainerx_array is (xp is chainerx)
-        xp.testing.assert_array_equal(
-            x.data.astype(expected_dtype, copy=False), xp.asarray(a))
+        xp.testing.assert_array_equal(x.data, xp.asarray(a))
         xp.testing.assert_array_equal(x.grad, np.float32('nan'))
         assert backend.get_device_from_array(x.data) == expected_device
         assert backend.get_device_from_array(x.grad) == expected_device
@@ -1852,23 +1850,14 @@ class TestUninitializedParameterWithDevices(unittest.TestCase):
         x = chainer.Parameter(initializer=initializers.Constant(self.a))
         x.to_device(backend_config.device)
         self.check_constant_initialization(
-            x, self.a, backend_config.xp, self.a.dtype, backend_config.device)
-
-    def test_initialize_to_device_with_dtype(self, backend_config):
-        x = chainer.Parameter(initializer=initializers.Constant(
-            self.a, dtype=np.float64))
-        x.to_device(backend_config.device)
-        with chainer.using_config('dtype', np.float16):
-            self.check_constant_initialization(
-                x, self.a, backend_config.xp, np.float64,
-                backend_config.device)
+            x, self.a, backend_config.xp, backend_config.device)
 
     def test_initialize_with_device(self, backend_config):
         a = backend_config.get_array(self.a)
         x = chainer.Parameter(initializer=initializers.Constant(a))
         # Parameters arrays are always initialized in numpy side
         self.check_constant_initialization(
-            x, self.a, np, self.a.dtype, _numpy_device)
+            x, self.a, np, _numpy_device)
 
     def check_zerograd(self, x, xp):
         assert isinstance(x.grad, xp.ndarray)


### PR DESCRIPTION
Separated from and depends on https://github.com/chainer/chainer/pull/8043.

This PR adds tests for a broken `Parameter` initialization scenario that is fixed via the above PR. 