### PR TITLE
Add chainerx test to dataset_tests

### DIFF
--- a/tests/chainermn_tests/datasets_tests/test_empty_dataset.py
+++ b/tests/chainermn_tests/datasets_tests/test_empty_dataset.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from chainermn.datasets import create_empty_dataset
+import chainerx as chx
 
 
 class TestEmptyDataset(unittest.TestCase):
@@ -16,7 +17,13 @@ class TestEmptyDataset(unittest.TestCase):
         for i in range(len(original_dataset)):
             self.assertEqual((), empty_dataset[i])
 
-    def test_scatter_dataset(self):
+    def test_empty_dataset_numpy(self):
+        self.check_empty_dataset(np)
+
+    def test_empty_dataset_chx(self):
+        self.check_empty_dataset(chx)
+
+    def check_empty_dataset(self, xp):
         n = 10
 
         self.check_create_empty_dataset([])
@@ -24,7 +31,9 @@ class TestEmptyDataset(unittest.TestCase):
         self.check_create_empty_dataset(list(range(n)))
         self.check_create_empty_dataset(list(range(n * 5 - 1)))
 
-        self.check_create_empty_dataset(np.array([]))
-        self.check_create_empty_dataset(np.array([0]))
-        self.check_create_empty_dataset(np.arange(n))
-        self.check_create_empty_dataset(np.arange(n * 5 - 1))
+        self.check_create_empty_dataset(xp.array([]))
+        self.check_create_empty_dataset(xp.array([0]))
+        self.check_create_empty_dataset(xp.arange(n))
+        self.check_create_empty_dataset(xp.arange(n * 5 - 1))
+
+

--- a/tests/chainermn_tests/datasets_tests/test_empty_dataset.py
+++ b/tests/chainermn_tests/datasets_tests/test_empty_dataset.py
@@ -35,5 +35,3 @@ class TestEmptyDataset(unittest.TestCase):
         self.check_create_empty_dataset(xp.array([0]))
         self.check_create_empty_dataset(xp.arange(n))
         self.check_create_empty_dataset(xp.arange(n * 5 - 1))
-
-

--- a/tests/chainermn_tests/datasets_tests/test_mnist.py
+++ b/tests/chainermn_tests/datasets_tests/test_mnist.py
@@ -46,7 +46,6 @@ def check_mnist(use_gpu, use_chx, display_log=True):
         chainer.cuda.get_device_from_id(comm.intra_rank).use()
 
     device = get_device(comm.intra_rank if use_gpu else None, use_chx)
-    device.use()
     model.to_device(device)
     optimizer = chainermn.create_multi_node_optimizer(
         chainer.optimizers.Adam(), comm)

--- a/tests/chainermn_tests/datasets_tests/test_mnist.py
+++ b/tests/chainermn_tests/datasets_tests/test_mnist.py
@@ -14,7 +14,7 @@ from chainer import training
 from chainer.training import extensions
 
 import chainermn
-from chainermn import testing
+from chainermn.testing import get_device
 from chainermn.extensions.checkpoint import create_multi_node_checkpointer
 
 
@@ -32,7 +32,7 @@ class MLP(chainer.Chain):
         return self.l3(h2)
 
 
-def check_mnist(use_gpu, use_chainerx, display_log=True):
+def check_mnist(use_gpu, use_chx, display_log=True):
     epoch = 5
     batchsize = 100
     n_units = 100
@@ -40,13 +40,14 @@ def check_mnist(use_gpu, use_chainerx, display_log=True):
 
     model = L.Classifier(MLP(n_units, 10))
     comm = chainermn.create_communicator('naive')
-    if use_gpu:
-        device = testing.get_device(comm.intra_rank, use_chainerx)
-        device.use()
-        model.to_device(device)
-    else:
-        device = testing.get_device(use_chainerx=use_chainerx)
 
+    if use_gpu:
+        # Call CuPy's `Device.use()` to force cudaSetDevice()
+        get_device(comm.intra_rank, False).use()
+
+    device = get_device(comm.intra_rank if use_gpu else None, use_chx)
+    device.use()
+    model.to_device(device)
     optimizer = chainermn.create_multi_node_optimizer(
         chainer.optimizers.Adam(), comm)
     optimizer.setup(model)
@@ -107,16 +108,16 @@ def check_mnist(use_gpu, use_chainerx, display_log=True):
     os.removedirs(path)
 
 
-@pytest.mark.parametrize("use_chainerx", [True, False])
+@pytest.mark.parametrize("use_chx", [True, False])
 @chainer.testing.attr.slow
-def test_mnist(use_chainerx):
-    check_mnist(False, use_chainerx)
+def test_mnist(use_chx):
+    check_mnist(False, use_chx)
 
 
-@pytest.mark.parametrize("use_chainerx", [True, False])
+@pytest.mark.parametrize("use_chx", [True, False])
 @chainer.testing.attr.gpu
-def test_mnist_gpu(use_chainerx):
-    check_mnist(True, use_chainerx)
+def test_mnist_gpu(use_chx):
+    check_mnist(True, use_chx)
 
 
 if __name__ == '__main__':

--- a/tests/chainermn_tests/datasets_tests/test_mnist.py
+++ b/tests/chainermn_tests/datasets_tests/test_mnist.py
@@ -43,7 +43,7 @@ def check_mnist(use_gpu, use_chx, display_log=True):
 
     if use_gpu:
         # Call CuPy's `Device.use()` to force cudaSetDevice()
