### PR TITLE
Use `PYBIND11_EXPORT` instead of visibility hack

### DIFF
--- a/chainerx_cc/chainerx/macro.h
+++ b/chainerx_cc/chainerx/macro.h
@@ -36,17 +36,3 @@
     } while (false)
 #endif  // NDEBUG
 #endif  // CHAINERX_NEVER_REACH
-
-// Hides a symbol from the ChainerX shared object symbol table.
-// Note that symbols are hidden by default on Windows, which is opposite from POSIX.
-//
-// CHAINERX_VISIBILITY_HIDDEN was introduced in order to allow defining classes holding pybind11 objects (which are hidden by default) as
-// members.
-// https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes
-#ifndef CHAINERX_VISIBILITY_HIDDEN
-#if defined(WIN32) || defined(_WIN32)
-#define CHAINERX_VISIBILITY_HIDDEN
-#else  // defined(WIN32) || defined(_WIN32)
-#define CHAINERX_VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
-#endif  // defined(WIN32) || defined(_WIN32)
-#endif  // CHAINERX_VISIBILITY_HIDDEN

--- a/chainerx_cc/chainerx/python/CMakeLists.txt
+++ b/chainerx_cc/chainerx/python/CMakeLists.txt
@@ -47,10 +47,7 @@ set_target_properties(${module_name}
     SKIP_BUILD_RPATH FALSE
     BUILD_WITH_INSTALL_RPATH TRUE)
 
-# Visibility (CXX_VISIBILITY_PRESET) must be set to "default" to register custom exceptions, overriding the visibility configured by pybind11_add_module.
-# Note however that this only seems to be an issue when building with libc++.
 set_target_properties(${module_name}
     PROPERTIES
     PREFIX "${PYTHON_MODULE_PREFIX}"
-    SUFFIX "${PYTHON_MODULE_SUFFIX}"
-    CXX_VISIBILITY_PRESET "default")
+    SUFFIX "${PYTHON_MODULE_SUFFIX}")

--- a/chainerx_cc/chainerx/python/array_index.cc
+++ b/chainerx_cc/chainerx/python/array_index.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/array_index.h"
 
 #include <type_traits>

--- a/chainerx_cc/chainerx/python/axes.cc
+++ b/chainerx_cc/chainerx/python/axes.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/axes.h"
 
 #include <algorithm>

--- a/chainerx_cc/chainerx/python/backend.cc
+++ b/chainerx_cc/chainerx/python/backend.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/backend.h"
 
 #include "chainerx/backend.h"

--- a/chainerx_cc/chainerx/python/backprop_mode.cc
+++ b/chainerx_cc/chainerx/python/backprop_mode.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/backprop_mode.h"
 
 #include <memory>

--- a/chainerx_cc/chainerx/python/backward.cc
+++ b/chainerx_cc/chainerx/python/backward.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/backward.h"
 
 #include <iterator>

--- a/chainerx_cc/chainerx/python/chainer_interop.cc
+++ b/chainerx_cc/chainerx/python/chainer_interop.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/chainer_interop.h"
 
 #include <algorithm>

--- a/chainerx_cc/chainerx/python/check_backward.cc
+++ b/chainerx_cc/chainerx/python/check_backward.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/check_backward.h"
 
 #include <algorithm>

--- a/chainerx_cc/chainerx/python/common_export.h
+++ b/chainerx_cc/chainerx/python/common_export.h
@@ -1,0 +1,20 @@
+// Every source file in this directory should include this file before anything else.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace chainerx {
+
+class PYBIND11_EXPORT ChainerxError;
+class PYBIND11_EXPORT ContextError;
+class PYBIND11_EXPORT BackendError;
+class PYBIND11_EXPORT DeviceError;
+class PYBIND11_EXPORT IndexError;
+class PYBIND11_EXPORT DimensionError;
+class PYBIND11_EXPORT DtypeError;
+class PYBIND11_EXPORT NotImplementedError;
+class PYBIND11_EXPORT GradientError;
+class PYBIND11_EXPORT GradientCheckError;
+
+}  // namespace chainerx

