### PR TITLE
Add documentation for `chainerx.minimum`

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -1656,6 +1656,26 @@ Note:
 """)
 
     _docs.set_doc(
+        chainerx.minimum,
+        """minimum(x1, x2)
+Minimum arguments, element-wise.
+
+Args:
+    x1 (~chainerx.ndarray or scalar): Input array.
+    x2 (~chainerx.ndarray or scalar): Input array.
+
+Returns:
+    :class:`~chainerx.ndarray`:
+        Returned array: :math:`y = min(\\{x_1, x_2\\})`.
+
+Note:
+    During backpropagation, this function propagates the gradient of the
+    output array to the input arrays ``x1`` and ``x2``.
+
+.. seealso:: :data:`numpy.minimum`
+""")
+
+    _docs.set_doc(
         chainerx.remainder,
         """remainder(x1, x2)
 Return element-wise remainder of division.

--- a/docs/source/chainerx/reference/routines.rst
+++ b/docs/source/chainerx/reference/routines.rst
@@ -172,6 +172,7 @@ Mathematical functions
    chainerx.remainder
    chainerx.sum
    chainerx.maximum
+   chainerx.minimum
    chainerx.exp
    chainerx.log
    chainerx.log10


### PR DESCRIPTION
This PR adds the missing documentation for `chainerx.minimum` .