### PR TITLE
Fix dim clearing on output

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -462,7 +462,8 @@ def _export(model, args, filename, export_params, graph_name, save_text,
 
     if input_shapes is not None:
         for output in model.graph.output:
-            output.type.Clear()
+            for d in output.type.tensor_type.shape.dim:
+                d.Clear()
         model = shape_inference.infer_shapes(model)
         check_onnx_model(model, external_converters, external_opset_imports)
 


### PR DESCRIPTION
When update onnx 1.6, exporting with `input_shapes` does not work. `onnx.shape_inference.infer_shape` does not allow output `Type` is cleared, and emits `TypeInferenceError`. To resolve it, exporting clears dimension information instead of `Type`.

[before]

```
>       inferred_model_str = C.infer_shapes(model_str)
E       RuntimeError: Parameterized test failed.
E
E       Base test method: TestCustomizedInputShape.test_output
E       Test parameters:
E         shape_option: ('N', 3, 28, 28)
E         x_shape: (10, 3, 28, 28)
E
E
E       (caused by)
E       RuntimeError: [TypeInferenceError] type case mismatch. existing=0 inferred=1
```

[after]
![image](https://user-images.githubusercontent.com/414255/66538216-65ddd200-eb5e-11e9-9c57-889af720f655.png)

