### PR TITLE
[backport] Fix `optimizer_hooks.GradientHardClipping` for scalar array

### DIFF
--- a/chainer/optimizer_hooks/gradient_hard_clipping.py
+++ b/chainer/optimizer_hooks/gradient_hard_clipping.py
@@ -52,7 +52,7 @@ class GradientHardClipping(object):
             # supports kwarg `out`.
             if xp == backend.chainerx \
                     or isinstance(param.grad, backend.intel64.mdarray):
-                grad[:] = grad.clip(self.lower_bound, self.upper_bound)
+                grad[...] = grad.clip(self.lower_bound, self.upper_bound)
             else:
                 # Save on new object allocation when using numpy and cupy
                 # using kwarg `out`


### PR DESCRIPTION
Backport of #7760

It only does the relevant change to the hard clipping hook but leaves out the test refactoring.
I can include it if needed.

merge after #8377 