### PR TITLE
Add chainerx tests to test_create_mnbn_model

### DIFF
--- a/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
+++ b/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
@@ -40,7 +40,7 @@ class TestCreateMnBnModel(unittest.TestCase):
 
         # Use CuPy's Device class to foce call cudaSetDevice()
         if chainer.backends.cuda.available:
-            get_device(self.communicator.intra_rank, False).use()
+            chainer.cuda.get_device_from_id(self.communicator.intra_rank).use()
 
     def check_create_mnbn_model_chain(self, use_gpu, use_chx):
         model = BnChain(3)
@@ -53,7 +53,6 @@ class TestCreateMnBnModel(unittest.TestCase):
                        chainermn.links.MultiNodeBatchNormalization))
         device = get_device(self.communicator.intra_rank if use_gpu else None,
                             use_chx)
-        device.use()
         mnbn_model.to_device(device)
 
         with chainer.using_device(mnbn_model.device):
@@ -71,7 +70,6 @@ class TestCreateMnBnModel(unittest.TestCase):
                        chainermn.links.MultiNodeBatchNormalization))
         device = get_device(self.communicator.intra_rank if use_gpu else None,
                             use_chx)
-        device.use()
         mnbn_model.to_device(device)
 
         with chainer.using_device(mnbn_model.device):
@@ -91,7 +89,6 @@ class TestCreateMnBnModel(unittest.TestCase):
 
         device = get_device(self.communicator.intra_rank if use_gpu else None,
                             use_chx)
-        device.use()
         mnbn_model.to_device(device)
 
         with chainer.using_device(mnbn_model.device):

--- a/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
+++ b/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
@@ -1,7 +1,6 @@
 import unittest
 
 import chainer
-from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
 import chainermn

--- a/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
+++ b/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
@@ -39,6 +39,9 @@ class TestCreateMnBnModel(unittest.TestCase):
     def setUp(self):
         self.communicator = chainermn.create_communicator('naive')
 
