### PR TITLE
Temporarily skip test that will break after CuPy #2437

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy
+import pytest
 import six
 
 import chainer
@@ -218,6 +219,10 @@ class DetFunctionTest(unittest.TestCase):
     def test_zero_det_cpu(self):
         self.check_zero_det(self.x, self.gy, ValueError)
 
+    # TODO(hvy): Do not skip but instead configure the errstate to raise linalg
+    # errors after the following PR in CuPy is merged.
+    # https://github.com/cupy/cupy/pull/2437.
+    @pytest.mark.skip
     @attr.gpu
     def test_zero_det_gpu(self):
         with chainer.using_config('debug', True):


### PR DESCRIPTION
A test is preventing [a compatibility breaking CuPy PR](https://github.com/cupy/cupy/pull/2437) from being merged. This PR temporarily skips the test. The test should be updated to use the new interface introduced in this CuPy PR and then unskipped.