### PR TITLE
Make `call_before_training` argument of `Trainer.extend` keyword-only

### DIFF
--- a/chainer/training/trainer.py
+++ b/chainer/training/trainer.py
@@ -198,7 +198,7 @@ class Trainer(object):
         return _get_time() - self._start_at + self._snapshot_elapsed_time
 
     def extend(self, extension, name=None, trigger=None, priority=None,
-               call_before_training=False, **kwargs):
+               *, call_before_training=False, **kwargs):
         """Registers an extension to the trainer.
 
         :class:`Extension` is a callable object which is called after each


### PR DESCRIPTION
Following [the policy](https://github.com/chainer/chainer/wiki/Development-policies/5acfc284fa9fecbea4998e95f7c127752476bc05#api)

Introduced in #3511
