### PR TITLE
Add documentation for `chainerx.ravel`

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -1108,6 +1108,25 @@ Note:
 """)
 
     _docs.set_doc(
+        chainerx.ravel,
+        """ravel(a)
+Returns a flattened array.
+
+Args:
+    a (~chainerx.ndarray): Array to be flattened.
+
+Returns:
+    :class:`~chainerx.ndarray`: A flattened view of ``a`` if possible,
+    otherwise a copy.
+
+Note:
+    During backpropagation, this function propagates the gradient of the
+    output array to the input array ``a``.
+
+.. seealso:: :func:`numpy.ravel`
+""")
+
+    _docs.set_doc(
         chainerx.transpose,
         """transpose(a, axes=None)
 Permutes the dimensions of an array.


### PR DESCRIPTION
This PR adds the missing documentation for `chainerx.ravel`.

https://docs.chainer.org/en/v7.0.0b4/chainerx/reference/routines.html#array-manipulation-routines