### PR TITLE
Allow `pytest.skip()` in combination with `testing.repeat`/`retry`

### DIFF
--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -1,6 +1,7 @@
 import functools
 import unittest
 
+import _pytest
 import six
 
 
@@ -50,6 +51,13 @@ def repeat_with_success_at_least(times, min_success):
                         msg += '\n\nThe first error message:\n' + err_msg
                 instance.fail(msg)
 
+            # Wrapper to convert pytest.skip() to unittest.SkipTest
+            def f_wrap(ins, *args, **kwargs):
+                try:
+                    f(ins, *args[1:], **kwargs)
+                except _pytest.outcomes.Skipped as e:
+                    ins.skipTest(e.msg)
+
             for _ in six.moves.range(times):
                 suite = unittest.TestSuite()
                 # Create new instance to call the setup and the teardown only
@@ -57,7 +65,7 @@ def repeat_with_success_at_least(times, min_success):
                 ins = type(instance)(instance._testMethodName)
                 suite.addTest(
                     unittest.FunctionTestCase(
-                        lambda: f(ins, *args[1:], **kwargs),
+                        lambda: f_wrap(ins, *args[1:], **kwargs),
                         setUp=ins.setUp,
                         tearDown=ins.tearDown))
 

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -52,7 +52,7 @@ def repeat_with_success_at_least(times, min_success):
                 instance.fail(msg)
 
             # Wrapper to convert pytest.skip() to unittest.SkipTest
-            def f_wrap(ins, *args, **kwargs):
+            def f_wrap(ins, args, kwargs):
                 try:
                     f(ins, *args[1:], **kwargs)
                 except _pytest.outcomes.Skipped as e:
@@ -65,7 +65,7 @@ def repeat_with_success_at_least(times, min_success):
                 ins = type(instance)(instance._testMethodName)
                 suite.addTest(
                     unittest.FunctionTestCase(
-                        lambda: f_wrap(ins, *args[1:], **kwargs),
+                        lambda: f_wrap(ins, args, kwargs),
                         setUp=ins.setUp,
                         tearDown=ins.tearDown))
 

--- a/chainer/testing/condition.py
+++ b/chainer/testing/condition.py
@@ -1,7 +1,7 @@
 import functools
 import unittest
 
-import _pytest
+import _pytest.outcomes
 import six
 
 

--- a/tests/chainer_tests/testing_tests/test_condition.py
+++ b/tests/chainer_tests/testing_tests/test_condition.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 from chainer import testing
 from chainer.testing import condition
 
@@ -38,6 +40,10 @@ class MockUnitTest(unittest.TestCase):
     def skip_case(self):
         MockUnitTest.skip_case_counter += 1
         self.skipTest(SKIP_REASON)
+
+    def skip_case_pytest(self):
+        MockUnitTest.skip_case_counter += 1
+        pytest.skip(SKIP_REASON)
 
     def error_case(self):
         raise Exception()
@@ -155,6 +161,11 @@ class TestRepeat(unittest.TestCase):
         _should_skip(self, f)
         self.assertEqual(self.unit_test.skip_case_counter, 1)
 
+    def test_skip_case_pytest(self):
+        f = self._decorate(MockUnitTest.skip_case_pytest, 10)
+        _should_skip(self, f)
+        self.assertEqual(self.unit_test.skip_case_counter, 1)
+
     def test_probabilistic_case(self):
         f = self._decorate(MockUnitTest.probabilistic_case, 10)
         _should_fail(self, f)
@@ -185,6 +196,11 @@ class TestRetry(unittest.TestCase):
 
     def test_skip_case(self):
         f = self._decorate(MockUnitTest.skip_case, 10)
+        _should_skip(self, f)
+        self.assertEqual(self.unit_test.skip_case_counter, 1)
+
+    def test_skip_case_pytest(self):
+        f = self._decorate(MockUnitTest.skip_case_pytest, 10)
         _should_skip(self, f)
         self.assertEqual(self.unit_test.skip_case_counter, 1)
 


### PR DESCRIPTION
Fixes #4272