### PR TITLE
Delete move and copy of virtual `*GradState` classes

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
@@ -221,11 +221,11 @@ public:
 
         // TODO(hvy): Implement recomputation of x_cont, x_mean and x_inv_std in case they are not given by the state.
         CHAINERX_ASSERT(state != nullptr);
-        auto cuda_state = dynamic_cast<CudaBatchNormGradState*>(state.get());
-        const Array& x_cont = cuda_state->x_cont();
-        const Array& x_mean = cuda_state->x_mean();
-        const Array& x_inv_std = cuda_state->x_inv_std();
-        Dtype beta_dtype = cuda_state->beta_dtype();
+        auto& cuda_state = dynamic_cast<CudaBatchNormGradState&>(*state);
+        const Array& x_cont = cuda_state.x_cont();
+        const Array& x_mean = cuda_state.x_mean();
+        const Array& x_inv_std = cuda_state.x_inv_std();
+        Dtype beta_dtype = cuda_state.beta_dtype();
         CHAINERX_ASSERT(x_cont.IsContiguous());
         CHAINERX_ASSERT(x_cont.shape() == x.shape());
         CHAINERX_ASSERT(x_mean.shape() == gamma.shape());

--- a/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
@@ -221,11 +221,11 @@ public:
 
         // TODO(hvy): Implement recomputation of x_cont, x_mean and x_inv_std in case they are not given by the state.
         CHAINERX_ASSERT(state != nullptr);
-        auto cuda_state = dynamic_cast<CudaBatchNormGradState&>(*state);
-        const Array& x_cont = cuda_state.x_cont();
-        const Array& x_mean = cuda_state.x_mean();
-        const Array& x_inv_std = cuda_state.x_inv_std();
-        Dtype beta_dtype = cuda_state.beta_dtype();
+        auto cuda_state = dynamic_cast<CudaBatchNormGradState*>(state.get());
+        const Array& x_cont = cuda_state->x_cont();
+        const Array& x_mean = cuda_state->x_mean();
+        const Array& x_inv_std = cuda_state->x_inv_std();
+        Dtype beta_dtype = cuda_state->beta_dtype();
         CHAINERX_ASSERT(x_cont.IsContiguous());
         CHAINERX_ASSERT(x_cont.shape() == x.shape());
         CHAINERX_ASSERT(x_mean.shape() == gamma.shape());

--- a/chainerx_cc/chainerx/cuda/cuda_device/rnn.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/rnn.cu
@@ -368,13 +368,13 @@ public:
         CudaSetDeviceScope scope{device.index()};
 
         cuda_internal::DeviceInternals& device_internals = cuda_internal::GetDeviceInternals(device);
-        auto cuda_state = dynamic_cast<GenericRnnGradState&>(*state);
+        auto cuda_state = dynamic_cast<GenericRnnGradState*>(state.get());
         Dtype type = hx.dtype();
         const auto input_dim = xs[0].shape()[1];
         const auto hidden_dim = hx.shape()[2];
         const auto num_directions = bidirectional == 1 ? 2 : 1;
 
-        cudnnRNNDescriptor_t rnn_desc = cuda_state.rnn_desc();
+        cudnnRNNDescriptor_t rnn_desc = cuda_state->rnn_desc();
         std::vector<Array> dxs;
         std::vector<cuda_internal::CudnnTensorDescriptor> _xs_desc, _dxs_desc, _ys_desc, _dys_desc;
         cudnnTensorDescriptor_t* xs_desc = reinterpret_cast<cudnnTensorDescriptor_t*>(malloc(xs.size() * sizeof(cudnnTensorDescriptor_t)));
@@ -403,10 +403,10 @@ public:
         Array x = AsContiguous(Concatenate(xs_cont, 0));
         Array y = AsContiguous(Concatenate(ys, 0));
         Array dy = AsContiguous(Concatenate(dys, 0));
-        cudnnFilterDescriptor_t w_desc = cuda_state.wDesc();
-        Array w = AsContiguous(cuda_state.w());
-        Array reserve = AsContiguous(cuda_state.reserve());
-        Array workspace = AsContiguous(cuda_state.workspace());
+        cudnnFilterDescriptor_t w_desc = cuda_state->wDesc();
+        Array w = AsContiguous(cuda_state->w());
+        Array reserve = AsContiguous(cuda_state->reserve());
+        Array workspace = AsContiguous(cuda_state->workspace());
         size_t reserve_size = reserve.shape()[0];
         size_t work_size = workspace.shape()[0];
         hx = AsContiguous(hx.AsType(Dtype::kFloat32));

