### PR TITLE
Avoid using private `_fix_random`

### DIFF
--- a/chainer/testing/random.py
+++ b/chainer/testing/random.py
@@ -147,11 +147,11 @@ def _fix_random(setup_method_name, teardown_method_name):
     return decorator
 
 
-def fix_random():
+def fix_random(*, setup_method='setUp', teardown_method='tearDown'):
     """Decorator that fixes random numbers in a test.
 
     This decorator can be applied to either a test case class or a test method.
     It should not be applied within ``condition.retry`` or
     ``condition.repeat``.
     """
-    return _fix_random('setUp', 'tearDown')
+    return _fix_random(setup_method, teardown_method)

--- a/tests/chainerx_tests/op_utils.py
+++ b/tests/chainerx_tests/op_utils.py
@@ -442,4 +442,6 @@ def fix_random():
 
     .. seealso:: :func:`~chainer.testing.fix_random`
     """
-    return chainer.testing.random._fix_random('setup', 'teardown')
+    return chainer.testing.random.fix_random(
+        setup_method='setup',
+        teardown_method='teardown')


### PR DESCRIPTION
by adding method name arguments to `fix_random`.
