### PR TITLE
Fix `-Wbraced-scalar-init` for clang

### DIFF
--- a/chainerx_cc/chainerx/native/reduce.h
+++ b/chainerx_cc/chainerx/native/reduce.h
@@ -201,7 +201,7 @@ void Scan(const Array& in, int8_t axis, const Array& out, ReductionImpl&& impl) 
         return;
     }
 
-    ReductionArg arg{in, Axes{{axis}}, out};
+    ReductionArg arg{in, Axes{axis}, out};
     int64_t reduce_len = in.shape()[axis];
 
     if (arg.in_shape().ndim() == 1 && arg.out_shape().ndim() == 1) {


### PR DESCRIPTION
Fixes https://github.com/chainer/chainer/issues/8072.

By the way, shouldn't `Cumsum` accept an `const OptionalAxes&` instead of an `optional<int8_t>` @asi1024 ?