### PR TITLE
Add timestamp to Travis CI log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,8 @@ script:
 addons:
   apt:
     update: true
+    packages:
+      - moreutils  # for ts
+  homebrew:
+    packages:
+      - moreutils  # for ts

--- a/scripts/ci/travis/run-step.sh
+++ b/scripts/ci/travis/run-step.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Runs a single step
 set -eu
+set -o pipefail
 
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -21,4 +22,6 @@ set -x
 step_"'$step'" '"$@"'
 set +x
 '
-bash -e -c "$cmd"
+# Using ts to add timestamp.
+# TODO(niboshi): Keep colorization
+bash -e -c "$cmd" | ts '[%Y-%m-%d %H:%M:%S]'


### PR DESCRIPTION
Travis CI doesn't have timestamps in log outputs (https://github.com/travis-ci/travis-ci/issues/4968)
It's difficult to tell how much time it takes in each command.
