### PR TITLE
Fix several documentation errors in chainer.functions.rnn.*

### DIFF
--- a/chainer/functions/rnn/n_step_gru.py
+++ b/chainer/functions/rnn/n_step_gru.py
@@ -136,7 +136,7 @@ def n_step_gru(
             ``ws[i]`` represents weights for i-th layer.
             Each ``ws[i]`` is a list containing six matrices.
             ``ws[i][j]`` is corresponding with ``W_j`` in the equation.
-            Only ``ws[0][j]`` where ``0 <= j < 3`` is ``(I, N)`` shape as they
+            Only ``ws[0][j]`` where ``0 <= j < 3`` is ``(N, I)`` shape as they
             are multiplied with input variables. All other matrices has
             ``(N, N)`` shape.
         bs (list of list of :class:`~chainer.Variable`): Bias vectors.
@@ -231,7 +231,7 @@ def n_step_bigru(
             ``ws[i]`` represents weights for i-th layer.
             Each ``ws[i]`` is a list containing six matrices.
             ``ws[i][j]`` is corresponding with ``W_j`` in the equation.
-            Only ``ws[0][j]`` where ``0 <= j < 3`` is ``(I, N)`` shape as they
+            Only ``ws[0][j]`` where ``0 <= j < 3`` is ``(N, I)`` shape as they
             are multiplied with input variables. All other matrices has
             ``(N, N)`` shape.
         bs (list of list of :class:`~chainer.Variable`): Bias vectors.
@@ -296,7 +296,7 @@ use_bi_direction)
             ``ws[i]`` represents weights for i-th layer.
             Each ``ws[i]`` is a list containing six matrices.
             ``ws[i][j]`` is corresponding with ``W_j`` in the equation.
-            Only ``ws[0][j]`` where ``0 <= j < 3`` is ``(I, N)`` shape as they
+            Only ``ws[0][j]`` where ``0 <= j < 3`` is ``(N, I)`` shape as they
             are multiplied with input variables. All other matrices has
             ``(N, N)`` shape.
         bs (list of list of :class:`~chainer.Variable`): Bias vectors.

--- a/chainer/functions/rnn/n_step_lstm.py
+++ b/chainer/functions/rnn/n_step_lstm.py
@@ -149,7 +149,7 @@ def n_step_lstm(
             ``ws[i]`` represents the weights for the i-th layer.
             Each ``ws[i]`` is a list containing eight matrices.
             ``ws[i][j]`` corresponds to :math:`W_j` in the equation.
-            Only ``ws[0][j]`` where ``0 <= j < 4`` are ``(I, N)``-shaped as
+            Only ``ws[0][j]`` where ``0 <= j < 4`` are ``(N, I)``-shaped as
             they are multiplied with input variables, where ``I`` is the size
             of the input and ``N`` is the dimension of the hidden units. All
             other matrices are ``(N, N)``-shaped.
@@ -306,7 +306,7 @@ def n_step_bilstm(
             ``m == 1`` means the backward direction.) Each ``ws[i]`` is a
             list containing eight matrices. ``ws[i][j]`` corresponds to
             :math:`W_j` in the equation. ``ws[0][j]`` and ``ws[1][j]`` where
-            ``0 <= j < 4`` are ``(I, N)``-shaped because they are multiplied
+            ``0 <= j < 4`` are ``(N, I)``-shaped because they are multiplied
             with input variables, where ``I`` is the size of the input.
             ``ws[i][j]`` where ``2 <= i`` and ``0 <= j < 4`` are
             ``(N, 2N)``-shaped because they are multiplied with two hidden
@@ -420,7 +420,7 @@ def n_step_lstm_base(
             ``ws[i]`` represents the weights for the i-th layer.
             Each ``ws[i]`` is a list containing eight matrices.
             ``ws[i][j]`` corresponds to :math:`W_j` in the equation.
-            Only ``ws[0][j]`` where ``0 <= j < 4`` are ``(I, N)``-shape as they
+            Only ``ws[0][j]`` where ``0 <= j < 4`` are ``(N, I)``-shape as they
             are multiplied with input variables, where ``I`` is the size of
             the input and ``N`` is the dimension of the hidden units. All
             other matrices are ``(N, N)``-shaped.

--- a/chainer/functions/rnn/n_step_rnn.py
+++ b/chainer/functions/rnn/n_step_rnn.py
@@ -485,7 +485,7 @@ def n_step_rnn(
             ``ws[i]`` represents weights for i-th layer.
             Each ``ws[i]`` is a list containing two matrices.
             ``ws[i][j]`` is corresponding with ``W_j`` in the equation.
-            Only ``ws[0][j]`` where ``0 <= j < 1`` is ``(I, N)`` shape as they
+            Only ``ws[0][j]`` where ``0 <= j < 1`` is ``(N, I)`` shape as they
             are multiplied with input variables. All other matrices has
             ``(N, N)`` shape.
         bs (list of list of :class:`~chainer.Variable`): Bias vectors.
@@ -580,22 +580,24 @@ def n_step_birnn(
             dimension of hidden units. Because of bi-direction, the
             first dimension length is ``2S``.
         ws (list of list of :class:`~chainer.Variable`): Weight matrices.
-            ``ws[i + di]`` represents weights for i-th layer.
+            ``ws[2 * i + di]`` represents weights for i-th layer.
             Note that ``di = 0`` for forward-RNN and ``di = 1`` for
             backward-RNN.
-            Each ``ws[i + di]`` is a list containing two matrices.
-            ``ws[i + di][j]`` is corresponding with ``W^{f}_j`` if ``di = 0``
-            and corresponding with ``W^{b}_j`` if ``di = 1`` in the equation.
+            Each ``ws[2 * i + di]`` is a list containing two matrices.
+            ``ws[2 * i + di][j]`` is corresponding with ``W^{f}_j`` if
+            ``di = 0`` and corresponding with ``W^{b}_j`` if ``di = 1`` in
+            the equation.
             Only ``ws[0][j]`` and ``ws[1][j]`` where ``0 <= j < 1`` are
-            ``(I, N)`` shape as they are multiplied with input variables.
+            ``(N, I)`` shape as they are multiplied with input variables.
             All other matrices has ``(N, N)`` shape.
         bs (list of list of :class:`~chainer.Variable`): Bias vectors.
-            ``bs[i + di]`` represnents biases for i-th layer.
+            ``bs[2 * i + di]`` represnents biases for i-th layer.
             Note that ``di = 0`` for forward-RNN and ``di = 1`` for
             backward-RNN.
-            Each ``bs[i + di]`` is a list containing two vectors.
-            ``bs[i + di][j]`` is corresponding with ``b^{f}_j`` if ``di = 0``
-            and corresponding with ``b^{b}_j`` if ``di = 1`` in the equation.
+            Each ``bs[2 * i + di]`` is a list containing two vectors.
+            ``bs[2 * i + di][j]`` is corresponding with ``b^{f}_j`` if
+            ``di = 0`` and corresponding with ``b^{b}_j`` if ``di = 1`` in
+            the equation.
             Shape of each matrix is ``(N,)`` where ``N`` is dimension of
             hidden units.
         xs (list of :class:`~chainer.Variable`):
@@ -653,7 +655,7 @@ use_bi_direction)
             ``ws[i]`` represents weights for i-th layer.
             Each ``ws[i]`` is a list containing two matrices.
             ``ws[i][j]`` is corresponding with ``W_j`` in the equation.
-            Only ``ws[0][j]`` where ``0 <= j < 1`` is ``(I, N)`` shape as they
+            Only ``ws[0][j]`` where ``0 <= j < 1`` is ``(N, I)`` shape as they
             are multiplied with input variables. All other matrices has
             ``(N, N)`` shape.
         bs (list of list of :class:`~chainer.Variable`): Bias vectors.


### PR DESCRIPTION
This PR contains two doc fixes:

* fixing weight matrix sizes from `(I, N)` to `(N, I)`, and
* fixing bias/weight indexes in `n_step_birnn` from `i + di` to `2 * i + di`.