### PR TITLE
Fix an improper implementation of a special function supporting a binary operation

### DIFF
--- a/chainer/_backend.py
+++ b/chainer/_backend.py
@@ -84,8 +84,7 @@ class Device(object):
         pass
 
     def __eq__(self, other):
-        raise NotImplementedError(
-            'Device implementation must override this method.')
+        return NotImplemented
 
     def __ne__(self, other):
         return not (self == other)


### PR DESCRIPTION
In file: _backend.py, class: `Device`, there is a special method `__eq__` that raises a `NotImplementedError`. If a special method supporting a binary operation is not implemented it should return [`NotImplemented`](https://docs.python.org/3/library/constants.html#NotImplemented). On the other hand, [`NotImplementedError`](https://docs.python.org/3/library/exceptions.html#NotImplementedError) should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. I suggested that the special method `__eq__` should return `NotImplemented` instead of raising an exception. An example of how `NotImplemented` helps the interpreter support a binary operation is [here](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations). 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.