### PR TITLE
Prevent importing chainer immediately raises an error with cupy>=10

### DIFF
--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -32,7 +32,6 @@ import binascii
 import functools
 import itertools
 import os
-import packaging
 import threading
 import time
 import typing as tp  # NOQA

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -32,6 +32,7 @@ import binascii
 import functools
 import itertools
 import os
+import packaging
 import threading
 import time
 import typing as tp  # NOQA
@@ -121,7 +122,7 @@ except Exception as e:
 
 
 if available:
-    _cupy_major = numpy.lib.NumpyVersion(cupy.__version__).major
+    _cupy_major = packaging.version.Version(cupy.__version__).major
     _cudnn_disabled_by_user = int(os.environ.get('CHAINER_CUDNN', '1')) == 0
     try:
         if 7 < _cupy_major:

--- a/chainer/backends/cuda.py
+++ b/chainer/backends/cuda.py
@@ -122,7 +122,7 @@ except Exception as e:
 
 
 if available:
-    _cupy_major = packaging.version.Version(cupy.__version__).major
+    _cupy_major = int(cupy.__version__.split('.')[0])
     _cudnn_disabled_by_user = int(os.environ.get('CHAINER_CUDNN', '1')) == 0
     try:
         if 7 < _cupy_major:


### PR DESCRIPTION
When cupy>=10 is installed, importing chainer immediately raises the following error.
```python
>>> import cupy; cupy.__version__
'10.0.0'
>>> import chainer
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/chainer/__init__.py", line 10, in <module>
    from chainer import backends  # NOQA
  File "/usr/local/lib/python3.9/site-packages/chainer/backends/__init__.py", line 1, in <module>
    from chainer.backends import cuda  # NOQA
  File "/usr/local/lib/python3.9/site-packages/chainer/backends/cuda.py", line 124, in <module>
    _cupy_major = numpy.lib.NumpyVersion(cupy.__version__).major
  File "/usr/local/lib/python3.9/site-packages/numpy/lib/_version.py", line 59, in __init__
    raise ValueError("Not a valid numpy version string")
ValueError: Not a valid numpy version string
```

This PR is to fix this issue.
I am quite aware that there is (and should be) absolutely no guarantee that chainer and the latest cupy work fine together. But for those who have to use or maintain codes that still rely on some of chainer functionalities with their own risk, I'd like to prevent the situation where just importing chainer immediately fails.