### PR TITLE
Allow `array_utils.uniform` to be deterministic with `fix_random` by default

### DIFF
--- a/tests/chainerx_tests/array_utils.py
+++ b/tests/chainerx_tests/array_utils.py
@@ -10,9 +10,7 @@ def total_size(shape):
     return functools.reduce(operator.mul, shape, 1)
 
 
-def uniform(shape, dtype, low=None, high=None, *, random_state=None):
-    if random_state is None:
-        random_state = numpy.random.RandomState()
+def uniform(shape, dtype, low=None, high=None, *, random_state=numpy.random):
     kind = numpy.dtype(dtype).kind
     if kind == 'f':
         return (random_state.uniform(


### PR DESCRIPTION
Fixes https://github.com/chainer/chainer/issues/8274, https://github.com/chainer/chainer/issues/8032 and https://github.com/chainer/chainer/issues/8033.

The above issues address ChainerX n-step RNN flaky tests. They were once worked around by https://github.com/chainer/chainer/pull/8136 by fixing the random seeds. However, https://github.com/chainer/chainer/pull/8342 made these tests non-deterministic since it changed the default behavior of `array_utils.uniform` to create new random states instead of utilizing the previous NumPy global `numpy.random`. This PR makes the tests deterministic again by defaulting to `numpy.random`.