### PR TITLE
Fix `TestMeshgrid`

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -1,7 +1,6 @@
 import io
 import sys
 import tempfile
-import random
 
 import chainer
 import numpy
@@ -1264,7 +1263,15 @@ class TestTrilTriu(op_utils.NumpyOpTest):
 
 @op_utils.op_test(['native:0', 'cuda:0'])
 @chainer.testing.parameterize_pytest('indexing', ['xy', 'ij'])
-@chainer.testing.parameterize_pytest('input_arrs', [1, 2, 3, 4])
+@chainer.testing.parameterize_pytest('input_lens', [
+    # Test up to 4 inputs to check `indexing` behaviors
+    # 'xy': (1, 0, 2, ..., N-1)
+    # 'ij': (0, 1, 2, ..., N-1)
+    (7,),
+    (6, 4),
+    (2, 3, 5),
+    (4, 3, 2, 5),
+])
 class TestMeshgrid(op_utils.NumpyOpTest):
 
     check_numpy_strides_compliance = False
@@ -1279,13 +1286,13 @@ class TestMeshgrid(op_utils.NumpyOpTest):
             self.check_backward_options.update({'rtol': 1e-2, 'atol': 1e-2})
 
     def generate_inputs(self):
-        arrs = ()
-        for _ in range(self.input_arrs):
-            arrs += (numpy.linspace(random.randint(-10, 0),
-                                    random.randint(1, 10),
-                                    random.randint(3, 7)).astype(self.dtype),)
-
-        return arrs
+        return tuple(
+            numpy.linspace(
+                numpy.random.uniform(-5, -1),
+                numpy.random.uniform(1, 5),
+                size)
+            .astype(self.dtype)
+            for size in self.input_lens)
 
     def forward_xp(self, inputs, xp):
         return tuple(xp.meshgrid(*inputs, indexing=self.indexing))


### PR DESCRIPTION
- Make the input values and the output shape smaller to fix the flakiness of the test. (Fix #8268)
- Avoid builtin `random` because `numpy.random` is available.