### PR TITLE
Annotate tests that usually run >30s

### DIFF
--- a/scripts/ci/travis/xpytest-hint-chainerx.pbtxt
+++ b/scripts/ci/travis/xpytest-hint-chainerx.pbtxt
@@ -18,3 +18,7 @@ rules { name: "chainerx_tests/unit_tests/routines_tests/test_logic.py" deadline:
 rules { name: "chainerx_tests/unit_tests/routines_tests/test_misc.py" deadline: 240 }
 rules { name: "chainerx_tests/unit_tests/routines_tests/test_normalization.py" deadline: 240 }
 rules { name: "chainerx_tests/unit_tests/routines_tests/test_reduction.py" deadline: 240 }
+
+# Slow tests take 30+ seconds.
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_binary.py" deadline: 120 }
+rules { name: "chainerx_tests/unit_tests/routines_tests/test_linalg.py" deadline: 120 }


### PR DESCRIPTION
To avoid test flakiness, all possibly slow tests have to be hinted.
Default timeout of xpytest is 60s.

Fix #8425.