### PR TITLE
Use type hint for method declaration

### DIFF
--- a/chainer/backend.py
+++ b/chainer/backend.py
@@ -98,8 +98,7 @@ def _guess_device_from_array_module(xp):
         return _cpu.CpuDevice()
 
 
-def get_device(device_spec):
-    # type: (types.DeviceSpec) -> Device
+def get_device(device_spec: types.DeviceSpec) -> Device:
     """Returns a device object.
 
     Args:

--- a/chainer/backends/_chainerx.py
+++ b/chainer/backends/_chainerx.py
@@ -17,9 +17,7 @@ class ChainerxDevice(_backend.Device):
 
     __hash__ = _backend.Device.__hash__
 
-    def __init__(self, device):
-        # type: (chainerx.Device) -> None
-
+    def __init__(self, device: 'chainerx.Device') -> None:
         assert isinstance(device, chainerx.Device)
         super(ChainerxDevice, self).__init__()
         self.device = device  # type: chainerx.Device

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -71,34 +71,31 @@ except Exception as e:
 
     class ndarray(object):  # type: ignore # for type testing
         @property
-        def shape(self):
-            # type: () -> types.Shape
+        def shape(self) -> types.Shape:
             pass
 
         @property
-        def device(self):
-            # type: () -> 'Device'
+        def device(self) -> 'Device':
             pass
 
-        def get(self, stream=None):
-            # type: (tp.Optional['Stream']) -> numpy.ndarray
+        def get(self, stream: tp.Optional['Stream'] = None) -> numpy.ndarray:
             pass
 
-        def set(self, arr, stream=None):
-            # type: (numpy.ndarray, tp.Optional['Stream']) -> None
+        def set(
+                self,
+                arr: numpy.ndarray,
+                stream: tp.Optional['Stream'] = None
+        ) -> None:
             pass
 
     class Device(object):  # type: ignore # for type testing
-        def __init__(self, device=None):
-            # type: (tp.Optional[int]) -> None
+        def __init__(self, device: tp.Optional[int] = None) -> None:
             pass
 
-        def __enter__(self):
-            # type: () -> 'Device'
+        def __enter__(self) -> 'Device':
             pass
 
-        def __exit__(self, *args):
-            # type: (*tp.Any) -> None
+        def __exit__(self, *args: tp.Any) -> None:
             pass
 
     class Event(object):  # type: ignore # for type testing
@@ -263,8 +260,7 @@ to the CUDA device ID.
 # ------------------------------------------------------------------------------
 # Global states
 # ------------------------------------------------------------------------------
-def get_device_from_id(device_id):
-    # type: (tp.Optional[int]) -> Device
+def get_device_from_id(device_id: tp.Optional[int]) -> Device:
     """Gets the device from an ID integer.
 
     Args:
@@ -278,8 +274,7 @@ def get_device_from_id(device_id):
     return DummyDevice
 
 
-def get_device_from_array(*arrays):
-    # type: (*ndarray) -> Device
+def get_device_from_array(*arrays: ndarray) -> Device:
     """Gets the device from a list of CuPy array or a single CuPy array.
 
     .. deprecated:: v6.0.0
@@ -361,9 +356,9 @@ def _get_cuda_device(*args):
     return DummyDevice
 
 
-def _get_device_or_current(device):
-    # type: (tp.Optional[types.CudaDeviceSpec]) -> Device
-
+def _get_device_or_current(
+        device: tp.Optional[types.CudaDeviceSpec]
+) -> Device:
     # Returns cuda.Device.
     # - If cuda.Device instance, it's returned intact.
     # - If None, the current device is returned.

--- a/chainer/device_resident.py
+++ b/chainer/device_resident.py
@@ -90,8 +90,8 @@ class DeviceResident(utils.enable_final(meta_base=abc.ABCMeta)):
 
     @utils.final(action=DeprecationWarning)
     def to_gpu(
-        self,
-        device: tp.Optional[types.CudaDeviceSpec] = None,
+            self,
+            device: tp.Optional[types.CudaDeviceSpec] = None,
     ) -> 'DeviceResident':
         """Copies parameter variables and persistent values to GPU.
 
@@ -176,8 +176,8 @@ to NumPy/CuPy devices without any copy."""
 
     @utils.final
     def to_device(
-        self,
-        device: types.DeviceSpec
+            self,
+            device: types.DeviceSpec
     ) -> 'DeviceResident':
         """Copies parameter variables and persistent values to the specified \
 device.

--- a/chainer/device_resident.py
+++ b/chainer/device_resident.py
@@ -55,8 +55,7 @@ class DeviceResident(utils.enable_final(meta_base=abc.ABCMeta)):
         return self._device
 
     @property
-    def xp(self):
-        # type: () -> types.Xp
+    def xp(self) -> types.Xp:
         """Array module corresponding to the device.
 
         Depending on the device in which this object resides, this property
@@ -69,8 +68,7 @@ class DeviceResident(utils.enable_final(meta_base=abc.ABCMeta)):
         return device.xp
 
     @utils.final(action=DeprecationWarning)
-    def to_cpu(self):
-        # type: () -> 'DeviceResident'
+    def to_cpu(self) -> 'DeviceResident':
         """Copies parameter variables and persistent values to CPU.
 
          .. deprecated:: v7.0.0
@@ -92,10 +90,9 @@ class DeviceResident(utils.enable_final(meta_base=abc.ABCMeta)):
 
     @utils.final(action=DeprecationWarning)
     def to_gpu(
-            self,
-            device=None,  # type: tp.Optional[types.CudaDeviceSpec]
-    ):
-        # type: (...) -> 'DeviceResident'
+        self,
+        device: tp.Optional[types.CudaDeviceSpec] = None,
+    ) -> 'DeviceResident':
         """Copies parameter variables and persistent values to GPU.
 
          .. deprecated:: v7.0.0
@@ -129,8 +126,7 @@ class DeviceResident(utils.enable_final(meta_base=abc.ABCMeta)):
         return self
 
     @utils.final(action=DeprecationWarning)
-    def to_intel64(self):
-        # type: () -> 'DeviceResident'
+    def to_intel64(self) -> 'DeviceResident':
         """Copies parameter variables and persistent values to CPU.
 
          .. deprecated:: v7.0.0
@@ -180,10 +176,9 @@ to NumPy/CuPy devices without any copy."""
 
     @utils.final
     def to_device(
-            self,
-            device  # type: types.DeviceSpec
-    ):
-        # type: (...) -> 'DeviceResident'
+        self,
+        device: types.DeviceSpec
+    ) -> 'DeviceResident':
         """Copies parameter variables and persistent values to the specified \
 device.
 

--- a/chainer/function.py
+++ b/chainer/function.py
@@ -142,9 +142,7 @@ class FunctionAdapter(function_node.FunctionNode):
     _function = None  # type: Function
     _weak_function = None  # type: weakref.ReferenceType[Function]
 
-    def __init__(self, function):
-        # type: (Function) -> None
-
+    def __init__(self, function: 'Function') -> None:
         super(FunctionAdapter, self).__init__()
         self._weak_function = weakref.ref(function)
         function._owned_node = self

--- a/chainer/initializer.py
+++ b/chainer/initializer.py
@@ -15,13 +15,10 @@ class Initializer(object):
 
     """
 
-    def __init__(self, dtype=None):
-        # type: (tp.Optional[types.DTypeSpec]) -> None
-
+    def __init__(self, dtype: tp.Optional[types.DTypeSpec] = None) -> None:
         self.dtype = dtype  # type: types.DTypeSpec
 
-    def __call__(self, array):
-        # type: (types.NdArray) -> None
+    def __call__(self, array: types.NdArray) -> None:
         """Initializes given array.
 
         This method destructively changes the value of array.

