### PR TITLE
Add document print runtime info

### DIFF
--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -51,13 +51,13 @@ class _RuntimeInfo(object):
         return s.getvalue()
 
 
-def get_runtime_info():
+def _get_runtime_info():
     return _RuntimeInfo()
 
 
 def print_runtime_info(out=None):
     if out is None:
         out = sys.stdout
-    out.write(str(get_runtime_info()))
+    out.write(str(_get_runtime_info()))
     if hasattr(out, 'flush'):
         out.flush()

--- a/chainer/_runtime_info.py
+++ b/chainer/_runtime_info.py
@@ -56,6 +56,25 @@ def _get_runtime_info():
 
 
 def print_runtime_info(out=None):
+    """Show Chainer runtime information.
+
+    Runtime information includes:
+    - OS platform
+    - Chainer version
+    - ChainerX version
+    - NumPy version
+    - CuPy version
+      - CUDA information
+      - cuDNN information
+      - NCCL information
+    - iDeep version
+
+    Args:
+        out: Output destination.
+            If it is None, runtime information will be shown in `sys.stdout`.
+
+    """
+    print()
     if out is None:
         out = sys.stdout
     out.write(str(_get_runtime_info()))

--- a/tests/chainer_tests/test_runtime_info.py
+++ b/tests/chainer_tests/test_runtime_info.py
@@ -9,13 +9,13 @@ from chainer import testing
 
 class TestRuntimeInfo(unittest.TestCase):
     def test_get_runtime_info(self):
-        info = _runtime_info.get_runtime_info()
+        info = _runtime_info._get_runtime_info()
         assert chainer.__version__ in str(info)
 
     def test_print_runtime_info(self):
         out = six.StringIO()
         _runtime_info.print_runtime_info(out)
-        assert out.getvalue() == str(_runtime_info.get_runtime_info())
+        assert out.getvalue() == str(_runtime_info._get_runtime_info())
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR solves #7180.

I add docstring for `chainer.print_runtime_info`.
And I made `chainer.get_runtime_info` private because
I feel it is not needed to expose to users.