### PR TITLE
fix gtest linkage weirdness

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -267,14 +267,6 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/abseil")
 add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/abseil" "${CMAKE_CURRENT_BINARY_DIR}/abseil-build")
 
 # gtest
-
-# TODO(niboshi): Remove gtest dependency from testing
-get_third_party(gtest)
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-    EXCLUDE_FROM_ALL)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include)
-
 if(MSVC)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GCC|Clang")
         # TODO(durswd): Remove it. It is hack for MSVC+LLVM
@@ -284,6 +276,13 @@ if(MSVC)
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     endif()
 endif()
+
+# TODO(niboshi): Remove gtest dependency from testing
+get_third_party(gtest)
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+    EXCLUDE_FROM_ALL)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/googletest-src/googletest/include)
 
 
 #------

--- a/chainerx_cc/third_party/abseil.cmake
+++ b/chainerx_cc/third_party/abseil.cmake
@@ -11,7 +11,4 @@ ExternalProject_Add(pybind11
     BUILD_COMMAND     ""
     INSTALL_COMMAND   ""
     TEST_COMMAND      ""
-    CMAKE_ARGS
-        -DCMAKE_INSTALL_MESSAGE=LAZY
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     )

--- a/chainerx_cc/third_party/gsl-lite.cmake
+++ b/chainerx_cc/third_party/gsl-lite.cmake
@@ -11,7 +11,4 @@ ExternalProject_Add(gsl-lite
         BUILD_COMMAND     ""
         INSTALL_COMMAND   ""
         TEST_COMMAND      ""
-        CMAKE_ARGS
-                -DCMAKE_INSTALL_MESSAGE=LAZY
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-)
+        )

--- a/chainerx_cc/third_party/gtest.cmake
+++ b/chainerx_cc/third_party/gtest.cmake
@@ -12,7 +12,4 @@ ExternalProject_Add(googletest
     BUILD_COMMAND     ""
     INSTALL_COMMAND   ""
     TEST_COMMAND      ""
-    CMAKE_ARGS
-        -DCMAKE_INSTALL_MESSAGE=LAZY
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     )

--- a/chainerx_cc/third_party/pybind11.cmake
+++ b/chainerx_cc/third_party/pybind11.cmake
@@ -11,7 +11,4 @@ ExternalProject_Add(pybind11
     BUILD_COMMAND     ""
     INSTALL_COMMAND   ""
     TEST_COMMAND      ""
-    CMAKE_ARGS
-        -DCMAKE_INSTALL_MESSAGE=LAZY
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     )


### PR DESCRIPTION
Previously, in #7966, there is an attempt to fix gtest crt linkage. It just don't work actually, it 'fixed' it simply by accident.

1. In those `chainerx_cc/third_party/*.cmake` files, the configure stage is disabled since the configure command is set to an empty string.
2. according to [add_subdirectory](https://cmake.org/cmake/help/v3.15/command/add_subdirectory.html) doc
> The CMakeLists.txt file in the specified source directory will be processed immediately by CMake before processing in the current input file continues beyond this command.

the `${CMAKE_CURRENT_BINARY_DIR}/googletest-src` is added first and then followed with a `set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)`. So, on the first pass of configure-build (trigged by setup.py), crt error, on the second pass, it disappear. Which makes it seems like adding flags to `chainerx_cc/third_party/*.cmake` files have addressed the problem, but it is not.