### PR TITLE
Bugfix: unable to use `gpu_id=0` in ChainerMN testing `get_device`

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -262,7 +262,7 @@ configs {
       disk: 50
     }
     time_limit: {
-      seconds: 900
+      seconds: 1200
     }
     command: "bash .pfnci/script.sh chainermn"
   }

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -261,6 +261,9 @@ configs {
       memory: 30
       disk: 50
     }
+    time_limit: {
+      seconds: 900
+    }
     command: "bash .pfnci/script.sh chainermn"
   }
 }
@@ -272,6 +275,9 @@ configs {
       memory: 30
       disk: 50
       gpu: 2
+    }
+    time_limit: {
+      seconds: 900
     }
 	environment_variables { key: "GPU" value: "2" }
     command: "bash .pfnci/script.sh chainermn"

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -202,7 +202,12 @@ test_chainermn_sub() {
   #-----------------------------------------------------------------------------
   # Install Chainer
   #-----------------------------------------------------------------------------
-  if ! python -m pip install /chainer[test] 2>&1 >/tmp/install-py3.log; then
+  CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 MAKEFLAGS="-j$(nproc)" \
+  CHAINERX_NVCC_GENERATE_CODE=arch=compute_70,code=sm_70 \
+      python -m pip install /chainer[test] 2>&1 >/tmp/install-py3.log &
+  install_pid=$!
+
+  if ! wait $install_pid; then
     cat /tmp/install-py3.log
     exit 1
   fi

--- a/chainermn/testing/device.py
+++ b/chainermn/testing/device.py
@@ -10,7 +10,7 @@ def get_device(gpu_id=None, use_chainerx=False):
     (numpy, cupy, chainerx+native, chainerx+cuda). This utility function
     is a boilerplate to get device object in ChainerMN contexts.
     """
-    if gpu_id:
+    if gpu_id is not None:
         if use_chainerx:
             device = 'cuda:{}'.format(gpu_id)
         else:

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,7 @@ setup_kwargs = dict(
               'chainermn.functions',
               'chainermn.iterators',
               'chainermn.links',
+              'chainermn.testing',
               'onnx_chainer',
               'onnx_chainer.functions',
               'onnx_chainer.testing'],

--- a/tests/chainermn_tests/testing_tests/test_device.py
+++ b/tests/chainermn_tests/testing_tests/test_device.py
@@ -1,0 +1,31 @@
+import pytest
+from chainermn import testing
+import chainer.testing.attr
+
+
+# use_chainerx, expected
+test_data_cpu = [
+    (False, "@numpy"),
+    (True, "native:0"),
+]
+
+# gpu_id, use_chainerx, expected
+test_data_gpu = [
+    (0, False, "@cupy:0"),
+    (1, False, "@cupy:1"),
+    (0, True, "cuda:0"),
+    (1, True, "cuda:1"),
+]
+
+
+@pytest.mark.parametrize("use_chainerx,expected", test_data_cpu)
+def test_get_device_cpu(use_chainerx, expected):
+    device = testing.get_device(use_chainerx=use_chainerx)
+    assert device.name == expected
+
+
+@chainer.testing.attr.gpu
+@pytest.mark.parametrize("gpu_id,use_chainerx,expected", test_data_gpu)
+def test_get_device(gpu_id, use_chainerx, expected):
+    device = testing.get_device(gpu_id, use_chainerx)
+    assert device.name == expected


### PR DESCRIPTION
This PR fixes a bug in the `get_device` in `chainermn.testing`,
which uses native when specifying to use gpu with `gpu_id=0`,
as the `0` is considered as `False` in `if`.

This PR also includes a unit test for the `chainermn.testing`, as well as installing ChainerX in the `chainermn-cpu` and `chainermn-gpu` tests.
The time limit for both tests are increased as the building with chainerx takes too much time, and to match with other chainer tests.