### PR TITLE
Revert output value check on SoftmaxCrossEntropy

### DIFF
--- a/tests/onnx_chainer_tests/functions_tests/test_loss.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_loss.py
@@ -30,8 +30,5 @@ class TestSoftmaxCrossEntropy(ONNXModelTest):
                                    high=self.in_shape[1]).astype(np.int32)
 
     def test_output(self):
-        # Currently, onnxruntime does not support OneHot node,
-        # so skip output value check
-        self.check_out_values = None
         self.expect(self.model, [self.x, self.t], name=self.name,
                     skip_opset_version=[7, 8])


### PR DESCRIPTION
latest ONNXRuntime supports float type inputs (ref:https://github.com/microsoft/onnxruntime/issues/1537) on OntHot, don't have to skip them.