### PR TITLE
Add try/finally block to yield in reporter.py

### DIFF
--- a/chainer/reporter.py
+++ b/chainer/reporter.py
@@ -106,9 +106,11 @@ class Reporter(object):
         old = self.observation
         self.observation = observation
         self.__enter__()
-        yield
-        self.__exit__(None, None, None)
-        self.observation = old
+        try:
+            yield
+        finally:
+            self.__exit__(None, None, None)
+            self.observation = old
 
     def add_observer(self, name, observer):
         """Registers an observer of values.


### PR DESCRIPTION
# background

In `reporter.py`, a logging context stack is maintained as its internal thread-local variable named `_thread_local.reporters`.

In `Reporter.scope()` function, a Reporter object is pushed and popped to the stack in `__enter__()` and `__exit__()` function. 

# the bug 
If the `yield` omits an exception, the `__exit__()` is not called and the stack becomes an inconsistent state. In most use cases, such runtime error causes program termination thus the bug does not matter a lot.

However, in rare cases, such as #8384, it matters.
The bug forces the whole `pytest` process to terminate during a test.

# fix
This PR fixes the problem by adding `try/finally` block around the `yield` sentence so the pop operation is done correctly and the stack is kept consistent.

# Appendix:
The error message from #8384 test looks like this:

```
tests/chainermn_tests/links_tests/test_batch_normalization.py .F

=================================== FAILURES ===================================
____________ test_multi_node_bn_cpu[NaiveCommunicator-mpi-float16] _____________

communicator_class = <class 'chainermn.communicators.naive_communicator.NaiveCommunicator'>
backend = 'mpi', dtype = <class 'numpy.float16'>

    @pytest.mark.parametrize(('communicator_class', 'backend', 'dtype'), [
        (NaiveCommunicator, 'mpi', numpy.float16),
        (NaiveCommunicator, 'mpi', numpy.float32),
        (NaiveCommunicator, 'mpi', chainer.mixed16)])
    def test_multi_node_bn_cpu(communicator_class, backend, dtype):
        comm = create_communicator(communicator_class, mpi_comm,
                                   use_gpu=False)
>       check_multi_node_bn(comm, backend=backend, dtype=dtype)

tests/chainermn_tests/links_tests/test_batch_normalization.py:240:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/chainermn_tests/links_tests/test_batch_normalization.py:137: in check_multi_node_bn
    l1 = m1(x, y)
chainer/link.py:287: in __call__
    out = forward(*args, **kwargs)
chainer/links/model/classifier.py:145: in forward
    reporter.report({'loss': self.loss}, self)
chainer/reporter.py:246: in report
    current.report(values, observer)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
```