-        get_device(comm.intra_rank, False).use()
+        chainer.cuda.get_device_from_id(comm.intra_rank).use()
 
     device = get_device(comm.intra_rank if use_gpu else None, use_chx)
     device.use()

--- a/tests/chainermn_tests/datasets_tests/test_scatter.py
+++ b/tests/chainermn_tests/datasets_tests/test_scatter.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from chainer import testing
-import chainer
 import chainermn
 from chainermn.communicators.flat_communicator import FlatCommunicator
 from chainermn.communicators.naive_communicator import NaiveCommunicator

--- a/tests/chainermn_tests/datasets_tests/test_scatter.py
+++ b/tests/chainermn_tests/datasets_tests/test_scatter.py
@@ -41,14 +41,24 @@ class TestDataset(unittest.TestCase):
             joined_dataset = sum((sub_dataset[:]
                                   for sub_dataset in sub_datasets), [])
 
-            # NOTE: values in original_dataset must be int-like type
-            # (i.e. dtype('int64') or dtype('int32')
-            # This is necessary because numpy and cupy/chainerx have
-            # different behaviours on this.
+            # NOTE: The values in `original_dataset` and
+            # `joined_dataset` must be casted to int to compare.
+            # There are 2 backgrounds on this issue.
+            #
+            # (1) numpy and cupy/chainerx have different behaviours on
+            # 1-element array. Numpy implicitly converts a 1-element array to
+            # a scalar value.
             # type(numpy.array([1])[0])
             # =>  <class 'numpy.int64'>  # Scalar
             # type(chainerx.array([1])[0])
             # => <class 'chainerx.ndarray'>  # array of one element
+            #
+            # (2) Two different ChainerX arrays are never identical in the
+            # context of `set()`.
+            # set([chainerx.array([0]), chainerx.array([0])])
+            # => {array([0], shape=(1,), dtype=int64, device='native:0'),
+            #     array([0], shape=(1,), dtype=int64, device='native:0')}
+
             joined_dataset = [int(e) for e in joined_dataset]
             original_dataset = [int(e) for e in original_dataset]
             self.assertEqual(set(joined_dataset), set(original_dataset))

--- a/tests/chainermn_tests/datasets_tests/test_scatter.py
+++ b/tests/chainermn_tests/datasets_tests/test_scatter.py
@@ -58,7 +58,6 @@ class TestDataset(unittest.TestCase):
 
         for shuffle in [True, False]:
             for root in range(self.communicator.size):
-                self.communicator.mpi_comm.barrier()
                 self.check_scatter_dataset([], shuffle, root)
                 self.check_scatter_dataset([0], shuffle, root)
                 self.check_scatter_dataset(list(range(n)), shuffle, root)

--- a/tests/chainermn_tests/datasets_tests/test_scatter.py
+++ b/tests/chainermn_tests/datasets_tests/test_scatter.py
@@ -44,6 +44,12 @@ class TestDataset(unittest.TestCase):
 
             # NOTE: values in original_dataset must be int-like type
             # (i.e. dtype('int64') or dtype('int32')
+            # This is necessary because numpy and cupy/chainerx have
+            # different behaviours on this.
+            # type(numpy.array([1])[0])
+            # =>  <class 'numpy.int64'>  # Scalar
+            # type(chainerx.array([1])[0])
+            # => <class 'chainerx.ndarray'>  # array of one element
             joined_dataset = [int(e) for e in joined_dataset]
             original_dataset = [int(e) for e in original_dataset]
             self.assertEqual(set(joined_dataset), set(original_dataset))

--- a/tests/chainermn_tests/datasets_tests/test_scatter.py
+++ b/tests/chainermn_tests/datasets_tests/test_scatter.py
@@ -10,6 +10,7 @@ import pytest
 import chainermn
 from chainermn.communicators.flat_communicator import FlatCommunicator
 from chainermn.communicators.naive_communicator import NaiveCommunicator
+import chainerx as chx
 
 
 class TestDataset(unittest.TestCase):
@@ -56,6 +57,11 @@ class TestDataset(unittest.TestCase):
                 self.check_scatter_dataset(np.array([0]), shuffle, root)
                 self.check_scatter_dataset(np.arange(n), shuffle, root)
                 self.check_scatter_dataset(np.arange(n * 5 - 1), shuffle, root)
+
+                self.check_scatter_dataset(chx.array([]), shuffle, root)
+                self.check_scatter_dataset(chx.array([0]), shuffle, root)
+                self.check_scatter_dataset(chx.arange(n), shuffle, root)
+                self.check_scatter_dataset(chx.arange(n * 5 - 1), shuffle, root)
 
 
 def scatter_large_data(communicator):

--- a/tests/chainermn_tests/datasets_tests/test_scatter.py
+++ b/tests/chainermn_tests/datasets_tests/test_scatter.py
@@ -68,7 +68,8 @@ class TestDataset(unittest.TestCase):
                 self.check_scatter_dataset(chx.array([]), shuffle, root)
                 self.check_scatter_dataset(chx.array([0]), shuffle, root)
                 self.check_scatter_dataset(chx.arange(n), shuffle, root)
-                self.check_scatter_dataset(chx.arange(n * 5 - 1), shuffle, root)
+                self.check_scatter_dataset(
+                    chx.arange(n * 5 - 1), shuffle, root)
 
 
 def scatter_large_data(communicator):


### PR DESCRIPTION
This PR is a part of #8031. It adds ChainerX tests to `test_emtpy_dataset.py` and `test_scatter.py` that use numpy arrays.

