### PR TITLE
[v6] Add missing FlexCI configurations

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -179,25 +179,90 @@ configs {
   }
 }
 
-# Python 2 tests are disabled in the master branch, but configs can be removed
-# only after removing web hooks.
-# TODO(niboshi): Completely remove them after discontinuing v6 series.
 configs {
   key: "chainer.py2.cv"
   value {
-    command: "true"
+    requirement {
+      cpu: 6
+      memory: 36
+      disk: 10
+    }
+    time_limit {
+      seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "git clone https://github.com/chainer/chainercv.git --depth 1 && sh chainercv/.pfnci/tests.sh"
+    environment_variables {
+      key: "REPOSITORY"
+      value: "chainer"
+    }
+    environment_variables {
+      key: "PYTHON"
+      value: "2"
+    }
+    environment_variables {
+      key: "OPTIONAL_MODULES"
+      value: "1"
+    }
   }
 }
 configs {
   key: "chainer.py2.cv.gpu"
   value {
-    command: "true"
+    requirement {
+      cpu: 4
+      memory: 24
+      gpu: 1
+      disk: 10
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "git clone https://github.com/chainer/chainercv.git --depth 1 && sh chainercv/.pfnci/tests_gpu.sh"
+    environment_variables {
+      key: "REPOSITORY"
+      value: "chainer"
+    }
+    environment_variables {
+      key: "PYTHON"
+      value: "2"
+    }
+    environment_variables {
+      key: "OPTIONAL_MODULES"
+      value: "1"
+    }
   }
 }
 configs {
   key: "chainer.py2.cv.examples"
   value {
-    command: "true"
+    requirement {
+      cpu: 6
+      memory: 36
+      gpu: 2
+      disk: 10
+    }
+    time_limit {
+      seconds: 1800
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "git clone https://github.com/chainer/chainercv.git --depth 1 && sh chainercv/.pfnci/examples_tests.sh"
+    environment_variables {
+      key: "REPOSITORY"
+      value: "chainer"
+    }
+    environment_variables {
+      key: "PYTHON"
+      value: "2"
+    }
+    environment_variables {
+      key: "OPTIONAL_MODULES"
+      value: "1"
+    }
   }
 }
 configs {
@@ -333,5 +398,49 @@ configs {
 	  seconds: 7200
 	}
 	command: "bash .pfnci/chainermn-ci-prep.sh chainermn-ci-prep-cuda92 9.2-cudnn7-devel"
+  }
+}
+
+# ONNX-Chainer is unavailable in v6.
+configs {
+  key: "onnxchainer.py37.gpu"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "onnxchainer.py37.cpu"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "onnxchainer.py37.cpu.onnx15"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "onnxchainer.py36.cpu"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "onnxchainer.py36.cpu.onnx14"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "onnxchainer.py35.cpu"
+  value {
+    command: "true"
+  }
+}
+configs {
+  key: "onnxchainer.win.py37.gpu"
+  value {
+    command: "true"
   }
 }


### PR DESCRIPTION
* Copy configuration from master branch.
* Activate `chainer.py2.cv`, `chainer.py2.cv.gpu`, `chainer.py2.cv.examples` configurations (copy configuration from the default config) and enable `include_dot_git` for https://github.com/chainer/chainercv/pull/935 .
* Disable onnx-chainer related tests to avoid invoking them in v6.

See also: https://github.com/cupy/cupy/pull/2591