### PR TITLE
Use different docker image for each base development branch

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -18,6 +18,9 @@ configs {
     time_limit: {
       seconds: 900
     }
+    checkout_strategy {
+      include_dot_git: true
+    }
     environment_variables { key: "GPU" value: "0" }
     environment_variables {
       key: "SPREADSHEET_ID"
@@ -36,6 +39,9 @@ configs {
     }
     time_limit: {
       seconds: 900
+    }
+    checkout_strategy {
+      include_dot_git: true
     }
     environment_variables { key: "GPU" value: "2" }
     # NOTE: If # of threads / # of GPUs exceeds 10, GPU tests may cause
@@ -63,6 +69,9 @@ configs {
     time_limit: {
       seconds: 900
     }
+    checkout_strategy {
+      include_dot_git: true
+    }
     environment_variables { key: "GPU" value: "0" }
     environment_variables {
       key: "SPREADSHEET_ID"
@@ -81,6 +90,9 @@ configs {
     }
     time_limit: {
       seconds: 900
+    }
+    checkout_strategy {
+      include_dot_git: true
     }
     environment_variables { key: "GPU" value: "2" }
     # NOTE: If # of threads / # of GPUs exceeds 10, GPU tests may cause
@@ -112,6 +124,9 @@ configs {
     time_limit: {
       seconds: 3600
     }
+    checkout_strategy {
+      include_dot_git: true
+    }
     command: "bash .pfnci/script.sh docker.py37.test"
   }
 }
@@ -124,6 +139,9 @@ configs {
     }
     time_limit: {
       seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
     }
     command: "bash .pfnci/script.sh docker.py27and35.test"
   }
@@ -138,6 +156,9 @@ configs {
     time_limit: {
       seconds: 3600
     }
+    checkout_strategy {
+      include_dot_git: true
+    }
     command: "bash .pfnci/script.sh docker.py37.push"
   }
 }
@@ -150,6 +171,9 @@ configs {
     }
     time_limit: {
       seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
     }
     command: "bash .pfnci/script.sh docker.py27and35.push"
   }
@@ -273,6 +297,9 @@ configs {
     time_limit: {
       seconds: 1200
     }
+    checkout_strategy {
+      include_dot_git: true
+    }
     command: "bash .pfnci/script.sh chainermn"
   }
 }
@@ -287,6 +314,9 @@ configs {
     }
     time_limit: {
       seconds: 900
+    }
+    checkout_strategy {
+      include_dot_git: true
     }
 	environment_variables { key: "GPU" value: "2" }
     command: "bash .pfnci/script.sh chainermn"

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -163,7 +163,7 @@ is_known_base_branch() {
 # get_base_branch returns the base development branch for the current HEAD.
 get_base_branch() {
   for BASE_BRANCH in master v6; do
-    run git merge-base --is-ancestor "${BASE_BRANCH}" HEAD && echo "${BASE_BRANCH}" && return 0
+    run git merge-base --is-ancestor "origin/${BASE_BRANCH}" HEAD && echo "${BASE_BRANCH}" && return 0
   done
   return 1
 }

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -120,7 +120,7 @@ main() {
 
 # run executes a command.  If DRYRUN is enabled, run just prints the command.
 run() {
-  echo '+' "$@"
+  echo '+' "$@" >&2
   if [ "${DRYRUN:-}" == '' ]; then
     "$@"
   fi

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -36,6 +36,9 @@ main() {
   # Prepare docker args.
   docker_args=(docker run  --rm)
 
+  # Base development branch name.
+  base_branch="$(get_base_branch)"
+
   # Run target-specific commands.
   case "${TARGET}" in
     # Unit tests.
@@ -55,7 +58,7 @@ main() {
         docker_args+=(--env="SPREADSHEET_ID=${SPREADSHEET_ID}")
       fi
       run "${docker_args[@]}" \
-          "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${TARGET}" \
+          "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${TARGET}:${base_branch}" \
           bash /src/.pfnci/run.sh "${TARGET}"
       ;;
     # Docker builds.
@@ -69,6 +72,11 @@ main() {
         echo "Unsupported docker target action: ${action}" >&2
         exit 1
       fi
+      if [ "${action}" = "push" ] && ! is_known_base_branch "${FLEXCI_BRANCH}"; then
+        echo "Branch invalid for docker push: ${FLEXCI_BRANCH}" >&2
+        exit 1
+      fi
+
       # This script can be run in CuPy repository to enable CI to build Chainer
       # base images with a specified CuPy version.  This block enables the
       # script can also be run even in Chainer repository.
@@ -78,15 +86,16 @@ main() {
       if [ ! -d "${cupy_directory}/cupy" ]; then
         if [ ! -d .pfnci/cupy ]; then
           run git clone https://github.com/cupy/cupy.git .pfnci/cupy
+          run git -C .pfnci/cupy checkout "${base_branch}"
         fi
         cupy_directory=.pfnci/cupy
       fi
       run docker build -t \
-          "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${target}" \
+          "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${target}:${base_branch}" \
           -f "$(dirname "${BASH_SOURCE}")/${target}.Dockerfile" \
           "${cupy_directory}"
       if [ "${action}" == 'push' ]; then
-        run docker push "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${target}"
+        run docker push "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${target}:${base_branch}"
       fi
       ;;
 	'chainermn' )
@@ -137,6 +146,26 @@ prepare_docker() {
   fi
   # Configure docker to pull images from gcr.io.
   run gcloud auth configure-docker
+}
+
+# is_known_base_branch returns 0 only if the given branch name is a known
+# base development branch.
+is_known_base_branch() {
+  local branch="${1##refs/heads/}"
+  for BASE_BRANCH in master v6; do
+    if [ "${branch}" = "${BASE_BRANCH}" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# get_base_branch returns the base development branch for the current HEAD.
+get_base_branch() {
+  for BASE_BRANCH in master v6; do
+    run git merge-base --is-ancestor "${BASE_BRANCH}" HEAD && echo "${BASE_BRANCH}" && return 0
+  done
+  return 1
 }
 
 ################################################################################

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -4,7 +4,7 @@
 # this should fall back to CPU testing automatically.  This script requires that
 # a corresponding Docker image is accessible from the machine.
 # TODO(imos): Enable external contributors to test this script on their
-# machines.  Specifically, locate a Dockerfile generating chainer-ci-prep.*.
+# machines.
 #
 # Usage: .pfnci/script.sh [target]
 # - target is a test target (e.g., "py37").


### PR DESCRIPTION
This fixes the issue that CuPy master is used for Chainer v6 tests.

After this got merged, configure CuPy webhook to trigger https://ci.preferred.jp/chainer.docker.py25and35.push/ and https://ci.preferred.jp/chainer.docker.py37.push/ for `v6` branch.