### PR TITLE
Support zero-sized matrix in `generate_matrix`

### DIFF
--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -44,6 +44,10 @@ def generate_matrix(shape, dtype=float, **kwargs):
     if (singular_values < 0).any():
         raise ValueError('negative singular value is given')
 
+    if 0 in shape:
+        # NumPy<1.16 does not support zero-sized matrices in svd, so skip it.
+        return numpy.empty(shape, dtype=dtype)
+
     # Generate random matrices with given singular values. We simply generate
     # orthogonal vectors using SVD on random matrices and then combine them
     # with the given singular values.

--- a/chainer/testing/matrix.py
+++ b/chainer/testing/matrix.py
@@ -46,6 +46,8 @@ def generate_matrix(shape, dtype=float, **kwargs):
 
     if 0 in shape:
         # NumPy<1.16 does not support zero-sized matrices in svd, so skip it.
+        # Try broadcast first to raise an error on shape mismatch.
+        _broadcast_to(singular_values, shape[:-2] + (min(shape[-2:]),))
         return numpy.empty(shape, dtype=dtype)
 
     # Generate random matrices with given singular values. We simply generate

--- a/tests/chainer_tests/testing_tests/test_matrix.py
+++ b/tests/chainer_tests/testing_tests/test_matrix.py
@@ -74,5 +74,10 @@ class TestGenerateMatrixInvalid(unittest.TestCase):
             testing.generate_matrix(
                 (2, 2), singular_values=numpy.ones(3))
 
+    def test_shape_mismatch_2(self):
+        with self.assertRaises(ValueError):
+            testing.generate_matrix(
+                (0, 2, 2), singular_values=numpy.ones(3))
+
 
 testing.run_module(__name__, __file__)

--- a/tests/chainer_tests/testing_tests/test_matrix.py
+++ b/tests/chainer_tests/testing_tests/test_matrix.py
@@ -12,6 +12,7 @@ from chainer.testing import matrix
         numpy.complex64, numpy.complex128,
     ],
     'x_s_shapes': [
+        ((0, 0), (0,)),
         ((2, 2), (2,)),
         ((2, 3), (2,)),
         ((3, 2), (2,)),
@@ -31,6 +32,9 @@ class TestGenerateMatrix(unittest.TestCase):
         sv = numpy.random.uniform(0.5, 1.5, s_shape).astype(dtype().real.dtype)
         x = testing.generate_matrix(x_shape, dtype=dtype, singular_values=sv)
         assert x.shape == x_shape
+
+        if 0 in x_shape:
+            return
 
         s = numpy.linalg.svd(
             x.astype(numpy.complex128), full_matrices=False, compute_uv=False,


### PR DESCRIPTION
I found in #7997 that `generate_matrix` fails to generate zero-sized matrices with NumPy<=1.15. Zero-sized shapes are tested in various functions, so it's convenient to support them in `generate_matrix`. I will use this fix in #7997.