### PR TITLE
Remove unused forward declaration of `AveragePoolPadMode` enum

### DIFF
--- a/chainerx_cc/chainerx/device.h
+++ b/chainerx_cc/chainerx/device.h
@@ -18,7 +18,6 @@
 namespace chainerx {
 
 class Array;
-enum class AveragePoolPadMode;
 
 class MaxPoolForwardBackward {
 public:

--- a/chainerx_cc/chainerx/kernels/pooling.h
+++ b/chainerx_cc/chainerx/kernels/pooling.h
@@ -10,6 +10,7 @@
 #include "chainerx/constant.h"
 #include "chainerx/dims.h"
 #include "chainerx/kernel.h"
+#include "chainerx/routines/pooling.h"
 
 namespace chainerx {
 


### PR DESCRIPTION
`AveragePoolPadMode` was no longer used in `device.h`.