### PR TITLE
Fix flaky `TestZeta`

### DIFF
--- a/tests/chainer_tests/functions_tests/math_tests/test_zeta.py
+++ b/tests/chainer_tests/functions_tests/math_tests/test_zeta.py
@@ -9,7 +9,9 @@ from chainer import testing
 
 @testing.parameterize(*testing.product({
     'dtype': [numpy.float16, numpy.float32, numpy.float64],
-    'shape': [(), (3, 2)]
+    'shape': [(), (3, 2)],
+    'x_range': [(1.1, 2), (2, 50)],
+    'q_range': [(1.1, 2), (2, 50)],
 }))
 @testing.inject_backend_tests(
     None,
@@ -32,16 +34,23 @@ from chainer import testing
 class TestZeta(testing.FunctionTestCase):
 
     def setUp(self):
-        self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
-        self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
-        self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+        if self.dtype == numpy.float16:
+            self.check_forward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            self.check_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+            self.check_double_backward_options = {'atol': 1e-2, 'rtol': 1e-2}
+        else:
+            self.check_forward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
+            self.check_double_backward_options = {'atol': 1e-3, 'rtol': 1e-3}
 
-        self._x = numpy.random.uniform(low=2, high=50, size=self.shape).\
-            astype(self.dtype)
+        low, high = self.x_range
+        self._x = numpy.random.uniform(
+            low=low, high=high, size=self.shape).astype(self.dtype)
 
     def generate_inputs(self):
-        q = numpy.random.uniform(low=1, high=50, size=self.shape).\
-            astype(self.dtype)
+        low, high = self.q_range
+        q = numpy.random.uniform(
+            low=low, high=high, size=self.shape).astype(self.dtype)
         return q,
 
     def forward_expected(self, inputs):


### PR DESCRIPTION
Fix #8166.

I have repeated the test 200K times without failure.
This PR fixes two parts of `TestZeta`.

- Relaxes the tolerances. `1e-3` is too tight for float16 tests.
- Fix the range of the generated input parameters.