### PR TITLE
Relax tolerances in ChainerX unary math tests

### DIFF
--- a/tests/chainerx_tests/math_utils.py
+++ b/tests/chainerx_tests/math_utils.py
@@ -34,6 +34,10 @@ class UnaryMathTestBase(object):
             self.check_backward_options.update({'rtol': 3e-3, 'atol': 3e-3})
             self.check_double_backward_options.update(
                 {'rtol': 1e-2, 'atol': 1e-2})
+        else:
+            self.check_backward_options.update({'rtol': 1e-3, 'atol': 1e-4})
+            self.check_double_backward_options.update(
+                {'rtol': 1e-3, 'atol': 1e-4})
 
         input = self.input
         if (in_kind == 'u'


### PR DESCRIPTION
Fixes  #7737

Tested with the same parameters as https://github.com/chainer/chainer/issues/7737#issuecomment-535459958 for 38277 times in a row without a failure.