### PR TITLE
Use clang-format-6.0 if possible and track the version of clang-format

### DIFF
--- a/chainerx_cc/scripts/run-clang-format.sh
+++ b/chainerx_cc/scripts/run-clang-format.sh
@@ -17,6 +17,11 @@ if command -v clang-format-${expected_clang_format_version} >/dev/null 2>&1 ; th
     clang_format=clang-format-${expected_clang_format_version}
 else
     clang_format=clang-format
+    # e.g. clang-format version 6.0.0-1ubuntu2~16.04.1 (tags/RELEASE_600/final)
+    if [ "$("${clang_format}" -version | cut -d' ' -f3 | awk -F. '{printf "%s.%s", $1,$2}')" != "${expected_clang_format_version}" ];
+        echo "clang-format version should be ${expected_clang_format_version}" >&2
+        exit 1
+    fi
 fi
 
 parallel_jobs=1

--- a/chainerx_cc/scripts/run-clang-format.sh
+++ b/chainerx_cc/scripts/run-clang-format.sh
@@ -18,7 +18,7 @@ if command -v clang-format-${expected_clang_format_version} >/dev/null 2>&1 ; th
 else
     clang_format=clang-format
     # e.g. clang-format version 6.0.0-1ubuntu2~16.04.1 (tags/RELEASE_600/final)
-    if [ "$("${clang_format}" -version | cut -d' ' -f3 | awk -F. '{printf "%s.%s", $1,$2}')" != "${expected_clang_format_version}" ];
+    if [ "$("${clang_format}" --version | cut -d' ' -f3 | awk -F. '{printf "%s.%s", $1,$2}')" != "${expected_clang_format_version}" ] ; then
         echo "clang-format version should be ${expected_clang_format_version}" >&2
         exit 1
     fi

--- a/chainerx_cc/scripts/run-clang-format.sh
+++ b/chainerx_cc/scripts/run-clang-format.sh
@@ -11,8 +11,13 @@ set -eu
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 root_dir="$(realpath "$script_dir"/..)"
 
+expected_clang_format_version=6.0
 
-clang_format=clang-format
+if which clang-format-${expected_clang_format_version} > /dev/null ; then
+    clang_format=clang-format-${expected_clang_format_version}
+else
+    clang_format=clang-format
+fi
 
 parallel_jobs=1
 inplace=0

--- a/chainerx_cc/scripts/run-clang-format.sh
+++ b/chainerx_cc/scripts/run-clang-format.sh
@@ -13,7 +13,7 @@ root_dir="$(realpath "$script_dir"/..)"
 
 expected_clang_format_version=6.0
 
-if which clang-format-${expected_clang_format_version} > /dev/null ; then
+if command -v clang-format-${expected_clang_format_version} >/dev/null 2>&1 ; then
     clang_format=clang-format-${expected_clang_format_version}
 else
     clang_format=clang-format


### PR DESCRIPTION
Since its expected in CI and in ubuntu 18.04 it can be installed as clang-format-6.0
https://github.com/chainer/chainer/blob/d0cfc08d64cd63c40a745501b1a9e05502bdfaba/scripts/ci/chainerx/setup-ubuntu.sh#L8