--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -30,8 +30,8 @@ def generate_array(
         initializer: types.AbstractInitializer,
         shape: types.ShapeSpec,
         xp: types.Xp,
-        dtype: types.DTypeSpec = None,
-        device: types.DeviceSpec = None
+        dtype: tp.Optional[types.DTypeSpec] = None,
+        device: tp.Optional[types.DeviceSpec] = None
 ) -> types.NdArray:
     """Return initialized array.
 

--- a/chainer/initializers/__init__.py
+++ b/chainer/initializers/__init__.py
@@ -26,8 +26,13 @@ from chainer.initializers.uniform import Uniform  # NOQA
 from chainer import types  # NOQA
 
 
-def generate_array(initializer, shape, xp, dtype=None, device=None):
-    # type: (types.AbstractInitializer, types.ShapeSpec, types.Xp, types.DTypeSpec, types.DeviceSpec) -> types.NdArray  # NOQA
+def generate_array(
+        initializer: types.AbstractInitializer,
+        shape: types.ShapeSpec,
+        xp: types.Xp,
+        dtype: types.DTypeSpec = None,
+        device: types.DeviceSpec = None
+) -> types.NdArray:
     """Return initialized array.
 
     The algorithms used to make the new values depend on the
@@ -70,9 +75,9 @@ def generate_array(initializer, shape, xp, dtype=None, device=None):
     return array
 
 
-def _get_initializer(initializer):
-    # type: (tp.Optional[types.InitializerSpec]) -> types.AbstractInitializer # NOQA
-
+def _get_initializer(
+        initializer: tp.Optional[types.InitializerSpec]
+) -> types.AbstractInitializer:
     if initializer is None:
         return LeCunNormal()
     if (isinstance(initializer, chainer.get_array_types())

--- a/chainer/link.py
+++ b/chainer/link.py
@@ -19,9 +19,7 @@ from chainer.utils import collections_abc
 from chainer import variable
 
 
-def _is_shape(value):
-    # type: (tp.Optional[tp.Any]) -> bool
-
+def _is_shape(value: tp.Optional[tp.Any]) -> bool:
     if value is None:
         return True
     elif isinstance(value, collections_abc.Sequence):
@@ -36,8 +34,9 @@ def _is_shape(value):
         return False
 
 
-def _ensure_shape_dtype(value):
-    # type: (tp.Optional[tp.Any]) -> tp.Tuple[tp.Optional[types.ShapeSpec], types.DTypeSpec] # NOQA
+def _ensure_shape_dtype(
+        value: tp.Optional[tp.Any]
+) -> tp.Tuple[tp.Optional[types.ShapeSpec], types.DTypeSpec]:
 
     # Return value paired with dtype FP32 if it is a shape.
     if _is_shape(value):
@@ -143,9 +142,7 @@ class Link(device_resident.DeviceResident):
     _local_link_hooks = None  # type: tp.Optional[collections.OrderedDict[str, chainer.LinkHook]] # NOQA
     __init_done = False
 
-    def __init__(self, **params):
-        # type: (**tp.Any) -> None
-
+    def __init__(self, **params: tp.Any) -> None:
         super(Link, self).__init__()
 
         self._params = set()  # type: tp.Set[str]
@@ -173,8 +170,9 @@ class Link(device_resident.DeviceResident):
         )
 
     @property
-    def local_link_hooks(self):
-        # type: () -> collections.OrderedDict[str, chainer.LinkHook]
+    def local_link_hooks(
+            self
+    ) -> 'collections.OrderedDict[str, chainer.LinkHook]':
         """Ordered dictionary of registered link hooks.
 
         Contrary to ``chainer.thread_local.link_hooks``,
@@ -187,9 +185,7 @@ class Link(device_resident.DeviceResident):
         return self._local_link_hooks
 
     @property
-    def _n_local_link_hooks(self):
-        # type: () -> int
-
+    def _n_local_link_hooks(self) -> int:
         return (0 if self._local_link_hooks is None
                 else len(self._local_link_hooks))
 
@@ -219,8 +215,7 @@ class Link(device_resident.DeviceResident):
             yield
 
     @property
-    def within_init_scope(self):
-        # type: () -> bool
+    def within_init_scope(self) -> bool:
         """True if the current code is inside of an initialization scope.
 
         See :meth:`init_scope` for the details of the initialization scope.
@@ -229,8 +224,7 @@ class Link(device_resident.DeviceResident):
         return getattr(self, '_within_init_scope', False)
 
     @contextlib.contextmanager
-    def init_scope(self):
-        # type: () -> tp.Iterator[None]
+    def init_scope(self) -> tp.Iterator[None]:
         """Creates an initialization scope.
 
         This method returns a context manager object that enables registration
@@ -265,8 +259,7 @@ class Link(device_resident.DeviceResident):
         finally:
             self._within_init_scope = old_flag
 
-    def __call__(self, *args, **kwargs):
-        # type: (*tp.Any, **tp.Any) -> tp.Any # NOQA
+    def __call__(self, *args: tp.Any, **kwargs: tp.Any) -> tp.Any:
         self.__check_init_done()
 
         # TODO(niboshi): Support link hooks for other forward methods.
@@ -302,25 +295,25 @@ class Link(device_resident.DeviceResident):
 
         return out
 
-    def __setattr__(self, name, value):
-        # type: (str, tp.Any) -> None
-
+    def __setattr__(self, name: str, value: tp.Any) -> None:
         if self.within_init_scope and isinstance(value, variable.Parameter):
             value.name = name
             self._params.add(name)
             self._persistent.discard(name)
         super(Link, self).__setattr__(name, value)
 
-    def __delattr__(self, name):
-        # type: (str) -> None
-
+    def __delattr__(self, name: str) -> None:
         self._params.discard(name)
         self._persistent.discard(name)
         super(Link, self).__delattr__(name)
 
-    def add_param(self, name, shape=None, dtype=numpy.float32,
-                  initializer=None):
-        # type: (str, tp.Optional[types.ShapeSpec], types.DTypeSpec, tp.Optional[types.InitializerSpec]) -> None # NOQA
+    def add_param(
+        self,
+        name: str,
+        shape: tp.Optional[types.ShapeSpec] = None,
+        dtype: types.DTypeSpec = numpy.float32,
+        initializer: tp.Optional[types.InitializerSpec] = None
+    ) -> None:
         """Registers a parameter to the link.
 
         Args:
@@ -348,8 +341,7 @@ class Link(device_resident.DeviceResident):
         with self.init_scope():
             setattr(self, name, param)
 
-    def add_persistent(self, name, value):
-        # type: (str, tp.Any) -> None
+    def add_persistent(self, name: str, value: tp.Any) -> None:
         """Registers a persistent value to the link.
 
         The registered value is saved and loaded on serialization and
@@ -370,8 +362,7 @@ class Link(device_resident.DeviceResident):
         self._params.discard(name)
         d[name] = value
 
-    def register_persistent(self, name):
-        # type: (str) -> None
+    def register_persistent(self, name: str) -> None:
         """Registers an attribute of a given name as a persistent value.
 
         This is a convenient method to register an existing attribute as a
