### PR TITLE
Support `chainerx.batch_norm` with 2D input on CUDA

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
@@ -29,7 +29,6 @@ namespace chainerx {
 namespace cuda {
 namespace {
 
-// TODO(sonots): Support other than 4, 5 dimensional arrays by reshaping into 4-dimensional arrays as Chainer does.
 cudnnBatchNormMode_t GetBatchNormMode(const Axes& axis) {
     if (axis.ndim() == 1 && axis[0] == 0) {  // (1, channels, (depth, )height, width)
         return CUDNN_BATCHNORM_PER_ACTIVATION;

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -43,10 +43,9 @@ def _create_batch_norm_ndarray_args(
     return x, gamma, beta, mean, var
 
 
-# Note that CUDA (cuDNN) only supports batch normalization with 4 or
-# 5-dimenisional data.
 # x_shape,reduced_shape,axis
 _batch_norm_params = [
+    ((3, 2), (2,), None),
     ((5, 4, 3, 2), (4, 3, 2), None),
     ((5, 4, 3, 2), (4, 3, 2), (0,)),
     ((5, 4, 3, 2), (4,), (0, 2, 3)),

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -43,6 +43,9 @@ def _create_batch_norm_ndarray_args(
     return x, gamma, beta, mean, var
 
 
+# Note that CUDA (cuDNN) only supports batch normalization with 4 or
+# 5-dimenisional data. Arrays with smaller dimensions are supported by the
+# CUDA backend, while those with larger dimensions are not.
 # x_shape,reduced_shape,axis
 _batch_norm_params = [
     ((3, 2), (2,), None),

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -44,7 +44,7 @@ def _create_batch_norm_ndarray_args(
 
 
 # Note that CUDA (cuDNN) only supports batch normalization with 4 or
-# 5-dimenisional data. Arrays with smaller dimensions are supported by the
+# 5-dimensional data. Arrays with smaller dimensions are supported by the
 # CUDA backend, while those with larger dimensions are not.
 # x_shape,reduced_shape,axis
 _batch_norm_params = [


### PR DESCRIPTION
Fix #6216. cuDNN batch norm only supports 4 or 5 dimension input, so this PR complements ones to the shape of input descriptors when ndim is lower than them.