### PR TITLE
Add cblas.h and modified CMakeLists.txt

### DIFF
--- a/chainerx_cc/chainerx/native/CMakeLists.txt
+++ b/chainerx_cc/chainerx/native/CMakeLists.txt
@@ -39,26 +39,8 @@ add_library(chainerx_native STATIC
     tensor_dot.cc)
 
 if(${BLAS_FOUND})
-    if(DEFINED ENV{CHAINERX_BLAS_INCLUDE_DIRS})
-        set(BLAS_INCLUDE_DIRS $ENV{CHAINERX_BLAS_INCLUDE_DIRS})
-    elseif(UNIX)
-        # Workaround for UNIX environments to guess the BLAS include directory from its library path (.so).
-        # This workaround is required since CMake does not set the BLAS_INCLUDE_DIRS variable.
-        list(GET BLAS_LIBRARIES 0 BLAS_LIBRARY)
-        get_filename_component(BLAS_ROOT_DIR ${BLAS_LIBRARY} DIRECTORY)  # Directory of .so.
-        get_filename_component(BLAS_ROOT_DIR ${BLAS_ROOT_DIR} DIRECTORY)  # Directory of lib.
-        find_path(BLAS_INCLUDE_DIRS cblas.h
-            HINTS ${BLAS_ROOT_DIR}
-            PATH_SUFFIXES include)
-    endif()
-    if(BLAS_INCLUDE_DIRS)
-        message(STATUS "Found BLAS (include directory: ${BLAS_INCLUDE_DIRS})")
-        add_definitions(-DCHAINERX_ENABLE_BLAS=1)
-        include_directories(${BLAS_INCLUDE_DIRS})
-        target_link_libraries(chainerx_native ${BLAS_LIBRARIES})
-    else()
-        message(WARNING "Found the BLAS library but not the include directory. Skipping BLAS.")
-    endif()
+    add_definitions(-DCHAINERX_ENABLE_BLAS=1)
+    target_link_libraries(chainerx_native ${BLAS_LIBRARIES})
 endif()
 
 if(${LAPACK_FOUND})

--- a/chainerx_cc/chainerx/native/native_device/cblas.h
+++ b/chainerx_cc/chainerx/native/native_device/cblas.h
@@ -1,3 +1,6 @@
+// This header provides chainerx a consistent interface to CBLAS code.
+// It is needed because not all providers of cblas provide cblas.h, e.g. MKL.
+
 #pragma once
 
 extern "C" {

--- a/chainerx_cc/chainerx/native/native_device/cblas.h
+++ b/chainerx_cc/chainerx/native/native_device/cblas.h
@@ -1,0 +1,43 @@
+#pragma once
+
+extern "C" {
+
+#ifndef CBLAS_ENUM_DEFINED_H
+#define CBLAS_ENUM_DEFINED_H
+enum CBLAS_ORDER { CblasRowMajor = 101 };
+enum CBLAS_TRANSPOSE { CblasNoTrans = 111, CblasTrans = 112 };
+#endif
+
+void cblas_sgemm(
+        const enum CBLAS_ORDER Order,
+        const enum CBLAS_TRANSPOSE TransA,
+        const enum CBLAS_TRANSPOSE TransB,
+        const int M,
+        const int N,
+        const int K,
+        const float alpha,
+        const float* A,
+        const int lda,
+        const float* B,
+        const int ldb,
+        const float beta,
+        float* C,
+        const int ldc);
+
+void cblas_dgemm(
+        const enum CBLAS_ORDER Order,
+        const enum CBLAS_TRANSPOSE TransA,
+        const enum CBLAS_TRANSPOSE TransB,
+        const int M,
+        const int N,
+        const int K,
+        const double alpha,
+        const double* A,
+        const int lda,
+        const double* B,
+        const int ldb,
+        const double beta,
+        double* C,
+        const int ldc);
+
+}  // extern "C"

--- a/chainerx_cc/chainerx/native/native_device/dot.cc
+++ b/chainerx_cc/chainerx/native/native_device/dot.cc
@@ -5,7 +5,7 @@
 #include <type_traits>
 
 #ifdef CHAINERX_ENABLE_BLAS
-#include <cblas.h>
+#include <chainerx/native/native_device/cblas.h>
 #endif  // CHAINERX_ENABLE_BLAS
 
 #include "chainerx/array.h"


### PR DESCRIPTION
ChainerX's native_device can't utilize BLAS libraries which don't have `cblas.h` (e.g. intel mkl). This PR adds ChainerX's `cblas.h` and removes workaround codes in CMakeLists.txt.