### PR TITLE
Fix imagenet example's replacement file for test

### DIFF
--- a/examples/imagenet/.testdata/replacements/train_imagenet.py
+++ b/examples/imagenet/.testdata/replacements/train_imagenet.py
@@ -114,18 +114,18 @@ def main():
         if device.xp is not chainer.backend.cuda.cupy:
             raise RuntimeError('Using DALI requires GPU device. Please '
                                'specify it with --device option.')
-        num_threads = args.loaderjob
-        if num_threads is None or num_threads <= 0:
-            num_threads = 1
+        n_threads = args.loaderjob
+        if n_threads is None or n_threads <= 0:
+            n_threads = 1
         ch_mean = list(np.average(mean, axis=(1, 2)))
         ch_std = [255.0, 255.0, 255.0]
         # Setup DALI pipelines
         train_pipe = dali_util.DaliPipelineTrain(
             args.train, args.root, model.insize, args.batchsize,
-            num_threads, device.device.id, True, mean=ch_mean, std=ch_std)
+            n_threads, device.device.id, True, mean=ch_mean, std=ch_std)
         val_pipe = dali_util.DaliPipelineVal(
             args.val, args.root, model.insize, args.val_batchsize,
-            num_threads, device.device.id, False, mean=ch_mean, std=ch_std)
+            n_threads, device.device.id, False, mean=ch_mean, std=ch_std)
         train_iter = chainer.iterators.DaliIterator(train_pipe)
         val_iter = chainer.iterators.DaliIterator(val_pipe, repeat=False)
         # converter = dali_converter


### PR DESCRIPTION
This fixes an error in the example test:

```
[2019-11-20 10:20:24] E               test_utils.ReplacementFileCorrectnessError: Replacement file correctness check failed: Line mismatch between the original and the replacement file.
[2019-11-20 10:20:24] E               
[2019-11-20 10:20:24] E               If you're seeing this error message, it's likely that you edited a file within the example directory but did not edit the matching replacement file which is used for testing. Please ensure the two files are synchronized.
[2019-11-20 10:20:24] E               
[2019-11-20 10:20:24] E               Original file: /home/travis/build/chainer/chainer/examples/imagenet/train_imagenet.py
[2019-11-20 10:20:24] E               Replacement file: /home/travis/build/chainer/chainer/examples/imagenet/.testdata/replacements/train_imagenet.py
[2019-11-20 10:20:24] E               Line number in the original file: 116
[2019-11-20 10:20:24] E               Line number in the replacement file: 117
[2019-11-20 10:20:24] E               Original line: [        n_threads = args.loaderjob]
[2019-11-20 10:20:24] E               Replacement line: [        num_threads = args.loaderjob]
[2019-11-20 10:20:24] 
[2019-11-20 10:20:24] /home/travis/build/chainer/chainer/examples/test_utils.py:225: ReplacementFileCorrectnessError
[2019-11-20 10:20:24] =============================================== short test summary info ================================================
[2019-11-20 10:20:24] FAIL examples/tests/test_imagenet.py::TestImagenet::test_1
[2019-11-20 10:20:24] =============================================== 1 failed in 0.77 seconds ===============================================
```