### PR TITLE
Do not install chainer>=7.0.0 in python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,13 @@ from setuptools import setup
 import chainerx_build_helper
 
 
+if sys.version_info[0] == 2:
+    msg = """
+Chainer does not work with Python 2.
+Please install Chainer lower than 7.0.0."""
+    print(msg)
+    sys.exit(1)
+
 if sys.version_info[:3] == (3, 5, 0):
     if not int(os.getenv('CHAINER_PYTHON_350_FORCE', '0')):
         msg = """
@@ -194,6 +201,7 @@ setup_kwargs = dict(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
+    python_requires='>=3',
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,6 @@ from setuptools import setup
 import chainerx_build_helper
 
 
-if sys.version_info[0] == 2:
-    msg = """
-Chainer does not work with Python 2.
-Please install Chainer lower than 7.0.0."""
-    print(msg)
-    sys.exit(1)
-
 if sys.version_info[:3] == (3, 5, 0):
     if not int(os.getenv('CHAINER_PYTHON_350_FORCE', '0')):
         msg = """
@@ -201,7 +194,7 @@ setup_kwargs = dict(
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
-    python_requires='>=3',
+    python_requires='>=3.5.0',
 )
 
 


### PR DESCRIPTION
I don't know why, but `chainer>=7.0.0` is released in python2.
This PR stops installing `chainer>=7.0.0` in python2.
`chainer>=7.0.0` includes type hint in https://github.com/chainer/chainer/pull/8248, which breaks backward compatibility in python 2.
Documentation says Chainer drops python 2 support, so there is no need to release chainer>=7.0.0 in python2.

I also want to stop releasing `chainer>=7.0.0` because python2 is unfortunately system python for Ubuntu 16.04, 18.04.
There are several people who are forced to use Python2 in this age.
I want to do releasing like `matplotlib`, but I don't have enough knowledge about releasing.