### PR TITLE
Fix overflow warning in div backward test

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_basic_math.py
@@ -1144,6 +1144,8 @@ class TestVariableConstantArrayOp(unittest.TestCase):
         self.gy = numpy.random.uniform(-1, 1, (3, 2)).astype(self.dtype)
         self.ggx = numpy.random.uniform(.5, 1, (3, 2)).astype(self.dtype)
         self.value = numpy.random.uniform(-1, 1, (3, 2)).astype(self.dtype)
+        # Avoid overflow in div test (especially backward)
+        self.value[abs(self.value) < 1e-2] = 1.
 
     def check_forward(self, op, array_conv, positive):
         value = self.value


### PR DESCRIPTION
Fixes #8094

https://jenkins.preferred.jp/job/chainer/job/cupy_pr/341/TEST=chainer-py3,label=mn1-p100/

>`FAIL tests/chainer_tests/functions_tests/math_tests/test_basic_math.py::TestVariableConstantArrayOp_param_0_{dtype=float16}::test_div_backward_cpu`

```
18:34:08 E       RuntimeWarning: Parameterized test failed.
18:34:08 E       
18:34:08 E       Base test method: TestVariableConstantArrayOp.test_div_backward_cpu
18:34:08 E       Test parameters:
18:34:08 E         dtype: <class 'numpy.float16'>
18:34:08 E       
18:34:08 E       
18:34:08 E       (caused by)
18:34:08 E       RuntimeWarning: overflow encountered in true_divide
```