### PR TITLE
Add support for `spawn` and `forkserver` start method in `PickleDataset`

### DIFF
--- a/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
@@ -2,6 +2,7 @@ import ctypes
 import io
 import multiprocessing
 import os
+import platform
 import sys
 import unittest
 
@@ -58,6 +59,8 @@ class TestPickleDataset(unittest.TestCase):
         assert dataset[2] == 1.5
         assert dataset[1] == 'hello'
 
+    @unittest.skipIf(platform.system() == 'Windows',
+                     'Windows does not support `fork` method')
     def test_after_fork(self):
         writer = datasets.PickleDatasetWriter(self.io)
         writer.write(1)

--- a/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
+++ b/tests/chainer_tests/datasets_tests/test_pickle_dataset.py
@@ -83,7 +83,8 @@ class TestPickleDataset(unittest.TestCase):
         dataset = datasets.PickleDataset(reader)
 
         assert reader.n_hook_called == 0
-        p = multiprocessing.Process()
+        ctx = multiprocessing.get_context('fork')
+        p = ctx.Process()
         p.start()
         p.join()
         assert reader.n_hook_called == 1


### PR DESCRIPTION
This PR solves #7768.

- Skip the test for `PickleDataset._after_hook()` on Windows
- Support `spawn` and `forkserver` start method
    - Make picklable `PickleDataset`
    - Make picklable `_FileReader`
    - cf. [Programming guidelines for multiprocessing](https://docs.python.org/3.6/library/multiprocessing.html#the-spawn-and-forkserver-start-methods)