### PR TITLE
Fix onnx_chainer's exporter of Separate to handle single output case

### DIFF
--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -494,6 +494,8 @@ def convert_Separate(func, opset_version, input_names, output_names, context):
     gb = onnx_helper.GraphBuilder()
     split_outs = gb.op(
         'Split', input_names, num_outputs=len(output_names), axis=func.axis)
+    if len(output_names) == 1:
+        split_outs = [split_outs]
     for i, node_name in enumerate(split_outs):
         gb.op_output_named(
             'Squeeze', [node_name], [output_names[i]], axes=[func.axis])

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -180,6 +180,8 @@ from onnx_chainer_tests.helper import ONNXModelTest
      'input_argname': 'x', 'args': {}, 'name': 'separate_axis0'},
     {'ops': 'separate', 'input_shape': (2, 3),
      'input_argname': 'x', 'args': {'axis': 1}, 'name': 'separate_axis1'},
+    {'ops': 'separate', 'input_shape': (1, 2, 3),
+     'input_argname': 'x', 'args': {}, 'name': 'separate_single_output'},
 
     # moveaxis
     {'ops': 'moveaxis', 'input_shape': (2, 3, 4, 5),


### PR DESCRIPTION
This PR fixes `IndexError: list index out of range` when the `Separate` node has only single output.


