### PR TITLE
Fix matrix generation in linear algebra `PseudoInverse` test

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
@@ -332,6 +332,7 @@ class TestPseudoInverse(NumpyLinalgOpTest):
 
     def generate_inputs(self):
         a = numpy.random.random(self.shape).astype(self.dtype)
+        a = a * 10 + numpy.ones(self.shape)
         return a,
 
     def forward_xp(self, inputs, xp):


### PR DESCRIPTION
Fixes #7986 

Confirmed to pass 4,000 times

pytest --count=1000 unit_tests/routines_tests/test_linalg.py -k 'PseudoInverse and _param_3_' 
