### PR TITLE
[v6] Fix Travis Openssl Error in OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       language: generic
       env:
       - CHAINER_TRAVIS_TEST="chainer"
-      - PYTHON_VERSION=2.7.10
+      - PYTHON_VERSION=2.7.16
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
       - SKIP_CHAINERX=1


### PR DESCRIPTION
Bumps Python v2 to 2.7.16 in the osx Travis config.

Some recent change to Travis macos image made v2.7.10 unable to be built.