### PR TITLE
Extend ONNX-Chainer's TransposeSequence converter to support more cases

### DIFF
--- a/tests/onnx_chainer_tests/functions_tests/test_arrays.py
+++ b/tests/onnx_chainer_tests/functions_tests/test_arrays.py
@@ -528,6 +528,8 @@ class TestPermutate(ONNXModelTest):
     {'in_shapes': [(3, 4)], 'name': 'transpose_sequence_single_input'},
     {'in_shapes': [(1, 3), (1, 3)],
      'name': 'transpose_sequence_single_output'},
+    {'in_shapes': [(2, 3), (2, 3), (2, 3), (2, 3)],
+     'name': 'transpose_sequence_same_shape'},
 )
 class TestTransposeSequence(ONNXModelTest):
 


### PR DESCRIPTION
In addition to the case where the input or output is length 1, this PR newly adds support for cases where all inputs have the same shape.
