### PR TITLE
Use `LinkTestCase` for `L.GroupNormalization`

### DIFF
--- a/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_group_normalization.py
@@ -4,7 +4,6 @@ import numpy
 
 import chainer
 from chainer.backends import cuda
-from chainer import gradient_check
 from chainer import links
 from chainer import testing
 from chainer.testing import attr


### PR DESCRIPTION
It seems `chainer.testing.LinkTestCase` supports backprop test with higher-prec `dtype` by overwriting parameters.  Use it and close #6911.