### PR TITLE
Explicit `h5py.File` `mode`

### DIFF
--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -393,39 +393,39 @@ class TestGroupHierachy(unittest.TestCase):
                             {'W', 'b'})
 
     def test_save_chain(self):
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'w') as h5:
             self._save(h5, self.parent, 'test')
             self.assertSetEqual(set(h5.keys()), {'test'})
             self._check_group(h5['test'], ('Wp',))
 
     def test_save_optimizer(self):
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'w') as h5:
             self._save(h5, self.optimizer, 'test')
             self.assertSetEqual(set(h5.keys()), {'test'})
             self._check_group(h5['test'], ('Wp', 'epoch', 't'))
 
     def test_save_chain2(self):
         hdf5.save_hdf5(self.temp_file_path, self.parent)
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'r') as h5:
             self._check_group(h5, ('Wp',))
 
     def test_save_optimizer2(self):
         hdf5.save_hdf5(self.temp_file_path, self.optimizer)
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'r') as h5:
             self._check_group(h5, ('Wp', 'epoch', 't'))
 
     def test_load_chain(self):
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'w') as h5:
             self._save(h5, self.parent, 'test')
 
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'r') as h5:
             self._load(h5, self.parent, 'test')
 
     def test_load_optimizer(self):
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'w') as h5:
             self._save(h5, self.optimizer, 'test')
 
-        with h5py.File(self.temp_file_path) as h5:
+        with h5py.File(self.temp_file_path, 'r') as h5:
             self._load(h5, self.optimizer, 'test')
 
 


### PR DESCRIPTION
Always pass `mode` to `h5py.File`. 

There was a recent new release `2.10.0` of `h5py`, deprecating `mode=None`. Travis is currently failing because of this update.