### PR TITLE
Raise `RuntimeError` when using `cudnn_fast` without cudnn

### DIFF
--- a/chainer/links/connection/convolution_2d.py
+++ b/chainer/links/connection/convolution_2d.py
@@ -121,8 +121,8 @@ nobias=False, initialW=None, initial_bias=None, *, dilate=1, groups=1)
         if ksize is None:
             out_channels, ksize, in_channels = in_channels, out_channels, None
 
-        cudnn_fast = chainer.get_compute_mode() == 'cudnn_fast'
-        if cudnn_fast:
+        self.cudnn_fast = chainer.get_compute_mode() == 'cudnn_fast'
+        if self.cudnn_fast:
             x_layout = memory_layouts.CUDNN_CHANNEL_LAST_X
             w_layout = memory_layouts.CUDNN_CHANNEL_LAST_W
         else:
@@ -248,7 +248,7 @@ nobias=False, *, dilate=1, groups=1)
             self._initialize_params(c)
         return convolution_2d.convolution_2d(
             x, self.W, self.b, self.stride, self.pad, dilate=self.dilate,
-            groups=self.groups)
+            groups=self.groups, cudnn_fast=self.cudnn_fast)
 
 
 def _pair(x):

--- a/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
+++ b/tests/chainer_tests/links_tests/connection_tests/test_convolution_2d.py
@@ -253,9 +253,9 @@ class Convolution2DMemoryLayoutsTestBase(object):
             (self.strides_height, self.strides_width))
         return link
 
-    def create_input_array(self):
+    def create_input_array(self, xp):
         x_shape = (self.batch, self.height, self.width, self.in_channels)
-        x = cuda.cupy.ones(x_shape, self.dtype)
+        x = xp.ones(x_shape, self.dtype)
         return x
 
 
@@ -287,7 +287,7 @@ class TestConvolution2DMemoryLayouts(unittest.TestCase,
             link = self.create_link()
         link.to_device(backend_config.device)
 
-        x = self.create_input_array()
+        x = self.create_input_array(backend_config.xp)
         x = chainer.Variable(x, layout=memory_layouts.CUDNN_CHANNEL_LAST_X)
         x.to_device(backend_config.device)
         with backend_config:
@@ -318,7 +318,7 @@ class TestConvolution2DInvalidComputeMode(unittest.TestCase,
             link = self.create_link()
         link.to_device(backend_config.device)
 
-        x = self.create_input_array()
+        x = self.create_input_array(backend_config.xp)
         x = chainer.Variable(x, layout=memory_layouts.CUDNN_CHANNEL_LAST_X)
         x.to_device(backend_config.device)
 


### PR DESCRIPTION
Convolution2d should not use `cudnn_fast` compute mode if cudnn is not enabled.

The changes required for this involve modifying `im2col` and `col2im` to support NHWC layout

The compute mode can only be checked at the link creation time but the associated function checks `use_cudnn` at forward time. Ideally we should check this at creation time in the link, but since chainer allows to dynamically change some of the backend properties based on the input I deferred the check to the function `forward`.