### PR TITLE
Fix resize_images documentation to reflect recent code changes

### DIFF
--- a/chainer/functions/array/resize_images.py
+++ b/chainer/functions/array/resize_images.py
@@ -303,7 +303,6 @@ def resize_images(x, output_shape, mode='bilinear', align_corners=True):
     """Resize images to the given shape.
 
     This function resizes 2D data to :obj:`output_shape`.
-    Currently, only bilinear interpolation is supported as the sampling method.
 
     Notation: here is a notation for dimensionalities.
 


### PR DESCRIPTION
Recently, a nearest mode was added to `resize_images`: https://github.com/chainer/chainer/commit/f8b3524a983b7785e90e7cb25e54e27f154b1dee
The function documentation should reflect this.