### PR TITLE
Do not expose global_kernel_registry

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_backend.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_backend.cc
@@ -76,5 +76,10 @@ size_t CudaBackend::GetCudnnMaxWorkspaceSize() {
     return *cudnn_max_workspace_size_;
 }
 
+KernelRegistry& CudaBackend::GetGlobalKernelRegistry() {
+    static gsl::owner<KernelRegistry*> global_kernel_registry = new KernelRegistry{};
+    return *global_kernel_registry;
+}
+
 }  // namespace cuda
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/cuda/cuda_backend.h
+++ b/chainerx_cc/chainerx/cuda/cuda_backend.h
@@ -50,10 +50,7 @@ public:
     // Gets maximum cuDNN workspace size.
     size_t GetCudnnMaxWorkspaceSize();
 
-    static KernelRegistry& GetGlobalKernelRegistry() {
-        static gsl::owner<KernelRegistry*> global_kernel_registry = new KernelRegistry{};
-        return *global_kernel_registry;
-    }
+    static KernelRegistry& GetGlobalKernelRegistry();
 
 protected:
     KernelRegistry& GetParentKernelRegistry() override { return GetGlobalKernelRegistry(); }

--- a/chainerx_cc/chainerx/native/native_backend.cc
+++ b/chainerx_cc/chainerx/native/native_backend.cc
@@ -37,5 +37,10 @@ bool NativeBackend::SupportsTransfer(Device& src_device, Device& dst_device) {
     return &src_device.backend() == this && &dst_device.backend() == this;
 }
 
+KernelRegistry& NativeBackend::GetGlobalKernelRegistry() {
+    static gsl::owner<KernelRegistry*> global_kernel_registry = new KernelRegistry{};
+    return *global_kernel_registry;
+}
+
 }  // namespace native
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/native/native_backend.h
+++ b/chainerx_cc/chainerx/native/native_backend.h
@@ -39,10 +39,7 @@ public:
 
     bool SupportsTransfer(Device& src_device, Device& dst_device) override;
 
-    static KernelRegistry& GetGlobalKernelRegistry() {
-        static gsl::owner<KernelRegistry*> global_kernel_registry = new KernelRegistry{};
-        return *global_kernel_registry;
-    }
+    static KernelRegistry& GetGlobalKernelRegistry();
 
 protected:
     KernelRegistry& GetParentKernelRegistry() override { return GetGlobalKernelRegistry(); }


### PR DESCRIPTION
Static variables in headers will be unique symbols, which are
shared among multiple shared objects. This means you cannot
load multiple shared objects which are linked against
ChainerX since kernel registrations in the second shared
object will fail due to the dup kernel detection.

It would be better to get rid of unique symbols created in
reduce.cuh (kMaxBlockSize), but this would be safer since this
is a constant value.
