### PR TITLE
Support cover_all=True on Unpooling2D in exporting to ONNX

### DIFF
--- a/onnx_chainer/functions/pooling.py
+++ b/onnx_chainer/functions/pooling.py
@@ -3,7 +3,6 @@ import warnings
 from chainer.utils import conv
 import numpy as np
 
-from onnx_chainer.functions.array import get_slice_node
 from onnx_chainer.functions.opset_version import support
 from onnx_chainer import onnx_helper
 
@@ -140,15 +139,12 @@ def convert_Unpooling2D(
     ksize = [func.kh, func.kw]
     outsize = [func.outh, func.outw]
     # TODO(hamaji): These could be implemented by `Slice` and `Pad`.
-    if func.cover_all and opset_version < 11:
-        raise RuntimeError('ONNX-chainer does not support `cover_all=True` '
-                           'for Unpooling2D with opset version < 11')
     h, w = func.inputs[0].shape[2:]
     expected_outsize = [
         conv.get_deconv_outsize(
             h, func.kh, func.sy, func.ph, cover_all=func.cover_all),
         conv.get_deconv_outsize(
-            w, func.kh, func.sy, func.ph, cover_all=func.cover_all)
+            w, func.kw, func.sx, func.pw, cover_all=func.cover_all)
     ]
     if outsize != expected_outsize:
         raise RuntimeError('ONNX-chainer does not support `outsize!=None` '
@@ -163,34 +159,30 @@ def convert_Unpooling2D(
                            'for Unpooling2D: stride={} ksize={}'.format(
                                stride, ksize))
 
-    scales = [1.0, 1.0, float(func.kh), float(func.kw)]
-
-    def add_const(array, name, dtype=np.float32):
-        return context.add_const(np.array(array, dtype=dtype), name)
-
+    if func.cover_all:
+        uncovered_outsize = [
+            conv.get_deconv_outsize(
+                h, func.kh, func.sy, func.ph, cover_all=False),
+            conv.get_deconv_outsize(
+                w, func.kw, func.sx, func.pw, cover_all=False)
+        ]
+        scales = [
+            1.0, 1.0,
+            func.kh * outsize[0] / uncovered_outsize[0],
+            func.kw * outsize[1] / uncovered_outsize[1],
+        ]
+    else:
+        scales = [1.0, 1.0, float(func.kh), float(func.kw)]
     if opset_version == 7:
         return onnx_helper.make_node('Upsample', input_names, output_names,
                                      scales=scales),
+    scales_name = context.add_const(
+        np.array(scales, dtype=np.float32), 'scales')
     if opset_version in [9, 10]:
-        input_names.append(add_const(scales, 'scales'))
+        input_names.append(scales_name)
         op = 'Upsample' if opset_version == 9 else 'Resize'
         return onnx_helper.make_node(op, input_names, output_names),
     if opset_version == 11:
         roi_name = context.add_const(np.array([]), 'roi')
-        if func.cover_all:
-            gb = onnx_helper.GraphBuilder()
-            # make output size considered dynamic shape
-            # get batch_size, channel_size and append deconv outsize
-            x_shape = gb.op('Shape', [input_names[0]])
-            x_shape_bc = get_slice_node(
-                gb, opset_version, context, [x_shape], [0], [0], [2])
-            deconv_outsize = add_const(outsize, 'sizes', np.int64)
-            outsize = gb.op('Concat', [x_shape_bc, deconv_outsize], axis=0)
-
-            scales_name = add_const([], 'scales')
-            input_names.extend([roi_name, scales_name, outsize])
-            gb.op_output_named('Resize', input_names, output_names)
-            return gb.nodes()
-        else:
-            input_names.extend([roi_name, add_const(scales, 'scales')])
-            return onnx_helper.make_node('Resize', input_names, output_names),
+        input_names.extend([roi_name, scales_name])
+        return onnx_helper.make_node('Resize', input_names, output_names),

--- a/tests/onnx_chainer_tests/functions_tests/test_poolings.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_poolings.py
@@ -24,6 +24,11 @@ from onnx_chainer_tests.helper import ONNXModelTest
      'in_shape': (1, 3, 6, 5, 4), 'args': [3, 2, 1], 'cover_all': True},
     {'op_name': 'unpooling_2d',
      'in_shape': (1, 3, 6, 6), 'args': [3, None, 0], 'cover_all': False},
