### PR TITLE
Remove ideep mixed dtype workaround in `F.batch_normalization`

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -105,10 +105,6 @@ class GeneralBatchNormalizationImpl(_BatchNormalizationImpl):
 
         inv_m = gamma.dtype.type(1. / (x.size // gamma.size))
         if xp is numpy:
-            # cast to avoid a error of "mkldnn::error"
-            if gy.dtype == numpy.float64 and gamma.dtype == numpy.float32:
-                gamma = gamma.astype(numpy.float64, copy=False)
-
             gx = (gamma * inv_std)[expander] * (
                 gy - (x_hat * ggamma[expander] + gbeta[expander]) * inv_m)
             gx = gx.astype(dtype=x.dtype, copy=False)


### PR DESCRIPTION
See: https://github.com/chainer/chainer/pull/8175#pullrequestreview-295345169

I cannot replicate the error after the PR was merged to master.