+        # Use CuPy's Device class to foce call cudaSetDevice()
+        get_device(self.communicator.intra_rank, False).use()
+
     def check_create_mnbn_model_chain(self, use_gpu, use_chx):
         model = BnChain(3)
         mnbn_model = chainermn.links.create_mnbn_model(model,

--- a/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
+++ b/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
@@ -5,6 +5,7 @@ from chainer.backends.cuda import cupy
 import chainer.testing
 import chainer.testing.attr
 import chainermn
+from chainermn.testing.device import get_device
 
 
 class BnChain(chainer.Chain):
@@ -38,7 +39,7 @@ class TestCreateMnBnModel(unittest.TestCase):
     def setUp(self):
         self.communicator = chainermn.create_communicator('naive')
 
-    def check_create_mnbn_model_chain(self, gpu):
+    def check_create_mnbn_model_chain(self, use_gpu, use_chx):
         model = BnChain(3)
         mnbn_model = chainermn.links.create_mnbn_model(model,
                                                        self.communicator)
@@ -47,14 +48,16 @@ class TestCreateMnBnModel(unittest.TestCase):
         self.assertTrue(
             isinstance(mnbn_model.bn,
                        chainermn.links.MultiNodeBatchNormalization))
-        if gpu:
-            mnbn_model.to_device(cupy.cuda.Device())
+        device = get_device(self.communicator.intra_rank if use_gpu else None,
+                            use_chx)
+        device.use()
+        mnbn_model.to_device(device)
 
         with chainer.using_device(mnbn_model.device):
             x = mnbn_model.xp.zeros((1, 1, 1, 1))
             mnbn_model(x)
 
-    def check_create_mnbn_model_chain_list(self, gpu):
+    def check_create_mnbn_model_chain_list(self, use_gpu, use_chx):
         model = BnChainList(3)
         mnbn_model = chainermn.links.create_mnbn_model(model,
                                                        self.communicator)
@@ -63,13 +66,16 @@ class TestCreateMnBnModel(unittest.TestCase):
         self.assertTrue(
             isinstance(mnbn_model[1],
                        chainermn.links.MultiNodeBatchNormalization))
-        if gpu:
-            mnbn_model.to_device(cupy.cuda.Device())
+        device = get_device(self.communicator.intra_rank if use_gpu else None,
+                            use_chx)
+        device.use()
+        mnbn_model.to_device(device)
+
         with chainer.using_device(mnbn_model.device):
             x = mnbn_model.xp.zeros((1, 1, 1, 1))
             mnbn_model(x)
 
-    def check_create_mnbn_model_sequential(self, gpu):
+    def check_create_mnbn_model_sequential(self, use_gpu, use_chx):
         size = 3
         model = chainer.Sequential(
             chainer.links.Convolution2D(
@@ -80,29 +86,38 @@ class TestCreateMnBnModel(unittest.TestCase):
         mnbn_model = chainermn.links.create_mnbn_model(model,
                                                        self.communicator)
 
-        if gpu:
-            mnbn_model.to_device(cupy.cuda.Device())
+        device = get_device(self.communicator.intra_rank if use_gpu else None,
+                            use_chx)
+        device.use()
+        mnbn_model.to_device(device)
+
         with chainer.using_device(mnbn_model.device):
             x = mnbn_model.xp.zeros((1, 1, 1, 1))
             mnbn_model(x)
 
     def test_create_mnbn_model_chain_cpu(self):
-        self.check_create_mnbn_model_chain(gpu=False)
+        self.check_create_mnbn_model_chain(use_gpu=False, use_chx=False)
+        self.check_create_mnbn_model_chain(use_gpu=False, use_chx=True)
 
     def test_create_mnbn_model_chain_list_cpu(self):
-        self.check_create_mnbn_model_chain_list(gpu=False)
+        self.check_create_mnbn_model_chain_list(use_gpu=False, use_chx=False)
+        self.check_create_mnbn_model_chain_list(use_gpu=False, use_chx=True)
 
     def test_create_mnbn_model_sequential_cpu(self):
-        self.check_create_mnbn_model_sequential(gpu=False)
+        self.check_create_mnbn_model_sequential(use_gpu=False, use_chx=False)
+        self.check_create_mnbn_model_sequential(use_gpu=False, use_chx=True)
 
     @chainer.testing.attr.gpu
     def test_create_mnbn_model_chain_gpu(self):
-        self.check_create_mnbn_model_chain(gpu=True)
+        self.check_create_mnbn_model_chain(use_gpu=True, use_chx=False)
+        self.check_create_mnbn_model_chain(use_gpu=True, use_chx=True)
 
     @chainer.testing.attr.gpu
     def test_create_mnbn_model_chain_list_gpu(self):
-        self.check_create_mnbn_model_chain_list(gpu=True)
+        self.check_create_mnbn_model_chain_list(use_gpu=True, use_chx=False)
+        self.check_create_mnbn_model_chain_list(use_gpu=True, use_chx=True)
 
     @chainer.testing.attr.gpu
     def test_create_mnbn_model_sequential_gpu(self):
-        self.check_create_mnbn_model_sequential(gpu=True)
+        self.check_create_mnbn_model_sequential(use_gpu=True, use_chx=False)
+        self.check_create_mnbn_model_sequential(use_gpu=True, use_chx=True)

--- a/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
+++ b/tests/chainermn_tests/links_tests/test_create_mnbn_model.py
@@ -39,7 +39,8 @@ class TestCreateMnBnModel(unittest.TestCase):
         self.communicator = chainermn.create_communicator('naive')
 
         # Use CuPy's Device class to foce call cudaSetDevice()
-        get_device(self.communicator.intra_rank, False).use()
+        if chainer.backends.cuda.available:
+            get_device(self.communicator.intra_rank, False).use()
 
     def check_create_mnbn_model_chain(self, use_gpu, use_chx):
         model = BnChain(3)


### PR DESCRIPTION
This PR is a part of #8031. It adds ChainerX tests to test_create_mnbn_model.py