### PR TITLE
Remove host-side branch on `F.accuracy` with `ignore_label`

### DIFF
--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -45,10 +45,9 @@ class Accuracy(function.Function):
             count = (pred == t).sum() - ignore_cnt
             total = t.size - ignore_cnt
 
-            if total == 0:
-                return xp.asarray(0.0, dtype=y.dtype),
-            else:
-                return xp.asarray(float(count) / total, dtype=y.dtype),
+            return xp.where(total == 0,
+                            xp.asarray(0.0, dtype=y.dtype),
+                            xp.asarray(count / total, dtype=y.dtype)),
         else:
             pred = y.argmax(axis=1).reshape(t.shape)
             return xp.asarray((pred == t).mean(dtype=y.dtype)),

--- a/chainer/functions/evaluation/accuracy.py
+++ b/chainer/functions/evaluation/accuracy.py
@@ -1,3 +1,4 @@
+import numpy
 import six
 
 from chainer import backend
@@ -45,9 +46,16 @@ class Accuracy(function.Function):
             count = (pred == t).sum() - ignore_cnt
             total = t.size - ignore_cnt
 
-            return xp.where(total == 0,
-                            xp.asarray(0.0, dtype=y.dtype),
-                            xp.asarray(count / total, dtype=y.dtype)),
+            if xp is numpy:
+                # Avoid warning of `divide by zero`
+                if total == 0:
+                    return xp.asarray(0.0, dtype=y.dtype),
+                else:
+                    return xp.asarray(float(count) / total, dtype=y.dtype),
+            else:
+                return xp.where(total == 0,
+                                xp.asarray(0.0, dtype=y.dtype),
+                                xp.asarray(count / total, dtype=y.dtype)),
         else:
             pred = y.argmax(axis=1).reshape(t.shape)
             return xp.asarray((pred == t).mean(dtype=y.dtype)),


### PR DESCRIPTION
Current F.accuracy with `ignore_label` implementation requires host-side branch `if total == 0`.
This causes unnecessary sync between forward and backward computation.

By this PR, we can avoid this synchronization so it can accelerate CPU-intensive model training (i.e. Mixed-precision training)
I've tried the Advanced Indexing feature, but it cannot help.