### PR TITLE
Use xpytest to parallelize tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
       env:
       - CHAINER_TRAVIS_TEST="chainer"
       - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+      - GOROOT=$HOME/go
       if: type in (pull_request)
 
     - name: "macOS Py35 | chainer, chainermn, chainerx, docs"
@@ -37,6 +38,7 @@ matrix:
       - PYTHON_VERSION=3.5.1
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
+      - GOROOT=/usr/local/opt/go/libexec
       if: (branch = master OR branch = v6) AND (NOT type in (pull_request))
 
 before_install:

--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -44,20 +44,38 @@ step_install_chainer_test_deps() {
         pillow
     )
     pip install "${reqs[@]}"
+
+    git clone --depth=1 https://github.com/chainer/xpytest.git $WORK_DIR/xpytest_repo
+    pushd $WORK_DIR/xpytest_repo
+    $GOROOT/bin/go version
+    $GOROOT/bin/go build -o $WORK_DIR/xpytest ./cmd/xpytest
+    popd
 }
 
 
 step_before_install_chainer_test() {
     # Remove oclint as it conflicts with GCC (indirect dependency of hdf5)
-    if [[ $TRAVIS_OS_NAME = "osx" ]]; then
-        brew outdated pyenv || brew upgrade pyenv
+    case "$TRAVIS_OS_NAME" in
+        linux)
+            # install golang to $HOME/go
+            wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
+            tar -C $HOME -xzf go1.13.3.linux-amd64.tar.gz
+            ;;
+        osx)
+            brew outdated pyenv || brew upgrade pyenv
 
-        PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION
-        pyenv global $PYTHON_VERSION
-        python --version
+            PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION
+            pyenv global $PYTHON_VERSION
+            python --version
 
-        brew install hdf5
-    fi
+            brew install hdf5
+
+            brew outdated go || brew upgrade go
+            ;;
+        *)
+            false
+            ;;
+    esac
 }
 
 step_before_install_chainermn_test_deps() {
@@ -146,6 +164,7 @@ step_chainer_install_from_sdist() {
 
 
 step_chainer_tests() {
+    pushd $WORK_DIR
     local mark="not slow and not gpu and not cudnn and not ideep"
 
     # On Windows theano fails to import
@@ -156,13 +175,20 @@ step_chainer_tests() {
     # In Travis CI only pairwise testing is performed.
     env CHAINER_TEST_PAIRWISE_PARAMETERIZATION=always \
         pytest -rfEX -m "$mark" "$REPO_DIR"/tests/chainer_tests
+    popd
 }
 
 
 step_chainerx_python_tests() {
+    pushd $WORK_DIR
     # In Travis CI only pairwise testing is performed.
     env CHAINER_TEST_PAIRWISE_PARAMETERIZATION=always \
-        pytest -rfEX "$REPO_DIR"/tests/chainerx_tests
+        OMP_NUM_THREADS=1 \
+        PYTEST_ADDOPTS="-rfEX" \
+        $WORK_DIR/xpytest --retry=1 --thread=2 \
+        --hint="$REPO_DIR"/scripts/ci/travis/xpytest-hint-chainerx.pbtxt \
+        $(find "$REPO_DIR"/tests/chainerx_tests -name "test_*.py")
+    popd
 }
 
 

--- a/scripts/ci/travis/xpytest-hint-chainerx.pbtxt
+++ b/scripts/ci/travis/xpytest-hint-chainerx.pbtxt
@@ -1,0 +1,20 @@
+# hint.pbtxt is a config file for xpytest.
+#
+# Proto type: xpytest.proto.HintFile
+# https://github.com/chainer/xpytest/blob/master/proto/test_case.proto
+
+# Slow tests take 240+ seconds.
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_indexing.py" deadline: 720 }
+
+# Slow tests take 120+ seconds.
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_arithmetic.py" deadline: 480 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_connection.py" deadline: 480 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_manipulation.py" deadline: 480 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_rnn.py" deadline: 480 }
+
+# Slow tests take 60+ seconds.
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_creation.py" deadline: 240 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_logic.py" deadline: 240 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_misc.py" deadline: 240 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_normalization.py" deadline: 240 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_reduction.py" deadline: 240 }


### PR DESCRIPTION
- Not applied to `chainer_test` because of an overhead.  Imports are not cached among files by `xpytest`.  The number of test files in `chainerx_test` is small.
- It seems Travis CI has 2 cores, but NumPy-heavy tests did not speed up by the condition: `--thread=2` and `OMP_NUM_THREADS=1`.
- Manual installation/upgrade is required because `xpytest` requires golang version >= 1.12, while Travis provides 1.11 unless the project is golang.
- See #8082 for the attempt with `pytest-xdist`.