### PR TITLE
Add ChainerX to test_mnist in chainermn_tests

### DIFF
--- a/tests/chainermn_tests/datasets_tests/test_mnist.py
+++ b/tests/chainermn_tests/datasets_tests/test_mnist.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 
 import os
+import pytest
 import sys
 import tempfile
 import warnings
 
 import chainer
-from chainer.backends.cuda import cupy
 import chainer.functions as F
 import chainer.links as L
 import chainer.testing
@@ -14,6 +14,7 @@ from chainer import training
 from chainer.training import extensions
 
 import chainermn
+from chainermn import testing
 from chainermn.extensions.checkpoint import create_multi_node_checkpointer
 
 
@@ -31,22 +32,20 @@ class MLP(chainer.Chain):
         return self.l3(h2)
 
 
-def check_mnist(gpu, display_log=True):
+def check_mnist(use_gpu, use_chainerx, display_log=True):
     epoch = 5
     batchsize = 100
     n_units = 100
     warnings.filterwarnings(action='always', category=DeprecationWarning)
 
-    comm = chainermn.create_communicator('naive')
-    if gpu:
-        device = comm.intra_rank
-        chainer.cuda.get_device_from_id(device).use()
-    else:
-        device = -1
-
     model = L.Classifier(MLP(n_units, 10))
-    if gpu:
-        model.to_device(cupy.cuda.Device())
+    comm = chainermn.create_communicator('naive')
+    if use_gpu:
+        device = testing.get_device(comm.intra_rank, use_chainerx)
+        device.use()
+        model.to_device(device)
+    else:
+        device = testing.get_device(use_chainerx=use_chainerx)
 
     optimizer = chainermn.create_multi_node_optimizer(
         chainer.optimizers.Adam(), comm)
@@ -108,14 +107,16 @@ def check_mnist(gpu, display_log=True):
     os.removedirs(path)
 
 
+@pytest.mark.parametrize("use_chainerx", [True, False])
 @chainer.testing.attr.slow
-def test_mnist():
-    check_mnist(False)
+def test_mnist(use_chainerx):
+    check_mnist(False, use_chainerx)
 
 
+@pytest.mark.parametrize("use_chainerx", [True, False])
 @chainer.testing.attr.gpu
-def test_mnist_gpu():
-    check_mnist(True)
+def test_mnist_gpu(use_chainerx):
+    check_mnist(True, use_chainerx)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds ChainerX tests for both cpu and gpu to the mnist tests.
A little code cleanup is also included.

This PR depends on #8304, and should be merged after it.
This PR resolves the `test_mnist` case in #8031. 