### PR TITLE
Fix typos in ONNX-Chainer introduction

### DIFF
--- a/docs/source/onnx_chainer/introduction/index.rst
+++ b/docs/source/onnx_chainer/introduction/index.rst
@@ -207,4 +207,4 @@ Contribution
 
 Any contribution to ONNX-Chainer is welcome!
 
-* Python codes follow `Chainer Coding Guidelines <ttps://docs.chainer.org/en/stable/contribution.html#coding-guidelines>`__
+* Python codes follow `Chainer Coding Guidelines <https://docs.chainer.org/en/stable/contribution.html#coding-guidelines>`__

--- a/docs/source/onnx_chainer/introduction/index.rst
+++ b/docs/source/onnx_chainer/introduction/index.rst
@@ -205,6 +205,6 @@ on GPU environment::
 Contribution
 ------------
 
-Any contribution to ONNX-Chainer is welcom!
+Any contribution to ONNX-Chainer is welcome!
 
 * Python codes follow `Chainer Coding Guidelines <ttps://docs.chainer.org/en/stable/contribution.html#coding-guidelines>`__


### PR DESCRIPTION
This PR fixes typos in `docs/source/onnx_chainer/introduction/index.rst`.
