### PR TITLE
[RFC]Avoid overflow on index calculations when using large arrays

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/fill.cu
@@ -111,7 +111,12 @@ __global__ void SetVecInMat(
         int64_t mat_row_start,
         int64_t mat_col_start) {
     auto mat_it = mat_indexer.It(0);
-    for (auto vec_it = vec_indexer.It(blockIdx.x * blockDim.x + threadIdx.x, blockDim.x * gridDim.x); vec_it; ++vec_it) {
+    int64_t id = static_cast<int64_t>(blockIdx.x);
+    int64_t size = static_cast<int64_t>(gridDim.x);
+    int64_t block_dim = static_cast<int64_t>(blockDim.x);
+    id = id * block_dim + static_cast<int64_t>(threadIdx.x);
+    size *= block_dim;
+    for (auto vec_it = vec_indexer.It(id, size); vec_it; ++vec_it) {
         mat_it.index()[0] = mat_row_start + vec_it.raw_index();
         mat_it.index()[1] = mat_col_start + vec_it.raw_index();
         mat_iarray[mat_it] = vec_iarray[vec_it];

--- a/chainerx_cc/chainerx/cuda/cuda_device/indexing.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/indexing.cu
@@ -60,7 +60,11 @@ __global__ void TakeCudaKernel(
         TIndex right_dim,
         TIndex num_iters,
         IndexBoundsMode mode) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t idx = static_cast<int64_t>(blockIdx.x);
+    int64_t size = static_cast<int64_t>(gridDim.x);
+    int64_t block_dim = static_cast<int64_t>(blockDim.x);
+    idx = idx * block_dim + static_cast<int64_t>(threadIdx.x);
+    size *= block_dim;
     if (idx >= num_iters) return;
     TIndex left_idx = idx / (num_indices * right_dim);
     TIndex index_idx = idx % (num_indices * right_dim);
@@ -96,7 +100,11 @@ __global__ void AddAtCudaKernel(
         TIndex b_right_dim,
         TIndex num_iters,
         IndexBoundsMode mode) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t idx = static_cast<int64_t>(blockIdx.x);
+    int64_t size = static_cast<int64_t>(gridDim.x);
+    int64_t block_dim = static_cast<int64_t>(blockDim.x);
+    idx = idx * block_dim + static_cast<int64_t>(threadIdx.x);
+    size *= block_dim;
     if (idx >= num_iters) return;
     TIndex i = idx / (target_dim * right_dim);
     TIndex j = idx % (target_dim * right_dim);

--- a/chainerx_cc/chainerx/cuda/cuda_device/pool.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/pool.cu
@@ -59,7 +59,12 @@ __global__ void MaxPoolDoubleBackwardKernel(
     auto it_kernel = kernel_indexer.It(kernel_indexer.total_size() - 1);
     auto it_x = x_indexer.It(0);
 
-    for (auto it_out = out_indexer.It(blockIdx.x * blockDim.x + threadIdx.x, blockDim.x * gridDim.x); it_out; ++it_out) {
+    int64_t id = static_cast<int64_t>(blockIdx.x);
+    int64_t size = static_cast<int64_t>(gridDim.x);
+    int64_t block_dim = static_cast<int64_t>(blockDim.x);
+    id = id * block_dim + static_cast<int64_t>(threadIdx.x);
+    size *= block_dim;
+    for (auto it_out = out_indexer.It(id, size); it_out; ++it_out) {
         it_x.index()[0] = it_out.index()[0];  // batch.
         it_x.index()[1] = it_out.index()[1];  // channel.
 

--- a/chainerx_cc/chainerx/cuda/cuda_device/rnn.cu
+++ b/chainerx_cc/chainerx/cuda/cuda_device/rnn.cu
@@ -44,7 +44,9 @@ namespace {
 namespace {
 
 __global__ void InitGpuDataKer(float* data, int64_t num_elements, float* value) {
-    int64_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+    int64_t tid = static_cast<int64_t>(blockIdx.x);
+    int64_t block_dim = static_cast<int64_t>(blockDim.x);
+    tid = tid * block_dim + static_cast<int64_t>(threadIdx.x);
     if (tid < num_elements) {
         data[tid] = value[tid];
     }

--- a/chainerx_cc/chainerx/cuda/elementwise.cuh
+++ b/chainerx_cc/chainerx/cuda/elementwise.cuh
@@ -22,7 +22,12 @@ namespace elementwise_detail {
 
 template <int8_t Ndim, typename Op, typename... Ts>
 __global__ void ElementwiseKernel(Op op, Indexer<Ndim> indexer, IndexableArray<Ts, Ndim>... args) {
-    for (auto it = indexer.It(blockIdx.x * blockDim.x + threadIdx.x, blockDim.x * gridDim.x); it; ++it) {
+    int64_t id = static_cast<int64_t>(blockIdx.x);
+    int64_t size = static_cast<int64_t>(gridDim.x);
+    int64_t block_dim = static_cast<int64_t>(blockDim.x);
+    id = id * block_dim + static_cast<int64_t>(threadIdx.x);
+    size *= block_dim;
+    for (auto it = indexer.It(id, size); it; ++it) {
         op(it.raw_index(), cuda_internal::StorageToDataType<Ts>(args[it])...);
     }
 }

--- a/tests/chainerx_tests/unit_tests/test_array_index.py
+++ b/tests/chainerx_tests/unit_tests/test_array_index.py
@@ -1,5 +1,43 @@
+import pytest
 import chainerx
 
 
 def test_newaxis():
     assert chainerx.newaxis is None
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('xp', [chainerx])
+@pytest.mark.parametrize_device(['cuda:0'])
+@pytest.mark.parametrize('shape', [
+    (64, 32, 6*1024*4),  # Less than 2^32 elems
+    (64, 32, 6*1024*512),  # More than 2^32 elems
+])
+def test_array_contiguous_indexing(xp, device, shape):
+    try:
+        a = xp.zeros(shape=shape, dtype=chainerx.int8, device=device)
+    except chainerx.ChainerxError as ex:
+        assert 'Out of memory' in ex.args
+        pytest.skip('Not enough memory to test large indexing')
+    a += 1
+    assert a.is_contiguous
+    assert a.sum() == a.size
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('xp', [chainerx])
+@pytest.mark.parametrize_device(['cuda:0'])
+@pytest.mark.parametrize('shape', [
+    (64, 32, 6*1024*4),  # Less than 2^32 elems
+    (64, 32, 6*1024*512)  # More than 2^32 elems
+])
+def test_array_noncontiguous_indexing(xp, device, shape):
+    try:
+        a = xp.zeros(shape=shape, dtype=chainerx.int8, device=device)
+    except chainerx.ChainerxError as ex:
+        assert 'Out of memory' in ex.args
+        pytest.skip('Not enough memory to test large indexing')
+    a = a.swapaxes(2, 0)
+    a += 1
+    assert not a.is_contiguous
+    assert a.sum() == a.size


### PR DESCRIPTION
Closes  #8385 

Changes had no measurable impact on smaller arrays Elementwise timing.

Native is not included in the tests since it takes several minutes.