### PR TITLE
Add TransposeSequence exporter to ONNX-Chainer

### DIFF
--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -35,6 +35,7 @@ from onnx_chainer.functions.array import convert_Stack  # NOQA
 from onnx_chainer.functions.array import convert_Swapaxes  # NOQA
 from onnx_chainer.functions.array import convert_Tile  # NOQA
 from onnx_chainer.functions.array import convert_Transpose  # NOQA
+from onnx_chainer.functions.array import convert_TransposeSequence  # NOQA
 from onnx_chainer.functions.array import convert_Vstack  # NOQA
 from onnx_chainer.functions.array import convert_Where  # NOQA
 

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -588,3 +588,17 @@ def convert_Rollaxis(func, opset_version, input_names, output_names, context):
                                  perm=order)
 
     return node,
+
+
+def convert_TransposeSequence(
+        func, opset_version, input_names, output_names, context):
+    if len(input_names) == 1:
+        return onnx_helper.make_node(
+            'Split', input_names, output_names, axis=0),
+    elif len(output_names) == 1:
+        return onnx_helper.make_node(
+            'Concat', input_names, output_names, axis=0),
+    else:
+        raise ValueError(
+            'ONNX-Chainer can convert TransposeSequence only when input '
+            'or output length is 1')

--- a/onnx_chainer/mapping.py
+++ b/onnx_chainer/mapping.py
@@ -42,6 +42,7 @@ _supported_function_node_set = {
     'Swapaxes',
     'Tile',
     'Transpose',
+    'TransposeSequence',
     'Vstack',
     'Where',
 

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -487,3 +487,26 @@ class TestPermutate(ONNXModelTest):
             indices = np.array([2, 0, 1], np.int32)
         self.expect(model, (x, indices), name=self.name,
                     skip_opset_version=[7, 8])
+
+
+@testing.parameterize(
+    {'in_shapes': [(3, 4)], 'name': 'transpose_sequence_single_input'},
+    {'in_shapes': [(1, 3), (1, 3)],
+     'name': 'transpose_sequence_single_output'},
+)
+class TestTransposeSequence(ONNXModelTest):
+
+    def test_output(self):
+
+        class Model(chainer.Chain):
+            def __init__(self):
+                super(Model, self).__init__()
+
+            def __call__(self, *xs):
+                return F.transpose_sequence(xs)
+
+        model = Model()
+        xs = [input_generator.increasing(*shape) for
+              shape in self.in_shapes]
+
+        self.expect(model, xs, name=self.name)


### PR DESCRIPTION
This PR adds `TransposeSequence` exporter to ONNX-Chainer

This exporter supports only limited cases where input or output length is 1.