### PR TITLE
Support step slicing on ONNX export

### DIFF
--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -73,14 +73,22 @@ def convert_Depth2Space(
 
 
 def get_slice_node(
-        gb, opset_version, context, input_names, axes, starts, ends):
+        gb, opset_version, context, input_names, axes, starts, ends, steps):
+    if opset_version < 11 and any([i != 1 for i in steps]):
+        raise ValueError(
+            'GetItem with n-step slicing is supported from opset11, '
+            'opset{} is not supported'.format(opset_version))
+
     if opset_version < 10:
         return gb.op(
             'Slice', input_names, axes=axes, starts=starts, ends=ends)
     else:
-        for param in [('starts', starts), ('ends', ends), ('axes', axes)]:
+        inputs = [('starts', starts), ('ends', ends), ('axes', axes)]
+        if opset_version > 10:
+            inputs.append(('steps', steps))
+        for name, values in inputs:
             param_name = context.add_const(
-                np.asarray(list(param[1]), dtype=np.int64), param[0])
+                np.asarray(list(values), dtype=np.int64), name)
             input_names.append(param_name)
         return gb.op('Slice', input_names)
 
@@ -95,7 +103,7 @@ def _to_ndarray(x, dtype=np.int64):
 @support((1, 10, 11))
 def convert_GetItem(func, opset_version, input_names, output_names, context):
     x = func.inputs[0]
-    axes, starts, ends = [], [], []
+    axes, starts, ends, steps = [], [], [], []
     squeeze_idxs, unsqueeze_idxs = [], []
     skipped = 0  # when set ellipsis, need to skip index rolling
 
@@ -109,18 +117,16 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
         # axis means the index of input x, adjust None and Ellipsis counts
         axis = i - len(unsqueeze_idxs) + skipped
         if isinstance(idx, slice):
-            if idx.step is not None and idx.step != 1:
-                raise ValueError(
-                    'GetItem with {}step slicing is not supported in ONNX '
-                    'Slice operator'.format(idx.step))
-            if idx.start is None and idx.stop is None:
+            if idx.start is None and idx.stop is None and idx.step is None:
                 is_used_slice_whole = True
                 continue
             axes.append(axis)
             starts.append(0 if idx.start is None else idx.start)
             ends.append(x.shape[axis] if idx.stop is None else idx.stop)
+            steps.append(1 if idx.step is None else idx.step)
         elif isinstance(idx, int):
             axes.append(axis)
+            steps.append(1)
             if idx == -1:
                 starts.append(idx)
                 ends.append(np.iinfo(np.int64).max)
@@ -133,6 +139,7 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
             axes.append(axis)
             starts.append(scalar_idx)
             ends.append(scalar_idx+1)
+            steps.append(1)
             squeeze_idxs.append(axis)
         elif idx is None:
             unsqueeze_idxs.append(i - len(squeeze_idxs) + skipped)
@@ -178,7 +185,8 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
     slice_output = input_names
     if axes:
         output = get_slice_node(
-            gb, opset_version, context, slice_output, axes, starts, ends)
+            gb, opset_version, context, slice_output, axes, starts, ends,
+            steps)
         slice_output = [output]
     if squeeze_idxs:
         output = gb.op('Squeeze', slice_output, axes=squeeze_idxs)

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -92,7 +92,7 @@ def _to_ndarray(x, dtype=np.int64):
         return chainer.cuda.to_cpu(x).astype(dtype)
 
 
-@support((1, 10))
+@support((1, 10, 11))
 def convert_GetItem(func, opset_version, input_names, output_names, context):
     x = func.inputs[0]
     axes, starts, ends = [], [], []
@@ -188,6 +188,10 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
         slice_output = [output]
 
     if gather_nd_idx is not None:
+        if opset_version < 11:
+            raise ValueError(
+                'ONNX-Chainer supports multiple advanced indexing from opset11'
+                ', opset{} is not supported'.format(opset_version))
         gather_nd_idx_name = context.add_const(gather_nd_idx.T, 'indices')
         slice_output.append(gather_nd_idx_name)
         gb.op('GatherND', slice_output)

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -1,8 +1,8 @@
 import warnings
 
 import chainer
-import onnx
 import numpy as np
+import onnx
 from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
 
 from onnx_chainer.functions.opset_version import support

--- a/onnx_chainer/functions/array.py
+++ b/onnx_chainer/functions/array.py
@@ -121,9 +121,17 @@ def convert_GetItem(func, opset_version, input_names, output_names, context):
                 is_used_slice_whole = True
                 continue
             axes.append(axis)
-            starts.append(0 if idx.start is None else idx.start)
-            ends.append(x.shape[axis] if idx.stop is None else idx.stop)
-            steps.append(1 if idx.step is None else idx.step)
+            step = 1 if idx.step is None else idx.step
+            steps.append(step)
+            if step < 0:
+                starts.append(
+                    np.iinfo(np.int64).max if idx.start is None else idx.start)
+                ends.append(
+                    np.iinfo(np.int64).min if idx.stop is None else idx.stop)
+            else:
+                starts.append(0 if idx.start is None else idx.start)
+                ends.append(
+                    np.iinfo(np.int64).max if idx.stop is None else idx.stop)
         elif isinstance(idx, int):
             axes.append(axis)
             steps.append(1)

