### PR TITLE
Fix intel64 support of `F.batch_normalization`

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -105,10 +105,9 @@ class GeneralBatchNormalizationImpl(_BatchNormalizationImpl):
 
         inv_m = gamma.dtype.type(1. / (x.size // gamma.size))
         if xp is numpy:
-            # cast to avoid a error of "mkldnn::error"
-            if gy.dtype == numpy.float64 and gamma.dtype == numpy.float32:
-                gamma = gamma.astype(numpy.float64, copy=False)
-
+            if isinstance(gamma, intel64.mdarray) and inv_std.dtype != numpy.float32:
+                # Convert to numpy to avoid an error of "mkldnn::error"
+                gamma = numpy.asarray(gamma)
             gx = (gamma * inv_std)[expander] * (
                 gy - (x_hat * ggamma[expander] + gbeta[expander]) * inv_m)
             gx = gx.astype(dtype=x.dtype, copy=False)


### PR DESCRIPTION
There are two kinds of intel64 support:
- to use intel64 routine; and
- not to be broken with other intel64 enhancements.

https://github.com/chainer/chainer/pull/8175/files#r329861075 missed the latter point.  For example, backward of `h = bn(x); y = F.relu(h)` may give `isinstance(h.grad, intel64.mdarray)` even if `x.array` is not.

Nonetheless `astype` can be avoided.

By the way,
- `_BNMode.can_use_ideep` has been too strict from #6456.  `intel64.inputs_all_ready` checks `x.dtype` but it seems intended to use intel64 if `(x.dtype, gamma.dtype) == (float16, float32)`.  https://github.com/chainer/chainer/blob/4f4dda143fafccd914345ac28d750f5be1a99ef8/chainer/functions/normalization/batch_normalization.py#L634
  - I don't fix this issue in this PR.
- #8175 correctly fixed the condition for `(x.dtype, gamma.dtype) == (float32, float64)`, where intel64 should not be used.
  - #8175 also allowed `gamma.dtype` to be less precise than `x.dtype`, which does not seem to be often used to me.