--- a/chainerx_cc/chainerx/python/context.cc
+++ b/chainerx_cc/chainerx/python/context.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/context.h"
 
 #include <memory>

--- a/chainerx_cc/chainerx/python/core_module.cc
+++ b/chainerx_cc/chainerx/python/core_module.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <string>

--- a/chainerx_cc/chainerx/python/cuda/cuda_module.cc
+++ b/chainerx_cc/chainerx/python/cuda/cuda_module.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/cuda/cuda_module.h"
 
 #include <cstddef>

--- a/chainerx_cc/chainerx/python/device.cc
+++ b/chainerx_cc/chainerx/python/device.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/device.h"
 
 #include <memory>

--- a/chainerx_cc/chainerx/python/dtype.cc
+++ b/chainerx_cc/chainerx/python/dtype.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/dtype.h"
 
 #include <string>

--- a/chainerx_cc/chainerx/python/error.cc
+++ b/chainerx_cc/chainerx/python/error.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/error.h"
 
 #include "chainerx/error.h"

--- a/chainerx_cc/chainerx/python/graph.cc
+++ b/chainerx_cc/chainerx/python/graph.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/graph.h"
 
 #include <memory>

--- a/chainerx_cc/chainerx/python/routines.cc
+++ b/chainerx_cc/chainerx/python/routines.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/routines.h"
 
 #include <algorithm>

--- a/chainerx_cc/chainerx/python/scalar.cc
+++ b/chainerx_cc/chainerx/python/scalar.cc
@@ -1,6 +1,8 @@
-#include <string>
+#include "chainerx/python/common_export.h"
 
 #include "chainerx/python/scalar.h"
+
+#include <string>
 
 #include <pybind11/operators.h>
 

--- a/chainerx_cc/chainerx/python/shape.cc
+++ b/chainerx_cc/chainerx/python/shape.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/shape.h"
 
 #include <algorithm>

--- a/chainerx_cc/chainerx/python/slice.cc
+++ b/chainerx_cc/chainerx/python/slice.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/slice.h"
 
 #include <absl/types/optional.h>

--- a/chainerx_cc/chainerx/python/strides.cc
+++ b/chainerx_cc/chainerx/python/strides.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/strides.h"
 
 #include <algorithm>

--- a/chainerx_cc/chainerx/python/testing/device_buffer.cc
+++ b/chainerx_cc/chainerx/python/testing/device_buffer.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/testing/device_buffer.h"
 
 #include <algorithm>
@@ -8,7 +10,6 @@
 
 #include "chainerx/device.h"
 #include "chainerx/error.h"
-#include "chainerx/macro.h"
 #include "chainerx/python/device.h"
 #include "chainerx/python/dtype.h"
 #include "chainerx/python/shape.h"
@@ -29,7 +30,7 @@ using py::literals::operator""_a;
 // (py::buffer_info only holds a raw pointer and does not manage the lifetime of the pointed data). Memoryviews created from this buffer
 // will also share ownership. Note that accessing the .obj attribute of a memoryview may increase the reference count and should thus be
 // avoided.
-class CHAINERX_VISIBILITY_HIDDEN PyDeviceBuffer {
+class PyDeviceBuffer {
 public:
     PyDeviceBuffer(std::shared_ptr<void> data, std::shared_ptr<py::buffer_info> info) : data_{std::move(data)}, info_{std::move(info)} {}
 

--- a/chainerx_cc/chainerx/python/testing/testing_module.cc
+++ b/chainerx_cc/chainerx/python/testing/testing_module.cc
@@ -1,3 +1,5 @@
+#include "chainerx/python/common_export.h"
+
 #include "chainerx/python/testing/testing_module.h"
 
 #include "chainerx/python/testing/device_buffer.h"


### PR DESCRIPTION
Instead of tweaking the default visibility (#5936), this PR applies `PYBIND11_EXPORT` to relevant classes, as suggested in https://github.com/pybind/pybind11/issues/1272#issuecomment-364132532.

