### PR TITLE
Fast `IndexIterator` for CUDA

### DIFF
--- a/tests/chainerx_tests/unit_tests/test_array_index.py
+++ b/tests/chainerx_tests/unit_tests/test_array_index.py
@@ -6,6 +6,29 @@ def test_newaxis():
     assert chainerx.newaxis is None
 
 
+@pytest.mark.parametrize('xp', [chainerx])
+@pytest.mark.parametrize_device(['native:0', 'cuda:0'])
+@pytest.mark.parametrize('shape, transpose', [
+    ((1,), None),
+    ((2,), None),
+    ((2, 3), None),
+    ((2, 3, 4), None),
+    ((2, 3, 4, 5), None),
+    ((2, 3, 4, 5, 6), None),
+    ((2, 3), (0, 1)),
+    ((2, 3, 4), (0, 2)),
+    ((2, 3, 4, 5), (0, 2)),
+    ((2, 3, 4, 5, 6), (1, 3)),
+])
+def test_array_indexing(xp, device, shape, transpose):
+    a = xp.zeros(shape=shape, dtype=chainerx.int8, device=device)
+    if transpose:
+        a = a.swapaxes(*transpose)
+        assert not a.is_contiguous
+    a += 1
+    assert a.sum() == a.size
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize('xp', [chainerx])
 @pytest.mark.parametrize_device(['cuda:0'])
@@ -13,7 +36,7 @@ def test_newaxis():
     (64, 32, 6*1024*4),  # Less than 2^32 elems
     (64, 32, 6*1024*512),  # More than 2^32 elems
 ])
-def test_array_contiguous_indexing(xp, device, shape):
+def test_large_array_contiguous_indexing(xp, device, shape):
     try:
         a = xp.zeros(shape=shape, dtype=chainerx.int8, device=device)
     except chainerx.ChainerxError as ex:
@@ -31,7 +54,7 @@ def test_array_contiguous_indexing(xp, device, shape):
     (64, 32, 6*1024*4),  # Less than 2^32 elems
     (64, 32, 6*1024*512)  # More than 2^32 elems
 ])
-def test_array_noncontiguous_indexing(xp, device, shape):
+def test_large_array_noncontiguous_indexing(xp, device, shape):
     try:
         a = xp.zeros(shape=shape, dtype=chainerx.int8, device=device)
     except chainerx.ChainerxError as ex:


### PR DESCRIPTION
Thanks to @asi1024 @shinh 

ChainerX indexer used pretty expensive int64 division and modulo operations when calculating array indexes on CUDA.

This was noticeable when arrays were not contiguous, severely affecting the execution time of even simple kernels as `ElementWise` ones.

This PR replaces the code for index calculation with the same one as Cupy.

In the following test time for chainerx is reduced from 0.70 secs to 0.27
```python
import numpy as np
import cupy
import chainer
import chainerx as chx
import time

def test_bench(name, xp, alloc_fn):
    np.random.seed(42)
    x = np.random.rand(800,389,2,66).astype(np.float32)
    y = np.random.rand(800,389,2,66).astype(np.float32)
    a = alloc_fn(x)
    b = alloc_fn(y)
    a = np.swapaxes(a, 2, 3)
    b = np.swapaxes(b, 2, 3)

    for i in range(1):
        cuda = xp.multiply(a,b)

    cupy.cuda.device.Device().synchronize()
    start = time.time()
    for i in range(400):
        cuda = xp.multiply(a,b)
    cupy.cuda.device.Device().synchronize()
    total = time.time() - start
    print(name, total)

test_bench('cupy', cupy, lambda x: cupy.array(x))
test_bench('chainerx', chx, lambda x: chx.array(x, device='cuda:0'))
```