--- a/onnx_chainer/functions/normalization.py
+++ b/onnx_chainer/functions/normalization.py
@@ -114,7 +114,7 @@ def convert_GroupNormalization(
     # make reduced input
     original_shape = gb.op('Shape', [input_names[0]])
     batch_size = get_slice_node(
-        gb, opset_version, context, [original_shape], [0], [0], [1])
+        gb, opset_version, context, [original_shape], [0], [0], [1], [1])
     batched_group = gb.op('Mul', [batch_size, group])
     reduce_shape = gb.op('Concat', [batched_group, neg_one], axis=0)
     reduced_x = gb.op('Reshape', [input_names[0], reduce_shape])

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -263,23 +263,34 @@ class TestGetItemGather(ONNXModelChecker):
             skip_opset_version=skip_opsets)
 
 
-@pytest.mark.skipif(
-    onnx.defs.onnx_opset_version() < 11, reason='not support GatherND')
-@pytest.mark.parametrize(
-    'slices', [
-        [slice(0, 2, 2)],
-        [[0, 1], 0, [0, 1]],
-        [slice(None), [0, 1], [0, 1]],
-        [None, [0, 1], [0, 1]]
-    ]
-)
-def test_get_item_error(slices):
-    model = chainer.Sequential(
-        lambda x: F.get_item(x, slices=slices))
-    x = input_generator.increasing(2, 3, 4)
+class TestGetItemError(object):
 
-    with pytest.raises(ValueError):
-        export(model, x)
+    @pytest.mark.parametrize('slices', [[[0, 1], [1, 2]]])
+    def test_get_item_not_supported(self, slices):
+        model = chainer.Sequential(
+            lambda x: F.get_item(x, slices=slices))
+        x = input_generator.increasing(2, 3, 4)
+
+        with pytest.raises(ValueError):
+            export(model, x, opset_version=7)
+
+    @pytest.mark.skipif(
+        onnx.defs.onnx_opset_version() < 11, reason='not support GatherND')
+    @pytest.mark.parametrize(
+        'slices', [
+            [slice(0, 2, 2)],
+            [[0, 1], 0, [0, 1]],
+            [slice(None), [0, 1], [0, 1]],
+            [None, [0, 1], [0, 1]]
+        ]
+    )
+    def test_get_item_error(self, slices):
+        model = chainer.Sequential(
+            lambda x: F.get_item(x, slices=slices))
+        x = input_generator.increasing(2, 3, 4)
+
+        with pytest.raises(ValueError):
+            export(model, x)
 
 
 class TestConcat(ONNXModelTest):

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -266,6 +266,8 @@ class TestGetItem(ONNXModelChecker):
         'name,slices', [
             ('step1', [slice(1, None, 1)]),
             ('step2', [slice(None, None, None), slice(None, 4, 2)]),
+            ('step_neg1', [slice(None, None, -1)]),
+            ('step_neg2', [slice(None, None, None), slice(4, None, -2)]),
         ])
     def test_get_item_slice_step(self, name, slices):
         skip_opsets = tuple(range(7, 11))

--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -226,7 +226,7 @@ class TestArrayOperators(ONNXModelTest):
             self.model, self.x, name=name, expected_num_initializers=0)
 
 
-class TestGetItemGather(ONNXModelChecker):
+class TestGetItem(ONNXModelChecker):
     # When chainer.testing.parameterize is used with list or ndarray parameter,
     # it causes regex warning. To resolve, use pytest's parameterize.
 
@@ -248,7 +248,7 @@ class TestGetItemGather(ONNXModelChecker):
             ('gathernd_after_slice', [[0, 1], [0, 2], 0]),
             ('gathernd_unsqueezed', [[0, 1], [0, 2], None])
         ])
-    def test_output(self, name, slices):
+    def test_get_item_gather(self, name, slices):
         skip_opsets = None
         if name.startswith('gathernd'):
             skip_opsets = tuple(range(7, 11))
@@ -262,11 +262,30 @@ class TestGetItemGather(ONNXModelChecker):
             model, x, name=name, expected_num_initializers=0,
             skip_opset_version=skip_opsets)
 
+    @pytest.mark.parametrize(
+        'name,slices', [
+            ('step1', [slice(1, None, 1)]),
+            ('step2', [slice(None, None, None), slice(None, 4, 2)]),
+        ])
+    def test_get_item_slice_step(self, name, slices):
+        skip_opsets = tuple(range(7, 11))
+        name = 'get_item_' + name
+
+        model = chainer.Sequential(
+            lambda x: F.get_item(x, slices=slices))
+        x = input_generator.increasing(2, 3, 4)
+
+        self.expect(
+            model, x, name=name, expected_num_initializers=0,
+            skip_opset_version=skip_opsets)
+
 
 class TestGetItemError(object):
 
-    @pytest.mark.parametrize('slices', [[[0, 1], [1, 2]]])
-    def test_get_item_not_supported(self, slices):
+    @pytest.mark.parametrize('slices', [
+        [[0, 1], [1, 2]], [slice(None, None, 2)]
+    ])
+    def test_get_item_unsupported(self, slices):
         model = chainer.Sequential(
             lambda x: F.get_item(x, slices=slices))
         x = input_generator.increasing(2, 3, 4)
@@ -278,13 +297,12 @@ class TestGetItemError(object):
         onnx.defs.onnx_opset_version() < 11, reason='not support GatherND')
     @pytest.mark.parametrize(
         'slices', [
-            [slice(0, 2, 2)],
             [[0, 1], 0, [0, 1]],
             [slice(None), [0, 1], [0, 1]],
             [None, [0, 1], [0, 1]]
         ]
     )
-    def test_get_item_error(self, slices):
+    def test_get_item_unsupported_advanced_index(self, slices):
         model = chainer.Sequential(
             lambda x: F.get_item(x, slices=slices))
         x = input_generator.increasing(2, 3, 4)


### PR DESCRIPTION
From opset11, Slice operator supports step input. Along with, add to check opset version when using GatherND.