### PR TITLE
Suppress warnings-as-errors from external libraries

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -107,9 +107,9 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|Intel")
     # cmake -DCHAINERX_WARNINGS_AS_ERRORS=ON|OFF
     if (CHAINERX_WARNINGS_AS_ERRORS)
         if (MSVC)
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+            set(CHAINERX_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
         else()
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+            set(CHAINERX_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
         endif()
     endif()
 
@@ -128,7 +128,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|AppleClang)$" AND NOT MSVC)
     if(CLANG_VERSION_STRING VERSION_LESS 6.0)
         # clang<6.0 suggests superfluous braces for std::array initialization.
         # https://bugs.llvm.org/show_bug.cgi?id=21629
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
+        set(CHAINERX_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
     endif()
 endif()
 

--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories("${PROJECT_SOURCE_DIR}")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CHAINERX_CXX_FLAGS}")
+
 add_subdirectory(kernels)
 add_subdirectory(routines)
 add_subdirectory(native)

--- a/chainerx_cc/examples/CMakeLists.txt
+++ b/chainerx_cc/examples/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_subdirectory(mnist)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CHAINERX_CXX_FLAGS}")


### PR DESCRIPTION
External libraries (e.g. abseil) can emit compiler warnings.
This fix prevents such warnings from being errors.