### PR TITLE
Stop setting too small tolerances in backprop tests

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_scale.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_scale.py
@@ -28,9 +28,6 @@ class TestScale(testing.FunctionTestCase):
 
     def setUp(self):
         self.axis = 1
-        self.check_backward_options.update({'atol': 1e-5, 'rtol': 1e-5})
-        self.check_double_backward_options.update(
-            {'atol': 1e-4, 'rtol': 1e-4})
 
     def generate_inputs(self):
         x1 = numpy.random.uniform(-1, 1, (3, 2, 3)).astype(numpy.float32)

--- a/tests/chainer_tests/functions_tests/noise_tests/test_zoneout.py
+++ b/tests/chainer_tests/functions_tests/noise_tests/test_zoneout.py
@@ -79,7 +79,7 @@ class TestZoneout(unittest.TestCase):
 
         gradient_check.check_double_backward(
             f, (h_data, x_data), y_grad, (h_grad_grad, x_grad_grad),
-            dtype=numpy.float64, atol=1e-7, rtol=1e-7)
+            dtype=numpy.float64)
 
     def test_forward_cpu(self):
         self.check_forward(self.h, self.x)


### PR DESCRIPTION
Backprop tests have little benefit to specify small tolerances because numerical computation of gradients is not necessarily accurate.