### PR TITLE
Fix AttributeError in WrappedFunctionNode.forward

### DIFF
--- a/onnx_chainer/replace_func.py
+++ b/onnx_chainer/replace_func.py
@@ -47,7 +47,7 @@ class WrappedFunctionNode(chainer.FunctionNode):
         if not chainer.is_arrays_compatible(dummy_results):
             raise ValueError(
                 'returned values from the function wrapped by \'as_funcnode\' '
-                'must consist only array, function name: {}'.format(self.name))
+                'must consist only array, function name: {}'.format(self.custom_function_node_name))
         return dummy_results
 
     def backward(self, target_input_indexes, grad_outputs):

--- a/onnx_chainer/replace_func.py
+++ b/onnx_chainer/replace_func.py
@@ -47,7 +47,8 @@ class WrappedFunctionNode(chainer.FunctionNode):
         if not chainer.is_arrays_compatible(dummy_results):
             raise ValueError(
                 'returned values from the function wrapped by \'as_funcnode\' '
-                'must consist only array, function name: {}'.format(self.custom_function_node_name))
+                'must consist only array, function name: {}'.format(
+                    self.custom_function_node_name))
         return dummy_results
 
     def backward(self, target_input_indexes, grad_outputs):


### PR DESCRIPTION
This PR fixes `AttributeError` in `onnx_chainer.replace_func.WrappedFunctionNode.forward`.
The `self.name` is not defined and I assume that this is a mistake of `self.custom_function_node_name`.