### PR TITLE
Fix Chainer CIs

### DIFF
--- a/.pfnci/chainermn.Dockerfile
+++ b/.pfnci/chainermn.Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM nvidia/cuda:${BASE_IMAGE}
+FROM nvidia/cuda:9.2-cudnn7-devel
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -52,12 +52,12 @@ RUN touch $BASH_PROFILE && \
 
 
 # Python 3.6.8
-
 ENV PYTHON_VERSION 3.6.8
-
-RUN . $BASH_PROFILE && pyenv install $PYTHON_VERSION && \
+COPY . /cupy
+RUN . $BASH_PROFILE && cd /cupy && pyenv install $PYTHON_VERSION && \
 	pyenv shell ${PYTHON_VERSION} && \
 	pip install -U pip && \
 	pip install cython && \
 	pip install chainer pytest mock mpi4py && \
-	pip uninstall -y chainer
+	pip uninstall -y chainer && \
+        pip install .

--- a/.pfnci/chainermn.Dockerfile
+++ b/.pfnci/chainermn.Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=9.2-cudnn7-devel
 
-FROM nvidia/cuda:9.2-cudnn7-devel
+FROM nvidia/cuda:${BASE_IMAGE}
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -97,7 +97,7 @@ configs {
     environment_variables { key: "GPU" value: "2" }
     # NOTE: If # of threads / # of GPUs exceeds 10, GPU tests may cause
     # cudaErrorLaunchFailure because of insufficient memory on GPU.
-    environment_variables { key: "XPYTEST_NUM_THREADS" value: "30" }
+    environment_variables { key: "XPYTEST_NUM_THREADS" value: "20" }
     environment_variables {
       key: "SPREADSHEET_ID"
       value: "1u5OYiPOL3XRppn73XBSgR-XyDuHKb_4Ilmx1kgJfa-k"
@@ -147,6 +147,22 @@ configs {
   }
 }
 configs {
+  key: "chainer.docker.chainermn.test"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+    }
+    time_limit: {
+      seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "bash .pfnci/script.sh docker.chainermn.test"
+  }
+}
+configs {
   key: "chainer.docker.py37.push"
   value {
     requirement {
@@ -176,6 +192,22 @@ configs {
       include_dot_git: true
     }
     command: "bash .pfnci/script.sh docker.py27and35.push"
+  }
+}
+configs {
+  key: "chainer.docker.chainermn.push"
+  value {
+    requirement {
+      cpu: 2
+      memory: 12
+    }
+    time_limit: {
+      seconds: 3600
+    }
+    checkout_strategy {
+      include_dot_git: true
+    }
+    command: "bash .pfnci/script.sh docker.chainermn.push"
   }
 }
 

--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -203,11 +203,6 @@ test_chainermn_sub() {
   fi
 
   #-----------------------------------------------------------------------------
-  # Install CuPy from wheel
-  #-----------------------------------------------------------------------------
-  pip install /cupy-wheel/cupy-*-cp${MAJOR_VERSION}*-cp${MAJOR_VERSION}*-linux_x86_64.whl
-
-  #-----------------------------------------------------------------------------
   # Install Chainer
   #-----------------------------------------------------------------------------
   CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 \
@@ -215,7 +210,6 @@ test_chainermn_sub() {
   CHAINERX_NVCC_GENERATE_CODE=arch=compute_70,code=sm_70 \
       python -m pip install /chainer[test] 2>&1 >/tmp/install-py3.log &
   install_pid=$!
-
   if ! wait $install_pid; then
     cat /tmp/install-py3.log
     exit 1

--- a/.pfnci/script.sh
+++ b/.pfnci/script.sh
@@ -102,21 +102,15 @@ main() {
         run docker push "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${target}:${base_branch}"
       fi
       ;;
-	'chainermn' )
+    'chainermn' )
       docker_args+=(
           --volume="$(cd "$(dirname "${BASH_SOURCE}")/.."; pwd):/src:ro")
       if [ "${GPU:-0}" != '0' ]; then
         docker_args+=(
             --ipc=host --privileged --env="GPU=${GPU}" --runtime=nvidia)
       fi
-      docker_args+=(--env="CUPY_VERSION=${CUPY_VERSION:-master}")
-      # prepare CuPy wheel
-      CUPY_MASTER=$(gsutil -q cp gs://tmp-asia-pfn-public-ci/cupy/wheel/master -)
-      mkdir /tmp/cupy-wheel
-      gsutil -q cp gs://tmp-asia-pfn-public-ci/cupy/wheel/${CUPY_MASTER}/cuda9.2/*.whl /tmp/cupy-wheel
-      docker_args+=(--volume="/tmp/cupy-wheel:/cupy-wheel:ro")
       run "${docker_args[@]}" \
-          "asia.gcr.io/pfn-public-ci/chainermn-ci-prep-${CUDATAG:-cuda92}" \
+          "asia.gcr.io/pfn-public-ci/chainer-ci-prep.${TARGET}:${base_branch}" \
           bash /src/.pfnci/run.sh "${TARGET}"
       ;;
     # Unsupported targets.

--- a/chainer/testing/parameterized.py
+++ b/chainer/testing/parameterized.py
@@ -92,7 +92,10 @@ def _parameterize_test_case(base, i, param):
                 s.write('Test parameters:\n')
                 for k, v in sorted(param.items()):
                     s.write('  {}: {}\n'.format(k, v))
-                utils._raise_from(e.__class__, s.getvalue(), e)
+                err_class = e.__class__
+                if err_class.__name__ == 'OutOfMemoryError':
+                    err_class = MemoryError
+                utils._raise_from(err_class, s.getvalue(), e)
         return new_method
 
     return (cls_name, mb, method_generator)

--- a/onnx_chainer/.flexci/run_test.sh
+++ b/onnx_chainer/.flexci/run_test.sh
@@ -11,12 +11,13 @@ if [ -n "${GPU+x}" ]; then
     export DOCKER_RUNTIME_ARG="--runtime=nvidia"
     export PYTEST_ARGS=""
 fi
+
 if [ -z "${ONNX_VER+x}" ]; then export ONNX_VER=""; fi
 
 cat <<EOM >test_script.sh
 set -eux
 
-if [[ "${INSTALL_CUPY}" == "on" ]]; then pip install --pre cupy-cuda101; fi
+if [[ "${INSTALL_CUPY}" == "on" ]]; then pip install --pre 'cupy-cuda101<8.0.0'; fi
 pip install -e .[test]
 pip install 'onnx<1.7.0' onnxruntime
 if [[ "${ONNX_VER}" != "" ]]; then pip install onnx==${ONNX_VER}; fi


### PR DESCRIPTION
py27and37.gpu needed to lower the concurrency to 20 threads, seems that some change in somewhere might have changed the order in which some tests were executed causing out-of-memory errors.

for onnxchainer.py37.gpu cupy v8 was being installed, setting <8.0.0 in the requirements was enough.

chainermn now installs cupy in the same way as the chainer tests instead of using a prebuilt wheel that we deleted. We need to push this before to make cupy aware of this and push the new image

AppVeyor error

```
  Downloading https://files.pythonhosted.org/packages/f1/2c/717bdd12404c73ec0c8c734c81a0bad7048866bc36a88a1b69fd52b01c07/numpy-1.19.0.zip (7.3MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-9xk8iqp8\numpy\setup.py", line 30, in <module>
        raise RuntimeError("Python version >= 3.6 required.")
    RuntimeError: Python version >= 3.6 required.
    
    ----------------------------------------
```
Limiting numpy fails with mock next, since newest mock is not supported by python 3.5Using another python version results in errors when comparing arrays due to datatype mismatches. 
Windows?