### PR TITLE
`test_average` is slow in FlexCI

### DIFF
--- a/.pfnci/hint.pbtxt
+++ b/.pfnci/hint.pbtxt
@@ -31,6 +31,7 @@ rules { name: "chainer_tests/functions_tests/activation_tests/test_softmax.py" x
 rules { name: "chainer_tests/functions_tests/activation_tests/test_tanh.py" xdist: 2 }
 rules { name: "chainer_tests/functions_tests/array_tests/test_cast.py" xdist: 2 }
 rules { name: "chainer_tests/functions_tests/activation_tests/test_elu.py" xdist: 2 }
+rules { name: "chainer_tests/functions_tests/math_tests/test_average.py" xdist: 2 }
 rules { name: "chainer_tests/functions_tests/math_tests/test_basic_math.py" xdist: 2 }
 rules { name: "chainer_tests/functions_tests/math_tests/test_maximum.py" xdist: 2 }
 rules { name: "chainer_tests/functions_tests/math_tests/test_prod.py" xdist: 2 }


### PR DESCRIPTION
#7670 roughly doubled the number of testcases in `test_average` and #8211 disabled pairwise testing in FlexCI.

I found the failure in https://ci.preferred.jp/chainer.py27and35.gpu/35308/

<details>

```
2019-10-17 16:01:32.581641 STDOUT 2318] 	[SUCCESS] /chainer/tests/chainer_tests/training_tests/updaters_tests/test_standard_updater.py (221 passed, 37 deselected in 4.18 seconds)
2019-10-17 16:01:32.628795 STDOUT 2318] 	[TIMEOUT] /chainer/tests/chainer_tests/functions_tests/math_tests/test_average.py (60 seconds)
2019-10-17 16:01:32.628820 STDERR 2318] 	[DEBUG] failed to wait a command: python3.5 -m pytest -m not slow and (gpu or cudnn or cuda) /chainer/tests/chainer_tests/functions_tests/math_tests/test_average.py: signal: killed
2019-10-17 16:01:32.628801 STDOUT 2318] 	============================= test session starts ==============================
2019-10-17 16:01:32.628803 STDOUT 2318] 	platform linux -- Python 3.5.2, pytest-4.1.1, py-1.8.0, pluggy-0.13.0
2019-10-17 16:01:32.628804 STDOUT 2318] 	rootdir: /chainer, inifile: setup.cfg
2019-10-17 16:01:32.628810 STDOUT 2318] 	plugins: xdist-1.26.1, forked-1.0.2
2019-10-17 16:01:32.628811 STDOUT 2318] 	collected 3717 items / 1413 deselected
2019-10-17 16:01:32.628813 STDOUT 2318] 	
2019-10-17 16:01:32.628814 STDOUT 2318] 	chainer/tests/chainer_tests/functions_tests/math_tests/test_average.py . [  0%]
2019-10-17 16:01:32.628815 STDOUT 2318] 	s..s..s..s..s.ssssss.s..s..s..s..s..s..s.sss.s..s..s..s.sss.s..s..s..s.. [  3%]
2019-10-17 16:01:32.628818 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s.sss.s.sss.s..s..s..s..s..s..s..s..s..s.. [  6%]
2019-10-17 16:01:32.628820 STDOUT 2318] 	s..s..s..s..s..s..s.sss.s..s..s..s..s..s..s..s..s..s.sss.s..s.ssssss.s.. [  9%]
2019-10-17 16:01:32.628821 STDOUT 2318] 	s.sss.s..s..s..s..s.sss.s..s..s.sss.s..s..s..s..s..s..s..s.sss.s..s..s.. [ 12%]
2019-10-17 16:01:32.628822 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.. [ 15%]
2019-10-17 16:01:32.628823 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.. [ 18%]
2019-10-17 16:01:32.628824 STDOUT 2318] 	s..s..s..s.sss.s..s..s..s..s.sss.s..s..s..s.sss.s.sss.s..s..s..s..s..s.s [ 21%]
2019-10-17 16:01:32.628825 STDOUT 2318] 	ss.s..s..s..s..s..s..s..s..s.sss.s..s..s..s..s..s..s..s.sss.s.sss.s..s.. [ 25%]
2019-10-17 16:01:32.628829 STDOUT 2318] 	s.sss.s..s..s..s..s.ssssss.s..s..s..s..s..s..s.sss.s..s..s..s..s..s.sss. [ 28%]
2019-10-17 16:01:32.628830 STDOUT 2318] 	s..s..s..s.sss.s..s.sss.s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.s [ 31%]
2019-10-17 16:01:32.629103 STDOUT 2318] 	ss.s..s.sss.s.sss.s..s.sss.s..s..s..s.sss.s..s..s..s..s.sss.s..s..s..s.. [ 34%]
2019-10-17 16:01:32.629104 STDOUT 2318] 	s..s..s.sss.s.sss.s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.. [ 37%]
2019-10-17 16:01:32.629105 STDOUT 2318] 	s..s..s..s..s..s..s..s.sss.s..s..s..s..s..s..s.sss.s.sss.s..s..s..s..s.. [ 40%]
2019-10-17 16:01:32.629106 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s..s..s.sss.s..s..s..s..s..s..s..s..s..s.. [ 43%]
2019-10-17 16:01:32.629106 STDOUT 2318] 	s..s.sss.s..s..s.sss.s..s.ssssss.s..s..s..s..s..s..s.sss.s..s..s..s..s.. [ 46%]
2019-10-17 16:01:32.629107 STDOUT 2318] 	s..s..s..s.sss.s..s..s..s..s.sss.s..s..s..s.sss.s..s..s..s..s..s..s..s.. [ 50%]
2019-10-17 16:01:32.629108 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s..s..s.ssssss.s..s..s..s..s..s..s.sss.s.. [ 53%]
2019-10-17 16:01:32.629109 STDOUT 2318] 	s..s.sss.s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.sss.s..s..s..s.s [ 56%]
2019-10-17 16:01:32.629126 STDOUT 2318] 	ss.s..s..s..s.sss.s..s..s..s.sss.s..s..s..s..s..s..s..s..s..s..s..s.sss. [ 59%]
2019-10-17 16:01:32.629126 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.sss.s..s..s.sss.s..s..s..s.s [ 62%]
2019-10-17 16:01:32.629127 STDOUT 2318] 	ss.s..s..s..s..s..s..s..s..s.sss.s.sss.s..s..s..s..s..s..s..s..s..s..s.. [ 65%]
2019-10-17 16:01:32.629128 STDOUT 2318] 	s..s..s.sss.s..s..s..s..s..s..s..s.sss.s..s..s..s.sss.s..s..s..s..s..s.. [ 68%]
2019-10-17 16:01:32.629129 STDOUT 2318] 	s..s..s..s..s.sss.s..s..s..s..s..s..s..s.sss.s..s..s..s..s..s.sss.s..s.. [ 71%]
2019-10-17 16:01:32.629223 STDOUT 2318] 	s..s..s..s..s..s.sss.s.sss.s..s..s..s..s.sss.s..s..s..s..s..s..s..s..s.. [ 75%]
2019-10-17 16:01:32.629224 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s..s.sss.s..s..s..s..s.sss.s..s..s..s..s.. [ 78%]
2019-10-17 16:01:32.629224 STDOUT 2318] 	s..s..s..s..s.sss.s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.. [ 81%]
2019-10-17 16:01:32.629225 STDOUT 2318] 	s..s..s.sss.s.sss.s..s..s..s..s..s..s..s..s..s..s..s..s..s.sss.s..s..s.s [ 84%]
2019-10-17 16:01:32.629226 STDOUT 2318] 	ss.s..s..s..s..s..s..s..s..s..s..s..s..s..s.sss.s..s..s..s..s..s..s..s.. [ 87%]
2019-10-17 16:01:32.629227 STDOUT 2318] 	s.sss.s..s..s..s..s..s..s..s..s.ssssss.s..s.sss.s.sss.s..s..s.sss.s..s.. [ 90%]
2019-10-17 16:01:32.629228 STDOUT 2318] 	s.ssssss.s..s.ssssss.s..s..s..s.sss.s..s..s..s..s..s..s..s..s..s..s..s.. [ 93%]
2019-10-17 16:01:32.629228 STDOUT 2318] 	s..s..s..s..s.sss.s.sss.s..s..s..s..s..s.sss.s..s..s.sss.s..s..s..s..s.. [ 96%]
2019-10-17 16:01:32.629229 STDOUT 2318] 	s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s.sss.s..s..s..s..s..s..s.  [100%]
2019-10-17 16:01:32.629230 STDOUT 2318] 	
2019-10-17 16:01:32.629231 STDOUT 2318] 	========== 1344 passed, 960 skipped, 1413 deselected in 58.50 seconds ==========
2019-10-17 16:01:34.923656 STDOUT 2318] 	[SUCCESS] /chainer/tests/chainer_tests/functions_tests/rnn_tests/test_function_lstm.py (438 passed, 282 deselected in 42.77 seconds)
2019-10-17 16:01:49.897633 STDERR 2318] 	[DEBUG] flushing reporter...
2019-10-17 16:01:49.897649 STDOUT 2318] 	[SUCCESS] /chainer/tests/chainer_tests/functions_tests/rnn_tests/test_function_slstm.py (975 passed, 492 deselected in 55.11 seconds)
2019-10-17 16:01:49.897654 STDOUT 2318] 	
2019-10-17 16:01:49.897655 STDOUT 2318] 	============================ FAILED TESTS ============================
2019-10-17 16:01:49.897656 STDOUT 2318] 	[TIMEOUT] /chainer/tests/chainer_tests/functions_tests/math_tests/test_average.py (60 seconds)
2019-10-17 16:01:49.897658 STDOUT 2318] 	
2019-10-17 16:01:49.897659 STDOUT 2318] 	============================ TEST SUMMARY ============================
2019-10-17 16:01:49.897660 STDOUT 2318] 	1 failed, 0 flaky, 356 passed
2019-10-17 16:01:51.257238 STDOUT 2318] 	Overall status: FAILED
2019-10-17 16:01:51.260355 STDERR 2318] 	+ py35_test_status=1
2019-10-17 16:01:51.260359 STDERR 2318] 	+ echo py35_test_status=1
2019-10-17 16:01:51.260382 STDOUT 2318] 	py35_test_status=1
2019-10-17 16:01:51.260362 STDERR 2318] 	+ exit 1
2019-10-17 16:01:51.773119 STDOUT 2318] 	[EOF]
2019-10-17 16:01:51.773120 STDERR 2318] 	[EOF]
```