### PR TITLE
Add `testing.generate_matrix` to get matrices of given singular values

### DIFF
--- a/chainer/testing/__init__.py
+++ b/chainer/testing/__init__.py
@@ -12,6 +12,7 @@ from chainer.testing.helper import assert_warns  # NOQA
 from chainer.testing.helper import patch  # NOQA
 from chainer.testing.helper import with_requires  # NOQA
 from chainer.testing.helper import without_requires  # NOQA
+from chainer.testing.matrix import generate_matrix  # NOQA
 from chainer.testing.parameterized import from_pytest_parameterize  # NOQA
 from chainer.testing.parameterized import parameterize  # NOQA
 from chainer.testing.parameterized import parameterize_pytest  # NOQA

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -4,7 +4,9 @@ from chainer.utils import argument
 
 
 def generate_matrix(shape, dtype=float, **kwargs):
-    r"""Generates a random matrix with given singular values.
+    r"""generate_matrix(shape, dtype=float, *, singular_values)
+
+    Generates a random matrix with given singular values.
 
     This function generates a random NumPy matrix (or a set of matrices) that
     has specified singular values. It can be used to generate the inputs for a
@@ -27,7 +29,7 @@ def generate_matrix(shape, dtype=float, **kwargs):
 
     if len(shape) <= 1:
         raise ValueError(
-            'shpae {} is invalid for matrices: too few axes'.format(shape)
+            'shape {} is invalid for matrices: too few axes'.format(shape)
         )
     k_shape = shape[:-2] + (min(shape[-2:]),)
     # TODO(beam2d): consider supporting integer/boolean matrices
@@ -38,7 +40,7 @@ def generate_matrix(shape, dtype=float, **kwargs):
     if singular_values is None:
         raise TypeError('singular_values is not given')
     singular_values = numpy.asarray(singular_values)
-    if (singular_values < 0).any():
+    if not numpy.isrealobj(singular_values) or (singular_values < 0).any():
         raise ValueError('negative singular value is given')
 
     # Generate random matrices with given singular values. We simply generate

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -8,7 +8,7 @@ def generate_matrix(shape, dtype=float, **kwargs):
 
     Generates a random matrix with given singular values.
 
-    This function generates a random NumPy matrix (or a set of matrices) that
+    This function generates a random NumPy matrix (or a stack of matrices) that
     has specified singular values. It can be used to generate the inputs for a
     test that can be instable when the input value behaves bad.
 
@@ -31,7 +31,6 @@ def generate_matrix(shape, dtype=float, **kwargs):
         raise ValueError(
             'shape {} is invalid for matrices: too few axes'.format(shape)
         )
-    k_shape = shape[:-2] + (min(shape[-2:]),)
     # TODO(beam2d): consider supporting integer/boolean matrices
     dtype = numpy.dtype(dtype)
     if dtype.kind not in 'fc':

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -34,12 +34,14 @@ def generate_matrix(shape, dtype=float, **kwargs):
     # TODO(beam2d): consider supporting integer/boolean matrices
     dtype = numpy.dtype(dtype)
     if dtype.kind not in 'fc':
-        raise ValueError('dtype {} is not supported'.format(dtype))
+        raise TypeError('dtype {} is not supported'.format(dtype))
 
     if singular_values is None:
         raise TypeError('singular_values is not given')
     singular_values = numpy.asarray(singular_values)
-    if not numpy.isrealobj(singular_values) or (singular_values < 0).any():
+    if not numpy.isrealobj(singular_values):
+        raise TypeError('singular_values is not real')
+    if (singular_values < 0).any():
         raise ValueError('negative singular value is given')
 
     # Generate random matrices with given singular values. We simply generate

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -1,5 +1,6 @@
 import numpy
 
+from chainer import functions
 from chainer.utils import argument
 
 
@@ -51,6 +52,15 @@ def generate_matrix(shape, dtype=float, **kwargs):
     if dtype.kind == 'c':
         a = a + 1j * numpy.random.randn(*shape)
     u, s, vh = numpy.linalg.svd(a, full_matrices=False)
-    sv = numpy.broadcast_to(singular_values, s.shape)
+    sv = _broadcast_to(singular_values, s.shape)
     a = numpy.einsum('...ik,...k,...kj->...ij', u, sv, vh)
     return a.astype(dtype)
