### PR TITLE
Fix subgraph construction for ChainerX backward

### DIFF
--- a/chainerx_cc/chainerx/backward.cc
+++ b/chainerx_cc/chainerx/backward.cc
@@ -156,47 +156,43 @@ std::unordered_map<OpNode*, std::vector<uint8_t>> CreateSubgraph(
         // "Forward" traverse array node queue towards outputs.
         while (!candidate_input_array_nodes.empty()) {
             ArrayNode* array_node = candidate_input_array_nodes.back();
+            candidate_input_array_nodes.pop_back();
 
             auto it_op_node = forward_op_nodes.find(array_node);
-            if (it_op_node == forward_op_nodes.end()) {
-                // Array node is not mapped. It could be an output of an op node that was not given as output.
-                candidate_input_array_nodes.pop_back();
-                continue;
-            }
+            // A single array node could have been an input to multiple op nodes.
+            while (it_op_node != forward_op_nodes.end()) {
+                OpNode* op_node = it_op_node->second;
+                if (op_node != nullptr) {  // If array node is not an output.
+                    std::vector<uint8_t>& flags = input_required_flags[op_node];
+                    if (flags.empty()) {
+                        flags.resize(op_node->input_array_node_count());
+                    }
 
-            OpNode* op_node = it_op_node->second;
-            if (op_node == nullptr) {
-                candidate_input_array_nodes.pop_back();
-                continue;  // Array node is an output.
-            }
+                    const std::vector<std::shared_ptr<ArrayNode>>& input_array_nodes = op_node->input_array_nodes();
+                    for (size_t i_input = 0; i_input < op_node->input_array_node_count(); ++i_input) {
+                        if (input_array_nodes[i_input].get() == array_node) {
+                            flags[i_input] = static_cast<int8_t>(true);
+                            // Cannot break since the same inputs may appear more than once in an op node.
+                        }
+                    }
 
-            std::vector<uint8_t>& flags = input_required_flags[op_node];
-            if (flags.empty()) {
-                flags.resize(op_node->input_array_node_count());
-            }
-
-            const std::vector<std::shared_ptr<ArrayNode>>& input_array_nodes = op_node->input_array_nodes();
-            for (size_t i_input = 0; i_input < op_node->input_array_node_count(); ++i_input) {
-                if (input_array_nodes[i_input].get() == array_node) {
-                    flags[i_input] = static_cast<int8_t>(true);
-                    // Cannot break since the same inputs may appear more than once in an op node.
-                }
-            }
-
-            for (const absl::optional<std::weak_ptr<ArrayNode>>& output_array_node : op_node->output_array_nodes()) {
-                if (output_array_node.has_value()) {
-                    if (std::shared_ptr<ArrayNode> out = output_array_node->lock()) {
-                        if (PushNodeIfNotSeen(candidate_input_array_nodes, out.get(), seen_array_nodes)) {
-                            candidate_input_array_nodes_keep_alive.emplace_back(std::move(out));
+                    for (const absl::optional<std::weak_ptr<ArrayNode>>& output_array_node : op_node->output_array_nodes()) {
+                        if (output_array_node.has_value()) {
+                            if (std::shared_ptr<ArrayNode> out = output_array_node->lock()) {
+                                if (PushNodeIfNotSeen(candidate_input_array_nodes, out.get(), seen_array_nodes)) {
+                                    candidate_input_array_nodes_keep_alive.emplace_back(std::move(out));
+                                }
+                            }
                         }
                     }
                 }
-            }
+                forward_op_nodes.erase(it_op_node);
 
-            forward_op_nodes.erase(it_op_node);
+                // Find the next op node that has this array node as input.
+                it_op_node = forward_op_nodes.find(array_node);
+            }
         }
     }
-
     return input_required_flags;
 }
 


### PR DESCRIPTION
Fixes #8050 

Simplify subgraph construction in ChainerX and fix a failure for when intermediate arrays also appeared as output in `chainerx::Grad`.