### PR TITLE
Allow `fix_random` decorator to be used with `OpTest`

### DIFF
--- a/tests/chainerx_tests/op_utils.py
+++ b/tests/chainerx_tests/op_utils.py
@@ -435,3 +435,11 @@ def op_test(devices):
         return None
 
     return wrap
+
+
+def fix_random():
+    """Decorator that fixes random numbers in an op test.
+
+    .. seealso:: :func:`~chainer.testing.fix_random`
+    """
+    return chainer.testing.random._fix_random('setup', 'teardown')

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
@@ -429,6 +429,7 @@ class TestNStepBiGRU(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
+@chainer.testing.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(
@@ -534,6 +535,7 @@ class TestNStepRNN(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
+@chainer.testing.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
@@ -429,7 +429,6 @@ class TestNStepBiGRU(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
-@chainer.testing.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(
@@ -535,7 +534,6 @@ class TestNStepRNN(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
-@chainer.testing.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(


### PR DESCRIPTION
Allow the `fix_random` decorator to be used with `OpTest`. It was previously not possible.

The motivation behind this PR is to allow flaky tests (in particular https://github.com/chainer/chainer/issues/8032 and https://github.com/chainer/chainer/issues/8033) to have their seeds fixed. I'll send a separate PR to addressed these tests.