### PR TITLE
Fix accuracy calculation of custom loop examples

### DIFF
--- a/examples/cifar/train_cifar_custom_loop.py
+++ b/examples/cifar/train_cifar_custom_loop.py
@@ -74,7 +74,6 @@ def main():
         train = train[:200]
         test = test[:200]
 
-    train_count = len(train)
     test_count = len(test)
 
     model = L.Classifier(models.VGG.VGG(class_labels))
@@ -99,6 +98,7 @@ def main():
     test_iter = chainer.iterators.SerialIterator(test, args.batchsize,
                                                  repeat=False, shuffle=False)
 
+    train_count = 0
     sum_acc = 0
     sum_loss = 0
 
@@ -111,6 +111,7 @@ def main():
 
         x, t = convert.concat_examples(batch, device)
         optimizer.update(model, x, t)
+        train_count += len(t)
         sum_loss += float(model.loss.array) * len(t)
         sum_acc += float(model.accuracy.array) * len(t)
 
@@ -118,6 +119,7 @@ def main():
             print('epoch: {}'.format(train_iter.epoch))
             print('train mean loss: {}, accuracy: {}'.format(
                 sum_loss / train_count, sum_acc / train_count))
+            train_count = 0
             sum_acc = 0
             sum_loss = 0
             # Enable evaluation mode.

--- a/examples/mnist/train_mnist_custom_loop.py
+++ b/examples/mnist/train_mnist_custom_loop.py
@@ -75,13 +75,13 @@ def main():
     # Load the MNIST dataset
     train, test = chainer.datasets.get_mnist()
 
-    train_count = len(train)
     test_count = len(test)
 
     train_iter = chainer.iterators.SerialIterator(train, args.batchsize)
     test_iter = chainer.iterators.SerialIterator(test, args.batchsize,
                                                  repeat=False, shuffle=False)
 
+    train_count = 0
     sum_accuracy = 0
     sum_loss = 0
 
@@ -89,6 +89,7 @@ def main():
         batch = train_iter.next()
         x, t = convert.concat_examples(batch, device)
         optimizer.update(model, x, t)
+        train_count += len(t)
         sum_loss += float(model.loss.array) * len(t)
         sum_accuracy += float(model.accuracy.array) * len(t)
 
@@ -97,6 +98,7 @@ def main():
             print('train mean loss: {}, accuracy: {}'.format(
                 sum_loss / train_count, sum_accuracy / train_count))
             # evaluation
+            train_count = 0
             sum_accuracy = 0
             sum_loss = 0
             # Enable evaluation mode.

--- a/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
+++ b/examples/static_graph_optimizations/mnist/train_mnist_custom_loop.py
@@ -28,10 +28,10 @@ import train_mnist
 
 
 def run_train_loop(
-        optimizer, train_iter, test_iter, train_count, test_count, epoch,
-        device):
+        optimizer, train_iter, test_iter, test_count, epoch, device):
     model = optimizer.target
 
+    train_count = 0
     sum_accuracy = 0
     sum_loss = 0
     while train_iter.epoch < epoch:
@@ -40,6 +40,7 @@ def run_train_loop(
         x = chainer.Variable(x_array)
         t = chainer.Variable(t_array, requires_grad=False)
         optimizer.update(model, x, t)
+        train_count += len(t)
         sum_loss += float(model.loss.array) * len(t)
         sum_accuracy += float(model.accuracy.array) * len(t)
 
@@ -48,6 +49,7 @@ def run_train_loop(
             print('train mean loss: {}, accuracy: {}'.format(
                 sum_loss / train_count, sum_accuracy / train_count))
             # evaluation
+            train_count = 0
             sum_accuracy = 0
             sum_loss = 0
             # It is good practice to turn off train mode during evaluation.
@@ -121,7 +123,6 @@ def main():
     # Load the MNIST dataset
     train, test = chainer.datasets.get_mnist()
 
-    train_count = len(train)
     test_count = len(test)
 
     train_iter = chainer.iterators.SerialIterator(train, args.batchsize)
@@ -130,16 +131,15 @@ def main():
 
     if device.xp is not chainerx:
         run_train_loop(
-            optimizer, train_iter, test_iter, train_count, test_count,
-            args.epoch, device)
+            optimizer, train_iter, test_iter, test_count, args.epoch, device)
     else:
         warnings.warn(
             'Static subgraph optimization does not support ChainerX and will'
             ' be disabled.', UserWarning)
         with chainer.using_config('use_static_graph', False):
             run_train_loop(
-                optimizer, train_iter, test_iter, train_count, test_count,
-                args.epoch, device)
+                optimizer, train_iter, test_iter, test_count, args.epoch,
+                device)
 
     # Save the model and the optimizer
     print('save the model')


### PR DESCRIPTION
Fix accuracy calculation of custom loop examples.

When the size of data (`len(train)`) is not a multiple of the batch size, the number of data used in one epoch is not equal to `len(train)`.
