### PR TITLE
Fix flaky `NStepRNN` and `NStepBiRNN`

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
@@ -429,6 +429,7 @@ class TestNStepBiGRU(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
+@chainer.testing.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(
@@ -534,6 +535,7 @@ class TestNStepRNN(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
+@chainer.testing.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(


### PR DESCRIPTION
Fixes https://github.com/chainer/chainer/issues/8032 and https://github.com/chainer/chainer/issues/8033 (cc. @kmaehashi) by fixing random seeds.

The cause of the flakiness was due to inputs to the ReLU activation values close to 0 while the non-differentiable point detection failed to get around this, so we decided to just fix the seed for now.

Depends on https://github.com/chainer/chainer/pull/8136.