### PR TITLE
Avoid ChainerX slow tests in Jenkins

### DIFF
--- a/scripts/ci/steps.sh
+++ b/scripts/ci/steps.sh
@@ -196,6 +196,7 @@ step_python_test_chainerx() {
     COVERAGE_FILE="$WORK_DIR"/coverage-data \
     pytest \
         -rfEX \
+        -m 'not slow' \
         --showlocals \
         --cov=chainerx \
         --no-cov-on-fail \


### PR DESCRIPTION
Merge before #8389 