### PR TITLE
Fix `F.det` with CuPy to be consistent with NumPy

### DIFF
--- a/chainer/functions/math/det.py
+++ b/chainer/functions/math/det.py
@@ -1,4 +1,5 @@
 import chainer
+from chainer.backends import cuda
 from chainer import function_node
 import chainer.functions
 from chainer.utils import precision
@@ -27,7 +28,12 @@ class BatchDet(function_node.FunctionNode):
         self.retain_outputs((0,))
         x, = inputs
         xp = chainer.backend.get_array_module(x)
-        detx = xp.linalg.det(x)
+        det = xp.linalg.det
+        if xp is cuda.cupy:
+            with cuda.cupyx.errstate(linalg='raise'):  # NumPy compatibility.
+                detx = det(x)
+        else:
+            detx = det(x)
         return detx,
 
     def backward(self, indexes, gy):

--- a/tests/chainer_tests/functions_tests/math_tests/test_det.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_det.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import pytest
 import six
 
 import chainer
@@ -219,10 +218,6 @@ class DetFunctionTest(unittest.TestCase):
     def test_zero_det_cpu(self):
         self.check_zero_det(self.x, self.gy, ValueError)
 
-    # TODO(hvy): Do not skip but instead configure the errstate to raise linalg
-    # errors after the following PR in CuPy is merged.
-    # https://github.com/cupy/cupy/pull/2437.
-    @pytest.mark.skip
     @attr.gpu
     def test_zero_det_gpu(self):
         with chainer.using_config('debug', True):


### PR DESCRIPTION
Fixes a recent incompatibility between CuPy/NumPy in `F.det`. C.f. https://github.com/chainer/chainer/pull/8434#issuecomment-553723111