### PR TITLE
Fix flaky `TestBatchNormalization`

### DIFF
--- a/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/functions_tests/normalization_tests/test_batch_normalization.py
@@ -59,8 +59,8 @@ def _batch_normalization(
         {'input_shape': (5, 4, 3), 'axis': (0, 1)},
     ],
     testing.product({
-        'xdtype': [numpy.float16, numpy.float32],
-        'dtype': [numpy.float16, numpy.float32],
+        'xdtype': [numpy.float32, numpy.float64],
+        'dtype': [numpy.float32, numpy.float64],
         'eps': [2e-5, 5e-1],
         'c_contiguous': [True, False],
         'running_statistics': [True, False],


### PR DESCRIPTION
Fixes https://github.com/chainer/chainer/issues/8145 (reopened by https://github.com/chainer/chainer/issues/8145#event-2676456289).

Inherently flaky test parameterizations introduced in https://github.com/chainer/chainer/pull/8175/files#diff-73bf7ec0733e38d72fc70a0850f9d5a3R62-R63 are fixed.