@@ -390,8 +381,7 @@ class Link(device_resident.DeviceResident):
         self._persistent.add(name)
         self._params.discard(name)
 
-    def copy(self, mode='share'):
-        # type: (str) -> 'Link'
+    def copy(self, mode: str = 'share') -> 'Link':
         """Copies the link hierarchy to new one.
 
         The whole hierarchy rooted by this link is copied. There are three
@@ -454,8 +444,10 @@ class Link(device_resident.DeviceResident):
             if isinstance(x, chainer.get_array_types()):
                 d[name] = visitor.visit_array(x)
 
-    def params(self, include_uninit=True):
-        # type: (bool) -> tp.Iterator[chainer.Parameter]
+    def params(
+            self,
+            include_uninit: bool = True
+    ) -> tp.Iterator['chainer.Parameter']:
         """Returns a generator of all parameters under the link hierarchy.
 
         Args:
@@ -471,8 +463,10 @@ class Link(device_resident.DeviceResident):
             if include_uninit or d[name].data is not None:
                 yield d[name]
 
-    def namedparams(self, include_uninit=True):
-        # type: (bool) -> tp.Iterator[tp.Tuple[str, chainer.Parameter]]
+    def namedparams(
+            self,
+            include_uninit: bool = True
+    ) -> tp.Iterator[tp.Tuple[str, 'chainer.Parameter']]:
         """Returns a generator of all (path, param) pairs under the hierarchy.
 
         Args:
@@ -489,8 +483,7 @@ class Link(device_resident.DeviceResident):
             if include_uninit or d[name].data is not None:
                 yield '/' + name, d[name]
 
-    def links(self, skipself=False):
-        # type: (bool) -> tp.Iterator['Link']
+    def links(self, skipself: bool = False) -> tp.Iterator['Link']:
         """Returns a generator of all links under the hierarchy.
 
         Args:
@@ -504,8 +497,10 @@ class Link(device_resident.DeviceResident):
         if not skipself:
             yield self
 
-    def namedlinks(self, skipself=False):
-        # type: (bool) -> tp.Iterator[tp.Tuple[str, 'Link']]
+    def namedlinks(
+            self,
+            skipself: bool = False
+    ) -> tp.Iterator[tp.Tuple[str, 'Link']]:
         """Returns a generator of all (path, link) pairs under the hierarchy.
 
         Args:
@@ -519,8 +514,7 @@ class Link(device_resident.DeviceResident):
         if not skipself:
             yield '/', self
 
-    def children(self):
-        # type: () -> tp.Iterator['Link']
+    def children(self) -> tp.Iterator['Link']:
         """Returns a generator of all child links.
 
         Returns:
@@ -530,8 +524,7 @@ class Link(device_resident.DeviceResident):
         if 0:
             yield
 
-    def copyparams(self, link, copy_persistent=True):
-        # type: ('Link', bool) -> None
+    def copyparams(self, link: 'Link', copy_persistent: bool = True) -> None:
         """Copies all parameters from given link.
 
         This method copies data arrays of all parameters in the hierarchy. The
@@ -564,8 +557,7 @@ class Link(device_resident.DeviceResident):
                 else:
                     dst[name] = copy.deepcopy(s)
 
-    def cleargrads(self):
-        # type: () -> None
+    def cleargrads(self) -> None:
         """Clears all gradient arrays.
 
         This method should be called before the backward computation at every
@@ -575,8 +567,7 @@ class Link(device_resident.DeviceResident):
         for param in self.params():
             param.cleargrad()
 
-    def zerograds(self):
-        # type: () -> None
+    def zerograds(self) -> None:
         """Initializes all gradient arrays by zero.
 
          .. deprecated:: v1.15
@@ -590,8 +581,7 @@ class Link(device_resident.DeviceResident):
         for param in self.params():
             param.zerograd()
 
-    def addgrads(self, link):
-        # type: ('Link') -> None
+    def addgrads(self, link: 'Link') -> None:
         """Accumulates gradient values from given link.
 
         This method adds each gradient array of the given link to corresponding
@@ -607,8 +597,7 @@ class Link(device_resident.DeviceResident):
         for name in self._params:
             dst[name].addgrad(src[name])
 
-    def enable_update(self):
-        # type: () -> None
+    def enable_update(self) -> None:
         """Enables update rules of all parameters under the link hierarchy.
 
         This method sets the :attr:`~chainer.UpdateRule.enabled` flag of the
@@ -620,8 +609,7 @@ class Link(device_resident.DeviceResident):
             if rule is not None:
                 rule.enabled = True
 
-    def disable_update(self):
-        # type: () -> None
+    def disable_update(self) -> None:
         """Disables update rules of all parameters under the link hierarchy.
 
         This method sets the :attr:`~chainer.UpdateRule.enabled` flag of the
@@ -634,8 +622,7 @@ class Link(device_resident.DeviceResident):
                 rule.enabled = False
 
     @property
-    def update_enabled(self):
-        # type: () -> bool
+    def update_enabled(self) -> bool:
         """``True`` if at least one parameter has an update rule enabled."""
         for param in self.params():
             rule = param.update_rule
@@ -643,8 +630,7 @@ class Link(device_resident.DeviceResident):
                 return True
         return False
 
-    def serialize(self, serializer):
-        # type: (chainer.AbstractSerializer) -> None
+    def serialize(self, serializer: 'chainer.AbstractSerializer') -> None:
         """Serializes the link object.
 
         Args:
@@ -663,8 +649,11 @@ class Link(device_resident.DeviceResident):
         for name in self._persistent:
             d[name] = serializer(name, d[name])
 
-    def repeat(self, n_repeat, mode='init'):
-        # type: (int, str) -> chainer.Sequential
+    def repeat(
+            self,
+            n_repeat: int,
+            mode: str = 'init'
+    ) -> 'chainer.Sequential':
         """Repeats this link multiple times to make a :class:`~chainer.Sequential`.
 
         This method returns a :class:`~chainer.Sequential` object which has
@@ -729,8 +718,7 @@ class Link(device_resident.DeviceResident):
             ret.append(link.copy(mode))
         return ret
 
-    def count_params(self):
-        # type: () -> int
+    def count_params(self) -> int:
         """Counts the total number of parameters.
 
         This method counts the total number of scalar values included in all
@@ -756,8 +744,11 @@ class Link(device_resident.DeviceResident):
             size += param.size
         return size
 
-    def add_hook(self, hook, name=None):
-        # type: (chainer.LinkHook, tp.Optional[str]) -> 'Link'
+    def add_hook(
+            self,
+            hook: 'chainer.LinkHook',
+            name: tp.Optional[str] = None
+    ) -> 'Link':
         """Registers a link hook.
 
         Args:
@@ -781,8 +772,7 @@ class Link(device_resident.DeviceResident):
         hook.added(self)
         return self
 
-    def delete_hook(self, name):
-        # type: (str) -> None
+    def delete_hook(self, name: str) -> None:
         """Unregisters the link hook.
 
         Args:
@@ -873,9 +863,7 @@ class Chain(Link):
 
     """
 
-    def __init__(self, **links):
-        # type: (**Link) -> None
-
+    def __init__(self, **links: 'Link') -> None:
         super(Chain, self).__init__()
         self._children = set()  # type: tp.Set[str]
 
@@ -899,14 +887,11 @@ class Chain(Link):
             cls=self.__class__.__name__, children=reps,
         )
 
-    def __getitem__(self, name):
-        # type: (str) -> tp.Any
+    def __getitem__(self, name: str) -> tp.Any:
         """Equivalent to getattr."""
         return getattr(self, name)
 
