### PR TITLE
Bug Fix: "copy" => "__deepcopy__" in ChainerMN "batch_normalization" & replace "to_gpu"

### DIFF
--- a/chainermn/links/batch_normalization.py
+++ b/chainermn/links/batch_normalization.py
@@ -9,6 +9,7 @@ from chainermn.functions import batch_normalization as \
     chainermn_batch_normalization
 
 import numpy
+import copy
 
 
 class MultiNodeBatchNormalization(link.Link):
@@ -130,14 +131,14 @@ class MultiNodeBatchNormalization(link.Link):
         """
         self.N = 0
 
-    def copy(self, mode='share'):
+    def __deepcopy__(self, memo):
         to_be_preserved = ['comm']
         preserved = {}
         for name in to_be_preserved:
             preserved[name] = getattr(self, name)
             setattr(self, name, None)
 
-        ret = super(MultiNodeBatchNormalization, self).copy(mode)
+        ret = copy.deepcopy(super(MultiNodeBatchNormalization, self))
 
         for name in to_be_preserved:
             setattr(self, name, preserved[name])

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -5,7 +5,7 @@ import pytest
 import unittest
 
 import chainer
-import chainer.cuda
+from chainer.backends.cuda import cupy
 import chainer.initializers
 import chainer.links
 import chainer.testing
@@ -21,7 +21,6 @@ from chainermn.communicators.non_cuda_aware_communicator \
 from chainermn.communicators.pure_nccl_communicator \
     import PureNcclCommunicator
 from chainermn import nccl
-import cupy
 
 
 class ExampleModel(chainer.Chain):

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -21,6 +21,7 @@ from chainermn.communicators.non_cuda_aware_communicator \
 from chainermn.communicators.pure_nccl_communicator \
     import PureNcclCommunicator
 from chainermn import nccl
+import cupy
 
 
 class ExampleModel(chainer.Chain):
@@ -374,7 +375,7 @@ def check_multi_node_mean_grad_mixed_dtype(param, model, use_gpu):
             answer_dtype = np.float16
 
     if use_gpu:
-        model.to_gpu()
+        model.to_device(cupy.cuda.Device())
 
     model.a.W.grad[:] = communicator.rank
     model.b.W.grad[:] = communicator.rank + 1
@@ -416,28 +417,29 @@ def check_collective_communication(param, use_gpu):
     mpi_comm.barrier()
 
     model = ExampleModel(param.model_dtype)
+    device = cupy.cuda.Device()
     if use_gpu:
-        model.to_gpu()
+        model.to_device(device)
     check_bcast_data(communicator, model)
 
     model = ExampleModel(param.model_dtype)
     if use_gpu:
-        model.to_gpu()
+        model.to_device(device)
     check_multi_node_mean_grad(communicator, model)
 
     model = ExampleModel(param.model_dtype)
     if use_gpu:
-        model.to_gpu()
+        model.to_device(device)
     check_multi_node_mean_grad_empty(communicator, model)
     model = ExampleModel(param.model_dtype)
     if use_gpu:
-        model.to_gpu()
+        model.to_device(device)
     check_multi_node_mean_grad_empty_half(communicator, model)
 
     # Check allreduce debug mode
     model = ExampleModel()
     if use_gpu:
-        model.to_gpu()
+        model.to_device(device)
 
     # The example model includes some nan parameters so the debug mode
     # must detect it.

--- a/tests/chainermn_tests/communicator_tests/test_communicator.py
+++ b/tests/chainermn_tests/communicator_tests/test_communicator.py
@@ -416,8 +416,8 @@ def check_collective_communication(param, use_gpu):
     mpi_comm.barrier()
 
     model = ExampleModel(param.model_dtype)
-    device = cupy.cuda.Device()
     if use_gpu:
+        device = cupy.cuda.Device()
         model.to_device(device)
     check_bcast_data(communicator, model)
 

--- a/tests/chainermn_tests/datasets_tests/test_mnist.py
+++ b/tests/chainermn_tests/datasets_tests/test_mnist.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 
-import cupy
 import os
 import sys
 import tempfile
 
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.functions as F
 import chainer.links as L
 import chainer.testing

--- a/tests/chainermn_tests/datasets_tests/test_mnist.py
+++ b/tests/chainermn_tests/datasets_tests/test_mnist.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+import cupy
 import os
 import sys
 import tempfile
@@ -43,7 +44,7 @@ def check_mnist(gpu, display_log=True):
 
     model = L.Classifier(MLP(n_units, 10))
     if gpu:
-        model.to_gpu()
+        model.to_device(cupy.cuda.Device())
 
     optimizer = chainermn.create_multi_node_optimizer(
         chainer.optimizers.Adam(), comm)

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -1,10 +1,10 @@
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
 import unittest
 
 import chainermn
-import cupy
 
 
 class ExampleModel(chainer.Chain):

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -4,6 +4,7 @@ import chainer.testing.attr
 import unittest
 
 import chainermn
+import cupy
 
 
 class ExampleModel(chainer.Chain):
@@ -47,5 +48,5 @@ class TestAllreducePersistent(unittest.TestCase):
         chainer.cuda.get_device_from_id(device).use()
 
         model = ExampleModel()
-        model.to_gpu()
+        model.to_device(cupy.cuda.Device(device))
         self._test(comm, model)

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -10,6 +10,7 @@ from chainer.training import extension
 from chainer.backend import cuda
 import chainermn
 from chainermn.extensions import ObservationAggregator
+import cupy
 
 
 class DummyChain(chainer.Chain):
@@ -55,7 +56,7 @@ def run_test_observation_aggregator(comm, xp,
                                     use_cupy):
     model = DummyChain()
     if use_cupy:
-        model.to_gpu()
+        model.to_device(cupy.cuda.Device())
     optimizer = chainermn.create_multi_node_optimizer(
         chainer.optimizers.Adam(), comm)
     optimizer.setup(model)

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -5,12 +5,12 @@ import pytest
 import numpy as np
 
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.testing
 from chainer.training import extension
 from chainer.backend import cuda
 import chainermn
 from chainermn.extensions import ObservationAggregator
-import cupy
 
 
 class DummyChain(chainer.Chain):

--- a/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
@@ -1,10 +1,9 @@
-import copy
 import functools
 
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
-import cupy
 import numpy
 import pytest
 

--- a/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
@@ -4,6 +4,7 @@ import functools
 import chainer
 import chainer.testing
 import chainer.testing.attr
+import cupy
 import numpy
 import pytest
 
@@ -63,9 +64,10 @@ def create_models(gpu, param, communicator):
         for l in range(communicator.size)]
 
     if gpu:
-        model.to_gpu()
+        device = cupy.cuda.Device()
+        model.to_device(device)
         for model_ in entire_model:
-            model_.to_gpu()
+            model_.to_device(device)
 
     return (model, entire_model)
 

--- a/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
+++ b/tests/chainermn_tests/functions_tests/test_point_to_point_communication.py
@@ -1,6 +1,7 @@
 import functools
 
 import chainer
+import copy
 from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -1,6 +1,7 @@
 import chainer
 import chainer.testing
 import chainer.utils
+import cupy
 import mpi4py.MPI
 import numpy
 import pytest
@@ -123,10 +124,11 @@ def check_multi_node_bn(comm, use_gpu=False, backend='auto',
         # m2 may be different.
 
     if use_gpu:
-        m1.to_gpu()
-        m2.to_gpu()
-        m3.to_gpu()
-        m4.to_gpu()
+        device = cupy.cuda.Device()
+        m1.to_device(device)
+        m2.to_device(device)
+        m3.to_device(device)
+        m4.to_device(device)
 
     m2.copyparams(m1)
     m3.copyparams(m1)

--- a/tests/chainermn_tests/links_tests/test_batch_normalization.py
+++ b/tests/chainermn_tests/links_tests/test_batch_normalization.py
@@ -1,7 +1,7 @@
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.utils
-import cupy
 import mpi4py.MPI
 import numpy
 import pytest

--- a/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
+++ b/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
@@ -4,6 +4,7 @@ import chainer
 import chainer.testing
 import chainer.testing.attr
 import chainermn
+import cupy
 
 
 class BnChain(chainer.Chain):
@@ -47,10 +48,8 @@ class TestCreateMnBnModel(unittest.TestCase):
             isinstance(mnbn_model.bn,
                        chainermn.links.MultiNodeBatchNormalization))
         if gpu:
-            device_id = self.communicator.intra_rank
-            mnbn_model.to_gpu(device=device_id)
-        else:
-            device_id = -1
+            mnbn_model.to_device(cupy.cuda.Device())
+
         with chainer.using_device(mnbn_model.device):
             x = mnbn_model.xp.zeros((1, 1, 1, 1))
             mnbn_model(x)
@@ -65,10 +64,7 @@ class TestCreateMnBnModel(unittest.TestCase):
             isinstance(mnbn_model[1],
                        chainermn.links.MultiNodeBatchNormalization))
         if gpu:
-            device_id = self.communicator.intra_rank
-            mnbn_model.to_gpu(device=device_id)
-        else:
-            device_id = -1
+            mnbn_model.to_device(cupy.cuda.Device())
         with chainer.using_device(mnbn_model.device):
             x = mnbn_model.xp.zeros((1, 1, 1, 1))
             mnbn_model(x)
@@ -85,10 +81,7 @@ class TestCreateMnBnModel(unittest.TestCase):
                                                        self.communicator)
 
         if gpu:
-            device_id = self.communicator.intra_rank
-            mnbn_model.to_gpu(device=device_id)
-        else:
-            device_id = -1
+            mnbn_model.to_device(cupy.cuda.Device())
         with chainer.using_device(mnbn_model.device):
             x = mnbn_model.xp.zeros((1, 1, 1, 1))
             mnbn_model(x)

--- a/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
+++ b/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
@@ -1,10 +1,10 @@
 import unittest
 
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
 import chainermn
-import cupy
 
 
 class BnChain(chainer.Chain):

--- a/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
+++ b/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
@@ -3,6 +3,7 @@ import chainer.cuda
 import chainer.links as L
 import chainer.testing
 import chainermn
+import cupy
 import numpy as np
 import pytest
 
@@ -247,7 +248,7 @@ def check_cycle_model(gpu, param):
                 Cycle0(d, communicator, rank_next, rank_prev))
 
             if gpu:
-                model.to_gpu()
+                model.to_device(cupy.cuda.Device())
                 X = chainer.cuda.to_gpu(X)
                 Y = chainer.cuda.to_gpu(Y)
 
@@ -258,7 +259,7 @@ def check_cycle_model(gpu, param):
             model = Cycle1(
                 d, communicator, rank_next, rank_prev)
             if gpu:
-                model.to_gpu()
+                model.to_device(cupy.cuda.Device())
 
             for i in range(n):
                 err = model()
@@ -294,7 +295,7 @@ def check_crossing_model(gpu, param):
                 d, communicator, rank_next, rank_prev))
 
         if gpu:
-            model.to_gpu()
+            model.to_device(cupy.cuda.Device())
             X = chainer.cuda.to_gpu(X)
             Y = chainer.cuda.to_gpu(Y)
 
@@ -328,7 +329,7 @@ def check_branching_model(gpu, communicator, rank_next, rank_prev,
             model = L.Classifier(parent_model(
                 d, communicator, rank_children))
             if gpu:
-                model.to_gpu()
+                model.to_device(cupy.cuda.Device())
                 X = chainer.cuda.to_gpu(X)
                 Y = chainer.cuda.to_gpu(Y)
 
@@ -338,7 +339,7 @@ def check_branching_model(gpu, communicator, rank_next, rank_prev,
         else:
             model = BranchChild(d, communicator, 0)
             if gpu:
-                model.to_gpu()
+                model.to_device(cupy.cuda.Device())
 
             for i in range(n):
                 err = model()
@@ -392,7 +393,7 @@ def check_twisting_model(gpu, param):
                 d, communicator, rank_prev, rank_next))
 
         if gpu:
-            model.to_gpu()
+            model.to_device(cupy.cuda.Device())
             X = chainer.cuda.to_gpu(X)
             Y = chainer.cuda.to_gpu(Y)
 
@@ -434,7 +435,7 @@ def check_tuple_data_model(gpu, param):
 
         assert model is not None
         if gpu:
-            model.to_gpu()
+            model.to_device(cupy.cuda.Device())
             X = chainer.cuda.to_gpu(X)
             Y = chainer.cuda.to_gpu(Y)
 

--- a/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
+++ b/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
@@ -1,9 +1,9 @@
 import chainer
-import chainer.cuda
+from chainer.backends import cuda
+from chainer.backends.cuda import cupy
 import chainer.links as L
 import chainer.testing
 import chainermn
-import cupy
 import numpy as np
 import pytest
 

--- a/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
+++ b/tests/chainermn_tests/links_tests/test_multi_node_chain_list.py
@@ -1,5 +1,5 @@
 import chainer
-from chainer.backends import cuda
+import chainer.backends
 from chainer.backends.cuda import cupy
 import chainer.links as L
 import chainer.testing
@@ -223,7 +223,7 @@ class TupleDataChild(chainermn.MultiNodeChainList):
 def create_communicator(gpu):
     if gpu:
         communicator = chainermn.create_communicator('flat')
-        chainer.cuda.get_device_from_id(communicator.intra_rank).use()
+        chainer.backends.cuda.get_device_from_id(communicator.intra_rank).use()
     else:
         communicator = chainermn.create_communicator('naive')
 
@@ -249,8 +249,8 @@ def check_cycle_model(gpu, param):
 
             if gpu:
                 model.to_device(cupy.cuda.Device())
-                X = chainer.cuda.to_gpu(X)
-                Y = chainer.cuda.to_gpu(Y)
+                X = chainer.backends.cuda.to_gpu(X)
+                Y = chainer.backends.cuda.to_gpu(Y)
 
             for i in range(n):
                 err = model(X[i:i + 1], Y[i:i + 1])
@@ -296,8 +296,8 @@ def check_crossing_model(gpu, param):
 
         if gpu:
             model.to_device(cupy.cuda.Device())
-            X = chainer.cuda.to_gpu(X)
-            Y = chainer.cuda.to_gpu(Y)
+            X = chainer.backends.cuda.to_gpu(X)
+            Y = chainer.backends.cuda.to_gpu(Y)
 
         for i in range(n):
             err = model(X[i:i + 1], Y[i:i + 1])
@@ -330,8 +330,8 @@ def check_branching_model(gpu, communicator, rank_next, rank_prev,
                 d, communicator, rank_children))
             if gpu:
                 model.to_device(cupy.cuda.Device())
-                X = chainer.cuda.to_gpu(X)
-                Y = chainer.cuda.to_gpu(Y)
+                X = chainer.backends.cuda.to_gpu(X)
+                Y = chainer.backends.cuda.to_gpu(Y)
 
             for i in range(n):
                 err = model(X[i:i + 1], Y[i:i + 1])
@@ -394,8 +394,8 @@ def check_twisting_model(gpu, param):
 
         if gpu:
             model.to_device(cupy.cuda.Device())
-            X = chainer.cuda.to_gpu(X)
-            Y = chainer.cuda.to_gpu(Y)
+            X = chainer.backends.cuda.to_gpu(X)
+            Y = chainer.backends.cuda.to_gpu(Y)
 
         for i in range(n):
             err = model(X[i:i + 1], Y[i:i + 1])
@@ -436,8 +436,8 @@ def check_tuple_data_model(gpu, param):
         assert model is not None
         if gpu:
             model.to_device(cupy.cuda.Device())
-            X = chainer.cuda.to_gpu(X)
-            Y = chainer.cuda.to_gpu(Y)
+            X = chainer.backends.cuda.to_gpu(X)
+            Y = chainer.backends.cuda.to_gpu(Y)
 
         for i in range(n):
             if communicator.rank % 2 == 0:

--- a/tests/chainermn_tests/links_tests/test_n_step_rnn.py
+++ b/tests/chainermn_tests/links_tests/test_n_step_rnn.py
@@ -1,12 +1,11 @@
 import unittest
 
 import chainer
-import chainer.cuda
+from chainer.backends.cuda import cupy
 import chainer.functions as F
 import chainer.links as L
 import chainer.testing
 import chainermn
-import cupy
 import numpy as np
 import pytest
 

--- a/tests/chainermn_tests/links_tests/test_n_step_rnn.py
+++ b/tests/chainermn_tests/links_tests/test_n_step_rnn.py
@@ -6,6 +6,7 @@ import chainer.functions as F
 import chainer.links as L
 import chainer.testing
 import chainermn
+import cupy
 import numpy as np
 import pytest
 
@@ -75,7 +76,7 @@ class TestNStepRNN(unittest.TestCase):
             n_vocab, n_hid, self.communicator, self.rank_next, self.rank_prev)
 
         if gpu:
-            model.to_gpu()
+            model.to_device(cupy.cuda.Device())
             X = [chainer.cuda.to_gpu(x) for x in X]
             Y = chainer.cuda.to_gpu(Y)
 
@@ -110,7 +111,7 @@ class TestNStepRNN(unittest.TestCase):
             n_vocab, n_hid, self.communicator, self.rank_next, self.rank_prev)
 
         if gpu:
-            model.to_gpu()
+            model.to_device(cupy.cuda.Device())
             X = [chainer.cuda.to_gpu(x) for x in X]
             Y = chainer.cuda.to_gpu(Y)
 

--- a/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
@@ -3,6 +3,7 @@ import chainer.testing
 import chainer.testing.attr
 import chainermn
 from chainermn import nccl
+import cupy
 import mock
 import numpy as np
 import pytest
@@ -29,7 +30,7 @@ class TestDoubleBufferingOptimizer(unittest.TestCase):
         device = self.comm.intra_rank
         chainer.cuda.get_device_from_id(device).use()
         self.target = ExampleModel()
-        self.target.to_gpu()
+        self.target.to_device(cupy.cuda.Device())
         self.target.a.W.data[:] = self.comm.rank
         self.target.b.W.data[:] = self.comm.rank + 1
         self.target.c.W.data[:] = self.comm.rank + 2
@@ -116,7 +117,7 @@ class TestDoubleBufferingOptimizerWithDynamicModel(unittest.TestCase):
         device = self.comm.intra_rank
         chainer.cuda.get_device_from_id(device).use()
         self.target = DynamicExampleModel()
-        self.target.to_gpu()
+        self.target.to_device(cupy.cuda.Device())
         self.target.a.W.data[:] = self.comm.rank
         self.target.b.W.data[:] = self.comm.rank + 1
         self.target.a.W.grad[:] = 0
@@ -165,7 +166,7 @@ class TestDoubleBufferingOptimizerWithDynamicModel(unittest.TestCase):
 
         with self.target.init_scope():
             c = chainer.links.Linear(4, 4)
-            c.to_gpu()
+            c.to_device(cupy.cuda.Device())
             self.target.c = c
         if self.comm.rank == 0:
             self.target.c.W.data[:] = self.comm.rank + 2

--- a/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_double_buffering_optimizer.py
@@ -1,9 +1,9 @@
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
 import chainermn
 from chainermn import nccl
-import cupy
 import mock
 import numpy as np
 import pytest

--- a/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
@@ -2,6 +2,7 @@ import chainer
 import chainer.testing
 import chainer.testing.attr
 import chainermn
+import cupy
 import mock
 import numpy as np
 import unittest
@@ -35,7 +36,7 @@ class TestMultiNodeOptimizer(unittest.TestCase):
         device = self.comm.intra_rank
         chainer.cuda.get_device_from_id(device).use()
         self.target = ExampleModel()
-        self.target.to_gpu()
+        self.target.to_device(cupy.cuda.Device())
         self.target.a.W.data[:] = self.comm.rank
         self.target.b.W.data[:] = self.comm.rank + 1
         self.target.c.W.data[:] = self.comm.rank + 2
@@ -131,7 +132,7 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
         device = self.comm.intra_rank
         chainer.cuda.get_device_from_id(device).use()
         self.target = DynamicExampleModel()
-        self.target.to_gpu()
+        self.target.to_device(cupy.cuda.Device())
         self.target.a.W.data[:] = self.comm.rank
         self.target.b.W.data[:] = self.comm.rank + 1
         self.target.a.W.grad[:] = 0
@@ -193,7 +194,7 @@ class TestMultiNodeOptimizerWithDynamicModel(unittest.TestCase):
 
         with self.target.init_scope():
             c = chainer.links.Linear(4, 4)
-            c.to_gpu()
+            c.to_device(cupy.cuda.Device())
             self.target.c = c
         if self.comm.rank == 0:
             self.target.c.W.data[:] = self.comm.rank + 2

--- a/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
+++ b/tests/chainermn_tests/optimizer_tests/test_multi_node_optimizer.py
@@ -1,8 +1,8 @@
 import chainer
+from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
 import chainermn
-import cupy
 import mock
 import numpy as np
 import unittest


### PR DESCRIPTION
This PR contains two fixes for ChainerMN to pass the CI tests.
1. A bug fix in the `batch_normalization`, from `copy` to use `__deepcopy__` to match the behavior of `chainer`.
2. Replace all the deprecated `to_gpu` to `to_device` in all the tests