### PR TITLE
Add chainerx test in observation_aggregator

### DIFF
--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -49,8 +49,8 @@ class ObservationAggregator(extension.Extension):
                 value.to_device("native")
             elif isinstance(value, chx.ndarray) and \
                     not value.device.name.startswith('native'):
-                raise ValueError(
-                    "observation aggregator does not support ChainerX ndarray")
+                raise ValueError("observation aggregator does not support "
+                                 "ChainerX ndarray on CUDA device.")
             self.observation_history.append(value)
 
         if not self.comm_trigger(trainer):

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -1,6 +1,7 @@
 from __future__ import division
 from chainer.training import extension, util
 from chainer import Variable
+import chainerx as chx
 
 
 class ObservationAggregator(extension.Extension):
@@ -37,7 +38,6 @@ class ObservationAggregator(extension.Extension):
 
         self.comm_trigger = util.get_trigger(comm_trigger)
         self.observation_history = []
-
         self.aggregator = aggregator or _average_2d
 
     def compute_summary(self, trainer):
@@ -47,6 +47,8 @@ class ObservationAggregator(extension.Extension):
                 # use to native device as ChainerX array cannot
                 # be converted to numpy directly, which is what `to_cpu()` does
                 value.to_device("native")
+            elif isinstance(value, chx.ndarray) and not value.device.name.startswith('native'):
+                raise ValueError("observation aggregator does not support ChainerX ndarray")
             self.observation_history.append(value)
 
         if not self.comm_trigger(trainer):
@@ -66,7 +68,6 @@ class ObservationAggregator(extension.Extension):
 
     def __call__(self, trainer):
         summary = self.compute_summary(trainer)
-
         if summary is not None:
             trainer.observation[self.aggregated_key] = summary
 

--- a/chainermn/extensions/observation_aggregator.py
+++ b/chainermn/extensions/observation_aggregator.py
@@ -47,8 +47,10 @@ class ObservationAggregator(extension.Extension):
                 # use to native device as ChainerX array cannot
                 # be converted to numpy directly, which is what `to_cpu()` does
                 value.to_device("native")
-            elif isinstance(value, chx.ndarray) and not value.device.name.startswith('native'):
-                raise ValueError("observation aggregator does not support ChainerX ndarray")
+            elif isinstance(value, chx.ndarray) and \
+                    not value.device.name.startswith('native'):
+                raise ValueError(
+                    "observation aggregator does not support ChainerX ndarray")
             self.observation_history.append(value)
 
         if not self.comm_trigger(trainer):

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -106,17 +106,17 @@ def run_test_observation_aggregator(comm, xp,
 
     @extension.make_extension(
         trigger=(1, 'iteration'), priority=extension.PRIORITY_WRITER)
-    def rank_reporter(trainer):
+    def rank_reporter(trainer_):
         tmp = xp.asarray(comm.rank, dtype=np.float32)
         if use_chainer_variable:
             tmp = chainer.Variable(tmp)
-        trainer.observation['rank'] = tmp
+        trainer_.observation['rank'] = tmp
 
     @extension.make_extension(
         trigger=(communicate_interval, 'iteration'),
         priority=extension.PRIORITY_READER)
-    def aggregated_rank_checker(trainer):
-        actual = trainer.observation['rank-aggregated']
+    def aggregated_rank_checker(trainer_):
+        actual = trainer_.observation['rank-aggregated']
         if use_chainer_variable:
             actual = actual.data
         expected = (comm.size - 1) / 2

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -84,7 +84,6 @@ def run_test_observation_aggregator(comm, xp,
         chainer.cuda.get_device_from_id(comm.intra_rank).use()
 
     device = get_device(comm.intra_rank if use_gpu else None, xp == chainerx)
-    device.use()
 
     if xp == chainerx:
         train = xp.array(np.random.rand(10, 1).astype(np.float32))

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -58,7 +58,6 @@ def test_observation_aggregator_gpu_chainerx(use_chainer_variable,
                                                 use_chainer_variable,
                                                 communicate_interval,
                                                 use_gpu=True)
-    del communicator
 
 
 @pytest.mark.parametrize('use_chainer_variable', [True, False])
@@ -82,7 +81,7 @@ def run_test_observation_aggregator(comm, xp,
 
     if use_gpu:
         # Use CuPy's Device class to force call cudaSetDevice()
-        get_device(comm.intra_rank, False).use()
+        chainer.cuda.get_device_from_id(comm.intra_rank).use()
 
     device = get_device(comm.intra_rank if use_gpu else None, xp == chainerx)
     device.use()

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -65,9 +65,8 @@ def test_observation_aggregator_gpu_chainerx(use_chainer_variable,
 @pytest.mark.parametrize('communicate_interval', [1, 2])
 @chainer.testing.attr.gpu
 def test_observation_aggregator_gpu_cupy(use_chainer_variable,
-                                    communicate_interval):
+                                         communicate_interval):
     communicator = chainermn.create_communicator('pure_nccl')
-    device = get_device(communicator.intra_rank, False).use()
 
     run_test_observation_aggregator(communicator, cuda.cupy,
                                     use_chainer_variable,

--- a/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
+++ b/tests/chainermn_tests/extensions_tests/test_observation_aggregator.py
@@ -5,7 +5,6 @@ import pytest
 import numpy as np
 
 import chainer
-from chainer.backends.cuda import cupy
 import chainer.testing
 from chainer.training import extension
 from chainer.backend import cuda


### PR DESCRIPTION
This PR depends on #8508

This PR is a replacement of #8322 by @belldandyxtq 

This PR adds ChainerX tests into the observation_aggregator
This PR partially solves #8031. This PR depends on #8321

~NOTE: This PR is completed w.r.t. the code, but it causes SEGV depending on the order of test cases in test_observatgion_aggregator.py. I guess it is because of the behavior of ChainerX's device setting. We need a deeper investigation on this issue.~

fixed!