### PR TITLE
Limit `coverage` version to < 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ requirements = {
         'pytest-timeout<1.3.0',
         'pytest-cov',
         'nose',
+        'coverage<5.0',
         'coveralls',
         'codecov',
     ],


### PR DESCRIPTION
Avoid incompatibility with python 3.8