### PR TITLE
Add workaround for cuSolver 10.2's new enums

### DIFF
--- a/chainerx_cc/chainerx/cuda/cusolver.cc
+++ b/chainerx_cc/chainerx/cuda/cusolver.cc
@@ -56,6 +56,9 @@ std::string BuildErrorMessage(cusolverStatus_t error) {
         CHAINERX_MATCH_AND_RETURN_MSG(CUSOLVER_STATUS_INVALID_LICENSE);
 
 #undef CHAINERX_MATCH_AND_RETURN_MSG
+
+        default:
+            return "(UNKNOWN)";
     }
     CHAINERX_NEVER_REACH();
 }


### PR DESCRIPTION
Seems `CUSOLVER_STATUS_IRS_*` is added but can't be handled in current code