-    def __setattr__(self, name, value):
-        # type: (str, tp.Any) -> None
-
+    def __setattr__(self, name: str, value: tp.Any) -> None:
         if self.within_init_scope and isinstance(value, Link):
             if hasattr(self, name):
                 raise AttributeError(
@@ -915,14 +900,11 @@ class Chain(Link):
             self._children.add(name)
         super(Chain, self).__setattr__(name, value)
 
-    def __delattr__(self, name):
-        # type: (str) -> None
-
+    def __delattr__(self, name: str) -> None:
         self._children.discard(name)
         super(Chain, self).__delattr__(name)
 
-    def add_link(self, name, link):
-        # type: (str, Link) -> None
+    def add_link(self, name: str, link: 'Link') -> None:
         """Registers a child link to this chain.
 
         Args:
@@ -939,9 +921,7 @@ class Chain(Link):
         with self.init_scope():
             setattr(self, name, link)
 
-    def copy(self, mode='share'):
-        # type: (str) -> 'Chain'
-
+    def copy(self, mode: str = 'share') -> 'Chain':
         ret = super(Chain, self).copy(mode)  # type: ignore # should be Chain
         ret._children = set(ret._children)  # type: ignore
         d = ret.__dict__  # type: tp.Dict[str, Link]
@@ -958,8 +938,10 @@ class Chain(Link):
         for name in self._children:
             d[name].device_resident_accept(visitor)
 
-    def params(self, include_uninit=True):
-        # type: (bool) -> tp.Iterator[chainer.Parameter]
+    def params(
+            self,
+            include_uninit: bool = True
+    ) -> tp.Iterator['chainer.Parameter']:
 
         for param in super(Chain, self).params(include_uninit):
             yield param
@@ -968,8 +950,10 @@ class Chain(Link):
             for param in d[name].params(include_uninit):
                 yield param
 
-    def namedparams(self, include_uninit=True):
-        # type: (bool) -> tp.Iterator[tp.Tuple[str, chainer.Parameter]]
+    def namedparams(
+            self,
+            include_uninit: bool = True
+    ) -> tp.Iterator[tp.Tuple[str, 'chainer.Parameter']]:
 
         for ret in super(Chain, self).namedparams(include_uninit):
             yield ret
@@ -979,9 +963,7 @@ class Chain(Link):
             for path, param in d[name].namedparams(include_uninit):
                 yield prefix + path, param
 
-    def links(self, skipself=False):
-        # type: (bool) -> tp.Iterator[Link]
-
+    def links(self, skipself: bool = False) -> tp.Iterator[Link]:
         if not skipself:
             yield self
         d = self.__dict__  # type: tp.Dict[str, Link]
@@ -989,8 +971,10 @@ class Chain(Link):
             for link in d[name].links():
                 yield link
 
-    def namedlinks(self, skipself=False):
-        # type: (bool) -> tp.Iterator[tp.Tuple[str, Link]]
+    def namedlinks(
+            self,
+            skipself: bool = False
+    ) -> tp.Iterator[tp.Tuple[str, Link]]:
 
         if not skipself:
             yield '/', self
@@ -1002,34 +986,26 @@ class Chain(Link):
             for path, link in d[name].namedlinks(True):
                 yield prefix + path, link
 
-    def children(self):
-        # type: () -> tp.Iterator[Link]
-
+    def children(self) -> tp.Iterator[Link]:
         d = self.__dict__  # type: tp.Dict[str, Link]
         for name in sorted(self._children):
             yield d[name]
 
-    def copyparams(self, link, copy_persistent=True):
-        # type: (Link, bool) -> None
-
+    def copyparams(self, link: Link, copy_persistent: bool = True) -> None:
         super(Chain, self).copyparams(link, copy_persistent)
         src = link.__dict__
         dst = self.__dict__
         for name in self._children:
             dst[name].copyparams(src[name], copy_persistent)
 
-    def addgrads(self, link):
-        # type: (Link) -> None
-
+    def addgrads(self, link: Link) -> None:
         super(Chain, self).addgrads(link)
         src = link.__dict__
         dst = self.__dict__
         for name in self._children:
             dst[name].addgrads(src[name])
 
-    def serialize(self, serializer):
-        # type: (chainer.AbstractSerializer) -> None
-
+    def serialize(self, serializer: 'chainer.AbstractSerializer') -> None:
         super(Chain, self).serialize(serializer)
         d = self.__dict__  # type: tp.Dict[str, Link]
         for name in self._children:
@@ -1056,9 +1032,7 @@ class ChainList(Link, collections_abc.MutableSequence):
 
     """
 
-    def __init__(self, *links):
-        # type: (*Link) -> None
-
+    def __init__(self, *links: Link) -> None:
         super(ChainList, self).__init__()
         self._children = []  # type: tp.List[Link]
 
@@ -1082,18 +1056,18 @@ class ChainList(Link, collections_abc.MutableSequence):
             cls=self.__class__.__name__, children=reps,
         )
 
-    def __setattr__(self, name, value):
-        # type: (str, tp.Any) -> None
-
+    def __setattr__(self, name: str, value: tp.Any) -> None:
         if self.within_init_scope and isinstance(value, Link):
             raise TypeError(
                 'cannot register a new link'
                 ' within a "with chainlist.init_scope():" block.')
         super(ChainList, self).__setattr__(name, value)
 
-    def __setitem__(self, index, value):
-        # type: (tp.Union[int, slice], tp.Union[Link, tp.Iterable[Link]]) -> None # NOQA
-
+    def __setitem__(
+            self,
+            index: tp.Union[int, slice],
+            value: tp.Union[Link, tp.Iterable[Link]]
+    ) -> None:
         if isinstance(index, int):
             link = value  # type: ignore # should be Link
             link.name = str(index)  # type: ignore
@@ -1119,15 +1093,12 @@ class ChainList(Link, collections_abc.MutableSequence):
         """
         return self._children[index]
 
-    def __delitem__(self, index):
-        # type: (tp.Union[int, slice]) -> None
-
+    def __delitem__(self, index: tp.Union[int, slice]) -> None:
         del self._children[index]
         for i, c in enumerate(self._children):
             c.name = str(i)
 
-    def insert(self, index, link):
-        # type: (int, Link) -> None
+    def insert(self, index: int, link: Link) -> None:
         """Insert a child link at the given index.
 
         Args:
@@ -1144,18 +1115,14 @@ class ChainList(Link, collections_abc.MutableSequence):
             for i, c in enumerate(self._children):
                 c.name = str(i)
 
-    def __iter__(self):
-        # type: () -> tp.Iterator[Link]
-
+    def __iter__(self) -> tp.Iterator[Link]:
         return iter(self._children)
 
-    def __len__(self):
-        # type: () -> int
+    def __len__(self) -> int:
         """Returns the number of children."""
         return len(self._children)
 
-    def add_link(self, link):
-        # type: (Link) -> None
+    def add_link(self, link: Link) -> None:
         """Registers a child link and adds it to the tail of the list.
 
         Args:
@@ -1164,8 +1131,7 @@ class ChainList(Link, collections_abc.MutableSequence):
         """
         self.append(link)
 
-    def copy(self, mode='share'):
-        # type: (str) -> 'ChainList'
+    def copy(self, mode: str = 'share') -> 'ChainList':
         """Returns a deep copy of the chainlist."""
         ret = super(ChainList, self).copy()  # type: ignore # should be ChainList # NOQA
         ret._children = list(ret._children)  # type: ignore # copy
