### PR TITLE
Add `ignore::ImportWarning` to `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ filterwarnings= error
                 ignore:numpy\.dtype size changed, may indicate binary incompatibility:RuntimeWarning
                 ignore:ChainerX core binary is built in debug mode:UserWarning
                 ignore:Accelerate has been detected as a NumPy backend library:UserWarning:chainer[.*]
+                ignore::ImportWarning
                 ignore::chainer.warnings.PerformanceWarning
                 ignore::FutureWarning:chainer\.utils\.experimental
                 # NumPy<1.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,14 @@ filterwarnings= error
                 ignore:numpy\.dtype size changed, may indicate binary incompatibility:RuntimeWarning
                 ignore:ChainerX core binary is built in debug mode:UserWarning
                 ignore:Accelerate has been detected as a NumPy backend library:UserWarning:chainer[.*]
-                ignore::ImportWarning
+		# Chainer internally imports cupy, and `import cupy` causes
+		# ImportWarning (see https://github.com/cupy/cupy/issues/2476).
+		# To import cupy successfully, we need to ignore ImportWarning.
+		# Also, ignore::chainer.warnings.PerformanceWarning seems to invoke
+		# import of chainer and cupy. Therefore, it is necessary to add
+		# the following line before the PerformanceWarning line
+		# to avoid failure of import cupy.
+                ignore:can\'t resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
                 ignore::chainer.warnings.PerformanceWarning
                 ignore::FutureWarning:chainer\.utils\.experimental
                 # NumPy<1.11


### PR DESCRIPTION
~This will resolve #8123.~
This will resolve issues related to `import cupy` when testing Chainer with `pytest`. (#8138)