### PR TITLE
Remove `DummySerializer` and  `DummyDeserializer` from `iterators_tests`

### DIFF
--- a/tests/chainer_tests/iterators_tests/test_iterator_compatibility.py
+++ b/tests/chainer_tests/iterators_tests/test_iterator_compatibility.py
@@ -2,44 +2,10 @@ from __future__ import division
 import unittest
 
 import itertools
-import numpy
 
 from chainer import iterators
-from chainer import serializer
+from chainer import serializers
 from chainer import testing
-
-
-class DummySerializer(serializer.Serializer):
-
-    def __init__(self, target):
-        super(DummySerializer, self).__init__()
-        self.target = target
-
-    def __getitem__(self, key):
-        raise NotImplementedError
-
-    def __call__(self, key, value):
-        self.target[key] = value
-        return self.target[key]
-
-
-class DummyDeserializer(serializer.Deserializer):
-
-    def __init__(self, target):
-        super(DummyDeserializer, self).__init__()
-        self.target = target
-
-    def __getitem__(self, key):
-        raise NotImplementedError
-
-    def __call__(self, key, value):
-        if value is None:
-            value = self.target[key]
-        elif isinstance(value, numpy.ndarray):
-            numpy.copyto(value, self.target[key])
-        else:
-            value = type(value)(numpy.asarray(self.target[key]))
-        return value
 
 
 @testing.parameterize(*testing.product({
@@ -79,10 +45,10 @@ class TestIteratorCompatibility(unittest.TestCase):
             self.assertAlmostEqual(it.epoch_detail, 4 / 6)
 
             target = dict()
-            it.serialize(DummySerializer(target))
+            it.serialize(serializers.DictionarySerializer(target))
 
             it = it_after()
-            it.serialize(DummyDeserializer(target))
+            it.serialize(serializers.NpzDeserializer(target))
             self.assertFalse(it.is_new_epoch)
             self.assertAlmostEqual(it.epoch_detail, 4 / 6)
 

--- a/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_multiprocess_iterator.py
@@ -16,42 +16,9 @@ import numpy
 import six
 
 from chainer import iterators
-from chainer import serializer
+from chainer import serializers
 from chainer import testing
 from chainer.testing import attr
-
-
-class DummySerializer(serializer.Serializer):
-
-    def __init__(self, target):
-        super(DummySerializer, self).__init__()
-        self.target = target
-
-    def __getitem__(self, key):
-        raise NotImplementedError
-
-    def __call__(self, key, value):
-        self.target[key] = value
-        return self.target[key]
-
-
-class DummyDeserializer(serializer.Deserializer):
-
-    def __init__(self, target):
-        super(DummyDeserializer, self).__init__()
-        self.target = target
-
-    def __getitem__(self, key):
-        raise NotImplementedError
-
-    def __call__(self, key, value):
-        if value is None:
-            value = self.target[key]
-        elif isinstance(value, numpy.ndarray):
-            numpy.copyto(value, self.target[key])
-        else:
-            value = type(value)(numpy.asarray(self.target[key]))
-        return value
 
 
 class BaseTestMultiprocessIterator(object):
@@ -481,10 +448,10 @@ class TestMultiprocessIteratorSerialize(unittest.TestCase):
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)
 
         target = dict()
-        it.serialize(DummySerializer(target))
+        it.serialize(serializers.DictionarySerializer(target))
 
         it = iterators.MultiprocessIterator(dataset, 2, **self.options)
-        it.serialize(DummyDeserializer(target))
+        it.serialize(serializers.NpzDeserializer(target))
         self.assertFalse(it.is_new_epoch)
         self.assertAlmostEqual(it.epoch_detail, 4 / 6)
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)
@@ -518,12 +485,12 @@ class TestMultiprocessIteratorSerialize(unittest.TestCase):
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)
 
         target = dict()
-        it.serialize(DummySerializer(target))
+        it.serialize(serializers.DictionarySerializer(target))
         # older version does not have previous_epoch_detail
         del target['previous_epoch_detail']
 
         it = iterators.MultiprocessIterator(dataset, 2, **self.options)
-        it.serialize(DummyDeserializer(target))
+        it.serialize(serializers.NpzDeserializer(target))
         self.assertFalse(it.is_new_epoch)
         self.assertAlmostEqual(it.epoch_detail, 4 / 6)
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)

--- a/tests/chainer_tests/iterators_tests/test_serial_iterator.py
+++ b/tests/chainer_tests/iterators_tests/test_serial_iterator.py
@@ -4,41 +4,8 @@ import unittest
 import numpy
 
 from chainer import iterators
-from chainer import serializer
+from chainer import serializers
 from chainer import testing
-
-
-class DummySerializer(serializer.Serializer):
-
-    def __init__(self, target):
-        super(DummySerializer, self).__init__()
-        self.target = target
-
-    def __getitem__(self, key):
-        raise NotImplementedError
-
-    def __call__(self, key, value):
-        self.target[key] = value
-        return self.target[key]
-
-
-class DummyDeserializer(serializer.Deserializer):
-
-    def __init__(self, target):
-        super(DummyDeserializer, self).__init__()
-        self.target = target
-
-    def __getitem__(self, key):
-        raise NotImplementedError
-
-    def __call__(self, key, value):
-        if value is None:
-            value = self.target[key]
-        elif isinstance(value, numpy.ndarray):
-            numpy.copyto(value, self.target[key])
-        else:
-            value = type(value)(numpy.asarray(self.target[key]))
-        return value
 
 
 class TestSerialIterator(unittest.TestCase):
@@ -269,10 +236,10 @@ class TestSerialIteratorSerialize(unittest.TestCase):
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)
 
         target = dict()
-        it.serialize(DummySerializer(target))
+        it.serialize(serializers.DictionarySerializer(target))
 
         it = iterators.SerialIterator(dataset, 2)
-        it.serialize(DummyDeserializer(target))
+        it.serialize(serializers.NpzDeserializer(target))
         self.assertFalse(it.is_new_epoch)
         self.assertAlmostEqual(it.epoch_detail, 4 / 6)
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)
@@ -307,7 +274,7 @@ class TestSerialIteratorSerialize(unittest.TestCase):
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)
 
         target = dict()
-        it.serialize(DummySerializer(target))
+        it.serialize(serializers.DictionarySerializer(target))
         # older version uses '_order'
         target['_order'] = target['order']
         del target['order']
@@ -315,7 +282,7 @@ class TestSerialIteratorSerialize(unittest.TestCase):
         del target['previous_epoch_detail']
 
         it = iterators.SerialIterator(dataset, 2)
-        it.serialize(DummyDeserializer(target))
+        it.serialize(serializers.NpzDeserializer(target))
         self.assertFalse(it.is_new_epoch)
         self.assertAlmostEqual(it.epoch_detail, 4 / 6)
         self.assertAlmostEqual(it.previous_epoch_detail, 2 / 6)


### PR DESCRIPTION
Chainer `DictionarySerializer` and `NpzDeserializer` offer the same functionality as the `DummySerializer` and `DummyDeserializer` used in the iterators test code.
