### PR TITLE
C++ cosmetic fixes

### DIFF
--- a/chainerx_cc/chainerx/array.h
+++ b/chainerx_cc/chainerx/array.h
@@ -235,7 +235,7 @@ public:
     // Creates a copy or a view. It will be disconnected from the specified graphs.
     // If `kind` is `CopyKind::kCopy`, the returned array will be always C-contiguous.
     Array AsGradStopped(absl::Span<const BackpropId> backprop_ids, CopyKind kind = CopyKind::kView) const;
-    Array AsGradStopped(std::initializer_list<const BackpropId> backprop_ids, CopyKind kind = CopyKind::kView) const {
+    Array AsGradStopped(std::initializer_list<BackpropId> backprop_ids, CopyKind kind = CopyKind::kView) const {
         return AsGradStopped(absl::MakeConstSpan(backprop_ids.begin(), backprop_ids.end()), kind);
     }
 

--- a/chainerx_cc/chainerx/backward.cc
+++ b/chainerx_cc/chainerx/backward.cc
@@ -202,7 +202,7 @@ public:
             DoubleBackpropOption double_backprop,
             std::unordered_map<ArrayNode*, internal::GradRef> array_node_grad_map,
             bool retain_grad,
-            const absl::optional<float>& loss_scale)
+            absl::optional<float> loss_scale)
         : inputs_{inputs},
           outputs_{outputs},
           backprop_id_{backprop_id},
@@ -240,7 +240,7 @@ public:
             const std::vector<ConstArrayRef>& outputs,
             const BackpropId& backprop_id,
             DoubleBackpropOption double_backprop,
-            const absl::optional<float>& loss_scale)
+            absl::optional<float> loss_scale)
         : BackwardImpl{inputs, outputs, backprop_id, double_backprop, {}, false, loss_scale} {}
 
     void Run() {
@@ -597,7 +597,7 @@ private:
     bool retain_grad_;
 
     // To apply the loss scale while going backward
-    const absl::optional<float>& loss_scale_;
+    absl::optional<float> loss_scale_;
 
     std::unordered_set<internal::GradRef*> to_scale_back_nodes_;
 };
