### PR TITLE
Compute `F.negative_sampling` in fp32 for fp16 inputs

### DIFF
--- a/chainer/functions/loss/negative_sampling.py
+++ b/chainer/functions/loss/negative_sampling.py
@@ -7,6 +7,7 @@ from chainer.backends import cuda
 from chainer import function_node
 from chainer import utils
 from chainer.utils import argument
+from chainer.utils import precision
 from chainer.utils import type_check
 
 
@@ -53,6 +54,8 @@ class NegativeSamplingFunction(function_node.FunctionNode):
             w_type.ndim == 2,
         )
 
+    # Avoid fp16 computation to keep the precision in reduction operations.
+    @precision._fp16_mixed_precision_helper
     def forward_cpu(self, inputs):
         self.retain_inputs((0, 1, 2))
         x, t, W = inputs
@@ -74,6 +77,7 @@ class NegativeSamplingFunction(function_node.FunctionNode):
         self.samples = samples
         return loss,
 
+    @precision._fp16_mixed_precision_helper
     def forward_gpu(self, inputs):
         self.retain_inputs((0, 1, 2))
         x, t, W = inputs


### PR DESCRIPTION
Fix #8289.

`F.negative_sampling` includes reduction operations, which lose accuracy when the inputs are fp16. In this PR, `F.negative_sampling` is fixed to use fp32 for computation. The flaky test then passed for 100k times repeats.