+
+
+def _broadcast_to(array, shape):
+    if hasattr(numpy, 'broadcast_to'):
+        return numpy.broadcast_to(array, shape)
+    # NumPy 1.9 does not support broadcast_to.
+    dummy = numpy.empty(shape, dtype=numpy.int8)
+    ret, _ = numpy.broadcast_arrays(array, dummy)
+    return ret

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -1,0 +1,70 @@
+import numpy
+
+from chainer.utils import argument
+
+
+def generate_matrix(shape, dtype=float, **kwargs):
+    """Generates a random matrix with given properties.
+
+    This function generates a random NumPy matrix (or a set of matrices) that
+    has desired properties. It can be used to generate the inputs for a test
+    that can be instable when the input value behaves bad.
+
+    Notation: denote the shape of the generated array by :math:`(B..., M, N)`,
+    and :math:`K = min\{M, N\}`. :math:`B...` may be an empty sequence.
+
+    Args:
+        shape (tuple of int): Shape of the generated array, i.e.,
+            :math:`(B..., M, N)`.
+        dtype: Dtype of the generated array.
+        singular_values (array-like): Singular values of the generated
+            matrices. This argument, if given, must be broadcastable to shape
+            :math:`(B..., K)`. It cannot be combined with ``condition_number``.
+        condition_number (array-like): Upper bound of the condition numbers of
+            the generated matrices. The generated matrices have singular values
+            in an interval :math:`[1, \\text{condition_number}]`. This
+            argument, if given, must be broadcastable to shape :math:`(B...)`.
+            It cannot be combined with ``singular_values``.
+
+    """
+    singular_values, condition_number = (
+        argument.parse_kwargs(
+            kwargs,
+            singular_values=None,
+            condition_number=None,
+        )
+    )
+
+    if len(shape) <= 1:
+        raise ValueError(
+            'shpae {} is invalid for matrices: too few axes'.format(shape))
+    k_shape = shape[:-2] + (min(shape[-2:]),)
+    # TODO(beam2d): consider supporting integer/boolean matrices
+    if dtype.kind not in 'fc':
+        raise ValueError('dtype {} is not supported'.format(dtype))
+
+    if condition_number is not None:
+        if singular_values is not None:
+            raise TypeError(
+                'condition_number and singular_values cannot be '
+                'specified at once'
+            )
+        if any(condition_number < 1):
+            raise ValueError('condition number must not be less than 1')
+        singular_values = numpy.random.uniform(
+            1, condition_number[..., None], size=k_shape
+        )
+    if singular_values is None:
+        raise TypeError('neither condition_number nor singula_values is given')
+    if any(singular_values < 0):
+        raise ValueError('negative singular value is given')
+
+    # Generate random matrices with given singular values. We simply generate
+    # orthogonal vectors using SVD on random matrices and then combine them
+    # with the given singular values.
+    a = numpy.random.randn(*shape)
+    if dtype.kind == 'c':
+        a += 1j * numpy.random.randn(*shape)
+    u, _, vh = numpy.linalg.svd(a, full_matrices=False)
+    a = numpy.einsum('...ik,...k,...kj->...ij', u, singular_values, vh)
+    return a.astype(dtype, copy=False)

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -4,11 +4,11 @@ from chainer.utils import argument
 
 
 def generate_matrix(shape, dtype=float, **kwargs):
-    """Generates a random matrix with given properties.
+    """Generates a random matrix with given singular values.
 
     This function generates a random NumPy matrix (or a set of matrices) that
-    has desired properties. It can be used to generate the inputs for a test
-    that can be instable when the input value behaves bad.
+    has specified singular values. It can be used to generate the inputs for a
+    test that can be instable when the input value behaves bad.
 
     Notation: denote the shape of the generated array by :math:`(B..., M, N)`,
     and :math:`K = min\{M, N\}`. :math:`B...` may be an empty sequence.
@@ -18,21 +18,11 @@ def generate_matrix(shape, dtype=float, **kwargs):
             :math:`(B..., M, N)`.
         dtype: Dtype of the generated array.
         singular_values (array-like): Singular values of the generated
