### PR TITLE
Remove chainerx dependency from test backends

### DIFF
--- a/chainerx_cc/chainerx/backend_testdata/CMakeLists.txt
+++ b/chainerx_cc/chainerx/backend_testdata/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_library(backend0.so MODULE
     backend0.cc)
-target_link_libraries(backend0.so chainerx)
 set_target_properties(backend0.so
     PROPERTIES
     PREFIX ""
@@ -9,7 +8,6 @@ set_target_properties(backend0.so
 
 add_library(backend1.so MODULE
     backend1.cc)
-target_link_libraries(backend1.so chainerx)
 set_target_properties(backend1.so
     PROPERTIES
     PREFIX ""


### PR DESCRIPTION
I think these are not necessary.