@@ -1181,18 +1147,20 @@ class ChainList(Link, collections_abc.MutableSequence):
         for link in self._children:
             link.device_resident_accept(visitor)
 
-    def params(self, include_uninit=True):
-        # type: (bool) -> tp.Iterator[chainer.Parameter]
-
+    def params(
+            self,
+            include_uninit: bool = True
+    ) -> tp.Iterator['chainer.Parameter']:
         for param in super(ChainList, self).params(include_uninit):
             yield param
         for link in self._children:
             for param in link.params(include_uninit):
                 yield param
 
-    def namedparams(self, include_uninit=True):
-        # type: (bool) -> tp.Iterator[tp.Tuple[str, chainer.Parameter]]
-
+    def namedparams(
+            self,
+            include_uninit: bool = True
+    ) -> tp.Iterator[tp.Tuple[str, 'chainer.Parameter']]:
         for ret in super(ChainList, self).namedparams(include_uninit):
             yield ret
         for idx, link in enumerate(self._children):
@@ -1200,18 +1168,17 @@ class ChainList(Link, collections_abc.MutableSequence):
             for path, param in link.namedparams(include_uninit):
                 yield prefix + path, param
 
-    def links(self, skipself=False):
-        # type: (bool) -> tp.Iterator[Link]
-
+    def links(self, skipself: bool = False) -> tp.Iterator[Link]:
         if not skipself:
             yield self
         for child in self._children:
             for link in child.links():
                 yield link
 
-    def namedlinks(self, skipself=False):
-        # type: (bool) -> tp.Iterator[tp.Tuple[str, Link]]
-
+    def namedlinks(
+            self,
+            skipself: bool = False
+    ) -> tp.Iterator[tp.Tuple[str, Link]]:
         if not skipself:
             yield '/', self
         for idx, child in enumerate(self._children):
@@ -1220,29 +1187,25 @@ class ChainList(Link, collections_abc.MutableSequence):
             for path, link in child.namedlinks(True):
                 yield prefix + path, link
 
-    def children(self):
-        # type: () -> tp.Iterator[Link]
-
+    def children(self) -> tp.Iterator[Link]:
         for child in self._children:
             yield child
 
-    def copyparams(self, link, copy_persistent=True):
-        # type: (Link, bool) -> None # link is actually a ChainList
+    def copyparams(self, link: Link, copy_persistent: bool = True) -> None:
+        # link is actually a ChainList
 
         super(ChainList, self).copyparams(link, copy_persistent)
         for idx, child in enumerate(self._children):
             child.copyparams(link[idx], copy_persistent)  # type: ignore
 
-    def addgrads(self, link):
-        # type: (Link) -> None # link is actually a ChainList
+    def addgrads(self, link: Link) -> None:
+        # link is actually a ChainList
 
         super(ChainList, self).addgrads(link)
         for idx, child in enumerate(self._children):
             child.addgrads(link[idx])  # type: ignore
 
-    def serialize(self, serializer):
-        # type: (chainer.AbstractSerializer) -> None
-
+    def serialize(self, serializer: 'chainer.AbstractSerializer') -> None:
         super(ChainList, self).serialize(serializer)
         for idx, child in enumerate(self._children):
             child.serialize(serializer['%d' % idx])

--- a/chainer/link_hook.py
+++ b/chainer/link_hook.py
@@ -7,9 +7,13 @@ from chainer import utils
 class _ForwardPreprocessCallbackArgs(object):
     """Callback data for LinkHook.forward_preprocess"""
 
-    def __init__(self, link, forward_name, args, kwargs):
-        # type: ('chainer.link.Link', str, tp.Tuple[tp.Any, ...], tp.Dict[str, tp.Any]) -> None # NOQA
-
+    def __init__(
+            self,
+            link: 'chainer.link.Link',
+            forward_name: str,
+            args: tp.Tuple[tp.Any, ...],
+            kwargs: tp.Dict[str, tp.Any]
+    ) -> None:
         self.link = link
         self.forward_name = forward_name
         self.args = args
@@ -24,9 +28,14 @@ class _ForwardPreprocessCallbackArgs(object):
 class _ForwardPostprocessCallbackArgs(object):
     """Callback data for LinkHook.forward_postprocess"""
 
-    def __init__(self, link, forward_name, args, kwargs, out):
-        # type: ('chainer.link.Link', str, tp.Tuple[tp.Any, ...], tp.Dict[str, tp.Any], tp.Any) -> None # NOQA
-
+    def __init__(
+            self,
+            link: 'chainer.link.Link',
+            forward_name: str,
+            args: tp.Tuple[tp.Any, ...],
+            kwargs: tp.Dict[str, tp.Any],
+            out: tp.Any
+    ) -> None:
         self.link = link
         self.forward_name = forward_name
         self.args = args
@@ -124,9 +133,7 @@ class LinkHook(object):
 
     name = 'LinkHook'
 
-    def __enter__(self):
-        # type: () -> LinkHook
-
+    def __enter__(self) -> 'LinkHook':
         link_hooks = chainer._get_link_hooks()
         if self.name in link_hooks:
             raise KeyError('hook %s already exists' % self.name)
@@ -140,8 +147,7 @@ class LinkHook(object):
         link_hooks[self.name].deleted(None)
         del link_hooks[self.name]
 
-    def added(self, link):
-        # type: (tp.Optional['chainer.link.Link']) -> None
+    def added(self, link: tp.Optional['chainer.link.Link']) -> None:
         """Callback function invoked when the link hook is registered
 
         Args:
@@ -151,8 +157,7 @@ class LinkHook(object):
         """
         pass
 
-    def deleted(self, link):
-        # type: (tp.Optional['chainer.link.Link']) -> None
+    def deleted(self, link: tp.Optional['chainer.link.Link']) -> None:
         """Callback function invoked when the link hook is unregistered
 
         Args:
@@ -163,8 +168,7 @@ class LinkHook(object):
         pass
 
     # forward
-    def forward_preprocess(self, args):
-        # type: (_ForwardPreprocessCallbackArgs) -> None
+    def forward_preprocess(self, args: _ForwardPreprocessCallbackArgs) -> None:
         """Callback function invoked before a forward call of a link.
 
         Args:
@@ -181,8 +185,10 @@ class LinkHook(object):
         """
         pass
 
-    def forward_postprocess(self, args):
-        # type: (_ForwardPostprocessCallbackArgs) -> None
+    def forward_postprocess(
+            self,
+            args: _ForwardPostprocessCallbackArgs
+    ) -> None:
         """Callback function invoked after a forward call of a link.
 
         Args:

--- a/chainer/link_hook.py
+++ b/chainer/link_hook.py
@@ -147,7 +147,7 @@ class LinkHook(object):
         link_hooks[self.name].deleted(None)
         del link_hooks[self.name]
 
-    def added(self, link: tp.Optional['chainer.link.Link']) -> None:
+    def added(self, link: 'tp.Optional[chainer.link.Link]') -> None:
         """Callback function invoked when the link hook is registered
 
         Args:
@@ -157,7 +157,7 @@ class LinkHook(object):
         """
         pass
 
-    def deleted(self, link: tp.Optional['chainer.link.Link']) -> None:
+    def deleted(self, link: 'tp.Optional[chainer.link.Link]') -> None:
         """Callback function invoked when the link hook is unregistered
 
         Args:

--- a/chainer/links/connection/linear.py
+++ b/chainer/links/connection/linear.py
@@ -94,10 +94,14 @@ class Linear(link.Link):
 
     """
 
