### PR TITLE
Add Optuna to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![travis](https://img.shields.io/travis/chainer/chainer/master.svg)](https://travis-ci.org/chainer/chainer)
 [![coveralls](https://img.shields.io/coveralls/chainer/chainer.svg)](https://coveralls.io/github/chainer/chainer)
 [![Read the Docs](https://readthedocs.org/projects/chainer/badge/?version=stable)](https://docs.chainer.org/en/stable/?badge=stable)
+[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://optuna.org)
 
 [**Website**](https://chainer.org/)
 | [**Docs**](https://docs.chainer.org/en/stable/)


### PR DESCRIPTION
Hi!

[Optuna]( (optuna.org) ) is a new hyperparameter optimization library, and we’ve written an integration module for Chainer to make it easy to use Optuna to search for good hyperparameter settings and prune unpromising trials. We’re looking for ways to let Chainer users know this is available and thought a badge to show Optuna integration is available would be helpful.

Here’s our example of using the pruning integration with Chainer: https://github.com/optuna/optuna/blob/master/examples/pruning/chainer_integration.py

If there are other ways you would recommend reaching out to Chainer users to let them know about Optuna, please let us know.

Thanks!