### PR TITLE
Link to examples directory for the current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [**Docs**](https://docs.chainer.org/en/stable/)
 | [**Install Guide**](https://docs.chainer.org/en/stable/install.html)
 | **Tutorials** ([ja](https://tutorials.chainer.org/ja/))
-| **Examples** ([Official](https://github.com/chainer/chainer/tree/master/examples), [External](https://github.com/chainer-community/awesome-chainer))
+| **Examples** ([Official](examples), [External](https://github.com/chainer-community/awesome-chainer))
 | [**Concepts**](https://docs.chainer.org/en/stable/guides/)
 | [**ChainerX**](#chainerx)
 


### PR DESCRIPTION
As pointed out in https://github.com/chainer/chainer/pull/7956#issuecomment-523247129, Examples links to master branch even when a user is browsing other branch.