### PR TITLE
Add scripts for Docker base images for Chainer CI

### DIFF
--- a/.pfnci/.gitignore
+++ b/.pfnci/.gitignore
@@ -1,0 +1,4 @@
+# cupy directory may be made by script.sh in docker.* targets.
+# docker.* targets of script.sh create /cupy directory to pull the latest CuPy
+# repository to create the base image of Chainer CI.
+/cupy

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -94,6 +94,67 @@ configs {
   }
 }
 
+# Chainer CI related targets: chainer.docker.{version}.{action}.
+# - version should be either "py37" or "py27and35".
+# - action should be either "test" or "push".  "test" only builds a Docker
+#   image, and "push" additionally pushes the Docker image to Google Container
+#   Registry.
+# CAVEAT: chainer.docker.*.push targets should be triggered by CuPy repository
+# to enable to fix its CuPy commit.  The process should be implemented as
+# a default command in the CI targets.
+configs {
+  key: "chainer.docker.py37.test"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+    }
+    time_limit: {
+      seconds: 3600
+    }
+    command: "bash .pfnci/script.sh docker.py37.test"
+  }
+}
+configs {
+  key: "chainer.docker.py27and35.test"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+    }
+    time_limit: {
+      seconds: 3600
+    }
+    command: "bash .pfnci/script.sh docker.py27and35.test"
+  }
+}
+configs {
+  key: "chainer.docker.py37.push"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+    }
+    time_limit: {
+      seconds: 3600
+    }
+    command: "bash .pfnci/script.sh docker.py37.push"
+  }
+}
+configs {
+  key: "chainer.docker.py27and35.push"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+    }
+    time_limit: {
+      seconds: 3600
+    }
+    command: "bash .pfnci/script.sh docker.py27and35.push"
+  }
+}
+
 # Python 2 tests are disabled in the master branch, but configs can be removed
 # only after removing web hooks.
 # TODO(niboshi): Completely remove them after discontinuing v6 series.

--- a/.pfnci/py27and35.Dockerfile
+++ b/.pfnci/py27and35.Dockerfile
@@ -1,0 +1,37 @@
+FROM golang AS xpytest
+RUN git clone --depth=1 https://github.com/chainer/xpytest.git /xpytest
+RUN cd /xpytest && \
+    go build -o /usr/local/bin/xpytest ./cmd/xpytest
+
+FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    python-dev python-pip python-wheel python-setuptools \
+    python3-dev python3-pip python3-wheel python3-setuptools \
+    wget git g++ make cmake libblas3 libblas-dev liblapack-dev && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+RUN python3.5 -m pip install --upgrade pip setuptools
+RUN python2.7 -m pip install --upgrade pip setuptools
+
+RUN python3.5 -m pip install \
+    'cython>=0.28.0' 'ideep4py<2.1' 'pytest==4.1.1' 'pytest-xdist==1.26.1' \
+    mock setuptools typing \
+    typing_extensions filelock numpy>=1.9.0 protobuf>=3.0.0 six>=1.9.0
+
+RUN python2.7 -m pip install \
+    'cython>=0.28.0' 'ideep4py<2.1' 'pytest==4.1.1' 'pytest-xdist==1.26.1' \
+    mock setuptools typing \
+    typing_extensions filelock protobuf>=3.0.0 six>=1.9.0
+
+# Newer versions of numpy and more-itertools no longer support python2.
+RUN python2.7 -m pip install 'numpy<=1.16.5' 'more-itertools<=5.0.0'
+
+COPY --from=xpytest /usr/local/bin/xpytest /usr/local/bin/xpytest
+
+COPY . /cupy
+RUN cd /cupy && \
+    echo 'install-%:\n\t$* -m pip install .\n' > /tmp/install.mk && \
+    cat /tmp/install.mk && \
+    make -f /tmp/install.mk -j 2 install-python3.5 install-python2.7

--- a/.pfnci/py37.Dockerfile
+++ b/.pfnci/py37.Dockerfile
@@ -1,0 +1,26 @@
+FROM golang AS xpytest
+RUN git clone --depth=1 https://github.com/chainer/xpytest.git /xpytest
+RUN cd /xpytest && \
+    go build -o /usr/local/bin/xpytest ./cmd/xpytest
+
+FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    python3.7-dev python3-pip python3-wheel python3-setuptools \
+    wget git g++ make cmake libblas3 libblas-dev liblapack-dev && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+RUN python3.7 -m pip install --upgrade pip setuptools
+
+# NOTE: protobuf version is fixed because of deprecation warning in 3.7.0:
+# https://github.com/protocolbuffers/protobuf/issues/5865
+RUN python3.7 -m pip install \
+    'cython>=0.28.0' 'ideep4py<2.1' \
+    'pytest==4.1.1' 'pytest-xdist==1.26.1' mock setuptools typing \
+    typing_extensions filelock 'numpy>=1.9.0' 'protobuf==3.6.1' 'six>=1.9.0'
+
+COPY --from=xpytest /usr/local/bin/xpytest /usr/local/bin/xpytest
+
+COPY . /cupy
+RUN cd /cupy && python3.7 -m pip install .

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -23,8 +23,6 @@
 
 set -eu
 
