### PR TITLE
Make `size` argument of `tabular.from_data` keyword-only

### DIFF
--- a/chainer/dataset/tabular/from_data.py
+++ b/chainer/dataset/tabular/from_data.py
@@ -2,7 +2,7 @@ import chainer
 from chainer.dataset.tabular import tabular_dataset
 
 
-def from_data(data, size=None):
+def from_data(data, *, size=None):
     """Create a TabularDataset from lists/arrays/callables.
 
     >>> from chainer.dataset import tabular


### PR DESCRIPTION
Following [the policy](https://github.com/chainer/chainer/wiki/Development-policies/5acfc284fa9fecbea4998e95f7c127752476bc05#api)

Introduced in #7847
