### PR TITLE
Fix bugs in cupy elementwise in batch_normalization

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -64,7 +64,7 @@ class GeneralBatchNormalizationImpl(_BatchNormalizationImpl):
                 running_var += (1 - decay) * adjust * var
             else:
                 cuda.elementwise(
-                    'U mean, U var, U decay, U adjust',
+                    'T mean, T var, U decay, U adjust',
                     'U r_mean, U r_var',
                     '''
                     r_mean = r_mean * decay + mean * (1 - decay);


### PR DESCRIPTION
This PR fixes a bug in cupy
elementwise of batch_normalization by assign different dtypes to mean
and var. 
This close #8148