### PR TITLE
Add documentation for ``chainerx.sigmoid_cross_entropy``

### DIFF
--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -1125,16 +1125,16 @@ Returns:
 
     _docs.set_doc(
         chainerx.sigmoid_cross_entropy,
-        """sigmoid_cross_entropy(x, t)
+        """sigmoid_cross_entropy(x1, x2)
 
 Element-wise cross entropy loss for pre-sigmoid activations.
 
 Args:
-    x (~chainerx.ndarray): An array whose (i, j)-th element indicates the
+    x1 (~chainerx.ndarray): An array whose (i, j)-th element indicates the
         unnormalized log probability of the j-th unit at the i-th example.
-    t (~chainerx.ndarray): An array whose (i, j)-th element indicates a signed
-        integer vector of ground truth labels 0 or 1. If ``t[i, j] == -1``,
-        corresponding ``x[i, j]`` is ignored. Loss is zero if all ground truth
+    x2 (~chainerx.ndarray): An array whose (i, j)-th element indicates a signed
+        integer vector of ground truth labels 0 or 1. If ``x2[i, j] == -1``,
+        corresponding ``x1[i, j]`` is ignored. Loss is zero if all ground truth
         labels are -1.
 
 Returns:
@@ -1142,7 +1142,7 @@ Returns:
 
 Note:
     During backpropagation, this function propagates the gradient of the output
-    array to the input array ``x`` only.
+    array to the input array ``x1`` only.
 """)
 
 

--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -1145,6 +1145,7 @@ Note:
     array to the input array ``x`` only.
 """)
 
+
 def _docs_manipulation():
     _docs.set_doc(
         chainerx.reshape,

--- a/chainerx/_docs/routines.py
+++ b/chainerx/_docs/routines.py
@@ -1123,6 +1123,27 @@ Returns:
 .. seealso:: :func:`chainer.functions.gaussian_kl_divergence`
 """)
 
+    _docs.set_doc(
+        chainerx.sigmoid_cross_entropy,
+        """sigmoid_cross_entropy(x, t)
+
+Element-wise cross entropy loss for pre-sigmoid activations.
+
+Args:
+    x (~chainerx.ndarray): An array whose (i, j)-th element indicates the
+        unnormalized log probability of the j-th unit at the i-th example.
+    t (~chainerx.ndarray): An array whose (i, j)-th element indicates a signed
+        integer vector of ground truth labels 0 or 1. If ``t[i, j] == -1``,
+        corresponding ``x[i, j]`` is ignored. Loss is zero if all ground truth
+        labels are -1.
+
+Returns:
+    :class:`~chainerx.ndarray`: An array of the cross entropy.
+
+Note:
+    During backpropagation, this function propagates the gradient of the output
+    array to the input array ``x`` only.
+""")
 
 def _docs_manipulation():
     _docs.set_doc(

--- a/docs/source/chainerx/reference/routines.rst
+++ b/docs/source/chainerx/reference/routines.rst
@@ -160,6 +160,7 @@ Loss functions
    chainerx.squared_error
    chainerx.huber_loss
    chainerx.gaussian_kl_divergence
+   chainerx.sigmoid_cross_entropy
 
 Mathematical functions
 ----------------------


### PR DESCRIPTION
This PR adds ``chainerx.sigmoid_cross_entropy``'s missing documentation.