### PR TITLE
Remove obsolete note in `chainerx.maximum` doc

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -1648,10 +1648,6 @@ Note:
     During backpropagation, this function propagates the gradient of the
     output array to the input arrays ``x1`` and ``x2``.
 
-Note:
-    maximum of :class:`~chainerx.ndarray` and :class:`~chainerx.ndarray` is
-    not supported yet.
-
 .. seealso:: :data:`numpy.maximum`
 """)
 


### PR DESCRIPTION
It is supposed that the following note in the documentation of `chainerx.maximum` is obsolete:

> Note:
> maximum of ndarray and ndarray is not supported yet.