### PR TITLE
Allow `concat_arrays` to be pickable

### DIFF
--- a/chainer/dataset/convert.py
+++ b/chainer/dataset/convert.py
@@ -110,8 +110,8 @@ def converter():
 
         Converters using this decorator can't be pickled
         causing :class:`chainer.training.updaters.MultiprocessParallelUpdater`
-        to fail when the multiprocessing start mode is set to `spawn` or
-        `forkserver`. Should you need to use such feature, please rely on
+        to fail when the multiprocessing start mode is set to ``'spawn'`` or
+        ``'forkserver'``. Should you need to use such feature, please rely on
         class style converters.
 
     """

--- a/tests/chainer_tests/dataset_tests/test_convert.py
+++ b/tests/chainer_tests/dataset_tests/test_convert.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 import unittest
 
@@ -46,6 +47,12 @@ class ConverterTestBase(object):
             numpy.testing.assert_array_equal(x, backend.CpuDevice().send(y))
 
     def test_concat_arrays(self, backend_config):
+        arrays = self.get_arrays_to_concat(backend_config)
+        self.check_concat_arrays(arrays, None, backend_config.device)
+
+    def test_concat_arrays_pickle(self, backend_config):
+        converter = pickle.dumps(self.converter)
+        self.converter = pickle.loads(converter)
         arrays = self.get_arrays_to_concat(backend_config)
         self.check_concat_arrays(arrays, None, backend_config.device)
 


### PR DESCRIPTION
This tries to fix a bug that happens when using  `MultiprocessParallelUpdater` with `forkserver` or `spawn` as the start mode.

There is an error because the multiprocessing module tries to pickle the converter function and this one has lost its complete import route from the `func_name` or `__name__` attribute due being decorated with `converter`.

Essentially I avoid the name classing in the module by not using the decorator.

I tried to solve this using `functools.wrap` but the case its trickier than it seems at first.