### PR TITLE
Relax `BatchNormalization` backward test tolerances

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -156,7 +156,8 @@ class TestBatchNormalization(unittest.TestCase):
         if hasattr(self, 'axis'):
             self.bn_options['axis'] = self.axis
         self.check_forward_options = {'atol': 1e-4, 'rtol': 1e-3}
-        self.check_backward_options = {'dtype': numpy.float64}
+        self.check_backward_options = {
+            'dtype': numpy.float64, 'atol': 1e-4, 'rtol': 1e-3}
         self.check_double_backward_options = {
             'dtype': numpy.float64, 'atol': 1e-3, 'rtol': 1e-2}
         if self.dtype == numpy.float16:


### PR DESCRIPTION
Attempts to fix https://github.com/chainer/chainer/issues/8145.

I can not reproduce this backward test failure locally but it has now occurred twice in our CI. I choose to relax the tolerances to be identical to that of the forward test (they used to be 10 times smaller utilizing the default values of `check_backward`). This should've at least made the two failing tests to pass. Again, I have not been able to verify the change in failure rates locally.