--- a/chainerx_cc/chainerx/cuda/cuda_device/rnn.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/rnn.cu
@@ -368,13 +368,13 @@ public:
         CudaSetDeviceScope scope{device.index()};
 
         cuda_internal::DeviceInternals& device_internals = cuda_internal::GetDeviceInternals(device);
-        auto cuda_state = dynamic_cast<GenericRnnGradState*>(state.get());
+        auto& cuda_state = dynamic_cast<GenericRnnGradState&>(*state);
         Dtype type = hx.dtype();
         const auto input_dim = xs[0].shape()[1];
         const auto hidden_dim = hx.shape()[2];
         const auto num_directions = bidirectional == 1 ? 2 : 1;
 
-        cudnnRNNDescriptor_t rnn_desc = cuda_state->rnn_desc();
+        cudnnRNNDescriptor_t rnn_desc = cuda_state.rnn_desc();
         std::vector<Array> dxs;
         std::vector<cuda_internal::CudnnTensorDescriptor> _xs_desc, _dxs_desc, _ys_desc, _dys_desc;
         cudnnTensorDescriptor_t* xs_desc = reinterpret_cast<cudnnTensorDescriptor_t*>(malloc(xs.size() * sizeof(cudnnTensorDescriptor_t)));
@@ -403,10 +403,10 @@ public:
         Array x = AsContiguous(Concatenate(xs_cont, 0));
         Array y = AsContiguous(Concatenate(ys, 0));
         Array dy = AsContiguous(Concatenate(dys, 0));
-        cudnnFilterDescriptor_t w_desc = cuda_state->wDesc();
-        Array w = AsContiguous(cuda_state->w());
-        Array reserve = AsContiguous(cuda_state->reserve());
-        Array workspace = AsContiguous(cuda_state->workspace());
+        cudnnFilterDescriptor_t w_desc = cuda_state.wDesc();
+        Array w = AsContiguous(cuda_state.w());
+        Array reserve = AsContiguous(cuda_state.reserve());
+        Array workspace = AsContiguous(cuda_state.workspace());
         size_t reserve_size = reserve.shape()[0];
         size_t work_size = workspace.shape()[0];
         hx = AsContiguous(hx.AsType(Dtype::kFloat32));

--- a/chainerx_cc/chainerx/kernels/normalization.h
+++ b/chainerx_cc/chainerx/kernels/normalization.h
@@ -23,10 +23,10 @@ public:
 
     virtual ~BatchNormGradState() = default;
 
