### PR TITLE
Replace Slack invitation links

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,4 +23,4 @@ python -c 'import chainer; chainer.print_runtime_info()'
 
 Thank you for your cooperation!
 
-Support is available on our [Slack Chat](https://bit.ly/join-chainer-slack).
+Support is available on our [Slack Chat](https://bit.ly/go-chainer-slack).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | [**ChainerX**](#chainerx)
 
 **Forum** ([en](https://groups.google.com/forum/#!forum/chainer), [ja](https://groups.google.com/forum/#!forum/chainer-jp))
-| **Slack invitation** ([en](https://bit.ly/join-chainer-slack), [ja](https://bit.ly/join-chainer-jp-slack))
+| **Slack invitation** ([en](https://bit.ly/go-chainer-slack), [ja](https://bit.ly/go-chainer-jp-slack))
 | **Twitter** ([en](https://twitter.com/ChainerOfficial), [ja](https://twitter.com/ChainerJP))
 
 *Chainer* is a Python-based deep learning framework aiming at flexibility.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,5 +54,5 @@ Indices and tables
    :maxdepth: 1
    :caption: Community
 
-   Slack Chat <https://bit.ly/join-chainer-slack>
+   Slack Chat <https://bit.ly/go-chainer-slack>
    Forums <https://groups.google.com/forum/#!forum/chainer>


### PR DESCRIPTION
Old Slack invitation links had expired for some reason.
Replacing it with new `bit.ly` link which redirects to GitHub Pages (repo: https://github.com/chainer/join-slack), which then automatically redirects to the actual invitation page.

The invitation link should "never expire" (according to Slack), but to detect accidental expiration, inviation links are now tested in https://travis-ci.org/chainer/join-slack as well.