### PR TITLE
Change version of python in travis macos test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       language: generic
       env:
       - CHAINER_TRAVIS_TEST="chainer"
-      - PYTHON_VERSION=3.5.1
+      - PYTHON_VERSION=3.5.2
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
       - GOROOT=/usr/local/opt/go/libexec


### PR DESCRIPTION
Since some API used in onnx package isn't available until 3.5.2

Rel:
- https://github.com/cython/cython/issues/1880
- https://github.com/pybind/pybind11/issues/314
