### PR TITLE
Fix documentation of NStepGRUBase

### DIFF
--- a/chainer/links/rnn/n_step_gru.py
+++ b/chainer/links/rnn/n_step_gru.py
@@ -8,8 +8,8 @@ class NStepGRUBase(n_step_rnn.NStepRNNBase):
 
     Base link class for Stacked GRU/BiGRU links.
 
-    This link is base link class for :func:`chainer.links.NStepRNN` and
-    :func:`chainer.links.NStepBiRNN`.
+    This link is base link class for :func:`chainer.links.NStepGRU` and
+    :func:`chainer.links.NStepBiGRU`.
     This link's behavior depends on argument, ``use_bi_direction``.
 
     Args:


### PR DESCRIPTION
This PR fixes documentation of `chainer.links.NStepGRUBase.`
`NStepRNN` and `NStepBiRNN` here should be `NStepGRU` and `NStepBiGRU` respectively.
