### PR TITLE
Fix backward of `chainerx.linalg.cholesky`

### DIFF
--- a/chainerx_cc/chainerx/routines/linalg.cc
+++ b/chainerx_cc/chainerx/routines/linalg.cc
@@ -440,7 +440,7 @@ Array Cholesky(const Array& a) {
 
                 Array gin = Dot(Dot(L_inv.Transpose(), phi), L_inv);
 
-                bctx.input_grad() = (gin + gin.Transpose()) * 0.5;
+                bctx.input_grad() = Tril(gin, 0) + Tril(gin.Transpose(), -1);
             });
         }
         bb.Finalize();

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_linalg.py
@@ -497,6 +497,10 @@ class TestCholesky(op_utils.NumpyOpTest):
         a = numpy.random.random(self.shape).astype(self.in_dtypes)
         # Make random square matrix a symmetric positive definite one
         a = numpy.array(a.T.dot(a)) + 1e-3 * numpy.eye(*self.shape)
+        # Scramble triu(k=1) to test the routine reads tril
+        a += numpy.triu(
+            numpy.random.random(self.shape).astype(self.in_dtypes),
+            k=1)
         return a,
 
     def forward_xp(self, inputs, xp):
@@ -504,9 +508,6 @@ class TestCholesky(op_utils.NumpyOpTest):
 
         if (_numpy_does_not_support_0d_input113 and a.size == 0):
             pytest.skip('Older NumPy versions do not work with empty arrays')
-
-        # Input has to be symmetrized for backward test to work
-        a = (a + a.T)/2. + 1e-3 * xp.eye(*self.shape)
 
         L = xp.linalg.cholesky(a)
         return L,


### PR DESCRIPTION
Backward of `chainerx.linalg.cholesky` should return a lower triangular `gx`.

The calculation of `numpy.linalg.cholesky` is done with the lower triangular part of the input, while it is not mentioned in the doc and the function does not take `UPLO` argument.  (cf. `numpy.linalg.eigh`, `scipy.linalg.cholesky`)

https://github.com/numpy/numpy/blob/1185880f153c5bbc2081a17121617beb588cfb1f/numpy/linalg/umath_linalg.c.src#L1803
`assert(uplo == 'L');`

