### PR TITLE
Ignore unused function warning in NVCC

### DIFF
--- a/chainerx_cc/CMakeLists.txt
+++ b/chainerx_cc/CMakeLists.txt
@@ -151,6 +151,12 @@ if(${CHAINERX_BUILD_CUDA})
 
     list(APPEND CUDA_NVCC_FLAGS "-std=c++${CMAKE_CXX_STANDARD}")
 
+    # Ignore unused function warnings in NVCC that comes from CUDA system headers.
+    # It's not possible to ignore warnings selectively in system headers because CMake's CUDA module doesn't support SYSTEM specification for include directories
+    # (https://gitlab.kitware.com/cmake/cmake/issues/16464),
+    # so relevant warnings from all the sources are ignored.
+    list(APPEND CUDA_NVCC_FLAGS -Xcompiler "-Wno-unused-function")
+
     # CUDA_cublas_device_LIBRARY is required for CUDA > 9.2 with cmake < to 3.12.2.
     # This is because cublas_device was deprecated in CUDA 9.2, but FindCUDA supported it in 3.12.2.
     set(CUDA_cublas_device_LIBRARY ${CUDA_LIBRARIES})


### PR DESCRIPTION
Ignore unused function warnings in NVCC that comes from CUDA system headers.
It's not possible to ignore warnings selectively in system headers because CMake's CUDA module doesn't support `SYSTEM` specification for include directories (https://gitlab.kitware.com/cmake/cmake/issues/16464), so relevant warnings from all the sources are ignored.