+    # when cover_all=True, interpolation between Chainer and ONNXRuntime
+    # does not match, so skip output value check.
+    {'op_name': 'unpooling_2d', 'condition': 'coverall',
+     'in_shape': (1, 3, 6, 6), 'args': [3, None, 0], 'cover_all': True,
+     'skip_ver': tuple(range(7, 11)), 'skip_check_ver': (11,)},
 )
 class TestPoolings(ONNXModelTest):
 
@@ -36,8 +41,11 @@ class TestPoolings(ONNXModelTest):
         name = self.op_name
         if hasattr(self, 'condition'):
             name += '_' + self.condition
-        self.expect(self.model, self.x, name=name,
-                    expected_num_initializers=0)
+        skip_ver = getattr(self, 'skip_ver', None)
+        skip_check_ver = getattr(self, 'skip_check_ver', None)
+        self.expect(
+            self.model, self.x, name=name, skip_opset_version=skip_ver,
+            skip_outvalue_version=skip_check_ver, expected_num_initializers=0)
 
 
 class Model(chainer.Chain):

--- a/tests/onnx_chainer_tests/functions_tests/test_poolings.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_poolings.py
@@ -24,8 +24,8 @@ from onnx_chainer_tests.helper import ONNXModelTest
      'in_shape': (1, 3, 6, 5, 4), 'args': [3, 2, 1], 'cover_all': True},
     {'op_name': 'unpooling_2d',
      'in_shape': (1, 3, 6, 6), 'args': [3, None, 0], 'cover_all': False},
-    # when cover_all=True, interpolation between Chainer and ONNXRuntime
-    # does not match, so skip output value check.
+    # TODO(disktnk): when cover_all=True, interpolation between Chainer and
+    # ONNXRuntime does not match, so skip output value check.
     {'op_name': 'unpooling_2d', 'condition': 'coverall',
      'in_shape': (1, 3, 6, 6), 'args': [3, None, 0], 'cover_all': True,
      'skip_check_ver': True},

--- a/tests/onnx_chainer_tests/functions_tests/test_poolings.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_poolings.py
@@ -28,7 +28,7 @@ from onnx_chainer_tests.helper import ONNXModelTest
     # does not match, so skip output value check.
     {'op_name': 'unpooling_2d', 'condition': 'coverall',
      'in_shape': (1, 3, 6, 6), 'args': [3, None, 0], 'cover_all': True,
-     'skip_ver': tuple(range(7, 11)), 'skip_check_ver': (11,)},
+     'skip_check_ver': True},
 )
 class TestPoolings(ONNXModelTest):
 
@@ -41,11 +41,12 @@ class TestPoolings(ONNXModelTest):
         name = self.op_name
         if hasattr(self, 'condition'):
             name += '_' + self.condition
-        skip_ver = getattr(self, 'skip_ver', None)
-        skip_check_ver = getattr(self, 'skip_check_ver', None)
+        skip_out_check = getattr(self, 'skip_check_ver', None)
+        if skip_out_check is not None:
+            skip_out_check = self.target_opsets
         self.expect(
-            self.model, self.x, name=name, skip_opset_version=skip_ver,
-            skip_outvalue_version=skip_check_ver, expected_num_initializers=0)
+            self.model, self.x, name=name,
+            skip_outvalue_version=skip_out_check, expected_num_initializers=0)
 
 
 class Model(chainer.Chain):


### PR DESCRIPTION
Support `cover_all=True` on Chainer's `Unpool2d`. Simply recalculate output size. Interpolation logic is differ between Chainer and ONNXRuntime, and output values checking is skipped.