### PR TITLE
Add unsigned suffix in float16 test

### DIFF
--- a/chainerx_cc/chainerx/float16_test.cc
+++ b/chainerx_cc/chainerx/float16_test.cc
@@ -11,9 +11,9 @@ namespace chainerx {
 namespace {
 
 bool IsNan(Float16 x) {
-    uint16_t exp = x.data() & 0x7c00;
-    uint16_t frac = x.data() & 0x03ff;
-    return exp == 0x7c00 && frac != 0x0000;
+    uint16_t exp = x.data() & 0x7c00U;
+    uint16_t frac = x.data() & 0x03ffU;
+    return exp == 0x7c00U && frac != 0x0000U;
 }
 
 // Checks if `d` is equal to FromFloat16(ToFloat16(d)) with tolerance `tol`.
@@ -58,64 +58,64 @@ void CheckFromFloat16ToFloat16Eq(Float16 h) {
 }
 
 TEST(NativeFloat16Test, Float16Zero) {
-    EXPECT_EQ(Float16{float{0.0}}.data(), 0x0000);
-    EXPECT_EQ(Float16{float{-0.0}}.data(), 0x8000);
-    EXPECT_EQ(Float16{double{0.0}}.data(), 0x0000);
-    EXPECT_EQ(Float16{double{-0.0}}.data(), 0x8000);
-    EXPECT_EQ(static_cast<float>(Float16::FromData(0x0000)), 0.0);
-    EXPECT_EQ(static_cast<float>(Float16::FromData(0x8000)), -0.0);
-    EXPECT_EQ(static_cast<double>(Float16::FromData(0x0000)), 0.0);
-    EXPECT_EQ(static_cast<double>(Float16::FromData(0x8000)), -0.0);
+    EXPECT_EQ(Float16{float{0.0}}.data(), 0x0000U);
+    EXPECT_EQ(Float16{float{-0.0}}.data(), 0x8000U);
+    EXPECT_EQ(Float16{double{0.0}}.data(), 0x0000U);
+    EXPECT_EQ(Float16{double{-0.0}}.data(), 0x8000U);
+    EXPECT_EQ(static_cast<float>(Float16::FromData(0x0000U)), 0.0);
+    EXPECT_EQ(static_cast<float>(Float16::FromData(0x8000U)), -0.0);
+    EXPECT_EQ(static_cast<double>(Float16::FromData(0x0000U)), 0.0);
+    EXPECT_EQ(static_cast<double>(Float16::FromData(0x8000U)), -0.0);
     // Checks if the value is casted to 0.0 or -0.0
-    EXPECT_EQ(1 / static_cast<float>(Float16::FromData(0x0000)), std::numeric_limits<float>::infinity());
-    EXPECT_EQ(1 / static_cast<float>(Float16::FromData(0x8000)), -std::numeric_limits<float>::infinity());
-    EXPECT_EQ(1 / static_cast<double>(Float16::FromData(0x0000)), std::numeric_limits<float>::infinity());
-    EXPECT_EQ(1 / static_cast<double>(Float16::FromData(0x8000)), -std::numeric_limits<float>::infinity());
+    EXPECT_EQ(1 / static_cast<float>(Float16::FromData(0x0000U)), std::numeric_limits<float>::infinity());
+    EXPECT_EQ(1 / static_cast<float>(Float16::FromData(0x8000U)), -std::numeric_limits<float>::infinity());
+    EXPECT_EQ(1 / static_cast<double>(Float16::FromData(0x0000U)), std::numeric_limits<float>::infinity());
+    EXPECT_EQ(1 / static_cast<double>(Float16::FromData(0x8000U)), -std::numeric_limits<float>::infinity());
 }
 
 TEST(NativeFloat16Test, Float16Normalized) {
     for (double x = 1e-3; x < 1e3; x *= 1.01) {  // NOLINT(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
-        EXPECT_NE(Float16{x}.data() & 0x7c00, 0);
+        EXPECT_NE(Float16{x}.data() & 0x7c00U, 0U);
         CheckToFloat16FromFloat16Near(x, 1e-3);
         CheckToFloat16FromFloat16Near(-x, 1e-3);
     }
     for (uint16_t bit = 0x0400; bit < 0x7c00; ++bit) {
-        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x0000));
-        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x8000));
+        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x0000U));
+        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x8000U));
     }
 }
 
 TEST(NativeFloat16Test, Float16Denormalized) {
     for (double x = 1e-7; x < 1e-5; x += 1e-7) {  // NOLINT(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
         // Check if the underflow gap around zero is filled with denormal number.
-        EXPECT_EQ(Float16{x}.data() & 0x7c00, 0x0000);
-        EXPECT_NE(Float16{x}.data() & 0x03ff, 0x0000);
+        EXPECT_EQ(Float16{x}.data() & 0x7c00U, 0x0000U);
+        EXPECT_NE(Float16{x}.data() & 0x03ffU, 0x0000U);
         CheckToFloat16FromFloat16Near(x, 1e-7);
         CheckToFloat16FromFloat16Near(-x, 1e-7);
     }
-    for (uint16_t bit = 0x0000; bit < 0x0400; ++bit) {
-        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x0000));
-        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x8000));
+    for (uint16_t bit = 0x0000U; bit < 0x0400U; ++bit) {
+        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x0000U));
+        CheckFromFloat16ToFloat16Eq(Float16::FromData(bit | 0x8000U));
     }
 }
 
 TEST(NativeFloat16Test, Float16Inf) {
-    EXPECT_EQ(Float16{std::numeric_limits<float>::infinity()}.data(), 0x7c00);
-    EXPECT_EQ(Float16{-std::numeric_limits<float>::infinity()}.data(), 0xfc00);
-    EXPECT_EQ(Float16{std::numeric_limits<double>::infinity()}.data(), 0x7c00);
-    EXPECT_EQ(Float16{-std::numeric_limits<double>::infinity()}.data(), 0xfc00);
-    EXPECT_EQ(std::numeric_limits<float>::infinity(), static_cast<float>(Float16::FromData(0x7c00)));
-    EXPECT_EQ(-std::numeric_limits<float>::infinity(), static_cast<float>(Float16::FromData(0xfc00)));
-    EXPECT_EQ(std::numeric_limits<double>::infinity(), static_cast<double>(Float16::FromData(0x7c00)));
-    EXPECT_EQ(-std::numeric_limits<double>::infinity(), static_cast<double>(Float16::FromData(0xfc00)));
+    EXPECT_EQ(Float16{std::numeric_limits<float>::infinity()}.data(), 0x7c00U);
+    EXPECT_EQ(Float16{-std::numeric_limits<float>::infinity()}.data(), 0xfc00U);
+    EXPECT_EQ(Float16{std::numeric_limits<double>::infinity()}.data(), 0x7c00U);
+    EXPECT_EQ(Float16{-std::numeric_limits<double>::infinity()}.data(), 0xfc00U);
+    EXPECT_EQ(std::numeric_limits<float>::infinity(), static_cast<float>(Float16::FromData(0x7c00U)));
+    EXPECT_EQ(-std::numeric_limits<float>::infinity(), static_cast<float>(Float16::FromData(0xfc00U)));
+    EXPECT_EQ(std::numeric_limits<double>::infinity(), static_cast<double>(Float16::FromData(0x7c00U)));
+    EXPECT_EQ(-std::numeric_limits<double>::infinity(), static_cast<double>(Float16::FromData(0xfc00U)));
 }
 
 TEST(NativeFloat16Test, Float16Nan) {
-    for (uint16_t bit = 0x7c01; bit < 0x8000; ++bit) {
-        EXPECT_TRUE(std::isnan(static_cast<float>(Float16::FromData(bit | 0x0000))));
-        EXPECT_TRUE(std::isnan(static_cast<float>(Float16::FromData(bit | 0x8000))));
-        EXPECT_TRUE(std::isnan(static_cast<double>(Float16::FromData(bit | 0x0000))));
-        EXPECT_TRUE(std::isnan(static_cast<double>(Float16::FromData(bit | 0x8000))));
+    for (uint16_t bit = 0x7c01U; bit < 0x8000U; ++bit) {
+        EXPECT_TRUE(std::isnan(static_cast<float>(Float16::FromData(bit | 0x0000U))));
+        EXPECT_TRUE(std::isnan(static_cast<float>(Float16::FromData(bit | 0x8000U))));
+        EXPECT_TRUE(std::isnan(static_cast<double>(Float16::FromData(bit | 0x0000U))));
+        EXPECT_TRUE(std::isnan(static_cast<double>(Float16::FromData(bit | 0x8000U))));
     }
     EXPECT_TRUE(IsNan(Float16{float{NAN}}));
     EXPECT_TRUE(IsNan(Float16{double{NAN}}));
@@ -132,11 +132,11 @@ public:
 TEST(NativeFloat16Test, Float16Rounding32) {
     // For the significand not to be rounded half significand must be even,
     // and the remaining pattern 1000...0
-    Float32Bits bits{static_cast<uint32_t>((0x3f << 24) + (5 << 12))};
+    Float32Bits bits{static_cast<uint32_t>((0x3fU << 24) + (5 << 12))};
     // If the number was not rounded, then the last bit of the
     // significand is lost and the rest remain as it was
     // (5 << 12 ) >> 13
-    EXPECT_EQ((Float16{bits.f}.data() & 0x3ffU), 0x2);
+    EXPECT_EQ((Float16{bits.f}.data() & 0x3ffU), 0x2U);
 }
 
 union Float64Bits {
@@ -154,7 +154,7 @@ TEST(NativeFloat16Test, Float16Rounding64) {
     // If the number was not rounded, then the last bit of the
     // significand is lost and the rest remain as it was
     // (5 << 12 ) >> 13
-    EXPECT_EQ((Float16{bits.f}.data() & 0x3ffU), 0x2);
+    EXPECT_EQ((Float16{bits.f}.data() & 0x3ffU), 0x2U);
 }
 
 // Get the partial set of all Float16 values for reduction of test execution time.
@@ -164,9 +164,9 @@ std::vector<Float16> GetFloat16Values() {
     std::vector<Float16> values;
     values.reserve(1 << 9);
     // Use uint32_t instead of uint16_t to avoid overflow
-    for (uint32_t bit = 0x0000; bit <= 0xffff; bit += 0x0100) {
-        values.emplace_back(Float16::FromData(bit | 0x0000));
-        values.emplace_back(Float16::FromData(bit | 0x0055));
+    for (uint32_t bit = 0x0000U; bit <= 0xffffU; bit += 0x0100U) {
+        values.emplace_back(Float16::FromData(bit | 0x0000U));
+        values.emplace_back(Float16::FromData(bit | 0x0055U));
     }
     return values;
 }
@@ -181,7 +181,7 @@ void ExpectEqFloat16(Float16 l, Float16 r) {
 
 TEST(NativeFloat16Test, Float16Neg) {
     // Use uint32_t instead of uint16_t to avoid overflow
-    for (uint32_t bit = 0x0000; bit <= 0xffff; ++bit) {
+    for (uint32_t bit = 0x0000U; bit <= 0xffffU; ++bit) {
         Float16 x = Float16::FromData(bit);
         Float16 expected{-static_cast<double>(x)};
         ExpectEqFloat16(expected, -x);


### PR DESCRIPTION
In some cases the suffix is needed to avoid a compiler warning: comparison between signed and unsigned integers.