### PR TITLE
Adjust TrueDiv tolerances

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_arithmetic.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_arithmetic.py
@@ -1021,8 +1021,11 @@ class TestTrueDivide(math_utils.BinaryMathTestBase, op_utils.NumpyOpTest):
         if dtype1 == 'float16' or dtype2 == 'float16':
             self.check_forward_options.update({'rtol': 5e-3, 'atol': 5e-3})
             self.check_backward_options.update({'rtol': 1e-2, 'atol': 5e-3})
+            # Double backward is heavily influenced by some fp16
+            # precision issues due to the way intermediate results
+            # are treated in ChainerX
             self.check_double_backward_options.update(
-                {'rtol': 1e-2, 'atol': 5e-3})
+                {'rtol': 1e-2, 'atol': 3e-1})
 
     def generate_inputs(self):
         a, b = super().generate_inputs()


### PR DESCRIPTION
Closes #7785 

The real reason behind the flakiness of this tests is #7991 but since it is not easily solvable, we decided to increase the tolerance.

100k runs of the double_backward tests with parameter combinations of float16 types and several shapes tests without issues.