### PR TITLE
Use numpy 1.18.x for Docker images

### DIFF
--- a/docker/intel/python3/Dockerfile
+++ b/docker/intel/python3/Dockerfile
@@ -15,4 +15,4 @@ RUN apt-get update -y && \
     && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN CHAINER_BUILD_CHAINERX=1 pip3 install --no-cache-dir 'ideep4py<2.1' chainer==7.7.0
+RUN CHAINER_BUILD_CHAINERX=1 pip3 install --no-cache-dir 'ideep4py<2.1' 'numpy<1.19' chainer==7.7.0

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update -y && \
     && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-RUN CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 pip3 install --no-cache-dir cupy-cuda92==7.7.0 chainer==7.7.0
+RUN CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 pip3 install --no-cache-dir 'numpy<1.19' cupy-cuda92==7.7.0 chainer==7.7.0


### PR DESCRIPTION
NumPy 1.19 does not support Python 3.5 which is the default system python in Ubuntu 16.
(avoid upgrading setuptools/pip as they are installed via package maanger)