### PR TITLE
Use `__name__` attribute in parameterized test names when available

### DIFF
--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -14,6 +14,9 @@ from chainer import utils
 def _param_to_str(obj):
     if isinstance(obj, type):
         return obj.__name__
+    elif hasattr(obj, '__name__') and isinstance(obj.__name__, str):
+        # print __name__ attribute for classes, functions and modules
+        return obj.__name__
     return repr(obj)
 
 


### PR DESCRIPTION
This is a tiny PR porting over a small change to parameterized test naming that I proposed in cupy/cupy#2633 (and at pytest-dev/pytest#6152).  If the object being parameterized has a `__name__` attribute string, then this will be used rather than falling back to the  `__repr__`.  Functions, classes and modules all have this attribute and it tends to make the parameterized test names more concise and readable.

As a specifc example, the cupy module's `__repr__` is quite long:
```
<module 'cupy' from '/home/lee8rx/miniconda3_ne...r/lib/python3.7/site-packages/cupy/__init__.py'>
```
whereas the `__name__` is just
```
cupy
```