### PR TITLE
Fix heading anchor in ChainerX docs

### DIFF
--- a/docs/source/chainerx/install/index.rst
+++ b/docs/source/chainerx/install/index.rst
@@ -1,7 +1,7 @@
+.. _chainerx_install:
+
 Installation
 ============
-
-.. _chainerx_install:
 
 ChainerX, or ``chainerx``, can be installed as a top level Python package along with Chainer by configuring the environment variables below.
 


### PR DESCRIPTION
Fixes the position of an anchor.

As an example, try following [this link](https://docs.chainer.org/en/v7.0.0b3/chainerx/install/index.html#chainerx-install).