@@ -608,7 +608,7 @@ void Backward(
         const Array& output,
         const absl::optional<BackpropId>& backprop_id,
         DoubleBackpropOption double_backprop,
-        const absl::optional<float>& loss_scale) {
+        absl::optional<float> loss_scale) {
     BackpropId actual_backprop_id = internal::GetArrayBackpropId(output, backprop_id);
     std::vector<ConstArrayRef> outputs{output};  // Do not inline it; we need to guarantee that the vector is alive until Run() finishes.
     BackwardImpl{{}, outputs, actual_backprop_id, double_backprop, loss_scale}.Run();
@@ -618,7 +618,7 @@ void Backward(
         const std::vector<ConstArrayRef>& outputs,
         const absl::optional<BackpropId>& backprop_id,
         DoubleBackpropOption double_backprop,
-        const absl::optional<float>& loss_scale) {
+        absl::optional<float> loss_scale) {
     if (outputs.empty()) {
         return;
     }
@@ -634,7 +634,7 @@ std::vector<absl::optional<Array>> Grad(
         bool set_grad,
         bool retain_grad,
         const std::vector<ConstArrayRef>& grad_outputs,
-        const absl::optional<float>& loss_scale) {
+        absl::optional<float> loss_scale) {
     if (inputs.empty()) {
         return {};
     }

--- a/chainerx_cc/chainerx/backward.h
+++ b/chainerx_cc/chainerx/backward.h
@@ -35,7 +35,7 @@ void Backward(
         const Array& output,
         const absl::optional<BackpropId>& backprop_id = absl::nullopt,
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable,
-        const absl::optional<float>& loss_scale = absl::nullopt);
+        absl::optional<float> loss_scale = absl::nullopt);
 
 // Updates the gradients held by the input arrays using backpropagation.
 //
@@ -44,7 +44,7 @@ void Backward(
         const std::vector<ConstArrayRef>& outputs,
         const absl::optional<BackpropId>& backprop_id = absl::nullopt,
         DoubleBackpropOption double_backprop = DoubleBackpropOption::kDisable,
-        const absl::optional<float>& loss_scale = absl::nullopt);
+        absl::optional<float> loss_scale = absl::nullopt);
 
 // Returns gradient arrays for all inputs.
 std::vector<absl::optional<Array>> Grad(
@@ -55,6 +55,6 @@ std::vector<absl::optional<Array>> Grad(
         bool set_grad = false,
         bool retain_grad = false,
         const std::vector<ConstArrayRef>& grad_outputs = {},
-        const absl::optional<float>& loss_scale = absl::nullopt);
+        absl::optional<float> loss_scale = absl::nullopt);
 
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/python/array.cc
+++ b/chainerx_cc/chainerx/python/array.cc
@@ -151,7 +151,7 @@ ArrayBodyPtr MakeArray(py::handle object, py::handle dtype, bool copy, py::handl
     return MakeArray(object, dtype_, copy, dev);
 }
 
-ArrayBodyPtr MakeArray(py::handle object, const absl::optional<Dtype>& dtype, bool copy, Device& device) {
+ArrayBodyPtr MakeArray(py::handle object, absl::optional<Dtype> dtype, bool copy, Device& device) {
     // object is chainerx.ndarray
     if (py::isinstance<ArrayBody>(object)) {
         Array a = Array{py::cast<ArrayBodyPtr>(object)};
@@ -247,7 +247,7 @@ void InitChainerxArrayConversion(pybind11::module& m, py::class_<ArrayBody, Arra
 
 void InitChainerxArrayManipulation(py::class_<ArrayBody, ArrayBodyPtr>& c) {
     c.def("take",
-          [](const ArrayBodyPtr& self, py::handle indices, const absl::optional<int8_t>& axis, absl::optional<std::string>& mode) {
+          [](const ArrayBodyPtr& self, py::handle indices, absl::optional<int8_t> axis, absl::optional<std::string>& mode) {
               if (!axis.has_value()) {
                   throw NotImplementedError{"axis=None is not yet supported for chainerx.ndarray.take."};
               }
@@ -599,10 +599,10 @@ void InitChainerxArrayCalculation(py::class_<ArrayBody, ArrayBodyPtr>& c) {
           "axis"_a = nullptr,
           "keepdims"_a = false);
     c.def("argmax",
-          [](const ArrayBodyPtr& self, const absl::optional<int8_t>& axis) { return MoveArrayBody(ArgMax(Array{self}, ToAxes(axis))); },
+          [](const ArrayBodyPtr& self, absl::optional<int8_t> axis) { return MoveArrayBody(ArgMax(Array{self}, ToAxes(axis))); },
           "axis"_a = nullptr);
     c.def("argmin",
-          [](const ArrayBodyPtr& self, const absl::optional<int8_t>& axis) { return MoveArrayBody(ArgMin(Array{self}, ToAxes(axis))); },
+          [](const ArrayBodyPtr& self, absl::optional<int8_t> axis) { return MoveArrayBody(ArgMin(Array{self}, ToAxes(axis))); },
           "axis"_a = nullptr);
 }
 
@@ -659,7 +659,7 @@ void InitChainerxArraySpecial(pybind11::module& m, py::class_<ArrayBody, ArrayBo
           [](const ArrayBodyPtr& self,
              const absl::optional<BackpropId>& backprop_id,
              bool enable_double_backprop,
-             const absl::optional<float>& loss_scale) {
+             absl::optional<float> loss_scale) {
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
               Backward(Array{self}, backprop_id, double_backprop, loss_scale);
           },

--- a/chainerx_cc/chainerx/python/array.h
+++ b/chainerx_cc/chainerx/python/array.h
@@ -30,7 +30,7 @@ using ConstArrayBodyPtr = std::shared_ptr<const ArrayBody>;
 
 ArrayBodyPtr MakeArray(pybind11::handle object, pybind11::handle dtype, bool copy, pybind11::handle device);
 
-ArrayBodyPtr MakeArray(pybind11::handle object, const absl::optional<Dtype>& dtype, bool copy, Device& device);
+ArrayBodyPtr MakeArray(pybind11::handle object, absl::optional<Dtype> dtype, bool copy, Device& device);
 
 pybind11::tuple ToTuple(const std::vector<Array>& ary);
 

--- a/chainerx_cc/chainerx/python/axes.h
+++ b/chainerx_cc/chainerx/python/axes.h
@@ -21,7 +21,7 @@ inline OptionalAxes ToAxes(const absl::optional<std::vector<int8_t>>& vec) {
     return absl::nullopt;
 }
 
-inline OptionalAxes ToAxes(const absl::optional<int8_t>& vec) {
+inline OptionalAxes ToAxes(absl::optional<int8_t> vec) {
     if (vec.has_value()) {
         return Axes{*vec};
     }

--- a/chainerx_cc/chainerx/python/backward.cc
+++ b/chainerx_cc/chainerx/python/backward.cc
@@ -42,7 +42,7 @@ void InitChainerxBackward(pybind11::module& m) {
           [](const ArrayBodyPtr& body,
              const absl::optional<BackpropId>& backprop_id,
              bool enable_double_backprop,
-             const absl::optional<float>& loss_scale) {
+             absl::optional<float> loss_scale) {
               Array array{body};
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
               Backward(array, backprop_id, double_backprop, loss_scale);
@@ -56,7 +56,7 @@ void InitChainerxBackward(pybind11::module& m) {
           [](const std::vector<ArrayBodyPtr>& outputs,
              const absl::optional<BackpropId>& backprop_id,
              bool enable_double_backprop,
-             const absl::optional<float>& loss_scale) {
+             absl::optional<float> loss_scale) {
               std::vector<Array> arrays = ConvertToArrays(outputs);
               auto double_backprop = enable_double_backprop ? DoubleBackpropOption::kEnable : DoubleBackpropOption::kDisable;
               Backward({arrays.begin(), arrays.end()}, backprop_id, double_backprop, loss_scale);
@@ -74,7 +74,7 @@ void InitChainerxBackward(pybind11::module& m) {
              bool set_grad,
              bool retain_grad,
              const std::vector<ArrayBodyPtr>& grad_outputs,
-             const absl::optional<float>& loss_scale) {
+             absl::optional<float> loss_scale) {
               std::vector<Array> output_arrays = ConvertToArrays(outputs);
               std::vector<Array> input_arrays = ConvertToArrays(inputs);
 

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -217,8 +217,8 @@ void InitChainerxCreation(pybind11::module& m) {
           "device"_a = nullptr);
     m.def("arange",
           [](Scalar start_or_stop,
-             const absl::optional<Scalar>& maybe_stop,
-             const absl::optional<Scalar>& maybe_step,
+             absl::optional<Scalar> maybe_stop,
+             absl::optional<Scalar> maybe_step,
              py::handle dtype,
              py::handle device) {
               DtypeKind start_or_stop_dtype_kind = start_or_stop.kind();
@@ -335,7 +335,7 @@ void InitChainerxCreation(pybind11::module& m) {
 void InitChainerxEvaluation(pybind11::module& m) {
     // evaluation routines
     m.def("accuracy",
-          [](const ArrayBodyPtr& y, const ArrayBodyPtr& t, const absl::optional<int64_t>& ignore_label) {
+          [](const ArrayBodyPtr& y, const ArrayBodyPtr& t, absl::optional<int64_t> ignore_label) {
               return MoveArrayBody(Accuracy(Array{y}, Array{t}, ignore_label));
           },
           "y"_a,
@@ -346,7 +346,7 @@ void InitChainerxEvaluation(pybind11::module& m) {
 void InitChainerxIndexing(pybind11::module& m) {
     // indexing routines
     m.def("take",
-          [](const ArrayBodyPtr& a, py::handle indices, const absl::optional<int8_t>& axis, const absl::optional<std::string>& mode) {
+          [](const ArrayBodyPtr& a, py::handle indices, absl::optional<int8_t> axis, const absl::optional<std::string>& mode) {
               if (!axis.has_value()) {
                   throw NotImplementedError{"axis=None is not yet supported for chainerx.take."};
               }
@@ -1023,7 +1023,7 @@ void InitChainerxReduction(pybind11::module& m) {
           "x"_a,
           "axis"_a = nullptr);
     m.def("cumsum",
-          [](const ArrayBodyPtr& a, const absl::optional<int8_t>& axis) { return MoveArrayBody(Cumsum(Array{a}, axis)); },
+          [](const ArrayBodyPtr& a, absl::optional<int8_t> axis) { return MoveArrayBody(Cumsum(Array{a}, axis)); },
           "a"_a,
           "axis"_a = nullptr);
     m.def("nansum",
@@ -1073,11 +1073,11 @@ void InitChainerxTrigonometric(pybind11::module& m) {
 void InitChainerxSorting(pybind11::module& m) {
     // sorting routines
     m.def("argmax",
-          [](const ArrayBodyPtr& a, const absl::optional<int8_t>& axis) { return MoveArrayBody(ArgMax(Array{a}, ToAxes(axis))); },
+          [](const ArrayBodyPtr& a, absl::optional<int8_t> axis) { return MoveArrayBody(ArgMax(Array{a}, ToAxes(axis))); },
           "a"_a,
           "axis"_a = nullptr);
     m.def("argmin",
-          [](const ArrayBodyPtr& a, const absl::optional<int8_t>& axis) { return MoveArrayBody(ArgMin(Array{a}, ToAxes(axis))); },
+          [](const ArrayBodyPtr& a, absl::optional<int8_t> axis) { return MoveArrayBody(ArgMin(Array{a}, ToAxes(axis))); },
           "a"_a,
           "axis"_a = nullptr);
     m.def("count_nonzero",
@@ -1091,11 +1091,11 @@ void InitChainerxSorting(pybind11::module& m) {
           "a"_a,
           "axis"_a = nullptr);
     m.def("nanargmax",
-          [](const ArrayBodyPtr& a, const absl::optional<int8_t>& axis) { return MoveArrayBody(NanArgMax(Array{a}, ToAxes(axis))); },
+          [](const ArrayBodyPtr& a, absl::optional<int8_t> axis) { return MoveArrayBody(NanArgMax(Array{a}, ToAxes(axis))); },
           "a"_a,
           "axis"_a = nullptr);
     m.def("nanargmin",
-          [](const ArrayBodyPtr& a, const absl::optional<int8_t>& axis) { return MoveArrayBody(NanArgMin(Array{a}, ToAxes(axis))); },
+          [](const ArrayBodyPtr& a, absl::optional<int8_t> axis) { return MoveArrayBody(NanArgMin(Array{a}, ToAxes(axis))); },
           "a"_a,
           "axis"_a = nullptr);
 }

--- a/chainerx_cc/chainerx/routines/creation.cc
+++ b/chainerx_cc/chainerx/routines/creation.cc
@@ -239,7 +239,7 @@ Array AsContiguous(const Array& a, Dtype dtype) {
     return out;
 }
 
-Array AsContiguousArray(const Array& a, const absl::optional<Dtype>& dtype) {
+Array AsContiguousArray(const Array& a, absl::optional<Dtype> dtype) {
     Dtype src_dt = a.dtype();
     Dtype dt = dtype.value_or(src_dt);
 
@@ -310,8 +310,7 @@ Array Diagflat(const Array& v, int64_t k) {
 }
 
 // Creates a 1-d array with evenly spaced numbers.
-Array Linspace(
-        Scalar start, Scalar stop, const absl::optional<int64_t>& num, bool endpoint, const absl::optional<Dtype>& dtype, Device& device) {
+Array Linspace(Scalar start, Scalar stop, absl::optional<int64_t> num, bool endpoint, absl::optional<Dtype> dtype, Device& device) {
     static const int64_t kDefaultNum = 50;
 
     // Always default to float type.

--- a/chainerx_cc/chainerx/routines/creation.h
+++ b/chainerx_cc/chainerx/routines/creation.h
@@ -96,7 +96,7 @@ inline Array AsContiguous(const Array& a) { return AsContiguous(a, a.dtype()); }
 
 // Returns a C-contiguous array.
 // An input array with shape {} results in a new array with shape {1}.
-Array AsContiguousArray(const Array& a, const absl::optional<Dtype>& dtype = absl::nullopt);
+Array AsContiguousArray(const Array& a, absl::optional<Dtype> dtype = absl::nullopt);
 
 Array Diag(const Array& v, int64_t k = 0);
 
@@ -106,9 +106,9 @@ Array Diagflat(const Array& v, int64_t k = 0);
 Array Linspace(
         Scalar start,
         Scalar stop,
-        const absl::optional<int64_t>& num = absl::nullopt,
+        absl::optional<int64_t> num = absl::nullopt,
         bool endpoint = true,
-        const absl::optional<Dtype>& dtype = absl::nullopt,
+        absl::optional<Dtype> dtype = absl::nullopt,
         Device& device = GetDefaultDevice());
 
 enum class MeshgridIndexingMode { kCartesian, kMatrix };

--- a/chainerx_cc/chainerx/routines/evaluation.cc
+++ b/chainerx_cc/chainerx/routines/evaluation.cc
@@ -21,7 +21,7 @@
 
 namespace chainerx {
 
-Array Accuracy(const Array& y, const Array& t, const absl::optional<int64_t>& ignore_label) {
+Array Accuracy(const Array& y, const Array& t, absl::optional<int64_t> ignore_label) {
     if (GetKind(y.dtype()) != DtypeKind::kFloat) {
         throw DtypeError{"y must be of float type."};
     }

--- a/chainerx_cc/chainerx/routines/evaluation.h
+++ b/chainerx_cc/chainerx/routines/evaluation.h
@@ -8,6 +8,6 @@
 
 namespace chainerx {
 
-Array Accuracy(const Array& y, const Array& t, const absl::optional<int64_t>& ignore_label);
+Array Accuracy(const Array& y, const Array& t, absl::optional<int64_t> ignore_label);
 
 }  // namespace chainerx

--- a/chainerx_cc/chainerx/slice.h
+++ b/chainerx_cc/chainerx/slice.h
@@ -12,7 +12,7 @@ namespace chainerx {
 
 class Slice {
 public:
-    Slice(absl::optional<int64_t> start, absl::optional<int64_t> stop, const absl::optional<int64_t>& step)
+    Slice(absl::optional<int64_t> start, absl::optional<int64_t> stop, absl::optional<int64_t> step)
         : start_{start}, stop_{stop}, step_{step.value_or(1)} {
         if (step_ == 0) {
             throw DimensionError{"Step must not be zero."};
@@ -22,9 +22,9 @@ public:
     explicit Slice(int64_t stop) : Slice{0, stop, 1} {}
     Slice(int64_t start, int64_t stop) : Slice{start, stop, 1} {}
 
-    const absl::optional<int64_t>& start() const { return start_; }
+    absl::optional<int64_t> start() const { return start_; }
 
-    const absl::optional<int64_t>& stop() const { return stop_; }
+    absl::optional<int64_t> stop() const { return stop_; }
 
     int64_t step() const { return step_; }
 


### PR DESCRIPTION
* Member type of `std::initializer_list` does not have to be `const`.
* `absl::optional` of lightweight types should be passed by value.