### PR TITLE
[v6] Fix kernel of double backward of max_pooling_2d

### DIFF
--- a/chainer/functions/pooling/max_pooling_2d.py
+++ b/chainer/functions/pooling/max_pooling_2d.py
@@ -332,8 +332,9 @@ class MaxPooling2DWithIndexes(function_node.FunctionNode):
             for (int y = in_y_0; y < in_y_1; ++y) {
                 int offset_y = w * (y + h * c0);
                 for (int x = in_x_0; x < in_x_1; ++x) {
-                    float v = in[x + offset_y];
+                    T v = in[x + offset_y];
                     if (maxval < v) {
+                        maxval = v;
                         argmax_y = y;
                         argmax_x = x;
                     }

--- a/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
+++ b/tests/chainer_tests/functions_tests/pooling_tests/test_max_pooling_2d.py
@@ -49,7 +49,7 @@ class TestMaxPooling2D(unittest.TestCase):
 
         # Avoid unstability of numerical gradient
         x = numpy.arange(2 * 3 * 4 * 3, dtype=dtype).reshape(2, 3, 4, 3)
-        numpy.random.shuffle(x)
+        numpy.random.shuffle(x.ravel())
         x = 2 * x / x.size - 1
         if self.cover_all:
             gy = numpy.random.uniform(-1, 1, (2, 3, 3, 2)).astype(dtype)
@@ -259,7 +259,7 @@ class TestMaxPooling2DIndices(unittest.TestCase):
     def setUp(self):
         self.x = numpy.arange(
             2 * 3 * 4 * 4, dtype=numpy.float32).reshape(2, 3, 4, 4)
-        numpy.random.shuffle(self.x)
+        numpy.random.shuffle(self.x.ravel())
 
     def _check(self, x):
         out, indices = functions.max_pooling_2d(


### PR DESCRIPTION
This PR fixes a bug found in #7923.  `v = maxval` was missing.  `master` branch is already fixed by #7939, which is confirmed by #8328, too.