### PR TITLE
Add `parametrize_device_name` to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ markers =
     multi_gpu: Tests to uses multi GPUs
     slow: Tests thats takes time
     parametrize_device: Parametrize ChainerX devices
+    parametrize_device_name: Parametrize ChainerX device names
 
 [mypy]
 


### PR DESCRIPTION
This was preventing ChainerX from running with newer pytest versions


```
E   pytest.PytestUnknownMarkWarning: Unknown pytest.mark.parametrize_device_name - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
```