### PR TITLE
Fix style of `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,47 +7,48 @@ ignore = E741,W503,W504,E241,E226
 exclude = .eggs,*.egg,build,caffe_pb2.py,caffe_pb3.py,docs,.git
 
 [tool:pytest]
-filterwarnings= error
-                # TODO(niboshi): Remove the entry below after solving #8062.
-                ignore:Some of grads are ignored by chainer\.backward\.:RuntimeWarning
-                # Ref. https://github.com/numpy/numpy/issues/11788
-                ignore:numpy\.ufunc size changed, may indicate binary incompatibility:RuntimeWarning
-                ignore:numpy\.dtype size changed, may indicate binary incompatibility:RuntimeWarning
-                ignore:ChainerX core binary is built in debug mode:UserWarning
-                ignore:Accelerate has been detected as a NumPy backend library:UserWarning:chainer[.*]
-                # Chainer internally imports cupy, and `import cupy` causes
-                # ImportWarning (see https://github.com/cupy/cupy/issues/2476).
-                # To import cupy successfully, we need to ignore ImportWarning.
-                # Also, ignore::chainer.warnings.PerformanceWarning seems to invoke
-                # import of chainer and cupy. Therefore, it is necessary to add
-                # the following line before the PerformanceWarning line
-                # to avoid failure of import cupy.
-                ignore:can\'t resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
-                ignore::chainer.warnings.PerformanceWarning
-                ignore::FutureWarning:chainer\.utils\.experimental
-                # NumPy<1.11
-                ignore:in the future np\.array_split will retain the shape of arrays with a zero size:FutureWarning:numpy\.lib\.shape_base
-                # importing old SciPy is warned because it tries to
-                # import nose via numpy.testing
-                ignore::DeprecationWarning:scipy\._lib\._numpy_compat
-                # importing stats from old SciPy is warned because it tries to
-                # import numpy.testing.decorators
-                ignore::DeprecationWarning:scipy\.stats\.morestats
-                # Theano 0.8 causes DeprecationWarnings. It is fixed in 0.9.
-                ignore::DeprecationWarning:theano\.configparser
-                # Theano 1.0.2 passes a deprecated argument to distutils during
-                # importing ``theano.gof`` module.
-                # Without this configuration, the DeprecationWarning would be
-                # treated as an exception, and therefore the import would fail,
-                # causing AttributeError in the subsequent uses of
-                # ``theano.gof``. (#4810)
-                ignore::DeprecationWarning:theano\.gof\.cmodule
-                # ``collections.MutableSequence`` in protobuf is warned by
-                # Python 3.7.
-                ignore:Using or importing the ABCs from 'collections':DeprecationWarning:google\.protobuf
-                # Importing abcs from ``collections`` in h5py is warned by
-                # Python 3.7.
-                ignore::DeprecationWarning:h5py\._hl\.base
+filterwarnings =
+    error
+    # TODO(niboshi): Remove the entry below after solving #8062.
+    ignore:Some of grads are ignored by chainer\.backward\.:RuntimeWarning
+    # Ref. https://github.com/numpy/numpy/issues/11788
+    ignore:numpy\.ufunc size changed, may indicate binary incompatibility:RuntimeWarning
+    ignore:numpy\.dtype size changed, may indicate binary incompatibility:RuntimeWarning
+    ignore:ChainerX core binary is built in debug mode:UserWarning
+    ignore:Accelerate has been detected as a NumPy backend library:UserWarning:chainer[.*]
+    # Chainer internally imports cupy, and `import cupy` causes
+    # ImportWarning (see https://github.com/cupy/cupy/issues/2476).
+    # To import cupy successfully, we need to ignore ImportWarning.
+    # Also, ignore::chainer.warnings.PerformanceWarning seems to invoke
+    # import of chainer and cupy. Therefore, it is necessary to add
+    # the following line before the PerformanceWarning line
+    # to avoid failure of import cupy.
+    ignore:can\'t resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning
+    ignore::chainer.warnings.PerformanceWarning
+    ignore::FutureWarning:chainer\.utils\.experimental
+    # NumPy<1.11
+    ignore:in the future np\.array_split will retain the shape of arrays with a zero size:FutureWarning:numpy\.lib\.shape_base
+    # importing old SciPy is warned because it tries to
+    # import nose via numpy.testing
+    ignore::DeprecationWarning:scipy\._lib\._numpy_compat
+    # importing stats from old SciPy is warned because it tries to
+    # import numpy.testing.decorators
+    ignore::DeprecationWarning:scipy\.stats\.morestats
+    # Theano 0.8 causes DeprecationWarnings. It is fixed in 0.9.
+    ignore::DeprecationWarning:theano\.configparser
+    # Theano 1.0.2 passes a deprecated argument to distutils during
+    # importing ``theano.gof`` module.
+    # Without this configuration, the DeprecationWarning would be
+    # treated as an exception, and therefore the import would fail,
+    # causing AttributeError in the subsequent uses of
+    # ``theano.gof``. (#4810)
+    ignore::DeprecationWarning:theano\.gof\.cmodule
+    # ``collections.MutableSequence`` in protobuf is warned by
+    # Python 3.7.
+    ignore:Using or importing the ABCs from 'collections':DeprecationWarning:google\.protobuf
+    # Importing abcs from ``collections`` in h5py is warned by
+    # Python 3.7.
+    ignore::DeprecationWarning:h5py\._hl\.base
 testpaths = tests docs
 python_files = test_*.py
 python_classes = Test


### PR DESCRIPTION
Follow the style
```
[pytest]
filterwarnings =
    error
    ignore::UserWarning
```
in https://docs.pytest.org/en/latest/warnings.html.

After the fix, I expect less number of editors will insert tabs by default.  (See also #8154)