### PR TITLE
Link ChainerX only statically

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -147,6 +147,8 @@ endif()
 
 # CUDA
 if(${CHAINERX_BUILD_CUDA})
+    unset(CUDA_USE_STATIC_CUDA_RUNTIME CACHE)
+    option(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
     find_package(CUDA REQUIRED QUIET)
 
     add_definitions(-DCHAINERX_ENABLE_CUDA=1)

--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -120,17 +120,8 @@ add_library(chainerx_base STATIC ${chainerx_srcs})
 add_library(chainerx STATIC empty.cc)
 add_library(chainerx_static STATIC empty.cc)
 add_library(chainerx_shared SHARED empty.cc)
-target_link_libraries(chainerx_static
-    PUBLIC
-    -Wl,--whole-archive
-    chainerx
-    -Wl,--no-whole-archive
-    )
-
-target_link_libraries(chainerx_shared
-    PRIVATE
-    chainerx
-    )
+target_link_libraries(chainerx_static PUBLIC chainerx)
+target_link_libraries(chainerx_shared PRIVATE chainerx)
 
 # abseil
 target_link_libraries(

--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -130,7 +130,7 @@ target_link_libraries(
     )
 
 # dlopen / dlclose
-target_link_libraries(chainerx PUBLIC ${CMAKE_DL_LIBS})
+target_link_libraries(chainerx_base PUBLIC ${CMAKE_DL_LIBS})
 
 # ChainerX
 set(chainerx_sub_libs
@@ -157,10 +157,6 @@ elseif(${APPLE})
 else()
     target_link_libraries(chainerx
         PRIVATE
-        # TODO(niboshi): --allow-multiple-definition should not be necessary,
-        # but without it there would be duplicate symbol errors.
-        # These respective causes should be addressed instead of using this flag.
-        -Wl,--allow-multiple-definition
         -Wl,--whole-archive
         ${chainerx_sub_libs}
         -Wl,--no-whole-archive

--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -157,6 +157,9 @@ elseif(${APPLE})
 else()
     target_link_libraries(chainerx
         PRIVATE
+        # TODO(niboshi): --allow-multiple-definition should not be necessary,
+        # but without it there would be duplicate symbol errors.
+        # These respective causes should be addressed instead of using this flag.
         -Wl,--allow-multiple-definition
         -Wl,--whole-archive
         ${chainerx_sub_libs}

--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -102,8 +102,6 @@ set(chainerx_srcs
     util.cc
     )
 
-add_library(chainerx_base STATIC ${chainerx_srcs})
-
 if(MSVC)
     install(FILES
         platform/windows.h
@@ -114,10 +112,12 @@ if(MSVC)
         "${chainerx_srcs}"
         platform/windows.cc
         )
-    add_library(chainerx STATIC empty.cc)
-else()
-    add_library(chainerx STATIC empty.cc)
 endif()
+
+
+add_library(chainerx_base STATIC ${chainerx_srcs})
+
+add_library(chainerx STATIC empty.cc)
 
 # abseil
 target_link_libraries(

--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -116,12 +116,12 @@ if(MSVC)
         )
     add_library(chainerx STATIC empty.cc)
 else()
-    add_library(chainerx SHARED empty.cc)
+    add_library(chainerx STATIC empty.cc)
 endif()
 
 # abseil
 target_link_libraries(
-    chainerx
+    chainerx_base
     PUBLIC
     absl::failure_signal_handler
     absl::bad_optional_access
@@ -157,6 +157,7 @@ elseif(${APPLE})
 else()
     target_link_libraries(chainerx
         PRIVATE
+        -Wl,--allow-multiple-definition
         -Wl,--whole-archive
         ${chainerx_sub_libs}
         -Wl,--no-whole-archive

--- a/chainerx_cc/chainerx/CMakeLists.txt
+++ b/chainerx_cc/chainerx/CMakeLists.txt
@@ -118,6 +118,19 @@ endif()
 add_library(chainerx_base STATIC ${chainerx_srcs})
 
 add_library(chainerx STATIC empty.cc)
+add_library(chainerx_static STATIC empty.cc)
+add_library(chainerx_shared SHARED empty.cc)
+target_link_libraries(chainerx_static
+    PUBLIC
+    -Wl,--whole-archive
+    chainerx
+    -Wl,--no-whole-archive
+    )
+
+target_link_libraries(chainerx_shared
+    PRIVATE
+    chainerx
+    )
 
 # abseil
 target_link_libraries(
@@ -156,14 +169,14 @@ elseif(${APPLE})
     target_link_libraries(chainerx PRIVATE -Wl,-noall_load)
 else()
     target_link_libraries(chainerx
-        PRIVATE
+        PUBLIC
         -Wl,--whole-archive
         ${chainerx_sub_libs}
         -Wl,--no-whole-archive
         )
 endif()
 
-install(TARGETS chainerx DESTINATION lib)
+install(TARGETS chainerx_static DESTINATION lib)
 
 if(${CHAINERX_BUILD_TEST})
     add_subdirectory(backend_testdata)
@@ -208,7 +221,7 @@ if(${CHAINERX_BUILD_TEST})
         CHAINERX_TEST_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 
     target_link_libraries(chainerx_test
-        chainerx
+        chainerx_shared
         chainerx_test_main
         # gtest is linked via chainerx_testing.
         )

--- a/chainerx_cc/chainerx/cuda/CMakeLists.txt
+++ b/chainerx_cc/chainerx/cuda/CMakeLists.txt
@@ -65,7 +65,7 @@ if(${CHAINERX_BUILD_TEST})
         memory_pool_test.cc
         )
     target_link_libraries(chainerx_cuda_test
-        chainerx
+        chainerx_shared
         chainerx_test_main
         # gtest is linked via chainerx_testing.
         )

--- a/chainerx_cc/chainerx/native/CMakeLists.txt
+++ b/chainerx_cc/chainerx/native/CMakeLists.txt
@@ -55,7 +55,7 @@ if(${CHAINERX_BUILD_TEST})
       native_device_test.cc
   )
   target_link_libraries(chainerx_native_test
-      chainerx
+      chainerx_shared
       chainerx_test_main
       # gtest is linked via chainerx_testing.
       )

--- a/chainerx_cc/chainerx/python/CMakeLists.txt
+++ b/chainerx_cc/chainerx/python/CMakeLists.txt
@@ -39,7 +39,11 @@ target_link_libraries(${module_name} PRIVATE -Wl,--exclude-libs,ALL)
 # CUDA specific bindings.
 if(${CUDA_FOUND})
     CUDA_ADD_LIBRARY(_core_cuda STATIC cuda/cuda_module.cc)
-    target_link_libraries(_core_cuda pybind11::module)
+    target_link_libraries(
+        _core_cuda
+        pybind11::module
+        chainerx
+        )
     target_link_libraries(${module_name} PRIVATE _core_cuda)
 endif()
 

--- a/chainerx_cc/chainerx/python/CMakeLists.txt
+++ b/chainerx_cc/chainerx/python/CMakeLists.txt
@@ -33,7 +33,8 @@ endif()
 pybind11_add_module(${module_name} MODULE ${srcs})
 
 # Strip symbols
-target_link_options(${module_name} PRIVATE -Wl,--exclude-libs,ALL)
+# (Note: target_link_options() is only since CMake 3.13)
+target_link_libraries(${module_name} PRIVATE -Wl,--exclude-libs,ALL)
 
 # CUDA specific bindings.
 if(${CUDA_FOUND})

--- a/chainerx_cc/chainerx/python/CMakeLists.txt
+++ b/chainerx_cc/chainerx/python/CMakeLists.txt
@@ -32,6 +32,9 @@ endif()
 
 pybind11_add_module(${module_name} MODULE ${srcs})
 
+# Strip symbols
+target_link_options(${module_name} PRIVATE -Wl,--exclude-libs,ALL)
+
 # CUDA specific bindings.
 if(${CUDA_FOUND})
     CUDA_ADD_LIBRARY(_core_cuda STATIC cuda/cuda_module.cc)

--- a/chainerx_cc/chainerx/testing/CMakeLists.txt
+++ b/chainerx_cc/chainerx/testing/CMakeLists.txt
@@ -27,7 +27,7 @@ if(${CHAINERX_BUILD_TEST})
         routines_test.cc)
 
     target_link_libraries(chainerx_testing_test
-      chainerx
+      chainerx_shared
       chainerx_test_main)
     add_test(NAME chainerx_testing_test COMMAND chainerx_testing_test)
 endif()

--- a/chainerx_cc/examples/mnist/CMakeLists.txt
+++ b/chainerx_cc/examples/mnist/CMakeLists.txt
@@ -5,5 +5,5 @@ add_executable(train_mnist
   train_mnist.cc
 )
 target_link_libraries(train_mnist
-  chainerx
+  chainerx_static
 )

--- a/chainerx_cc/third_party/abseil.cmake
+++ b/chainerx_cc/third_party/abseil.cmake
@@ -4,7 +4,8 @@ project(abseil-download NONE)
 include(ExternalProject)
 ExternalProject_Add(abseil
     GIT_REPOSITORY    https://github.com/abseil/abseil-cpp.git
-    GIT_TAG           20190808
+    # TODO(niboshi): Should use a tagged version. 20190808 has a problem causing duplicate symbol errors.
+    GIT_TAG           0514227d2547793b23e209809276375e41c76617
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/abseil"
     BINARY_DIR        ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Depends on ~#8409~, ~#8408~, ~#8414~, ~#8421~, ~#8422~, ~#8437~, ~#8442~

If `chainerx` Python binding depends on a dynamic library `libchainerx.so`, that can cause a problem regarding library versions: If another python module depended on another version of `libchainerx.so`, different versions of chainerx could be loaded depending of the order of `import`s.

This is an attempt to circumvent the problem by linking chainerx statically from the `chainerx` Python binding.