### PR TITLE
Skip `chainerx.fromfile` test when dtype is bool_ and mode is text

### DIFF
--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -1082,6 +1082,10 @@ def test_frombuffer_with_device(device):
 @pytest.mark.parametrize('device', ['native:0', 'cuda:0'])
 @chainerx.testing.parametrize_dtype_specifier('dtype_spec')
 def test_fromfile(xp, count, sep, dtype_spec, device):
+    # Skip if bool_ dtype and text mode
+    if numpy.dtype(dtype_spec) == numpy.bool_ and sep == 'a':
+        return []
+
     # Write array data to temporary file.
     if isinstance(dtype_spec, chainerx.dtype):
         numpy_dtype_spec = dtype_spec.name

--- a/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
+++ b/tests/chainerx_tests/unit_tests/routines_tests/test_creation.py
@@ -1084,7 +1084,8 @@ def test_frombuffer_with_device(device):
 def test_fromfile(xp, count, sep, dtype_spec, device):
     # Skip if bool_ dtype and text mode
     if numpy.dtype(dtype_spec) == numpy.bool_ and sep == 'a':
-        return []
+        pytest.skip(
+            'numpy.fromfile does not work with bool_ dtype and text mode')
 
     # Write array data to temporary file.
     if isinstance(dtype_spec, chainerx.dtype):


### PR DESCRIPTION
This PR fixes the test of `chainerx.fromfile` to skip when the `dtype` is `bool_` and mode is text. It is because that, with NumPy 1.18, `numpy.fromfile` gives a `DeprecationWarning` in such case to make CI fail. With NumPy <1.18, it suppose to silently return invalid data, an empty array, and happens to pass the test.

https://github.com/numpy/numpy/releases/tag/v1.18.0
> np.fromfile and np.fromstring will error on bad data