### PR TITLE
Fix macOS Travis error caused by Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,6 @@ addons:
     packages:
       - moreutils  # for ts
   homebrew:
+    update: true
     packages:
       - moreutils  # for ts

--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -50,7 +50,6 @@ step_install_chainer_test_deps() {
 step_before_install_chainer_test() {
     # Remove oclint as it conflicts with GCC (indirect dependency of hdf5)
     if [[ $TRAVIS_OS_NAME = "osx" ]]; then
-        brew update >/dev/null
         brew outdated pyenv || brew upgrade pyenv
 
         PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION


### PR DESCRIPTION
Fixes a failure on Travis in our macOS builds (e.g. https://travis-ci.org/chainer/chainer/builds/584025005).

`brew` used to be manually updated in `step_before_install_chainer_test` but it seems like it must be done in `addons` if we are to use Homebrew via this `addons` feature.

I tested this change in a local branch and it seems to work. https://travis-ci.org/hvy/chainer/jobs/584037565