### PR TITLE
Write CMake generator when building

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -72,6 +72,8 @@ endif()
 # Build setup
 #-------------
 
+message(STATUS "CMake generator: " ${CMAKE_GENERATOR})
+
 # Set CMAKE_BUILD_TYPE (defaults to Release).
 # CMake's specification is case-insensitive, but we only accept capitalized ones.
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Writes the name of the CMake generator when building. Could be friendly when testing alternative generators (c.f. https://github.com/chainer/chainer/pull/8194).