### PR TITLE
Fix possible data race in CUDA memory keeper

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device.h
+++ b/chainerx_cc/chainerx/cuda/cuda_device.h
@@ -4,6 +4,7 @@
 #include <cudnn.h>
 #include <cusolverDn.h>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -64,6 +65,7 @@ public:
 private:
     std::mutex mutex_{};
     std::queue<std::pair<cudaEvent_t, std::shared_ptr<void>>> queue_{};
+    std::atomic<bool> is_empty_{true};
 };
 
 // Keeps handles and other device internals.


### PR DESCRIPTION
`std::queue::empty()` is not thread safe.