### PR TITLE
[v6] Use CuPy v6 in ChainerX test in Jenkins

### DIFF
--- a/scripts/ci/chainerx/jenkins/Dockerfile.template
+++ b/scripts/ci/chainerx/jenkins/Dockerfile.template
@@ -37,4 +37,4 @@ RUN mkdir -p "$CONDA_DIR"
 RUN bash "$TEMP_DIR"/setup-conda.sh "$USER_TEMP_DIR"/conda "$CONDA_DIR"
 
 # Install cupy
-RUN bash -c 'source '"$CONDA_DIR"'/bin/activate testenv && pip install -U cython && pip install git+https://github.com/cupy/cupy'
+RUN bash -c 'source '"$CONDA_DIR"'/bin/activate testenv && pip install -U cython && pip install git+https://github.com/cupy/cupy@v6'


### PR DESCRIPTION
Use CuPy v6 branch in Chainer v6 ChainerX test