### PR TITLE
Fix SCE with ChainerX and normalize

### DIFF
--- a/chainer/functions/loss/softmax_cross_entropy.py
+++ b/chainer/functions/loss/softmax_cross_entropy.py
@@ -100,8 +100,6 @@ class SoftmaxCrossEntropy(function_node.FunctionNode):
             return False
         if self.ignore_label != -1:
             return False
-        if self.reduce != 'mean':
-            return False
 
         x, t = input_arrays
 
@@ -111,15 +109,22 @@ class SoftmaxCrossEntropy(function_node.FunctionNode):
         return True
 
     def forward_chainerx(self, inputs):
-        # TODO(niboshi): Current implementation is only intended to support
-        # MNIST example.
         x, t = inputs
         n_classes = x.shape[1]
         score = chainerx.log_softmax(x, axis=1)
         mask = (t[:, chainerx.newaxis] == chainerx.arange(
             n_classes, dtype=t.dtype, device=x.device)).astype(score.dtype)
-        # TODO(beam2d): implement mean
-        y = -(score * mask).sum() * (1 / x.shape[0])
+
+        neg_log_p = -score * mask
+        if self.reduce == 'mean':
+            if self.normalize:
+                count = mask.sum()
+            else:
+                count = x.shape[0]
+            y = neg_log_p.sum() * (1 / count)
+        else:
+            y = neg_log_p.sum(axis=1)
+
         return y,
 
     def forward_cpu(self, inputs):

--- a/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
+++ b/tests/chainer_tests/functions_tests/loss_tests/test_softmax_cross_entropy.py
@@ -40,6 +40,7 @@ import chainerx
         'normalize': [True, False],
         'weight_apply': [True, False],
         'shape_ignore': ['special',
+                         ((2, 3), (0,)),
                          ((2, 3, 2, 2), (0, 1, 0))],
         'dtype': [numpy.float32],
         'label_dtype': [numpy.int32],


### PR DESCRIPTION
`F.softmax_cross_entropy` with ChainerX ndarrays used to return wrong results when called with default arguments (`reduce='mean'`, `normalize=True` and `ignore_label=-1`) with ignored labels in the target `t`. The issue was that `normalize` was not accounted for. This PR fixes this issue and addresses some TODOs.

### TODO
- [x] Fix `forward_chainerx`.
- [x] Add tests. 