### PR TITLE
Set up documentation for loss functions in ChainerX

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -8,6 +8,7 @@ def set_docs():
     _docs_indexing()
     _docs_linalg()
     _docs_logic()
+    _docs_loss()
     _docs_manipulation()
     _docs_math()
     _docs_sorting()


### PR DESCRIPTION
It looks that the documentation for the loss functions are missing in the ChainerX reference.

https://docs.chainer.org/en/v7.0.0b4/chainerx/reference/routines.html#loss-functions