### PR TITLE
Add ChainerX test to test_allreduce_persistent.py

### DIFF
--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -26,7 +26,6 @@ class TestAllreducePersistent(unittest.TestCase):
             chainer.cuda.get_device_from_id(comm.intra_rank).use()
 
         device = get_device(comm.intra_rank if use_gpu else None, use_chx)
-        device.use()
         model.to_device(device)
 
         rank = comm.rank

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -48,12 +48,12 @@ class TestAllreducePersistent(unittest.TestCase):
     def test_allreduce_persistent_cpu(self):
         comm = chainermn.create_communicator('naive')
         model = ExampleModel()
-        self._test(comm, model, False, False)
-        self._test(comm, model, False, True)
+        self._test(comm, model, False, False)  # CPU test (numpy)
+        self._test(comm, model, False, True)  # CPU test (ChainerX)
 
     @chainer.testing.attr.gpu
     def test_allreduce_persistent_gpu(self):
         comm = chainermn.create_communicator('flat')
         model = ExampleModel()
-        self._test(comm, model, True, False)
-        self._test(comm, model, True, True)
+        self._test(comm, model, True, False)  # GPU test (CuPy)
+        self._test(comm, model, True, True)  # GPU test (ChainerX)

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -23,7 +23,7 @@ class TestAllreducePersistent(unittest.TestCase):
     def _test(self, comm, model, use_gpu, use_chx):
         if use_gpu:
             # Use CuPy's Device class to force call cudaSetDevice()
-            get_device(comm.intra_rank, False).use()
+            chainer.cuda.get_device_from_id(comm.intra_rank).use()
 
         device = get_device(comm.intra_rank if use_gpu else None, use_chx)
         device.use()

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -21,6 +21,10 @@ class ExampleModel(chainer.Chain):
 class TestAllreducePersistent(unittest.TestCase):
 
     def _test(self, comm, model, use_gpu, use_chx):
+        if use_gpu:
+            # Use CuPy's Device class to force call cudaSetDevice()
+            get_device(comm.intra_rank, False).use()
+
         device = get_device(comm.intra_rank if use_gpu else None, use_chx)
         device.use()
         model.to_device(device)

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -1,5 +1,4 @@
 import chainer
-from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
 import unittest
@@ -44,7 +43,6 @@ class TestAllreducePersistent(unittest.TestCase):
 
     def test_allreduce_persistent_cpu(self):
         comm = chainermn.create_communicator('naive')
-        device = chainer.get_device('native')
         model = ExampleModel()
         self._test(comm, model, False, False)
         self._test(comm, model, False, True)

--- a/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
+++ b/tests/chainermn_tests/extensions_tests/test_allreduce_persistent.py
@@ -5,7 +5,7 @@ import chainer.testing.attr
 import unittest
 
 import chainermn
-import chainerx as chx
+from chainermn.testing.device import get_device
 
 
 class ExampleModel(chainer.Chain):
@@ -22,19 +22,7 @@ class ExampleModel(chainer.Chain):
 class TestAllreducePersistent(unittest.TestCase):
 
     def _test(self, comm, model, use_gpu, use_chx):
-
-        if use_gpu:
-            if use_chx:
-                device_id = 'cuda:{}'.format(comm.intra_rank)
-            else:
-                device_id = '@cupy:{}'.format(comm.intra_rank)
-        else:
-            if use_chx:
-                device_id = 'native'
-            else:
-                device_id = '@numpy'
-
-        device = chainer.get_device(device_id)
+        device = get_device(comm.intra_rank if use_gpu else None, use_chx)
         device.use()
         model.to_device(device)
 


### PR DESCRIPTION
This PR is a part of #8031. It adds ChainerX tests to `test_allreduce_persistent.py`.