-    def __init__(self, in_size, out_size=None, nobias=False,
-                 initialW=None, initial_bias=None):
-        # type: (tp.Optional[int], tp.Optional[int], bool, tp.Optional[types.InitializerSpec], tp.Optional[types.InitializerSpec]) -> None # NOQA
-
+    def __init__(
+            self,
+            in_size: tp.Optional[int],
+            out_size: tp.Optional[int] = None,
+            nobias: bool = False,
+            initialW: tp.Optional[types.InitializerSpec] = None,
+            initial_bias: tp.Optional[types.InitializerSpec] = None
+    ) -> None:
         super(Linear, self).__init__()
 
         if out_size is None:
@@ -119,9 +123,7 @@ class Linear(link.Link):
                 bias_initializer = initializers._get_initializer(initial_bias)
                 self.b = variable.Parameter(bias_initializer, out_size)
 
-    def _initialize_params(self, in_size):
-        # type: (int) -> None
-
+    def _initialize_params(self, in_size: int) -> None:
         self.W.initialize((self.out_size, in_size))  # type: ignore
 
     @property
@@ -134,8 +136,11 @@ class Linear(link.Link):
         for spec in specs:
             yield spec
 
-    def forward(self, x, n_batch_axes=1):
-        # type: (variable.Variable, int) -> variable.Variable
+    def forward(
+            self,
+            x: variable.Variable,
+            n_batch_axes: int = 1
+    ) -> variable.Variable:
         """Applies the linear layer.
 
         Args:

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -169,9 +169,8 @@ def _pairwise_product_dict(*parameters):
 
 
 def _pairwise_product_dict_iter(
-        *parameters  # type: tp.Iterable[tp.Dict[str, tp.Any]]
-):
-    # type: (...) -> tp.Iterator[tp.Dict[str, tp.Any]]
+        *parameters: tp.Iterable[tp.Dict[str, tp.Any]]
+) -> tp.Iterator[tp.Dict[str, tp.Any]]:
     """Generate combinations that cover all pairs.
 
     The argument is the same as `chainer.testing.product_dict`.
@@ -187,8 +186,9 @@ def _pairwise_product_dict_iter(
             for k, v in dicts[i].items()}
 
 
-def _nd_indices_to_cover_each_2d(shape):
-    # type: (tp.Sequence[int]) -> tp.Iterator[tp.Tuple[int, ...]]
+def _nd_indices_to_cover_each_2d(
+        shape: tp.Sequence[int]
+) -> tp.Iterator[tp.Tuple[int, ...]]:
     rs = numpy.random.RandomState(seed=0)
     n = len(shape)
     indices = [list(range(length)) for length in shape]  # type: tp.List[tp.List[int]]  # NOQA

--- a/chainer/types.py
+++ b/chainer/types.py
@@ -54,8 +54,7 @@ class AbstractInitializer(tpe.Protocol):
     """
     dtype = None  # type: tp.Optional[DTypeSpec]
 
-    def __call__(self, array):
-        # type: (NdArray) -> None
+    def __call__(self, array: NdArray) -> None:
         pass
 
 

--- a/chainer/variable.py
+++ b/chainer/variable.py
@@ -178,9 +178,12 @@ class VariableNode(object):
     # by an old-style Function
     _old_style_grad_generator = None  # type: str
 
-    def __init__(self, variable, name, **kwargs):
-        # type: (Variable, tp.Optional[str], **tp.Any) -> None
-
+    def __init__(
+            self,
+            variable: 'Variable',
+            name: tp.Optional[str],
+            **kwargs: tp.Any
+    ) -> None:
         if kwargs:
             argument.check_unexpected_kwargs(
                 kwargs,
@@ -517,9 +520,11 @@ class Variable(object):
     # instance.
     _grad = None
 
-    def __init__(self, data=None, **kwargs):
-        # type: (tp.Optional[types.NdArray], **tp.Any) -> None
-
+    def __init__(
+            self,
+            data: tp.Optional[types.NdArray] = None,
+            **kwargs: tp.Any
+    ) -> None:
         name, grad, requires_grad, grad_valid = argument.parse_kwargs(
             kwargs, ('name', None), ('grad', None), ('requires_grad', True),
             ('_grad_valid', True),
@@ -651,8 +656,11 @@ class Variable(object):
             if self._grad is not None:
                 self._grad_var = Variable(self._grad)
 
-    def _set_chainerx_array(self, array, grad):
-        # type: (tp.Optional[chainerx.ndarray], tp.Optional[chainerx.ndarray]) -> None # NOQA
+    def _set_chainerx_array(
+            self,
+            array: tp.Optional['chainerx.ndarray'],
+            grad: tp.Optional['chainerx.ndarray']
+    ) -> None:
 
         # Sets chainerx array and grad.
         assert array is None or isinstance(array, chainerx.ndarray)
@@ -700,8 +708,7 @@ class Variable(object):
         return self._device
 
     @property
-    def xp(self):
-        # type: () -> tp.Optional[types.Xp]
+    def xp(self) -> tp.Optional[types.Xp]:
         """Array module for the data array of this variable."""
         if self._has_chainerx_array:
             return chainerx
@@ -848,8 +855,7 @@ class Variable(object):
         self._node.creator_node = func
 
     @property
-    def array(self):
-        # type: () -> tp.Optional[types.NdArray]
+    def array(self) -> tp.Optional[types.NdArray]:
         """The underlying data array.
 
         It is either :class:`numpy.ndarray` or :class:`cupy.ndarray` object,
@@ -868,9 +874,7 @@ class Variable(object):
         return self._data[0]
 
     @array.setter
