### PR TITLE
Add `WIN32_LEAN_AND_MEAN` definition

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -65,6 +65,7 @@ option(CHAINERX_ENABLE_LAPACK "Use LAPACK if available" ${DEFAULT_CHAINERX_ENABL
 if(MSVC)
     option(CUDA_USE_STATIC_CUDA_RUNTIME "Use the static version of the CUDA runtime library if available" OFF)
     set(CUDA_USE_STATIC_CUDA_RUNTIME OFF CACHE INTERNAL "")
+    add_definitions(-DWIN32_LEAN_AND_MEAN)
 endif()
 
 #-------------


### PR DESCRIPTION
Potentially save developer from preprocessing error due to macro expansion when accidentally include `windows.h`, e.g. `nvToolsExt.h` will do this.