### PR TITLE
SelectItem using GatherElements for ONNX opset>=11

### DIFF
--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -199,27 +199,35 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
     return gb.nodes(output_names=output_names)
 
 
+@support((9, 11))
 def convert_SelectItem(func, opset_version, input_names, output_names,
                        context):
     gb = onnx_helper.GraphBuilder()
 
-    data, target_idxs = input_names
-    target_idxs = gb.op('Cast', [target_idxs],
-                        to=NP_TYPE_TO_TENSOR_TYPE[np.dtype('int64')])
-    n_rows = gb.op('Shape', [target_idxs])
+    if opset_version >= 11:
+        t = gb.op('Unsqueeze', [input_names[1]], axes=[1])
+        out = gb.op('GatherElements', [input_names[0], t], axis=1)
+        gb.op('Squeeze', [out], axes=[1])
+    else:
+        data, target_idxs = input_names
+        target_idxs = gb.op('Cast', [target_idxs],
+                            to=NP_TYPE_TO_TENSOR_TYPE[np.dtype('int64')])
+        n_rows = gb.op('Shape', [target_idxs])
 
-    # This is an equivalent of using Range.
-    one_1 = onnx.helper.make_tensor('one_1', onnx.TensorProto.FLOAT, [1], [1])
-    ones = gb.op('ConstantOfShape', [n_rows], value=one_1)
-    row_idxs = gb.op('Squeeze', [gb.op('NonZero', [ones])])
+        # This is an equivalent of using Range.
+        one_1 = onnx.helper.make_tensor(
+            'one_1', onnx.TensorProto.FLOAT, [1], [1])
+        ones = gb.op('ConstantOfShape', [n_rows], value=one_1)
+        row_idxs = gb.op('Squeeze', [gb.op('NonZero', [ones])])
 
-    data_shape = gb.op('Shape', [data])
-    one_2 = context.add_const(np.array([1]), 'one_2')
-    n_cols = gb.op('Gather', [data_shape, one_2], axis=0)
+        data_shape = gb.op('Shape', [data])
+        one_2 = context.add_const(np.array([1]), 'one_2')
+        n_cols = gb.op('Gather', [data_shape, one_2], axis=0)
 
-    data = gb.op('Squeeze', [gb.op('Flatten', [data], axis=2)])
-    target_idxs = gb.op('Add', [target_idxs, gb.op('Mul', [row_idxs, n_cols])])
-    gb.op('Gather', [data, target_idxs], axis=0)
+        data = gb.op('Squeeze', [gb.op('Flatten', [data], axis=2)])
+        target_idxs = gb.op(
+            'Add', [target_idxs, gb.op('Mul', [row_idxs, n_cols])])
+        gb.op('Gather', [data, target_idxs], axis=0)
 
     return gb.nodes(output_names)
 

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -525,8 +525,8 @@ class TestSelectItem(ONNXModelTest):
                 return F.select_item(x, t)
 
         model = Model()
-        x = input_generator.increasing(3, 3)
-        t = np.array([2, 1, 0], dtype=np.int32)
+        x = input_generator.increasing(3, 5)
+        t = np.array([4, 1, 0], dtype=np.int32)
 
         self.expect(
             model, (x, t), expected_num_initializers=0,


### PR DESCRIPTION
`GatherElements` is more intuitive for `F.select_item` converter, but remain current logic for some runtimes which not support `GatherElements` operator.

ref: https://github.com/chainer/chainer/pull/8450#issuecomment-555285981