### PR TITLE
Support sign function on exporting ONNX

### DIFF
--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -334,12 +334,7 @@ def _export(model, args, filename, export_params, graph_name, save_text,
         # if input shapes are invalid, raise exception before forwarding.
         input_shapes = format_customized_shapes(args, input_shapes)
 
-    import chainer.functions as F
-    from onnx_chainer.replace_func import fake_as_funcnode
-    org_sign = F.sign
-    F.sign = fake_as_funcnode(org_sign, 'Sign')
-
-    with RetainInputHook():
+    with RetainInputHook(), mapping.patch_functions():
         # Forward computation
         context = Context(model)
         network_inputs = OrderedDict()

--- a/onnx_chainer/export.py
+++ b/onnx_chainer/export.py
@@ -334,6 +334,11 @@ def _export(model, args, filename, export_params, graph_name, save_text,
         # if input shapes are invalid, raise exception before forwarding.
         input_shapes = format_customized_shapes(args, input_shapes)
 
+    import chainer.functions as F
+    from onnx_chainer.replace_func import fake_as_funcnode
+    org_sign = F.sign
+    F.sign = fake_as_funcnode(org_sign, 'Sign')
+
     with RetainInputHook():
         # Forward computation
         context = Context(model)

--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -82,6 +82,7 @@ from onnx_chainer.functions.math import convert_PowVarConst  # NOQA
 from onnx_chainer.functions.math import convert_PowVarVar  # NOQA
 from onnx_chainer.functions.math import convert_Prod  # NOQA
 from onnx_chainer.functions.math import convert_RsqrtGPU  # NOQA
+from onnx_chainer.functions.math import convert_Sign  # NOQA
 from onnx_chainer.functions.math import convert_Sin  # NOQA
 from onnx_chainer.functions.math import convert_Sinh  # NOQA
 from onnx_chainer.functions.math import convert_Sqrt  # NOQA

--- a/onnx_chainer/functions/__init__.py
+++ b/onnx_chainer/functions/__init__.py
@@ -82,7 +82,7 @@ from onnx_chainer.functions.math import convert_PowVarConst  # NOQA
 from onnx_chainer.functions.math import convert_PowVarVar  # NOQA
 from onnx_chainer.functions.math import convert_Prod  # NOQA
 from onnx_chainer.functions.math import convert_RsqrtGPU  # NOQA
-from onnx_chainer.functions.math import convert_Sign  # NOQA
+from onnx_chainer.functions.math import convert_sign  # NOQA
 from onnx_chainer.functions.math import convert_Sin  # NOQA
 from onnx_chainer.functions.math import convert_Sinh  # NOQA
 from onnx_chainer.functions.math import convert_Sqrt  # NOQA

--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -394,3 +394,8 @@ def convert_ArgMax(func, opset_version, input_names, output_names, context):
 @support((6,))
 def convert_ArgMin(func, opset_version, input_names, output_names, context):
     return _argminmax_nodes('ArgMin', func, input_names, output_names, context)
+
+
+@support((9,))
+def convert_Sign(func, opset_verseion, input_names, output_names, context):
+    return onnx_helper.make_node('Sign', input_names, output_names),

--- a/onnx_chainer/functions/math.py
+++ b/onnx_chainer/functions/math.py
@@ -397,5 +397,5 @@ def convert_ArgMin(func, opset_version, input_names, output_names, context):
 
 
 @support((9,))
-def convert_Sign(func, opset_verseion, input_names, output_names, context):
+def convert_sign(func, opset_verseion, input_names, output_names, context):
     return onnx_helper.make_node('Sign', input_names, output_names),

--- a/onnx_chainer/mapping.py
+++ b/onnx_chainer/mapping.py
@@ -1,5 +1,10 @@
+from contextlib import contextmanager
+
+import chainer.functions as F
+
 from onnx_chainer import functions
 from onnx_chainer.functions.converter import FunctionConverter
+from onnx_chainer.replace_func import fake_as_funcnode
 
 
 _supported_function_node_set = {
@@ -92,7 +97,7 @@ _supported_function_node_set = {
     'PowVarVar',
     'Prod',
     'RsqrtGPU',
-    'Sign',
+    'sign',
     'Sin',
     'Sinh',
     'Sqrt',
@@ -137,3 +142,24 @@ def _get_converters():
 
 
 converters = _get_converters()
+
+
+_supported_function_set = {
+    # Math
+    'sign',
+}
+
+
+@contextmanager
+def patch_functions():
+    org_funcs = {}
+    for name in _supported_function_set:
+        org_func = getattr(F, name)
+        org_funcs[name] = org_func
+        setattr(F, name, fake_as_funcnode(
+            org_func, name, experimental_warning=False))
+    try:
+        yield
+    finally:
+        for name in _supported_function_set:
+            setattr(F, name, org_funcs[name])

--- a/onnx_chainer/mapping.py
+++ b/onnx_chainer/mapping.py
@@ -92,6 +92,7 @@ _supported_function_node_set = {
     'PowVarVar',
     'Prod',
     'RsqrtGPU',
+    'Sign',
     'Sin',
     'Sinh',
     'Sqrt',

--- a/onnx_chainer/replace_func.py
+++ b/onnx_chainer/replace_func.py
@@ -86,7 +86,8 @@ class WrappedFunctionNode(chainer.FunctionNode):
         return f(self.skeleton)
 
 
-def fake_as_funcnode(alt_func, name, rename_attributes=None):
+def fake_as_funcnode(alt_func, name, rename_attributes=None,
+                     experimental_warning=True):
     """The target function fakes FunctionNode
 
     The target function is replaced to the alternative function to connect
@@ -129,6 +130,8 @@ def fake_as_funcnode(alt_func, name, rename_attributes=None):
         rename_attributes (list or tuple): rename attribute name, set list
             of ``tuple(index_of_args, new_name)`` or
             ``tuple(kwargs_name, new_name)``
+        experimental_warning: this function is experimental utility, if set
+            ``False``, run without experimental warning.
 
     Returns:
         func: wrapped function, called on exporting.
@@ -190,7 +193,8 @@ def fake_as_funcnode(alt_func, name, rename_attributes=None):
         ret = wrapped.apply(inputs)
         return wrapped.reconstruct_return_value(ret)
 
-    chainer.utils.experimental('as_funcnode')
+    if experimental_warning:
+        chainer.utils.experimental('as_funcnode')
     return _wrapper
 
 

--- a/tests/onnx_chainer_tests/functions_tests/test_maths.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_maths.py
@@ -64,6 +64,7 @@ from onnx_chainer_tests.helper import ONNXModelTest
     {'op_name': 'Tan', 'ops': 'chainer.functions.tan(a)'},
     {'op_name': 'BroadcastTo',
      'ops': 'chainer.functions.broadcast_to(a, (2,2,3))'},
+    {'op_name': 'Sign', 'ops': 'chainer.functions.sign(a)'},
 )
 class TestUnaryMathOperators(ONNXModelTest):
 
@@ -89,7 +90,8 @@ class TestUnaryMathOperators(ONNXModelTest):
         self.name = name
 
         skip_opset_version = []
-        if self.op_name == 'Cosh' or self.op_name == 'Sinh':
+        if self.op_name == 'Cosh' or self.op_name == 'Sinh' or\
+                self.op_name == 'Sign':
             skip_opset_version.append(7)
             skip_opset_version.append(8)
 


### PR DESCRIPTION
Sign is not implemented as `FunctionNode` and ONNX-Chainer cannot convert such functions. This PR support them, at first support `sign`.