### PR TITLE
Fix `HDF5Serializer` test for h5py<2.9

### DIFF
--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -23,6 +23,15 @@ if hdf5._available:
     import h5py
 
 
+# The tests call `fd, path = tempfile.mkstemp(); os.close(fd)` rather than
+# `with tempfile.TemporaryFile() as f:` because the file-like objects support
+# for `h5py.File` is from h5py>=2.9 (h5py/h5py#1061). h5py>=2.5 is supported.
+#
+# `os.remove(path)` is necessary. The tests could utilize
+# `tempfile.NamedTemporaryFile` but cannot utilize its with-blocks because it
+# is platform-dependent behavior to open `f.name` before `f.file` is closed.
+
+
 @unittest.skipUnless(hdf5._available, 'h5py is not available')
 class TestHDF5Serializer(unittest.TestCase):
 

--- a/tests/chainer_tests/serializers_tests/test_hdf5.py
+++ b/tests/chainer_tests/serializers_tests/test_hdf5.py
@@ -193,10 +193,14 @@ class TestHDF5Deserializer(unittest.TestCase):
         # It should be bit-identical to the result directly retrieved from
         # h5py.
         arr_hdf5 = numpy.empty((2, 3), dtype=numpy.float16)
-        with tempfile.TemporaryFile() as buf:
-            with h5py.File(buf, 'w') as f:
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            with h5py.File(path, 'w') as f:
                 f.create_dataset('a', data=self.data)
                 f['a'].read_direct(arr_hdf5)
+        finally:
+            os.remove(path)
         numpy.testing.assert_array_equal(y, arr_hdf5)
 
     @attr.gpu


### PR DESCRIPTION
Chainer is tested with h5py>=2.5.
https://github.com/chainer/chainer-test/blob/b1b40421a2d7c73b86590575b19b82c801a12778/run_combination_test.py#L21

#8182 uses a feature of h5py>=2.9 (h5py/h5py#1061).