-cd "$(dirname "${BASH_SOURCE}")"/..
-
 ################################################################################
 # Main function
 ################################################################################
@@ -36,25 +34,59 @@ main() {
   wait
 
   # Prepare docker args.
-  docker_args=(docker run  --rm --volume="$(pwd):/src:ro")
-  if [ "${GPU:-0}" != '0' ]; then
-    docker_args+=(--ipc=host --privileged --env="GPU=${GPU}" --runtime=nvidia)
-  fi
-  if [ "${XPYTEST:-}" != '' ]; then
-    docker_args+=(--volume="${XPYTEST}:/usr/local/bin/xpytest:ro")
-  fi
-  docker_args+=(--env="XPYTEST_NUM_THREADS=${XPYTEST_NUM_THREADS:-$(nproc)}")
-  if [ "${SPREADSHEET_ID:-}" != '' ]; then
-    docker_args+=(--env="SPREADSHEET_ID=${SPREADSHEET_ID}")
-  fi
+  docker_args=(docker run  --rm)
 
   # Run target-specific commands.
   case "${TARGET}" in
     # Unit tests.
     'py37' | 'py27and35' )
+      docker_args+=(--volume="$(dirname "${BASH_SOURCE}")/..:/src:ro")
+      if [ "${GPU:-0}" != '0' ]; then
+        docker_args+=(
+            --ipc=host --privileged --env="GPU=${GPU}" --runtime=nvidia)
+      fi
+      if [ "${XPYTEST:-}" != '' ]; then
+        docker_args+=(--volume="${XPYTEST}:/usr/local/bin/xpytest:ro")
+      fi
+      docker_args+=(
+          --env="XPYTEST_NUM_THREADS=${XPYTEST_NUM_THREADS:-$(nproc)}")
+      if [ "${SPREADSHEET_ID:-}" != '' ]; then
+        docker_args+=(--env="SPREADSHEET_ID=${SPREADSHEET_ID}")
+      fi
       run "${docker_args[@]}" \
           "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${TARGET}" \
           bash /src/.pfnci/run.sh "${TARGET}"
+      ;;
+    # Docker builds.
+    docker.* )
+      # Parse the target as "docker.{target}.{action}".
+      local fragments
+      IFS=. fragments=(${TARGET})
+      local target="${fragments[1]}"
+      local action="${fragments[2]}"
+      if [ "${action}" != 'push' -a "${action}" != 'test' ]; then
+        echo "Unsupported docker target action: ${action}" >&2
+        exit 1
+      fi
+      # This script can be run in CuPy repository to enable CI to build Chainer
+      # base images with a specified CuPy version.  This block enables the
+      # script can also be run even in Chainer repository.
+      # NOTE: This explicitly pulls CuPy repository instead of pulling from
+      # docker because of ensuring its CuPy version.
+      local cupy_directory="$(pwd)"
+      if [ ! -d "${cupy_directory}/cupy" ]; then
+        if [ ! -d .pfnci/cupy ]; then
+          run git clone https://github.com/cupy/cupy.git .pfnci/cupy
+        fi
+        cupy_directory=.pfnci/cupy
+      fi
+      run docker build -t \
+          "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${target}" \
+          -f "$(dirname "${BASH_SOURCE}")/${target}.Dockerfile" \
+          "${cupy_directory}"
+      if [ "${action}" == 'push' ]; then
+        run docker push "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${target}"
+      fi
       ;;
     # Unsupported targets.
     * )

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -40,7 +40,8 @@ main() {
   case "${TARGET}" in
     # Unit tests.
     'py37' | 'py27and35' )
-      docker_args+=(--volume="$(dirname "${BASH_SOURCE}")/..:/src:ro")
+      docker_args+=(
+          --volume="$(cd "$(dirname "${BASH_SOURCE}")/.."; pwd):/src:ro")
       if [ "${GPU:-0}" != '0' ]; then
         docker_args+=(
             --ipc=host --privileged --env="GPU=${GPU}" --runtime=nvidia)


### PR DESCRIPTION
This PR adds scripts to create base images used for Chainer CI. Chainer CI targets build Docker images using scripts out of Chainer repository.

This PR creates new 4 CI targets "chainer.docker.(py37|py27and35).(test|push)", but they will not be trigger automatically mainly because they take about ten minutes.