### PR TITLE
Make arguments in `ObservationAggregator` and `MultiNodeEarlyStoppingTrigger` keyword-only

### DIFF
--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -45,7 +45,8 @@ class MultiNodeEarlyStoppingTrigger(object):
        historical reason.
     """
 
-    def __init__(self, comm, check_trigger=(1, 'epoch'), monitor='main/loss',
+    def __init__(self, comm,
+                 *, check_trigger=(1, 'epoch'), monitor='main/loss',
                  patience=None, mode='auto', verbose=False,
                  max_trigger=(100, 'epoch'), suffix='_aggregated', **kwargs):
 

--- a/chainermn/extensions/multi_node_early_stopping_trigger.py
+++ b/chainermn/extensions/multi_node_early_stopping_trigger.py
@@ -59,9 +59,10 @@ class MultiNodeEarlyStoppingTrigger(object):
                                                    mode=mode, verbose=verbose,
                                                    max_trigger=max_trigger,
                                                    **kwargs)
-        self.aggregator = ObservationAggregator(comm, monitor,
-                                                monitor_aggregated,
-                                                check_trigger)
+        self.aggregator = ObservationAggregator(
+            comm, monitor,
+            aggregated_key=monitor_aggregated,
+            comm_trigger=check_trigger)
 
     def __call__(self, trainer):
         self.aggregator(trainer)

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -26,7 +26,7 @@ class ObservationAggregator(extension.Extension):
     name = None
 
     def __init__(self, comm, original_key, aggregated_key=None,
-                 comm_trigger=(1, 'iteration'), aggregator=None):
+                 *, comm_trigger=(1, 'iteration'), aggregator=None):
         self.comm = comm
         self.original_key = original_key
 


### PR DESCRIPTION
Following [the policy](https://github.com/chainer/chainer/wiki/Development-policies/5acfc284fa9fecbea4998e95f7c127752476bc05#api)

Introduced in #7302
