### PR TITLE
Add support of SelectItem in ONNX-Chainer

### DIFF
--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -26,6 +26,7 @@ from onnx_chainer.functions.array import convert_Repeat  # NOQA
 from onnx_chainer.functions.array import convert_Reshape  # NOQA
 from onnx_chainer.functions.array import convert_ResizeImages  # NOQA
 from onnx_chainer.functions.array import convert_Rollaxis  # NOQA
+from onnx_chainer.functions.array import convert_SelectItem  # NOQA
 from onnx_chainer.functions.array import convert_Separate  # NOQA
 from onnx_chainer.functions.array import convert_Shape  # NOQA
 from onnx_chainer.functions.array import convert_Space2Depth  # NOQA

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -1,6 +1,7 @@
 import warnings
 
 import chainer
+import onnx
 import numpy as np
 from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
 
@@ -192,6 +193,31 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
         gb.op('Gather', slice_output, axis=gather_axis)
 
     return gb.nodes(output_names=output_names)
+
+
+@support((9, 11))
+def convert_SelectItem(func, opset_version, input_names, output_names,
+                       context):
+    gb = onnx_helper.GraphBuilder()
+
+    data, target_idxs = input_names
+    target_idxs = gb.op('Cast', [target_idxs],
+                        to=NP_TYPE_TO_TENSOR_TYPE[np.dtype('int64')])
+    n_rows = gb.op('Shape', [target_idxs])
+
+    one_1 = onnx.helper.make_tensor('one_1', onnx.TensorProto.FLOAT, [1], [1])
+    ones = gb.op('ConstantOfShape', [n_rows], value=one_1)
+    row_idxs = gb.op('Squeeze', [gb.op('NonZero', [ones])])
+
+    data_shape = gb.op('Shape', [data])
+    one_2 = context.add_const(np.array([1]), 'one_2')
+    n_cols = gb.op('Gather', [data_shape, one_2], axis=0)
+
+    data = gb.op('Squeeze', [gb.op('Flatten', [data], axis=2)])
+    target_idxs = gb.op('Add', [target_idxs, gb.op('Mul', [row_idxs, n_cols])])
+    gb.op('Gather', [data, target_idxs], axis=0)
+
+    return gb.nodes(output_names)
 
 
 @support((1, 2, 11))

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -195,7 +195,6 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
     return gb.nodes(output_names=output_names)
 
 
-@support((9, 11))
 def convert_SelectItem(func, opset_version, input_names, output_names,
                        context):
     gb = onnx_helper.GraphBuilder()

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -205,6 +205,7 @@ def convert_SelectItem(func, opset_version, input_names, output_names,
                         to=NP_TYPE_TO_TENSOR_TYPE[np.dtype('int64')])
     n_rows = gb.op('Shape', [target_idxs])
 
+    # This is an equivalent of using Range.
     one_1 = onnx.helper.make_tensor('one_1', onnx.TensorProto.FLOAT, [1], [1])
     ones = gb.op('ConstantOfShape', [n_rows], value=one_1)
     row_idxs = gb.op('Squeeze', [gb.op('NonZero', [ones])])

--- a/onnx_chainer/mapping.py
+++ b/onnx_chainer/mapping.py
@@ -33,6 +33,7 @@ _supported_function_node_set = {
     'Reshape',
     'ResizeImages',
     'Rollaxis',
+    'SelectItem',
     'Separate',
     'Shape',
     'Space2Depth',

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -155,6 +155,11 @@ from onnx_chainer_tests.helper import ONNXModelTest
      'args': {'slices': (slice(None), slice(0, 1), slice(None, 2))},
      'name': 'get_item_start_from_none'},
 
+    # select_item
+    {'ops': 'select_item', 'input_shape': (3, 3),
+     'input_argname': 'x',
+     'args': {'t': np.array([2, 1, 0], dtype=np.int32)}},
+
     # expand_dims
     {'ops': 'expand_dims', 'input_shape': (3,),
      'input_argname': 'x', 'args': {'axis': 0},

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -155,11 +155,6 @@ from onnx_chainer_tests.helper import ONNXModelTest
      'args': {'slices': (slice(None), slice(0, 1), slice(None, 2))},
      'name': 'get_item_start_from_none'},
 
-    # select_item
-    {'ops': 'select_item', 'input_shape': (3, 3),
-     'input_argname': 'x',
-     'args': {'t': np.array([2, 1, 0], dtype=np.int32)}},
-
     # expand_dims
     {'ops': 'expand_dims', 'input_shape': (3,),
      'input_argname': 'x', 'args': {'axis': 0},
@@ -515,3 +510,20 @@ class TestTransposeSequence(ONNXModelTest):
               shape in self.in_shapes]
 
         self.expect(model, xs, name=self.name)
+
+
+class TestSelectItem(ONNXModelTest):
+
+    def test_output(self):
+
+        class Model(chainer.Chain):
+            def forward(self, x, t):
+                return F.select_item(x, t)
+
+        model = Model()
+        x = input_generator.increasing(3, 3)
+        t = np.array([2, 1, 0], dtype=np.int32)
+
+        self.expect(
+            model, (x, t), expected_num_initializers=0,
+            skip_opset_version=list(range(1, 9)))


### PR DESCRIPTION
This Pull Request addresses #8449. The implementation encodes an equivalent of the following NumPy snippet:

```python
row_idxs = np.nonzero(np.ones(t.shape))[0]
n_cols = x.shape[1]
idxs = row_idxs * n_cols + t
output = np.ravel(x)[idxs]
```

I could have used [`Range`](https://github.com/onnx/onnx/blob/master/docs/Operators.md#Range) to create `row_idxs`, but found that some of other ONNX conversion tools out there have not supported it yet. So I settled on the sequence of [`ConstantOfShape`](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ConstantOfShape) followed by [`NonZero`](https://github.com/onnx/onnx/blob/master/docs/Operators.md#nonzero) to create the indices.

I'm not sure if I correctly used `support` decorator. Among the ops used in the implementation, [`ConstantOfShape`](https://github.com/onnx/onnx/blob/master/docs/Operators.md#ConstantOfShape) is the newest one introduced in opset 9, and some ops have been updated in opset 11. So I set the argument to the decorator as `(9, 11)`. It will be great if you can take a look at it.