-            matrices. This argument, if given, must be broadcastable to shape
-            :math:`(B..., K)`. It cannot be combined with ``condition_number``.
-        condition_number (array-like): Upper bound of the condition numbers of
-            the generated matrices. The generated matrices have singular values
-            in an interval :math:`[1, \\text{condition_number}]`. This
-            argument, if given, must be broadcastable to shape :math:`(B...)`.
-            It cannot be combined with ``singular_values``.
+            matrices. It must be broadcastable to shape :math:`(B..., K)`.
 
     """
-    singular_values, condition_number = (
-        argument.parse_kwargs(
-            kwargs,
-            singular_values=None,
-            condition_number=None,
-        )
+    singular_values, = argument.parse_kwargs(
+        kwargs, singular_values=None,
     )
 
     if len(shape) <= 1:
@@ -43,19 +33,9 @@ def generate_matrix(shape, dtype=float, **kwargs):
     if dtype.kind not in 'fc':
         raise ValueError('dtype {} is not supported'.format(dtype))
 
-    if condition_number is not None:
-        if singular_values is not None:
-            raise TypeError(
-                'condition_number and singular_values cannot be '
-                'specified at once'
-            )
-        if any(condition_number < 1):
-            raise ValueError('condition number must not be less than 1')
-        singular_values = numpy.random.uniform(
-            1, condition_number[..., None], size=k_shape
-        )
     if singular_values is None:
-        raise TypeError('neither condition_number nor singula_values is given')
+        raise TypeError('singular_values is not given')
+    singular_values = numpy.asarray(singular_values)
     if any(singular_values < 0):
         raise ValueError('negative singular value is given')
 

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -48,6 +48,7 @@ def generate_matrix(shape, dtype=float, **kwargs):
     a = numpy.random.randn(*shape)
     if dtype.kind == 'c':
         a = a + 1j * numpy.random.randn(*shape)
-    u, _, vh = numpy.linalg.svd(a, full_matrices=False)
-    a = numpy.einsum('...ik,...k,...kj->...ij', u, singular_values, vh)
+    u, s, vh = numpy.linalg.svd(a, full_matrices=False)
+    sv = numpy.broadcast_to(singular_values, s.shape)
+    a = numpy.einsum('...ik,...k,...kj->...ij', u, sv, vh)
     return a.astype(dtype)

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -4,7 +4,7 @@ from chainer.utils import argument
 
 
 def generate_matrix(shape, dtype=float, **kwargs):
-    """Generates a random matrix with given singular values.
+    r"""Generates a random matrix with given singular values.
 
     This function generates a random NumPy matrix (or a set of matrices) that
     has specified singular values. It can be used to generate the inputs for a
@@ -22,21 +22,23 @@ def generate_matrix(shape, dtype=float, **kwargs):
 
     """
     singular_values, = argument.parse_kwargs(
-        kwargs, singular_values=None,
+        kwargs, ('singular_values', None),
     )
 
     if len(shape) <= 1:
         raise ValueError(
-            'shpae {} is invalid for matrices: too few axes'.format(shape))
+            'shpae {} is invalid for matrices: too few axes'.format(shape)
+        )
     k_shape = shape[:-2] + (min(shape[-2:]),)
     # TODO(beam2d): consider supporting integer/boolean matrices
+    dtype = numpy.dtype(dtype)
     if dtype.kind not in 'fc':
         raise ValueError('dtype {} is not supported'.format(dtype))
 
     if singular_values is None:
         raise TypeError('singular_values is not given')
     singular_values = numpy.asarray(singular_values)
-    if any(singular_values < 0):
+    if (singular_values < 0).any():
         raise ValueError('negative singular value is given')
 
     # Generate random matrices with given singular values. We simply generate
@@ -44,7 +46,7 @@ def generate_matrix(shape, dtype=float, **kwargs):
     # with the given singular values.
     a = numpy.random.randn(*shape)
     if dtype.kind == 'c':
-        a += 1j * numpy.random.randn(*shape)
+        a = a + 1j * numpy.random.randn(*shape)
     u, _, vh = numpy.linalg.svd(a, full_matrices=False)
     a = numpy.einsum('...ik,...k,...kj->...ij', u, singular_values, vh)
-    return a.astype(dtype, copy=False)
+    return a.astype(dtype)

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -1,6 +1,5 @@
 import numpy
 
-from chainer import functions
 from chainer.utils import argument
 
 

--- a/tests/chainer_tests/testing_tests/test_matrix.py
+++ b/tests/chainer_tests/testing_tests/test_matrix.py
@@ -3,7 +3,6 @@ import unittest
 import numpy
 
 from chainer import testing
-from chainer.testing import condition
 
 
 @testing.parameterize(*testing.product({

--- a/tests/chainer_tests/testing_tests/test_matrix.py
+++ b/tests/chainer_tests/testing_tests/test_matrix.py
@@ -52,9 +52,17 @@ class TestGenerateMatrixInvalid(unittest.TestCase):
             testing.generate_matrix((2,), singular_values=1)
 
     def test_invalid_dtype(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             testing.generate_matrix(
                 (2, 2), dtype=numpy.int32, singular_values=1)
+
+    def test_invalid_dtype_singular_values(self):
+        with self.assertRaises(TypeError):
+            testing.generate_matrix((2, 2), singular_values=1 + 0j)
+
+    def test_negative_singular_values(self):
+        with self.assertRaises(ValueError):
+            testing.generate_matrix((2, 2), singular_values=[1, -1])
 
     def test_shape_mismatch(self):
         with self.assertRaises(ValueError):

--- a/tests/chainer_tests/testing_tests/test_matrix.py
+++ b/tests/chainer_tests/testing_tests/test_matrix.py
@@ -18,6 +18,9 @@ from chainer.testing import condition
         ((2, 3, 4), (2, 3)),
         ((2, 4, 3), (2, 3)),
         ((0, 2, 3), (0, 2)),
+        # broadcast
+        ((2, 2), ()),
+        ((2, 3, 4), (2, 1)),
     ],
 }))
 class TestGenerateMatrix(unittest.TestCase):
