### PR TITLE
Fix test_Meshgrid

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -1270,7 +1270,7 @@ class TestTrilTriu(op_utils.NumpyOpTest):
 
 @op_utils.op_test(['native:0', 'cuda:0'])
 @chainer.testing.parameterize_pytest('indexing', ['xy', 'ij'])
-@chainer.testing.parameterize_pytest('input_arrs', [1, 2, 3, 4, 5, 6])
+@chainer.testing.parameterize_pytest('input_arrs', [1, 2, 3, 4])
 class TestMeshgrid(op_utils.NumpyOpTest):
 
     check_numpy_strides_compliance = False


### PR DESCRIPTION
~Probably this fixes <!-- --> #8268.  (Reopen the issue later if it does not.)~
This PR reduces the failure rate of `test_Meshgrid`.

The outputs are six arrays of the shape `(6, 5, 3, 3, 6, 3)`, which seems too big to test backward with `float16`, in the failed example.