### PR TITLE
Fix onnx_chainer.replace_func.fake_as_funcnode to reconstruct return value structure

### DIFF
--- a/tests/onnx_chainer_tests/test_replace_func.py
+++ b/tests/onnx_chainer_tests/test_replace_func.py
@@ -335,3 +335,44 @@ def test_replace_func_collection_return(tmpdir, return_type):
     assert len(output_names) == 5
     for i, name in enumerate(output_names):
         assert name == 'xTiledArray_0_{:d}'.format(i)
+
+
+def test_fake_as_funcnode_keep_structure(tmpdir):
+    path = str(tmpdir)
+
+    class Model(chainer.Chain):
+        def __init__(self):
+            super().__init__()
+
+        def f(self, x):
+            return {'a': (x, x+1), 'b': [x+2, x+3, x+4]}
+
+        def __call__(self, x):
+            ret = self.f(x)
+            return ret['a'][0] + ret['b'][1]
+
+    model = Model()
+    x = input_generator.increasing(2, 3)
+
+    with warnings.catch_warnings(record=True):
+        model.f = fake_as_funcnode(model.f, 'xF')
+
+    def f_converter(params):
+        return onnx_helper.make_node(
+            'xF', params.input_names, params.output_names),
+
+    addon_converters = {'xF': f_converter}
+
+    with testing.assert_warns(UserWarning):
+        export_testcase(model, x, path, external_converters=addon_converters)
+        export_testcase(model, x, ".", external_converters=addon_converters)
+
+    model_filepath = os.path.join(path, 'model.onnx')
+    assert os.path.isfile(model_filepath)
+
+    onnx_model = onnx.load(model_filepath)
+    node_names = [n.name for n in onnx_model.graph.node]
+    assert len(node_names) == 2
+    assert node_names[0] == 'xF_0'
+    assert len(onnx_model.graph.node[0].output) == 5
+    assert len(onnx_model.graph.output) == 1


### PR DESCRIPTION
With the current implementation, `alt_func` is allowed to return a `dict`, but it is flattened into a tuple. For example, 

```python
def f(x):
    return {"a": x+1, "b": x-1}
```

returns a `dict`, while `onnx_chainer.replace_func.fake_as_funcnode(f, 'F')` returns a tuple, so that the consumer of the result who expects `dict` does not work.

This PR fixes the problem by explicitly saving the structure as a skeleton and reconstructing original structure from the skeleton and flattened values.

As a side effect, not only a single level of `tuple`/`list`/`dict` but also arbitrary nesting of `tuple`/`list`/`dict` is allowed in return value.