### PR TITLE
Fix `BatchNormalization` for NHWC without cudnn

### DIFF
--- a/chainer/functions/normalization/batch_normalization.py
+++ b/chainer/functions/normalization/batch_normalization.py
@@ -426,12 +426,18 @@ class BatchNormalization(function_node.FunctionNode):
 
         self._impl = self._impl_selector(self, inputs)
 
+        raw_axis = self.axis
+        t = chainer.memory_layouts._get_layout_transpose_axes(
+            x.ndim, None, x_layout, True)
+        if t is not None:
+            raw_axis = tuple(t[i] for i in self.axis)
+
         (
             y, y_layout, self.running_mean, self.running_var,
             self.mean, self.var, self.inv_std,
             self.forward_data) = (
                 self._impl.forward(
-                    axis=self.axis, gamma=gamma, x=x, x_layout=x_layout,
+                    axis=raw_axis, gamma=gamma, x=x, x_layout=x_layout,
                     xp=xp, expander=expander, beta=beta, eps=self.eps,
                     decay=self.decay,
                     running_mean=self.running_mean,

--- a/chainer/memory_layouts.py
+++ b/chainer/memory_layouts.py
@@ -91,7 +91,7 @@ def _get_layout_transpose_axes(ndim, src_layout, dst_layout, inverse=False):
     if inverse:
         t = [None] * ndim
         for i, n in enumerate(trans):
-            t[i] = n
+            t[n] = i
         trans = tuple(t)
 
     # Postconditions:

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -708,8 +708,7 @@ class TestSerialize(unittest.TestCase):
         'test_forward',
     ],
     # CPU tests
-    [{},
-     {'use_ideep': 'always'}]
+    [{}]
     # GPU tests
     + testing.product({
         'use_cuda': [True],
@@ -753,10 +752,6 @@ class TestBatchNormalizationMemoryLayouts(unittest.TestCase):
         assert link.beta.layout is None
 
     def test_forward(self, backend_config):
-        if not backend_config.use_cuda:
-            raise unittest.SkipTest(
-                'forward with non-standard layout is only supported with '
-                'cupy arrays.')
         with chainer.using_config('compute_mode', 'cudnn_fast'):
             link = self.create_link()
         link.to_device(backend_config.device)

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -708,7 +708,8 @@ class TestSerialize(unittest.TestCase):
         'test_forward',
     ],
     # CPU tests
-    [{}]
+    [{},
+     {'use_ideep': 'always'}]
     # GPU tests
     + testing.product({
         'use_cuda': [True],
@@ -763,7 +764,8 @@ class TestBatchNormalizationMemoryLayouts(unittest.TestCase):
         x = self.create_input_array()
         x = chainer.Variable(x, layout=memory_layouts.CUDNN_CHANNEL_LAST_X)
         x.to_device(backend_config.device)
-        y = link(x)
+        with backend_config:
+            y = link(x)
 
         assert link.gamma.device == backend_config.device
         assert link.beta.device == backend_config.device

--- a/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
+++ b/tests/chainer_tests/links_tests/normalization_tests/test_batch_normalization.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy
-import pytest
 import six
 
 import chainer
@@ -729,9 +728,9 @@ class TestBatchNormalizationMemoryLayouts(unittest.TestCase):
             axis=self.axis)
         return link
 
-    def create_input_array(self):
+    def create_input_array(self, xp):
         x_shape = (self.batch, self.height, self.width, self.channels)
-        x = cuda.cupy.ones(x_shape, self.dtype)
+        x = xp.ones(x_shape, self.dtype)
         return x
 
     def test_param_layout(self):
@@ -756,7 +755,7 @@ class TestBatchNormalizationMemoryLayouts(unittest.TestCase):
             link = self.create_link()
         link.to_device(backend_config.device)
 
-        x = self.create_input_array()
+        x = self.create_input_array(backend_config.xp)
         x = chainer.Variable(x, layout=memory_layouts.CUDNN_CHANNEL_LAST_X)
         x.to_device(backend_config.device)
         with backend_config:
@@ -770,18 +769,6 @@ class TestBatchNormalizationMemoryLayouts(unittest.TestCase):
             self.channels,
             self.height,
             self.width)
-
-    def test_forward_invalid_backend(self):
-        with chainer.using_config('compute_mode', 'cudnn_fast'):
-            link = self.create_link()
-        link.to_device('@numpy')
-
-        x = self.create_input_array()
-        x = chainer.Variable(x, layout=memory_layouts.CUDNN_CHANNEL_LAST_X)
-        x.to_device('@numpy')
-
-        with pytest.raises(RuntimeError):
-            link(x)
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
Miss configuration in the tests made nhwc batchnorm test to use always cudnn.
There was a bug when using NHWC without cudnn due to doing reductions in the incorrect axes.