### PR TITLE
Fix ChainerX CMake test dependencies

### DIFF
--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -225,6 +225,8 @@ if(${CHAINERX_BUILD_TEST})
 
     target_link_libraries(chainerx_test
         chainerx
-        gtest)
+        chainerx_test_main
+        # gtest is linked via chainerx_testing.
+        )
     add_test(NAME chainerx_test COMMAND chainerx_test)
 endif()

--- a/chainerx_cc/chainerx/cuda/CMakeLists.txt
+++ b/chainerx_cc/chainerx/cuda/CMakeLists.txt
@@ -56,7 +56,7 @@ CUDA_ADD_CUBLAS_TO_TARGET(chainerx_cuda)
 target_link_libraries(chainerx_cuda ${CUDNN_LIBRARIES} ${CUDA_cusolver_LIBRARY})
 
 if(${CHAINERX_BUILD_TEST})
-    add_executable(chainerx_cuda_test
+    CUDA_ADD_EXECUTABLE(chainerx_cuda_test
         cuda_backend_test.cc
         cuda_conv_test.cc
         cuda_set_device_scope_test.cc
@@ -66,8 +66,8 @@ if(${CHAINERX_BUILD_TEST})
         )
     target_link_libraries(chainerx_cuda_test
         chainerx
-        chainerx_cuda
-        chainerx_testing
-        gtest)
+        chainerx_test_main
+        # gtest is linked via chainerx_testing.
+        )
     add_test(NAME chainerx_cuda_test COMMAND chainerx_cuda_test)
 endif()

--- a/chainerx_cc/chainerx/native/CMakeLists.txt
+++ b/chainerx_cc/chainerx/native/CMakeLists.txt
@@ -56,8 +56,8 @@ if(${CHAINERX_BUILD_TEST})
   )
   target_link_libraries(chainerx_native_test
       chainerx
-      chainerx_native
-      chainerx_testing
-      gtest)
+      chainerx_test_main
+      # gtest is linked via chainerx_testing.
+      )
   add_test(NAME chainerx_native_test COMMAND chainerx_native_test)
 endif()

--- a/chainerx_cc/chainerx/routines/CMakeLists.txt
+++ b/chainerx_cc/chainerx/routines/CMakeLists.txt
@@ -60,8 +60,8 @@ if(${CHAINERX_BUILD_TEST})
   )
   target_link_libraries(chainerx_routines_test
       chainerx
-      chainerx_routines
-      chainerx_testing
-      gtest)
+      chainerx_test_main
+      # gtest is linked via chainerx_testing.
+      )
   add_test(NAME chainerx_routines_test COMMAND chainerx_routines_test)
 endif()

--- a/chainerx_cc/chainerx/testing/CMakeLists.txt
+++ b/chainerx_cc/chainerx/testing/CMakeLists.txt
@@ -14,20 +14,20 @@ add_library(chainerx_testing STATIC
     util.cc
     routines.cc)
 
-# TODO(niboshi): Remove gtest dependency from testing
+# TODO(niboshi): Remove gtest dependency from testing. When fixed, add gtest
+# dependency to *_test libraries.
 target_link_libraries(chainerx_testing
     gtest)
 
-if(${CHAINERX_BUILD_TEST})
-    target_sources(chainerx_testing PRIVATE
-        gtest_main.cc)
+add_library(chainerx_test_main STATIC gtest_main.cc)
 
+if(${CHAINERX_BUILD_TEST})
     add_executable(chainerx_testing_test
         array_test.cc
         routines_test.cc)
 
     target_link_libraries(chainerx_testing_test
       chainerx
-      chainerx_testing)
+      chainerx_test_main)
     add_test(NAME chainerx_testing_test COMMAND chainerx_testing_test)
 endif()


### PR DESCRIPTION
* Previously the `main` function was included in `chainerx` via `chainerx_testing`, if `CHAINERX_BUILD_TEST` was set. Removed `main` from `chainerx_testing`.
* Avoid referencing `gtest` multiple times.
* ChainerX submodules are included in `chainerx`. Removed redundancy.
* Use `CUDA_ADD_EXECUTABLE` instead of `add_executable` for `chainerx_cuda_test`.