### PR TITLE
Fix local_convolution_2d result shape documentation

### DIFF
--- a/chainer/functions/connection/local_convolution_2d.py
+++ b/chainer/functions/connection/local_convolution_2d.py
@@ -154,7 +154,7 @@ def local_convolution_2d(x, W, b=None, stride=1):
 
     Returns:
         ~chainer.Variable:
-            Output variable. Its shape is :math:`(n, c_I * c_O, h_O, w_O)`.
+            Output variable. Its shape is :math:`(n, c_O, h_O, w_O)`.
 
     Like ``Convolution2D``, ``LocalConvolution2D`` function computes
     correlations between filters and patches of size :math:`(k_H, k_W)` in


### PR DESCRIPTION
Result shape should be `(n, c_O, h_O, w_O)` instead of `(n, c_I * c_O, h_O, w_O)`.

Example section is written correctly.
```
>>> x = np.random.uniform(0, 1, (2, 3, 7, 7))
>>> W = np.random.uniform(0, 1, (2, 5, 5, 3, 3, 3))
>>> b = np.random.uniform(0, 1, (2, 5, 5))
>>> y = F.local_convolution_2d(x, W, b)
>>> y.shape
(2, 2, 5, 5)
```

Here, `W`'s shape shows `(c_O, h_O, w_O, c_I, k_H, k_W) = (2, 5, 5, 3, 3, 3)`,  so `y.shape` is `(2, 2, 5, 5) = (n, c_O, h_O, w_O)`.

If it was `(n, c_I * c_O, h_O, w_O)`, `y.shape`  must be `(2, 6, 5, 5)`.