### PR TITLE
Remove typing requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,7 @@ set CHAINER_PYTHON_350_FORCE environment variable to 1."""
 requirements = {
     'install': [
         'setuptools',
-        # typing==3.7.4 causes error "TypeError: Instance and class checks can
-        # only be used with @runtime_checkable protocols" only with Python 2.
-        # https://github.com/chainer/chainer/pull/7562
-        'typing' + ('<=3.6.6' if sys.version_info[0] <= 2 else ''),
-        'typing_extensions' + ('<=3.6.6' if sys.version_info[0] <= 2 else ''),
+        'typing_extensions',
         'filelock',
         'numpy>=1.9.0',
         'protobuf>=3.0.0',


### PR DESCRIPTION
Was packaging this for nixpkgs and noticed some odd import behaviors.

`typing` package is a backport and doesn't need to be imported for python>=3.5

see https://github.com/python/typing/issues/573