-    def array(self, d):
-        # type: (tp.Optional[types.NdArray]) -> None
-
+    def array(self, d: tp.Optional[types.NdArray]) -> None:
         if self._has_chainerx_array:
             d_old = self._data[0]
             if (d_old is not None
@@ -906,8 +910,7 @@ class Variable(object):
         return self._data[0].view()
 
     @property
-    def data(self):
-        # type: () -> tp.Optional[types.NdArray]
+    def data(self) -> tp.Optional[types.NdArray]:
         """The underlying data array (equivalent to :attr:`array`).
 
         Note that using this attribute directly is discouraged; use
@@ -920,9 +923,7 @@ class Variable(object):
         return self.array
 
     @data.setter
-    def data(self, d):
-        # type: (types.NdArray) -> None
-
+    def data(self, d: types.NdArray) -> None:
         self.array = d
 
     def _set_chainerx_grad(self, g, from_grad_var):
@@ -965,8 +966,7 @@ class Variable(object):
         self._grad_valid = True
 
     @property
-    def grad(self):
-        # type: () -> tp.Optional[types.NdArray]
+    def grad(self) -> tp.Optional[types.NdArray]:
         """Gradient array of this variable.
 
         Note that this property returns the underlying array of the gradient
@@ -1014,8 +1014,7 @@ class Variable(object):
         return self._grad
 
     @grad.setter
-    def grad(self, g):
-        # type: (tp.Optional[types.NdArray]) -> None
+    def grad(self, g: tp.Optional[types.NdArray]) -> None:
         if g is not None:
             _check_grad_type(None, self, False, g)
         self._set_grad_without_check(g)
@@ -1032,15 +1031,13 @@ class Variable(object):
         self._grad = None if gv is None else gv.array
 
     @property
-    def grad_var(self):
-        # type: () -> tp.Optional["Variable"]
+    def grad_var(self) -> tp.Optional['Variable']:
         """Gradient variable."""
         self._ensure_grad_var_up_to_date()
         return self._grad_var
 
     @grad_var.setter
-    def grad_var(self, g):
-        # type: (tp.Optional["Variable"]) -> None
+    def grad_var(self, g: tp.Optional['Variable']) -> None:
         if g is not None:
             _check_grad_type(None, self, False, g.array)
         self._set_grad_var_without_check(g)
@@ -1661,9 +1658,12 @@ class Parameter(Variable):
     # TODO(okapies): fix the behavior when shape is None and remove NdArray
     _grad_initializer = None  # type: tp.Optional[types.AbstractInitializer]
 
-    def __init__(self, initializer=None, shape=None, name=None):
-        # type: (tp.Optional[types.InitializerSpec], tp.Optional[types.ShapeSpec], tp.Optional[str]) -> None # NOQA
-
+    def __init__(
+            self,
+            initializer: tp.Optional[types.InitializerSpec] = None,
+            shape: tp.Optional[types.ShapeSpec] = None,
+            name: tp.Optional[str] = None
+    ) -> None:
         if initializer is None:
             initializer = constant.NaN()
         elif numpy.isscalar(initializer):

--- a/chainermn/communicators/communicator_base.py
+++ b/chainermn/communicators/communicator_base.py
@@ -414,8 +414,7 @@ class CommunicatorBase(six.with_metaclass(ABCMeta)):
         self.multi_node_mean_grad(model, zero_fill)
 
     @property
-    def within_config_scope(self):
-        # type: () -> bool
+    def within_config_scope(self) -> bool:
         """True if the current code is inside of an initialization scope.
 
         See :meth:`init_scope` for the details of the initialization scope.

--- a/docs/source/_napoleon_patch.py
+++ b/docs/source/_napoleon_patch.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import sphinx
 
 
@@ -16,8 +18,7 @@ def qualify_name(attr_name, klass):
 def setup(app):
     app.setup_extension('sphinx.ext.napoleon')
 
-    def _parse_attributes_section(self, section):
-        # type: (unicode) -> List[unicode]
+    def _parse_attributes_section(self, section: str) -> List[str]:
         lines = []
         for _name, _type, _desc in self._consume_fields():
             if self._config.napoleon_use_ivar:


### PR DESCRIPTION
Close #8240.

[edited: 2019/10/08] I revised module list by running following command.
`grep -v "=.\+# type: " **/*.py| grep "# type: "`

This intended to exclude variable annotations. (https://github.com/chainer/chainer/pull/8248#issuecomment-538743366)

- [x] chainer/backend.py
- [x] chainer/backends/_chainerx.py
- [x] chainer/backends/cuda.py
- [x] chainer/backends/intel64.py (no method affected)
- [x] chainer/device_resident.py
- [x] chainer/function.py
- [x] chainer/initializer.py
- [x] chainer/initializers/__init__.py
- [x] chainer/iterators/multiprocess_iterator.py (no method affected)
- [x] chainer/link.py
- [x] chainer/link_hook.py
- [x] chainer/links/connection/linear.py
- [x] chainer/testing/parameterized.py
- [x] chainer/types.py
- [x] chainer/variable.py
- [x] chainermn/communicators/communicator_base.py
- [x] docs/source/_napoleon_patch.py


### grep result

<details>

```
chainer/backend.py:    # type: (types.DeviceSpec) -> Device
chainer/backends/_chainerx.py:        # type: (chainerx.Device) -> None
chainer/backends/cuda.py:    from cupy import ndarray  # type: ignore # NOQA
chainer/backends/cuda.py:    from cupy.cuda import Device  # type: ignore # NOQA
chainer/backends/cuda.py:    from cupy.cuda import Event  # type: ignore # NOQA
chainer/backends/cuda.py:    from cupy.cuda import Stream  # type: ignore # NOQA
chainer/backends/cuda.py:    class ndarray(object):  # type: ignore # for type testing
chainer/backends/cuda.py:            # type: () -> types.Shape
chainer/backends/cuda.py:            # type: () -> 'Device'
chainer/backends/cuda.py:            # type: (tp.Optional['Stream']) -> numpy.ndarray
chainer/backends/cuda.py:            # type: (numpy.ndarray, tp.Optional['Stream']) -> None
chainer/backends/cuda.py:    class Device(object):  # type: ignore # for type testing
chainer/backends/cuda.py:            # type: (tp.Optional[int]) -> None
chainer/backends/cuda.py:            # type: () -> 'Device'
chainer/backends/cuda.py:            # type: (*tp.Any) -> None
chainer/backends/cuda.py:    class Event(object):  # type: ignore # for type testing
chainer/backends/cuda.py:    class Stream(object):  # type: ignore # for type testing
chainer/backends/cuda.py:    # type: (tp.Optional[int]) -> Device
chainer/backends/cuda.py:    # type: (*ndarray) -> Device
chainer/backends/cuda.py:    # type: (tp.Optional[types.CudaDeviceSpec]) -> Device
chainer/backends/intel64.py:    from ideep4py import mdarray  # type: ignore # NOQA
chainer/backends/intel64.py:    class mdarray(object):  # type: ignore
chainer/device_resident.py:        # type: () -> types.Xp
chainer/device_resident.py:        # type: () -> 'DeviceResident'
chainer/device_resident.py:        # type: (...) -> 'DeviceResident'
chainer/device_resident.py:        # type: () -> 'DeviceResident'
chainer/device_resident.py:            device  # type: types.DeviceSpec
chainer/device_resident.py:        # type: (...) -> 'DeviceResident'
chainer/function.py:        # type: (Function) -> None
chainer/initializer.py:        # type: (tp.Optional[types.DTypeSpec]) -> None
chainer/initializer.py:        # type: (types.NdArray) -> None
chainer/initializers/__init__.py:    # type: (types.AbstractInitializer, types.ShapeSpec, types.Xp, types.DTypeSpec, types.DeviceSpec) -> types.NdArray  # NOQA
chainer/initializers/__init__.py:    # type: (tp.Optional[types.InitializerSpec]) -> types.AbstractInitializer # NOQA
chainer/iterators/multiprocess_iterator.py:from multiprocessing import sharedctypes  # type: ignore
chainer/link.py:    # type: (tp.Optional[tp.Any]) -> bool
chainer/link.py:    # type: (tp.Optional[tp.Any]) -> tp.Tuple[tp.Optional[types.ShapeSpec], types.DTypeSpec] # NOQA
chainer/link.py:        return value  # type: ignore
chainer/link.py:        # type: (**tp.Any) -> None
chainer/link.py:        # type: () -> collections.OrderedDict[str, chainer.LinkHook]
chainer/link.py:        # type: () -> int
chainer/link.py:        # type: () -> bool
chainer/link.py:        # type: () -> tp.Iterator[None]
chainer/link.py:        # type: (*tp.Any, **tp.Any) -> tp.Any # NOQA
chainer/link.py:        # type: (str, tp.Any) -> None
chainer/link.py:        # type: (str) -> None
chainer/link.py:        # type: (str, tp.Optional[types.ShapeSpec], types.DTypeSpec, tp.Optional[types.InitializerSpec]) -> None # NOQA
chainer/link.py:        # type: (str, tp.Any) -> None
chainer/link.py:        # type: (str) -> None
chainer/link.py:        # type: (str) -> 'Link'
chainer/link.py:        # type: (bool) -> tp.Iterator[chainer.Parameter]
chainer/link.py:        # type: (bool) -> tp.Iterator[tp.Tuple[str, chainer.Parameter]]
chainer/link.py:        # type: (bool) -> tp.Iterator['Link']
chainer/link.py:        # type: (bool) -> tp.Iterator[tp.Tuple[str, 'Link']]
chainer/link.py:        # type: () -> tp.Iterator['Link']
chainer/link.py:        # type: ('Link', bool) -> None
chainer/link.py:        # type: () -> None
chainer/link.py:        # type: () -> None
chainer/link.py:        # type: ('Link') -> None
chainer/link.py:        # type: () -> None
chainer/link.py:        # type: () -> None
chainer/link.py:        # type: () -> bool
chainer/link.py:        # type: (chainer.AbstractSerializer) -> None
chainer/link.py:        # type: (int, str) -> chainer.Sequential
chainer/link.py:        # type: () -> int
chainer/link.py:        # type: (chainer.LinkHook, tp.Optional[str]) -> 'Link'
chainer/link.py:        # type: (str) -> None
chainer/link.py:        # type: (**Link) -> None
chainer/link.py:        # type: (str) -> tp.Any
chainer/link.py:        # type: (str, tp.Any) -> None
chainer/link.py:        # type: (str) -> None
chainer/link.py:        # type: (str, Link) -> None
chainer/link.py:        # type: (str) -> 'Chain'
chainer/link.py:        for name in ret._children:  # type: ignore
chainer/link.py:        return ret  # type: ignore
chainer/link.py:        # type: (bool) -> tp.Iterator[chainer.Parameter]
chainer/link.py:        # type: (bool) -> tp.Iterator[tp.Tuple[str, chainer.Parameter]]
chainer/link.py:        # type: (bool) -> tp.Iterator[Link]
chainer/link.py:        # type: (bool) -> tp.Iterator[tp.Tuple[str, Link]]
chainer/link.py:        # type: () -> tp.Iterator[Link]
chainer/link.py:        # type: (Link, bool) -> None
chainer/link.py:        # type: (Link) -> None
chainer/link.py:        # type: (chainer.AbstractSerializer) -> None
chainer/link.py:        # type: (*Link) -> None
chainer/link.py:        # type: (str, tp.Any) -> None
chainer/link.py:        # type: (tp.Union[int, slice], tp.Union[Link, tp.Iterable[Link]]) -> None # NOQA
chainer/link.py:            for i, c in enumerate(self._children):  # type: ignore
chainer/link.py:        # type: (tp.Union[int, slice]) -> None
chainer/link.py:        # type: (int, Link) -> None
chainer/link.py:        # type: () -> tp.Iterator[Link]
chainer/link.py:        # type: () -> int
chainer/link.py:        # type: (Link) -> None
chainer/link.py:        # type: (str) -> 'ChainList'
chainer/link.py:        return ret  # type: ignore
chainer/link.py:        # type: (bool) -> tp.Iterator[chainer.Parameter]
chainer/link.py:        # type: (bool) -> tp.Iterator[tp.Tuple[str, chainer.Parameter]]
chainer/link.py:        # type: (bool) -> tp.Iterator[Link]
chainer/link.py:        # type: (bool) -> tp.Iterator[tp.Tuple[str, Link]]
chainer/link.py:        # type: () -> tp.Iterator[Link]
chainer/link.py:        # type: (Link, bool) -> None # link is actually a ChainList
chainer/link.py:            child.copyparams(link[idx], copy_persistent)  # type: ignore
chainer/link.py:        # type: (Link) -> None # link is actually a ChainList
chainer/link.py:            child.addgrads(link[idx])  # type: ignore
chainer/link.py:        # type: (chainer.AbstractSerializer) -> None
chainer/link_hook.py:        # type: ('chainer.link.Link', str, tp.Tuple[tp.Any, ...], tp.Dict[str, tp.Any]) -> None # NOQA
chainer/link_hook.py:        # type: ('chainer.link.Link', str, tp.Tuple[tp.Any, ...], tp.Dict[str, tp.Any], tp.Any) -> None # NOQA
chainer/link_hook.py:        # type: () -> LinkHook
chainer/link_hook.py:        # type: (tp.Optional['chainer.link.Link']) -> None
chainer/link_hook.py:        # type: (tp.Optional['chainer.link.Link']) -> None
chainer/link_hook.py:        # type: (_ForwardPreprocessCallbackArgs) -> None
chainer/link_hook.py:        # type: (_ForwardPostprocessCallbackArgs) -> None
chainer/links/connection/linear.py:        # type: (tp.Optional[int], tp.Optional[int], bool, tp.Optional[types.InitializerSpec], tp.Optional[types.InitializerSpec]) -> None # NOQA
chainer/links/connection/linear.py:        # type: (int) -> None
chainer/links/connection/linear.py:        self.W.initialize((self.out_size, in_size))  # type: ignore
chainer/links/connection/linear.py:        # type: (variable.Variable, int) -> variable.Variable
chainer/testing/parameterized.py:        *parameters  # type: tp.Iterable[tp.Dict[str, tp.Any]]
chainer/testing/parameterized.py:    # type: (...) -> tp.Iterator[tp.Dict[str, tp.Any]]
chainer/testing/parameterized.py:    # type: (tp.Sequence[int]) -> tp.Iterator[tp.Tuple[int, ...]]
chainer/types.py:        # type: (NdArray) -> None
chainer/variable.py:        # type: (Variable, tp.Optional[str], **tp.Any) -> None
chainer/variable.py:        # type: (tp.Optional[types.NdArray], **tp.Any) -> None
chainer/variable.py:            self._set_chainerx_array(data, grad)  # type: ignore
chainer/variable.py:        # type: (tp.Optional[chainerx.ndarray], tp.Optional[chainerx.ndarray]) -> None # NOQA
chainer/variable.py:        # type: () -> tp.Optional[types.Xp]
chainer/variable.py:        # type: () -> tp.Optional[types.NdArray]
chainer/variable.py:                    self._data[0].as_grad_stopped())  # type: ignore
chainer/variable.py:        # type: (tp.Optional[types.NdArray]) -> None
chainer/variable.py:                    and (d_old.is_backprop_required()  # type: ignore
chainer/variable.py:                         or d.is_backprop_required())):  # type: ignore
chainer/variable.py:            self._set_chainerx_array(d, None)  # type: ignore
chainer/variable.py:            self._node._update_data_info(d)  # type: ignore # _node doesn't have value when xp is chainerx # NOQA
chainer/variable.py:        # type: () -> tp.Optional[types.NdArray]
chainer/variable.py:        # type: (types.NdArray) -> None
chainer/variable.py:        # type: () -> tp.Optional[types.NdArray]
chainer/variable.py:        # type: (tp.Optional[types.NdArray]) -> None
chainer/variable.py:        # type: () -> tp.Optional["Variable"]
chainer/variable.py:        # type: (tp.Optional["Variable"]) -> None
chainer/variable.py:        # type: (tp.Optional[types.InitializerSpec], tp.Optional[types.ShapeSpec], tp.Optional[str]) -> None # NOQA
chainermn/communicators/communicator_base.py:        # type: () -> bool
docs/source/_napoleon_patch.py:        # type: (unicode) -> List[unicode]
```


ref. https://www.python.org/dev/peps/pep-0484/