### PR TITLE
fix env CHAINERX_ENABLE_LAPACK=0 causes error

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -224,7 +224,6 @@ if(${CHAINERX_ENABLE_LAPACK})
         add_definitions(-DCHAINERX_ENABLE_LAPACK=1)
     else()
         message(STATUS "LAPACK not found")
-        add_definitions(-DCHAINERX_ENABLE_LAPACK=0)
     endif()
 endif()
 

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -359,7 +359,11 @@ void InitChainerxLinalg(pybind11::module& m) {
     m.def("dot", [](const ArrayBodyPtr& a, const ArrayBodyPtr& b) { return MoveArrayBody(Dot(Array{a}, Array{b})); }, "a"_a, "b"_a);
 
     pybind11::module mlinalg = m.def_submodule("linalg");
-    mlinalg.def("_is_lapack_available", []() -> bool { return CHAINERX_ENABLE_LAPACK; });
+#if CHAINERX_ENABLE_LAPACK
+    mlinalg.def("_is_lapack_available", []() -> bool { return true; });
+#else
+    mlinalg.def("_is_lapack_available", []() -> bool { return false; });
+#endif
     mlinalg.def(
             "solve", [](const ArrayBodyPtr& a, const ArrayBodyPtr& b) { return MoveArrayBody(Solve(Array{a}, Array{b})); }, "a"_a, "b"_a);
     mlinalg.def("inv", [](const ArrayBodyPtr& a) { return MoveArrayBody(Inverse(Array{a})); }, "a"_a);


### PR DESCRIPTION
fixed #8084

to be conservative, instead of `add_definitions(-DCHAINERX_ENABLE_LAPACK=1)` in `CMakeLists.txt`, I remove `add_definitions(-DCHAINERX_ENABLE_LAPACK=0)` and add proper test in code.
