### PR TITLE
Adjust `SoftmaxCrossEntropy` test tolerances

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_loss.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_loss.py
@@ -189,8 +189,10 @@ class TestSoftmaxCrossEntropy(op_utils.ChainerOpTest):
         self.t = t.astype(self.t_dtype)
 
         if self.x_dtype == 'float16':
-            self.check_forward_options.update({'rtol': 5e-3, 'atol': 5e-4})
-            self.check_backward_options.update({'rtol': 5e-3, 'atol': 5e-4})
+            self.check_forward_options.update({'rtol': 5e-3, 'atol': 5e-3})
+            self.check_backward_options.update({'rtol': 1e-2, 'atol': 5e-3})
+            self.check_double_backward_options.update(
+                {'rtol': 1e-2, 'atol': 3e-1})
 
     def generate_inputs(self):
         x = numpy.random.normal(loc=0, scale=1.0, size=self.shape)


### PR DESCRIPTION
Closes #8315

This patch sets the same tolerances of `LossBase` for `SoftmaxCrossEntropy` 

Before the patch 2,500 Failures every 10,000 runs.

The real reason behind the test failures seems to be #7991, but we don't have a mechanism to avoid precision loss on intermediate calculations.