### PR TITLE
Remove obsolete comment in `F.softmax_cross_entropy`

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -144,8 +144,6 @@ class SoftmaxCrossEntropy(function_node.FunctionNode):
 
         log_p *= t_valid.ravel()
         if self.reduce == 'mean':
-            # deal with the case where the SoftmaxCrossEntropy is
-            # unpickled from the old version
             if self.normalize:
                 count = t_valid.sum()
             else:


### PR DESCRIPTION
This PR removes a comment in `F.softmax_cross_entropy`, which looks obsolete and makes no sense now:

https://github.com/chainer/chainer/blob/5ea0cd395e02f2a190408f446f90657d4374a506/chainer/functions/loss/softmax_cross_entropy.py#L147

It is supposed that it was originally introduced at https://github.com/chainer/chainer/commit/bc0409074645809e2ccabdfb131df527569d9a41#diff-b795608ebf49fbc4e2379c9f44daa1d6R46 to note why getting `normalize` attribute with `getattr()`.
