### PR TITLE
Support `chainerx.batch_norm` with 2D input on CUDA

### DIFF
--- a/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
@@ -211,6 +211,7 @@ public:
             const absl::optional<Array>& ggamma,
             const absl::optional<Array>& gbeta) override {
         CHAINERX_ASSERT(gamma.shape() == internal::ReduceShape(x.shape(), axis, true));
+        CHAINERX_ASSERT(x.dtype() == gout.dtype());
         CHAINERX_ASSERT(x.shape() == gout.shape());
         CHAINERX_ASSERT(&x.device() == &gamma.device());
         CHAINERX_ASSERT(&x.device() == &gout.device());
@@ -252,9 +253,6 @@ public:
         Array gout_cont = AsContiguous(gout);
         Array actual_gx = EmptyLike(x, device);
         cuda_internal::CudnnTensorDescriptor x_desc{ExpandToAtLeast4D(x_cont)};
-
-        // The CudnnTensorDescriptor for `x_cont` can be reused for `gout_cont`.
-        CHAINERX_ASSERT(x_desc.GetDtype() == cuda_internal::CudnnTensorDescriptor{gout_cont}.GetDtype());
 
         cudnnBatchNormMode_t mode = GetBatchNormMode(axis);
 

--- a/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
+++ b/chainerx_cc/chainerx/cuda/cuda_device/batch_norm.cc
@@ -29,7 +29,6 @@ namespace chainerx {
 namespace cuda {
 namespace {
 
-// TODO(sonots): Support other than 4, 5 dimensional arrays by reshaping into 4-dimensional arrays as Chainer does.
 cudnnBatchNormMode_t GetBatchNormMode(const Axes& axis) {
     if (axis.ndim() == 1 && axis[0] == 0) {  // (1, channels, (depth, )height, width)
         return CUDNN_BATCHNORM_PER_ACTIVATION;

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -43,10 +43,9 @@ def _create_batch_norm_ndarray_args(
     return x, gamma, beta, mean, var
 
 
-# Note that CUDA (cuDNN) only supports batch normalization with 4 or
-# 5-dimenisional data.
 # x_shape,reduced_shape,axis
 _batch_norm_params = [
+    ((3, 2), (2,), None),
     ((5, 4, 3, 2), (4, 3, 2), None),
     ((5, 4, 3, 2), (4, 3, 2), (0,)),
     ((5, 4, 3, 2), (4,), (0, 2, 3)),

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -43,6 +43,9 @@ def _create_batch_norm_ndarray_args(
     return x, gamma, beta, mean, var
 
 
+# Note that CUDA (cuDNN) only supports batch normalization with 4 or
+# 5-dimenisional data. Arrays with smaller dimensions are supported by the
+# CUDA backend, while those with larger dimensions are not.
 # x_shape,reduced_shape,axis
 _batch_norm_params = [
     ((3, 2), (2,), None),

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_normalization.py
@@ -44,7 +44,7 @@ def _create_batch_norm_ndarray_args(
 
 
 # Note that CUDA (cuDNN) only supports batch normalization with 4 or
-# 5-dimenisional data. Arrays with smaller dimensions are supported by the
+# 5-dimensional data. Arrays with smaller dimensions are supported by the
 # CUDA backend, while those with larger dimensions are not.
 # x_shape,reduced_shape,axis
 _batch_norm_params = [


### PR DESCRIPTION
Takeover #8302 

Error only happened on the Debug version of ChainerX because of an assert that was doing a CUDNN call with an invalid shape.

