### PR TITLE
[WIP] Implement Lookahead optimizer

### DIFF
--- a/chainer/optimizers/__init__.py
+++ b/chainer/optimizers/__init__.py
@@ -7,6 +7,7 @@ from chainer.optimizers.adam import AMSGrad  # NOQA
 from chainer.optimizers.adam import AdaBound  # NOQA
 from chainer.optimizers.adam import AMSBound  # NOQA
 from chainer.optimizers.corrected_momentum_sgd import CorrectedMomentumSGD  # NOQA
+from chainer.optimizers.lookahead import Lookahead  # NOQA
 from chainer.optimizers.momentum_sgd import MomentumSGD  # NOQA
 from chainer.optimizers.msvag import MSVAG  # NOQA
 from chainer.optimizers.nesterov_ag import NesterovAG  # NOQA

--- a/chainer/optimizers/lookahead.py
+++ b/chainer/optimizers/lookahead.py
@@ -1,0 +1,85 @@
+import chainer
+from chainer import optimizer
+
+
+_default_hyperparam = optimizer.Hyperparameter()  # # NOQA
+_default_hyperparam.lr = 0.5
+_default_hyperparam.n_updates = 5
+_default_hyperparam.state = 'maintain'
+
+
+class LookaheadRule(optimizer.UpdateRule):
+
+    def __init__(self, rule, parent_hyperparam=None, lr=None,
+                 n_updates=None, state=None):
+        super(LookaheadRule, self).__init__(
+            parent_hyperparam or _default_hyperparam)
+        if lr is not None:
+            self.hyperparam.lr = lr
+        if n_updates is not None:
+            self.hyperparam.n_updates = n_updates
+        if state is not None:
+            self.hyperparam.state = state
+        self._base_rule = rule
+
+    def init_state(self, param):
+        device = param.device
+        with chainer.using_device(device):
+            self.state['slow_param'] = param.array.copy()
+
+    def update_core(self, param):
+        self._base_rule.update_core(param)
+
+        hp = self.hyperparam
+        if self.t % hp.n_updates == 0:
+            # Update both the slow and the fast parameters.
+            slow_param = self.state['slow_param']
+            slow_param += (param.array - slow_param) * hp.lr
+            param.array[...] = slow_param
+
+            # Reset state.
+            state = hp.state
+            if state == 'maintain':
+                pass
+            elif state == 'interpolate':
+                raise NotImplementedError()
+            elif state == 'reset':
+                self._base_rule.init_state(param)
+            else:
+                raise ValueError('Unsupported state policy: {}'.format(state))
+
+    def serialize(self, serializer):
+        super(LookaheadRule, self).serialize(serializer)
+        self._base_rule.serialize(serializer['base_rule'])
+
+    def _init_states(self, param):
+        super(LookaheadRule, self)._init_states(param)
+
+        # Transfer the states of the base rule to the correct device (the
+        # device of `param`) on deserialization. Note that `init_state` is not
+        # meant to perform any device transfers.
+        self._base_rule._init_states(param)
+
+
+class Lookahead(optimizer.GradientMethod):
+
+    def __init__(self, optimizer, lr=_default_hyperparam.lr,
+                 n_updates=_default_hyperparam.n_updates,
+                 state=_default_hyperparam.state):
+        super(Lookahead, self).__init__()
+        self.hyperparam.lr = lr
+        self.hyperparam.n_updates = n_updates
+        self.hyperparam.state = state
+        self._base_optimizer = optimizer
+
+    lr = optimizer.HyperparameterProxy('lr')
+    n_updates = optimizer.HyperparameterProxy('n_updates')
+    state = optimizer.HyperparameterProxy('state')
+
+    def setup(self, link):
+        super(Lookahead, self).setup(link)
+        self._base_optimizer.setup(link)
+
+    def create_update_rule(self):
+        return LookaheadRule(
+            self._base_optimizer.create_update_rule(), self.hyperparam)


### PR DESCRIPTION
Partially fixes https://github.com/chainer/chainer/issues/8153, implementing the lookahead optimizer (https://arxiv.org/abs/1907.08610).

This PR mostly aims to demonstrate a possible implementation and might not be suitable in Chainer in which case we can close this PR (this optimizer might not be suitable at all considering the fact that PyTorch rejected it). 

It introduces a new `GradientMethod ` that is slightly different from the existing ones in that it accepts an `Optimizer` instance as an argument and updates using that one in the "inner loop". ~Thus, there are some tricks in order to get around initialization/serialization/deserialization such as overriding `setup` and `_init_states`. I might be missing some.~ There are other ways to implement this optimizer e.g. using arguments to existing optimizers or in the `Updater` layer but I didn't think those would be easier to maintain. I'd be more than happy to hear other ideas.

### TODO
- [ ] Write tests.
- [ ] Write docs.
- [ ] Compare results with paper.