### PR TITLE
Inverse

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
@@ -212,6 +212,7 @@ class TestInverse(NumpyLinalgOpTest):
 
     def generate_inputs(self):
         a = numpy.random.random(self.shape).astype(self.dtype)
+        a = a * 10 + numpy.ones(self.shape)
         return a,
 
     def forward_xp(self, inputs, xp):


### PR DESCRIPTION
Fix matrix generation to prevent divide by zero-like matrices, which have high error rates.

Fixes #8034 

Error reproduced, and solved with this PR. 4000 trials. Previously 8 errors, none after fix.