### PR TITLE
Mitigate breaking changes in CuPy v8

### DIFF
--- a/chainer/_version.py
+++ b/chainer/_version.py
@@ -5,6 +5,7 @@ _optional_dependencies = [
     {
         'name': 'CuPy',
         'packages': [
+            'cupy-cuda111',
             'cupy-cuda110',
             'cupy-cuda102',
             'cupy-cuda101',
@@ -16,7 +17,7 @@ _optional_dependencies = [
             'cupy',
         ],
         'specifier': '>=7.7.0,<8.0.0',
-        'help': 'https://docs-cupy.chainer.org/en/latest/install.html',
+        'help': 'https://docs.cupy.dev/en/latest/install.html',
     },
     {
         'name': 'iDeep',

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -68,7 +68,7 @@ try:
     # Alias for ignoring the warning in setup.cfg
     try:
         from cupy._util import PerformanceWarning as _PerformanceWarning  # NOQA
-    except Exception as e:
+    except ImportError:
         from cupy.util import PerformanceWarning as _PerformanceWarning  # NOQA
 
     available = True

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -66,7 +66,10 @@ try:
     from cupy.cuda import Stream  # type: ignore # NOQA
 
     # Alias for ignoring the warning in setup.cfg
-    from cupy.util import PerformanceWarning as _PerformanceWarning  # NOQA
+    try:
+        from cupy._util import PerformanceWarning as _PerformanceWarning  # NOQA
+    except Exception as e:
+        from cupy.util import PerformanceWarning as _PerformanceWarning  # NOQA
 
     available = True
 except Exception as e:

--- a/onnx_chainer/.flexci/run_test.sh
+++ b/onnx_chainer/.flexci/run_test.sh
@@ -19,7 +19,7 @@ set -eux
 
 if [[ "${INSTALL_CUPY}" == "on" ]]; then pip install --pre 'cupy-cuda101<8.0.0'; fi
 pip install -e .[test]
-pip install 'onnx<1.7.0' onnxruntime
+pip install 'onnx<1.7.0' 'onnxruntime<1.5.0'
 if [[ "${ONNX_VER}" != "" ]]; then pip install onnx==${ONNX_VER}; fi
 pip install pytest-cov
 pip list -v


### PR DESCRIPTION
Although we do not support CuPy v8 + Chainer v7, this mitigates the situation that Chainer cannot run on CuPy v8. (#8582)