### PR TITLE
Fix Travis macOS failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       language: generic
       env:
       - CHAINER_TRAVIS_TEST="chainer"
-      - PYTHON_VERSION=3.5.2
+      - PYTHON_VERSION=3.5.9
       - PYENV_ROOT=~/.pyenv
       - PATH=$PYENV_ROOT/shims:$PATH:$PYENV_ROOT/bin
       - GOROOT=/usr/local/opt/go/libexec

--- a/scripts/ci/travis/steps.sh
+++ b/scripts/ci/travis/steps.sh
@@ -62,15 +62,16 @@ step_before_install_chainer_test() {
             tar -C $HOME -xzf go1.13.3.linux-amd64.tar.gz
             ;;
         osx)
-            brew outdated pyenv || brew upgrade pyenv
+            # brew install foo returns 1 if foo is already installed but outdated
+            brew install pyenv || brew upgrade pyenv
 
             PYTHON_CONFIGURE_OPTS="--enable-unicode=ucs2" pyenv install -ks $PYTHON_VERSION
             pyenv global $PYTHON_VERSION
             python --version
 
-            brew install hdf5
+            brew install hdf5 || brew upgrade hdf5
 
-            brew outdated go || brew upgrade go
+            brew install go || brew upgrade go
             ;;
         *)
             false


### PR DESCRIPTION
This PR partially fixes Travis macOS failure on the `master` branch by using a newer Python 3.5.x.