@@ -32,6 +35,7 @@ class TestGenerateMatrix(unittest.TestCase):
         s = numpy.linalg.svd(
             x.astype(numpy.complex128), full_matrices=False, compute_uv=False,
         )
+        sv = numpy.broadcast_to(sv, s.shape)
         sv_sorted = numpy.sort(sv, axis=-1)[..., ::-1]
 
         rtol = 1e-3 if dtype == numpy.float16 else 1e-7

--- a/tests/chainer_tests/testing_tests/test_matrix.py
+++ b/tests/chainer_tests/testing_tests/test_matrix.py
@@ -3,6 +3,7 @@ import unittest
 import numpy
 
 from chainer import testing
+from chainer.testing import matrix
 
 
 @testing.parameterize(*testing.product({
@@ -34,7 +35,7 @@ class TestGenerateMatrix(unittest.TestCase):
         s = numpy.linalg.svd(
             x.astype(numpy.complex128), full_matrices=False, compute_uv=False,
         )
-        sv = numpy.broadcast_to(sv, s.shape)
+        sv = matrix._broadcast_to(sv, s.shape)
         sv_sorted = numpy.sort(sv, axis=-1)[..., ::-1]
 
         rtol = 1e-3 if dtype == numpy.float16 else 1e-7

--- a/tests/chainer_tests/testing_tests/test_matrix.py
+++ b/tests/chainer_tests/testing_tests/test_matrix.py
@@ -1,0 +1,62 @@
+import unittest
+
+import numpy
+
+from chainer import testing
+from chainer.testing import condition
+
+
+@testing.parameterize(*testing.product({
+    'dtype': [
+        numpy.float16, numpy.float32, numpy.float64,
+        numpy.complex64, numpy.complex128,
+    ],
+    'x_s_shapes': [
+        ((2, 2), (2,)),
+        ((2, 3), (2,)),
+        ((3, 2), (2,)),
+        ((2, 3, 4), (2, 3)),
+        ((2, 4, 3), (2, 3)),
+        ((0, 2, 3), (0, 2)),
+    ],
+}))
+class TestGenerateMatrix(unittest.TestCase):
+
+    def test_generate_matrix(self):
+        dtype = self.dtype
+        x_shape, s_shape = self.x_s_shapes
+        sv = 0.5 + numpy.random.random(s_shape).astype(dtype().real.dtype)
+        x = testing.generate_matrix(x_shape, dtype=dtype, singular_values=sv)
+        assert x.shape == x_shape
+
+        s = numpy.linalg.svd(
+            x.astype(numpy.complex128), full_matrices=False, compute_uv=False,
+        )
+        sv_sorted = numpy.sort(sv, axis=-1)[..., ::-1]
+
+        rtol = 1e-3 if dtype == numpy.float16 else 1e-7
+        numpy.testing.assert_allclose(s, sv_sorted, rtol=rtol)
+
+
+class TestGenerateMatrixInvalid(unittest.TestCase):
+
+    def test_no_singular_values(self):
+        with self.assertRaises(TypeError):
+            testing.generate_matrix((2, 2))
+
+    def test_invalid_shape(self):
+        with self.assertRaises(ValueError):
+            testing.generate_matrix((2,), singular_values=1)
+
+    def test_invalid_dtype(self):
+        with self.assertRaises(ValueError):
+            testing.generate_matrix(
+                (2, 2), dtype=numpy.int32, singular_values=1)
+
+    def test_shape_mismatch(self):
+        with self.assertRaises(ValueError):
+            testing.generate_matrix(
+                (2, 2), singular_values=numpy.ones(3))
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR adds a helper function for testing numerical functions that are sensitive to singular values (e.g. linalg functions). See the docstring for the interface and specification.

I'm planning to use this function in #7997 and some other flaky test fixes. The design and implementation are influenced by some existing tests that generate such matrices, e.g. #7900, https://github.com/cupy/cupy/pull/2084.

Comments and suggestions are welcome.