-    BatchNormGradState(const BatchNormGradState&) = default;
-    BatchNormGradState(BatchNormGradState&&) = default;
-    BatchNormGradState& operator=(const BatchNormGradState&) = default;
-    BatchNormGradState& operator=(BatchNormGradState&&) = default;
+    BatchNormGradState(const BatchNormGradState&) = delete;
+    BatchNormGradState(BatchNormGradState&&) = delete;
+    BatchNormGradState& operator=(const BatchNormGradState&) = delete;
+    BatchNormGradState& operator=(BatchNormGradState&&) = delete;
 };
 
 class BatchNormKernel : public Kernel {

--- a/chainerx_cc/chainerx/kernels/pooling.h
+++ b/chainerx_cc/chainerx/kernels/pooling.h
@@ -19,10 +19,10 @@ public:
 
     virtual ~MaxPoolGradState() = default;
 
-    MaxPoolGradState(const MaxPoolGradState&) = default;
-    MaxPoolGradState(MaxPoolGradState&&) = default;
-    MaxPoolGradState& operator=(const MaxPoolGradState&) = default;
-    MaxPoolGradState& operator=(MaxPoolGradState&&) = default;
+    MaxPoolGradState(const MaxPoolGradState&) = delete;
+    MaxPoolGradState(MaxPoolGradState&&) = delete;
+    MaxPoolGradState& operator=(const MaxPoolGradState&) = delete;
+    MaxPoolGradState& operator=(MaxPoolGradState&&) = delete;
 };
 
 class MaxPoolKernel : public Kernel {
@@ -37,10 +37,10 @@ public:
 
     virtual ~MaxPoolGradGradState() = default;
 
-    MaxPoolGradGradState(const MaxPoolGradGradState&) = default;
-    MaxPoolGradGradState(MaxPoolGradGradState&&) = default;
-    MaxPoolGradGradState& operator=(const MaxPoolGradGradState&) = default;
-    MaxPoolGradGradState& operator=(MaxPoolGradGradState&&) = default;
+    MaxPoolGradGradState(const MaxPoolGradGradState&) = delete;
+    MaxPoolGradGradState(MaxPoolGradGradState&&) = delete;
+    MaxPoolGradGradState& operator=(const MaxPoolGradGradState&) = delete;
+    MaxPoolGradGradState& operator=(MaxPoolGradGradState&&) = delete;
 };
 
 class MaxPoolGradKernel : public Kernel {
@@ -73,10 +73,10 @@ public:
 
     virtual ~AveragePoolGradState() = default;
 
-    AveragePoolGradState(const AveragePoolGradState&) = default;
-    AveragePoolGradState(AveragePoolGradState&&) = default;
-    AveragePoolGradState& operator=(const AveragePoolGradState&) = default;
-    AveragePoolGradState& operator=(AveragePoolGradState&&) = default;
+    AveragePoolGradState(const AveragePoolGradState&) = delete;
+    AveragePoolGradState(AveragePoolGradState&&) = delete;
+    AveragePoolGradState& operator=(const AveragePoolGradState&) = delete;
+    AveragePoolGradState& operator=(AveragePoolGradState&&) = delete;
 };
 
 class AveragePoolKernel : public Kernel {

--- a/chainerx_cc/chainerx/kernels/rnn.h
+++ b/chainerx_cc/chainerx/kernels/rnn.h
@@ -25,10 +25,10 @@ public:
 
     virtual ~RnnGradState() = default;
 
-    RnnGradState(const RnnGradState&) = default;
-    RnnGradState(RnnGradState&&) = default;
-    RnnGradState& operator=(const RnnGradState&) = default;
-    RnnGradState& operator=(RnnGradState&&) = default;
+    RnnGradState(const RnnGradState&) = delete;
+    RnnGradState(RnnGradState&&) = delete;
+    RnnGradState& operator=(const RnnGradState&) = delete;
+    RnnGradState& operator=(RnnGradState&&) = delete;
 };
 
 class RnnKernel : public Kernel {

--- a/chainerx_cc/chainerx/routines/normalization.cc
+++ b/chainerx_cc/chainerx/routines/normalization.cc
@@ -219,11 +219,11 @@ std::tuple<Array, Array, Array> GenericBatchNormGradKernel::Call(
 
     // TODO(hvy): Implement recomputation of x_mean and x_inv_std in case they are not given by the state.
     CHAINERX_ASSERT(state != nullptr);
-    auto generic_state = dynamic_cast<GenericBatchNormGradState*>(state.get());
+    auto& generic_state = dynamic_cast<GenericBatchNormGradState&>(*state);
     // x_mean and x_inv_std have promoted dtypes.
-    const Array& x_mean = generic_state->x_mean();
-    const Array& x_inv_std = generic_state->x_inv_std();  // Note: x_inv_std_ has the information of eps.
-    Dtype beta_dtype = generic_state->beta_dtype();
+    const Array& x_mean = generic_state.x_mean();
+    const Array& x_inv_std = generic_state.x_inv_std();  // Note: x_inv_std_ has the information of eps.
+    Dtype beta_dtype = generic_state.beta_dtype();
 
     // TODO(hvy): Avoid `AsType`.
     Dtype interm_dtype = x_mean.dtype();

--- a/chainerx_cc/chainerx/routines/normalization.cc
+++ b/chainerx_cc/chainerx/routines/normalization.cc
@@ -219,11 +219,11 @@ std::tuple<Array, Array, Array> GenericBatchNormGradKernel::Call(
 
     // TODO(hvy): Implement recomputation of x_mean and x_inv_std in case they are not given by the state.
     CHAINERX_ASSERT(state != nullptr);
-    auto generic_state = dynamic_cast<GenericBatchNormGradState&>(*state);
+    auto generic_state = dynamic_cast<GenericBatchNormGradState*>(state.get());
     // x_mean and x_inv_std have promoted dtypes.
-    const Array& x_mean = generic_state.x_mean();
-    const Array& x_inv_std = generic_state.x_inv_std();  // Note: x_inv_std_ has the information of eps.
-    Dtype beta_dtype = generic_state.beta_dtype();
+    const Array& x_mean = generic_state->x_mean();
+    const Array& x_inv_std = generic_state->x_inv_std();  // Note: x_inv_std_ has the information of eps.
+    Dtype beta_dtype = generic_state->beta_dtype();
 
     // TODO(hvy): Avoid `AsType`.
     Dtype interm_dtype = x_mean.dtype();


### PR DESCRIPTION
Following practices to avoid object slicing.