### PR TITLE
Fix `_set_cover_all` in deconvolution_2d.py

### DIFF
--- a/chainer/functions/connection/deconvolution_2d.py
+++ b/chainer/functions/connection/deconvolution_2d.py
@@ -337,7 +337,7 @@ class Deconvolution2DFunction(function_node.FunctionNode):
             ret.append(gx)
         if 1 in indexes:
             if self.cover_all is None:
-                self._set_cover_all(x, W)
+                self._set_cover_all(x.shape, W.shape)
             gW, = convolution_2d.Convolution2DGradW(
                 self, W.shape, W.dtype, w_layout).apply((gy, x))
             ret.append(gW)

--- a/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
+++ b/tests/chainer_tests/functions_tests/connection_tests/test_deconvolution_2d.py
@@ -336,4 +336,32 @@ class TestDeconvolution2DInvalidDilation(unittest.TestCase):
                 self.check_invalid_dilation(x, w)
 
 
+@testing.parameterize(*(testing.product({
+    'n_batches': [2, 3],
+    'requires_x_grad': [True, False],
+    'requires_w_grad': [True, False],
+    'requires_b_grad': [True, False],
+})))
+class TestDeconvolution2DVariousGradTargets(unittest.TestCase):
+
+    in_channels = 3
+    out_channels = 2
+
+    def check_backward_succeed(self, x_data, w_data, b_data):
+        x = chainer.Variable(x_data, requires_grad=self.requires_x_grad)
+        w = chainer.Variable(w_data, requires_grad=self.requires_w_grad)
+        b = chainer.Variable(b_data, requires_grad=self.requires_b_grad)
+        y = F.deconvolution_2d(x, w, b)
+        F.sum(y).backward()
+
+    def test_backward_cpu(self):
+        x_shape = (self.n_batches, self.in_channels, 10, 10)
+        w_shape = (self.in_channels, self.out_channels, 5, 5)
+        x = numpy.ones(x_shape, numpy.float32)
+        w = numpy.ones(w_shape, numpy.float32)
+        b = numpy.ones(self.out_channels, numpy.float32)
+        with chainer.using_config('use_ideep', 'never'):
+            self.check_backward_succeed(x, w, b)
+
+
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
This PR fixes wrong arguments of `_set_cover_all` in deconvolution_2d.py,

which causes an error during double-backprop of 2D convolution when CPU is used.

```py
>>> x = ch.Variable(np.ones((1, 1, 3, 3), dtype="float32"))
>>> w = ch.Variable(np.ones((1, 1, 2, 2), dtype="float32"))
>>> y = F.convolution_2d(x ** 2, w)
>>> g, = ch.grad([y], [x], enable_double_backprop=True)
>>> F.sum(g).backward()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/testuser/ch/chainer/chainer/variable.py", line 1581, in backward
    _backprop._backprop_to_all(
  File "/home/testuser/ch/chainer/chainer/_backprop.py", line 225, in _backprop_to_all
    _backprop_utils.backprop_step(
  File "/home/testuser/ch/chainer/chainer/_backprop_utils.py", line 140, in backprop_step
    _reraise_with_stack(func, e)
  File "/home/testuser/ch/chainer/chainer/_backprop_utils.py", line 137, in backprop_step
    gxs = func.backward(
  File "/home/testuser/ch/chainer/chainer/functions/connection/deconvolution_2d.py", line 340, in backward
    self._set_cover_all(x, W)
  File "/home/testuser/ch/chainer/chainer/functions/connection/deconvolution_2d.py", line 351, in _set_cover_all
    _, _, kh, kw = w_shape
ValueError: not enough values to unpack (expected 4, got 1)
```

Fixed:

```py
>>> F.sum(g).backward()
>>> x.grad
array([[[[2., 4., 2.],
         [4., 8., 4.],
         [2., 4., 2.]]]], dtype=float32)
```