### PR TITLE
Remove unused headers in `arithmetic.{h,cc}`

### DIFF
--- a/chainerx_cc/chainerx/routines/arithmetic.cc
+++ b/chainerx_cc/chainerx/routines/arithmetic.cc
@@ -1,12 +1,9 @@
 #include "chainerx/routines/arithmetic.h"
 
 #include <cmath>
-#include <cstdint>
 #include <numeric>
 #include <utility>
 #include <vector>
-
-#include <absl/types/optional.h>
 
 #include "chainerx/array.h"
 #include "chainerx/backprop_mode.h"

--- a/chainerx_cc/chainerx/routines/arithmetic.h
+++ b/chainerx_cc/chainerx/routines/arithmetic.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <cstdint>
-
-#include <absl/types/optional.h>
-
 #include "chainerx/array.h"
 #include "chainerx/scalar.h"
 


### PR DESCRIPTION
Removes unused headers but I could be missing some.