### PR TITLE
Fix a typo in the Cauchy distribution page

### DIFF
--- a/chainer/distributions/cauchy.py
+++ b/chainer/distributions/cauchy.py
@@ -28,7 +28,7 @@ class Cauchy(distribution.Distribution):
 
     Args:
         loc(:class:`~chainer.Variable` or :ref:`ndarray`): Parameter of
-            distribution representing the location :math:`\\x_0`.
+            distribution representing the location :math:`x_0`.
         scale(:class:`~chainer.Variable` or :ref:`ndarray`): Parameter of
             distribution representing the scale :math:`\\gamma`.
     """


### PR DESCRIPTION
[The Cauchy distribution page]((https://docs.chainer.org/en/stable/reference/generated/chainer.distributions.Cauchy.html)) does not show the $x_0$ correctly due to the typo.

<img width="697" alt="Screenshot 2019-10-01 at 21 11 39" src="https://user-images.githubusercontent.com/7121753/65960809-44ab2080-e490-11e9-8d39-93a95696cdbc.png">



So I fixed it. By applying this PR, the page shows it correctly:
<img width="691" alt="Screenshot 2019-10-01 at 21 09 56" src="https://user-images.githubusercontent.com/7121753/65960808-44128a00-e490-11e9-9eb9-54a9a14ef1d9.png">
