### PR TITLE
Fix flaky `NStepRNN` and `NStepBiRNN`

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
@@ -429,7 +429,9 @@ class TestNStepBiGRU(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
-@op_utils.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
+# ReLU activation is unstable around 0 but can seemingly not be dodged
+# automatically.
+@op_utils.fix_random()
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(
@@ -535,7 +537,9 @@ class TestNStepRNN(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
-@op_utils.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
+# ReLU activation is unstable around 0 but can seemingly not be dodged
+# automatically.
+@op_utils.fix_random()
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_rnn.py
@@ -429,6 +429,7 @@ class TestNStepBiGRU(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
+@op_utils.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(
@@ -534,6 +535,7 @@ class TestNStepRNN(op_utils.ChainerOpTest):
 
 
 @op_utils.op_test(['native:0', 'cuda:0'])
+@op_utils.fix_random()  # ReLU activation is unstable around 0 but can seemingly not be dodged automatically.  # NOQA
 @chainer.testing.parameterize(*(
     chainer.testing.product([
         chainer.testing.from_pytest_parameterize(


### PR DESCRIPTION
Fixes #8032 and fixes #8033 (cc. @kmaehashi) by fixing random seeds.

https://github.com/chainer/chainer/pull/8137 which at a first glance looks like a duplicate was mistakenly merged but only as a part of https://github.com/chainer/chainer/pull/8136#event-2645556785 so no fixes actually got in. Sorry for the trouble.